### PR TITLE
update install method of flagcx torch plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ A vLLM plugin built on the FlagOS unified multi-chip backend.
     3.4 Installation FlagCX
     ```sh
     cd plugin/torch/
+    FLAGCX_ADAPTOR=[xxx] pip install . --no-build-isolation
+    # or editable install
     FLAGCX_ADAPTOR=[xxx] pip install -e . --no-build-isolation
     ```
     Note: [xxx] should be selected according to the current platform, e.g., nvidia, ascend, etc.


### PR DESCRIPTION
### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others ] -->
Others
### PR Types
<!-- One of [ User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change| Deprecations | Test Case | Docs | Others ] -->
Docs
### PR Description
<!-- Describe what you’ve done -->
This PR updates the installation command of flagcx torch plugin. The old installation command using `setup.py` may cause compilation error in certain environments. It is recommended to use `pip install` to ensure successful compilation of the plugin. This change is reflected in FlagCX v0.9.0.