### PR TITLE
update qwen3next to use fused_recurrent in flag_gems

### DIFF
--- a/vllm_fl/models/qwen3_next.py
+++ b/vllm_fl/models/qwen3_next.py
@@ -438,7 +438,7 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
             (query, key),
         )
         value = rearrange(value, "l (h d) -> 1 l h d", d=self.head_v_dim)
-        return query.contiguous(), key.contiguous(), value.contiguous()
+        return query, key, value
 
     def forward(
         self,
@@ -649,9 +649,9 @@ class Qwen3NextGatedDeltaNet(nn.Module, MambaBase):
                 core_attn_out_non_spec,
                 last_recurrent_state,
             ) = self.chunk_gated_delta_rule(
-                q=query_non_spec,
-                k=key_non_spec,
-                v=value_non_spec,
+                q=query_non_spec.contiguous(),
+                k=key_non_spec.contiguous(),
+                v=value_non_spec.contiguous(),
                 g=g_non_spec,
                 beta=beta_non_spec,
                 initial_state=initial_state,

--- a/vllm_fl/ops/_fl_ops.py
+++ b/vllm_fl/ops/_fl_ops.py
@@ -26,9 +26,8 @@ class FLOps:
             topk_indices,
             token_expert_indices,
             gating_output,
+            renormalize,
         )
-        if renormalize:
-            topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
         return topk_weights, topk_indices
     
     @staticmethod

--- a/vllm_fl/ops/fla/fused_recurrent.py
+++ b/vllm_fl/ops/fla/fused_recurrent.py
@@ -32,9 +32,9 @@ class FusedRecurrentFunction(torch.autograd.Function):
         use_qk_l2norm_in_kernel: bool = False,
     ):
         o, final_state = fused_recurrent_gated_delta_rule_fwd(
-            q=q.contiguous(),
-            k=k.contiguous(),
-            v=v.contiguous(),
+            q=q,
+            k=k,
+            v=v,
             g=g.contiguous(),
             beta=beta.contiguous(),
             scale=scale,


### PR DESCRIPTION
### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others ] -->
OP

### PR Types
<!-- One of [ User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change| Deprecations | Test Case | Docs | Others ] -->
Performance

### PR Description
<!-- Describe what you’ve done -->
update qwen3next to use fused_recurrent in flag_gems