### PR TITLE
[Vendor] add kunlunxin vendor and support qwen3.5

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
 
 import os
 import logging
@@ -47,7 +49,16 @@ def register():
 def register_model():
     """Register the FL model."""
     from vllm import ModelRegistry
-    import vllm.model_executor.models.qwen3_next as qwen3_next_module
+
+    # Kunlunxin: patch torch.xpu.get_device_name BEFORE any import that
+    # transitively loads vllm.model_executor.layers.fla.ops.utils, which
+    # crashes on "Torch not compiled with XPU enabled" (see patch_fla_utils.py)
+    from vllm_fl.dispatch.config.utils import get_platform_name
+    if get_platform_name() == "kunlunxin":
+        from vllm_fl.dispatch.backends.vendor.kunlunxin.patches.patch_fla_utils import (
+            ensure_fla_compat,
+        )
+        ensure_fla_compat()
 
     # Register Qwen3.5 MoE config
     try:
@@ -59,6 +70,7 @@ def register_model():
 
     # Register Qwen3Next model
     try:
+        import vllm.model_executor.models.qwen3_next as qwen3_next_module
         from vllm_fl.models.qwen3_next import Qwen3NextForCausalLM  # noqa: F401
 
         qwen3_next_module.Qwen3NextForCausalLM = Qwen3NextForCausalLM

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin backend for vllm-plugin-FL dispatch.
+"""
+
+from .kunlunxin import KunlunxinBackend
+
+__all__ = ["KunlunxinBackend"]

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/__init__.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin operator implementations.
+"""
+
+from .activation import silu_and_mul_kunlunxin
+from .normalization import rms_norm_kunlunxin
+from .rotary import rotary_embedding_kunlunxin
+from .attention import (
+    KunlunxinAttentionBackend,
+    KunlunxinAttentionBackendImpl,
+    KunlunxinAttentionMetadataBuilder,
+    KunlunxinMetadata,
+    is_kunlunxin_ops_available,
+)
+from .causal_conv1d import causal_conv1d_fn_kunlunxin, causal_conv1d_update_kunlunxin
+from .fused_gdn_gating import fused_gdn_gating_kunlunxin
+
+__all__ = [
+    "silu_and_mul_kunlunxin",
+    "rms_norm_kunlunxin",
+    "rotary_embedding_kunlunxin",
+    "KunlunxinAttentionBackend",
+    "KunlunxinAttentionBackendImpl",
+    "KunlunxinAttentionMetadataBuilder",
+    "KunlunxinMetadata",
+    "is_kunlunxin_ops_available",
+    "causal_conv1d_fn_kunlunxin",
+    "causal_conv1d_update_kunlunxin",
+    "fused_gdn_gating_kunlunxin",
+]

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/activation.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/activation.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin activation operator implementations.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def silu_and_mul_kunlunxin(obj, x: torch.Tensor) -> torch.Tensor:
+    """
+    SiLU activation followed by element-wise multiplication.
+
+    Args:
+        obj: The calling obj (for interface consistency)
+        x: Input tensor of shape [..., 2*d]
+
+    Returns:
+        Output tensor of shape [..., d]
+    """
+    import xtorch_ops
+
+    d = x.shape[-1] // 2
+    out = torch.empty(
+        *x.shape[:-1], d, dtype=x.dtype, device=x.device
+    )
+    xtorch_ops.swiglu(x, out)
+    return out

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
@@ -1,0 +1,985 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
+
+"""
+Kunlunxin attention backend for vllm-plugin-FL.
+
+This module provides Kunlunxin attention using xtorch_ops:
+  - xtorch_ops.prefill_attention(...)          -- prefill (flash attention)
+  - xtorch_ops.decode_paged_attention(...)     -- decode (paged attention)
+  - xtorch_ops.reshape_and_cache(...)          -- KV cache update (HND layout)
+  - xtorch_ops.reshape_and_cache_flash(...)    -- KV cache update (hybrid attention, e.g. Qwen3-Next)
+
+KV cache layout HND by default: (2, num_blocks, num_kv_heads, block_size, head_size)
+"""
+
+from __future__ import annotations
+
+import os
+import logging
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Type
+
+import torch
+
+from vllm.attention.backends.abstract import (
+    AttentionBackend,
+    AttentionImpl,
+    AttentionLayer,
+    AttentionType
+)
+
+from vllm.attention.ops.paged_attn import PagedAttention
+from vllm.v1.kv_cache_interface import AttentionSpec
+from vllm.v1.attention.backends.utils import (
+    CommonAttentionMetadata,
+    split_decodes_and_prefills,
+    AttentionCGSupport
+)
+
+from vllm.v1.attention.backends.utils import AttentionMetadataBuilder
+
+from vllm.config import VllmConfig
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.worker.gpu_input_batch import InputBatch
+
+logger = logging.getLogger(__name__)
+
+# Check torch_xmlir / xtorch_ops availability
+_KUNLUNXIN_OPS_AVAILABLE = False
+try:
+    import torch_xmlir  # noqa: F401
+    import xtorch_ops
+    _KUNLUNXIN_OPS_AVAILABLE = True
+except ImportError:
+    logger.debug(
+        "xtorch_ops or torch_xmlir not available. "
+        "Kunlunxin attention ops will not work."
+    )
+
+
+def is_kunlunxin_ops_available() -> bool:
+    """Check if Kunlunxin ops are available."""
+    return _KUNLUNXIN_OPS_AVAILABLE
+
+
+@dataclass
+class KunlunxinMetadata:
+    """Metadata for Kunlunxin attention."""
+    # (batch_size,). The length of sequences (entire tokens seen so far) per
+    # sequence.
+    seq_lens_tensor: torch.Tensor | None
+    # Maximum sequence length in the batch. 0 if it is prefill-only batch.
+    max_decode_seq_len: int
+    # (batch_size, max_blocks_per_seq).
+    # Block addresses per sequence. (Seq id -> list of physical block)
+    # E.g., [0, 1, 2] means tokens are stored in 0th, 1st, and 2nd blocks
+    # in the kv cache. Each block can contain up to block_size tokens.
+    # 2nd dimensions are padded up to max_blocks_per_seq if it is cuda-graph
+    # captured.
+    block_tables: torch.Tensor | None
+
+    num_prefills: int
+
+    num_prefill_tokens: int
+
+    num_decode_tokens: int
+
+    slot_mapping: torch.Tensor
+
+    enable_kv_scales_calculation: bool
+
+    # seq_lens stored as a tensor.
+    seq_lens_tensor: Optional[torch.Tensor]
+
+
+    # Maximum sequence length among prefill batch. 0 if there are decoding
+    # requests only.
+    max_prefill_seq_len: int
+    # Maximum sequence length among decode batch. 0 if there are prefill
+    # requests only.
+    max_decode_seq_len: int
+    num_actual_tokens: int
+    # Whether or not if cuda graph is enabled.
+    use_cuda_graph: bool
+
+    # (batch_size,). The sequence length per sequence. Sequence length means
+    # the computed tokens + new tokens None if it is a decoding.
+    seq_lens: Optional[List[int]] = None
+    seq_lens_tensor_host: Optional[torch.Tensor] = None
+    # (batch_size + 1,). The cumulative sequence lengths of the sequences in
+    # the batch, used to index into sequence. E.g., if the sequence length is
+    # [4, 6], it is [0, 4, 10].
+    seq_start_loc: Optional[torch.Tensor] = None
+
+    # (batch_size,) A tensor of context lengths (tokens that are computed
+    # so far).
+    context_lens_tensor: Optional[torch.Tensor] = None
+
+    # Maximum query length in the batch. None for decoding.
+    max_query_len: Optional[int] = None
+
+    # Max number of key/value length in the batch, especially for prefix cache
+    max_kv_len: Optional[int] = None
+
+    # Max number of query tokens among request in the batch.
+    max_decode_query_len: Optional[int] = None
+
+    # (batch_size + 1,). The cumulative subquery lengths of the sequences in
+    # the batch, used to index into subquery. E.g., if the subquery length
+    # is [4, 6], it is [0, 4, 10].
+    query_start_loc: Optional[torch.Tensor] = None
+    query_start_loc_host: Optional[torch.Tensor] = None
+    # serve only for prefix cache
+    kv_prefix_start_loc_host: Optional[torch.Tensor] = None
+    kv_prefix_start_loc: Optional[torch.Tensor] = None
+
+    # Self-attention prefill/decode metadata cache
+    _cached_prefill_metadata: Optional["KunlunxinMetadata"] = None
+    _cached_decode_metadata: Optional["KunlunxinMetadata"] = None
+
+    # Begin encoder attn & enc/dec cross-attn fields...
+
+    # Encoder sequence lengths representation
+    encoder_seq_lens: Optional[List[int]] = None
+    encoder_seq_lens_tensor: Optional[torch.Tensor] = None
+
+    # Maximum sequence length among encoder sequences
+    max_encoder_seq_len: Optional[int] = None
+
+    # Number of tokens input to encoder
+    num_encoder_tokens: Optional[int] = None
+
+    # Cross-attention memory-mapping data structures: slot mapping
+    # and block tables
+    cross_slot_mapping: Optional[torch.Tensor] = None
+    cross_block_tables: Optional[torch.Tensor] = None
+
+    # Input positions for rotrary embeddings since for MLA the rotary
+    # position embeddings are applied inside the attention backend
+    input_positions: Optional[torch.Tensor] = None
+
+    # for spec decode api
+    is_spec_decode: Optional[bool] = False
+
+    def __post_init__(self):
+        # Set during the execution of the first attention op.
+        # It is a list because it is needed to set per prompt
+        # when alibi slopes is used. It is because of the limitation
+        # from xformer API.
+        # will not appear in the __repr__ and __init__
+        self.attn_bias: Optional[List[AttentionBias]] = None
+        self.encoder_attn_bias: Optional[List[AttentionBias]] = None
+        self.cross_attn_bias: Optional[List[AttentionBias]] = None
+
+    @property
+    def is_all_encoder_attn_metadata_set(self):
+        '''
+        All attention metadata required for encoder attention is set.
+        '''
+        return ((self.encoder_seq_lens is not None)
+                and (self.encoder_seq_lens_tensor is not None)
+                and (self.max_encoder_seq_len is not None))
+
+    @property
+    def is_all_cross_attn_metadata_set(self):
+        '''
+        All attention metadata required for enc/dec cross-attention is set.
+
+        Superset of encoder attention required metadata.
+        '''
+        return (self.is_all_encoder_attn_metadata_set
+                and (self.cross_slot_mapping is not None)
+                and (self.cross_block_tables is not None))
+
+    @property
+    def prefill_metadata(self) -> Optional["KunlunxinMetadata"]:
+        if self.num_prefills == 0:
+            return None
+
+        if self._cached_prefill_metadata is not None:
+            # Recover cached prefill-phase attention
+            # metadata structure
+            return self._cached_prefill_metadata
+
+        assert ((self.seq_lens_tensor is not None)
+                or (self.encoder_seq_lens_tensor is not None))
+
+        # Compute some attn_metadata fields which default to None
+        query_start_loc = (None if self.query_start_loc is None else
+                           self.query_start_loc[-(self.num_prefills + 1):] - self.query_start_loc[-(self.num_prefills + 1)])
+        # flash attention needs both lod information on host and device
+        query_start_loc_host = (None if self.query_start_loc_host is None else
+                           self.query_start_loc_host[-(self.num_prefills + 1):] - self.query_start_loc_host[-(self.num_prefills + 1)])
+
+        kv_prefix_start_loc = (None if self.kv_prefix_start_loc is None else
+                    self.kv_prefix_start_loc[-(self.num_prefills + 1):] - self.kv_prefix_start_loc[-(self.num_prefills + 1)])
+        kv_prefix_start_loc_host = (None if self.kv_prefix_start_loc_host is None else
+            self.kv_prefix_start_loc_host[-(self.num_prefills + 1):] - self.kv_prefix_start_loc_host[-(self.num_prefills + 1)])
+
+        slot_mapping = (None if self.slot_mapping is None else
+                        self.slot_mapping[-self.num_prefill_tokens:])
+
+        seq_lens_tensor = (None if self.seq_lens_tensor is None else
+                           self.seq_lens_tensor[-self.num_prefills:])
+        context_lens_tensor = (None if self.context_lens_tensor is None else
+                               self.context_lens_tensor[-self.num_prefills:])
+
+        block_tables = (None if self.block_tables is None else
+                        self.block_tables[-self.num_prefills:])
+        input_positions = (None if self.input_positions is None else
+                    self.input_positions[-self.num_prefills:])
+
+        # Construct & cache prefill-phase attention metadata structure
+        self._cached_prefill_metadata = KunlunxinMetadata(
+            num_actual_tokens=self.num_actual_tokens,
+            num_prefills=self.num_prefills,
+            num_prefill_tokens=self.num_prefill_tokens,
+            num_decode_tokens=0,
+            slot_mapping=slot_mapping,
+            seq_lens=None,
+            seq_lens_tensor=seq_lens_tensor,
+            max_query_len=self.max_query_len,
+            max_kv_len=self.max_kv_len,
+            max_prefill_seq_len=self.max_prefill_seq_len,
+            max_decode_seq_len=0,
+            query_start_loc=query_start_loc,
+            query_start_loc_host=query_start_loc_host,
+            input_positions=input_positions,
+            kv_prefix_start_loc=kv_prefix_start_loc,
+            kv_prefix_start_loc_host=kv_prefix_start_loc_host,
+            context_lens_tensor=context_lens_tensor,
+            block_tables=block_tables,
+            use_cuda_graph=False,
+            # Begin encoder & cross attn fields below...
+            encoder_seq_lens=self.encoder_seq_lens,
+            encoder_seq_lens_tensor=self.encoder_seq_lens_tensor,
+            max_encoder_seq_len=self.max_encoder_seq_len,
+            cross_slot_mapping=self.cross_slot_mapping,
+            cross_block_tables=self.cross_block_tables,
+            enable_kv_scales_calculation=False)
+        return self._cached_prefill_metadata
+
+    @property
+    def decode_metadata(self) -> Optional["KunlunxinMetadata"]:
+        if self.num_decode_tokens == 0:
+            return None
+
+        if self._cached_decode_metadata is not None:
+            # Recover cached decode-phase attention
+            # metadata structure
+            return self._cached_decode_metadata
+        assert ((self.seq_lens_tensor is not None)
+                or (self.encoder_seq_lens_tensor is not None))
+
+        if self.num_prefills != 0:
+            # Compute some attn_metadata fields which default to None
+            slot_mapping = (None if self.slot_mapping is None else
+                        self.slot_mapping[:-self.num_prefill_tokens])
+            seq_lens_tensor = (None if self.seq_lens_tensor is None else
+                           self.seq_lens_tensor[:-self.num_prefills])
+            seq_lens_tensor_host = (None if self.seq_lens_tensor_host is None else
+                           self.seq_lens_tensor_host[:-self.num_prefills])
+
+            block_tables = (None if self.block_tables is None else
+                        self.block_tables[:-self.num_prefills])
+            query_start_loc = (None if self.query_start_loc is None else
+                               self.query_start_loc[:-self.num_prefills])
+            query_start_loc_host = (None if self.query_start_loc_host is None else
+                                    self.query_start_loc_host[:-self.num_prefills])
+        else:
+            # Compute some attn_metadata fields which default to None
+            slot_mapping = (None if self.slot_mapping is None else
+                        self.slot_mapping)
+            seq_lens_tensor = (None if self.seq_lens_tensor is None else
+                           self.seq_lens_tensor)
+            seq_lens_tensor_host = (None if self.seq_lens_tensor_host is None else
+                           self.seq_lens_tensor_host)
+            block_tables = (None if self.block_tables is None else
+                        self.block_tables)
+            query_start_loc = (None if self.query_start_loc is None else
+                               self.query_start_loc[:-self.num_prefills])
+            query_start_loc_host = (None if self.query_start_loc_host is None else
+                                    self.query_start_loc_host[:-self.num_prefills])
+
+        # Construct & cache decode-phase attention metadata structure
+        self._cached_decode_metadata = KunlunxinMetadata(
+            num_actual_tokens=self.num_actual_tokens,
+            num_prefills=0,
+            num_prefill_tokens=0,
+            num_decode_tokens=self.num_decode_tokens,
+            slot_mapping=slot_mapping,
+            seq_lens_tensor=seq_lens_tensor,
+            seq_lens_tensor_host=seq_lens_tensor_host,
+            query_start_loc=query_start_loc,
+            query_start_loc_host=query_start_loc_host,
+            max_prefill_seq_len=0,
+            max_decode_seq_len=self.max_decode_seq_len,
+            block_tables=block_tables,
+            use_cuda_graph=self.use_cuda_graph,
+            # Begin encoder & cross attn fields below...
+            encoder_seq_lens=self.encoder_seq_lens,
+            encoder_seq_lens_tensor=self.encoder_seq_lens_tensor,
+            max_encoder_seq_len=self.max_encoder_seq_len,
+            cross_slot_mapping=self.cross_slot_mapping,
+            cross_block_tables=self.cross_block_tables,
+            enable_kv_scales_calculation=False,
+            is_spec_decode=self.is_spec_decode)
+        return self._cached_decode_metadata
+
+
+class KunlunxinAttentionMetadataBuilder(AttentionMetadataBuilder):
+    """Builder for Kunlunxin attention metadata."""
+
+    reorder_batch_threshold: ClassVar[int] = 1
+    _cudagraph_support: ClassVar[AttentionCGSupport] = \
+        AttentionCGSupport.UNIFORM_BATCH
+
+    def __init__(self, kv_cache_spec: AttentionSpec,
+                 layer_names: list[str],
+                 vllm_config: VllmConfig,
+                 device: torch.device):
+        self.device = device
+        self.is_spec_decode = vllm_config.speculative_config is not None
+        if self.is_spec_decode:
+            self.reorder_batch_threshold = 1 + vllm_config.speculative_config.num_speculative_tokens
+
+    def reorder_batch(self, input_batch: "InputBatch",
+                      scheduler_output: "SchedulerOutput") -> bool:
+        decodes = []
+        prefills = []
+        num_decode_tokens = 0
+        num_prefill_tokens = 0
+
+        for i, req_id in enumerate(input_batch.req_ids):
+            num_tokens = scheduler_output.num_scheduled_tokens[req_id]
+            # TODO: how if a prefilled sequence has only one token
+            if num_tokens == 1:
+                decodes.append(i)
+                num_decode_tokens += num_tokens
+            else:
+                prefills.append(i)
+                num_prefill_tokens += num_tokens
+
+        num_decodes = len(decodes)
+        num_prefills = len(prefills)
+        first_prefill = 0
+        modified_batch = False
+
+        for i in range(1, min(num_decodes, num_prefills) + 1):
+            if decodes[num_decodes - i] >= num_decodes:
+                input_batch.swap_states(prefills[first_prefill],
+                                        decodes[num_decodes - i])
+                first_prefill += 1
+                modified_batch = True
+            else:
+                break
+        self._num_decodes = num_decodes
+        self._num_prefills = num_prefills
+        self._num_decode_tokens = num_decode_tokens
+        self._num_prefill_tokens = num_prefill_tokens
+        return modified_batch
+
+
+    def build(
+        self, common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False
+    ) -> KunlunxinMetadata:
+        num_reqs = common_attn_metadata.num_reqs
+        num_actual_tokens = common_attn_metadata.num_actual_tokens
+        max_query_len = common_attn_metadata.max_query_len
+        block_table_tensor = common_attn_metadata.block_table_tensor
+        slot_mapping = common_attn_metadata.slot_mapping
+        seq_lens_cpu = common_attn_metadata.seq_lens_cpu
+        seq_lens = common_attn_metadata.seq_lens
+
+        max_kv_len = max(seq_lens_cpu).item()
+        query_start_loc_host = common_attn_metadata.query_start_loc_cpu
+        query_start_loc = common_attn_metadata.query_start_loc
+
+        seq_lens_loc_host = torch.zeros(num_reqs + 1, dtype=torch.int32)
+        seq_lens_loc_host[1:] = torch.cumsum(seq_lens_cpu, dim=0)
+        seq_lens_loc = seq_lens_loc_host.to(self.device, non_blocking=True)
+        seq_lens_host = seq_lens_cpu
+
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = \
+            split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.reorder_batch_threshold)
+        num_scheduled_tokens = torch.diff(query_start_loc_host)
+        tmp_decode_scheduled_tokens = num_scheduled_tokens[:num_decodes]
+        if num_decode_tokens == 0:
+            max_decode_seq_len = 0
+        else:
+            max_decode_seq_len = torch.max(tmp_decode_scheduled_tokens).item()
+        tmp_prefill_scheduled_tokens = num_scheduled_tokens[num_decodes: num_reqs]
+        if num_prefill_tokens == 0:
+            max_prefill_seq_len = 0
+        else:
+            max_prefill_seq_len = torch.max(tmp_prefill_scheduled_tokens).item()
+
+
+        attn_metadata = KunlunxinMetadata(
+            num_actual_tokens=num_actual_tokens,
+            num_prefills=num_prefills,
+            slot_mapping=slot_mapping,
+            enable_kv_scales_calculation=True,
+            num_prefill_tokens=num_prefill_tokens,
+            num_decode_tokens=num_decode_tokens,
+            seq_lens_tensor=seq_lens,
+            seq_lens_tensor_host=seq_lens_host,
+            max_query_len=max_prefill_seq_len,
+            max_decode_query_len=(self.reorder_batch_threshold if self.is_spec_decode else None),
+            max_kv_len=max_kv_len,
+            max_prefill_seq_len=max_prefill_seq_len,
+            max_decode_seq_len=max_decode_seq_len,
+            query_start_loc=query_start_loc,
+            query_start_loc_host=query_start_loc_host,
+            kv_prefix_start_loc_host=seq_lens_loc_host,
+            kv_prefix_start_loc=seq_lens_loc,
+            seq_start_loc=None,
+            context_lens_tensor=None,
+            block_tables=block_table_tensor,
+            use_cuda_graph=False,
+            is_spec_decode=self.is_spec_decode,
+        )
+
+        return attn_metadata
+
+
+    def build_for_cudagraph_capture(
+            self, common_attn_metadata: CommonAttentionMetadata):
+        """
+        This method builds the metadata for full cudagraph capture.
+        Currently, only decode is supported for full cudagraphs with MHA.
+        """
+        m = common_attn_metadata
+        assert m.num_reqs <= (m.num_actual_tokens *
+                              self.reorder_batch_threshold), \
+            "MHA only supports decode-only full CUDAGraph capture. " \
+            "Make sure all cudagraph capture sizes <= max_num_seq."
+
+        assert m.max_query_len <= self.reorder_batch_threshold  # decode only
+
+        return self.build(0, m)
+
+    def use_cascade_attention(self, *args, **kwargs) -> bool:
+        return False
+
+
+class KunlunxinAttentionBackend(AttentionBackend):
+    """
+    Kunlunxin attention backend.
+
+    KV cache shape: (2, num_blocks, num_kv_heads, block_size, head_size), must be contiguous
+    """
+    # crucial to cuda graph
+    accept_output_buffer: bool = True
+
+    supports_quant_query_input: bool = False
+
+    @staticmethod
+    def get_name() -> str:
+        return "KUNLUNXIN_FL"
+
+    @staticmethod
+    def get_impl_cls() -> Type["KunlunxinAttentionBackendImpl"]:
+        return KunlunxinAttentionBackendImpl
+
+    @staticmethod
+    def get_metadata_cls() -> Type["KunlunxinMetadata"]:
+        return KunlunxinMetadata
+
+    @staticmethod
+    def get_builder_cls() -> Type["KunlunxinAttentionMetadataBuilder"]:
+        return KunlunxinAttentionMetadataBuilder
+
+    @staticmethod
+    def get_supported_head_size() -> List[int]:
+        # Note: 128 is best for performance
+        return [32, 64, 80, 96, 112, 120, 128, 192, 256]
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> Tuple[int, ...]:
+        # Kunlunxin uses NHD layout
+        return (2, num_blocks, num_kv_heads, block_size, head_size)
+
+    @staticmethod
+    def swap_blocks(
+        src_kv_cache: List[torch.Tensor],
+        dst_kv_cache: List[torch.Tensor],
+        src_to_dst: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+
+    @staticmethod
+    def copy_blocks(
+        kv_caches: List[torch.Tensor],
+        src_to_dists: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+
+
+class KunlunxinPagedAttention(PagedAttention):
+    @staticmethod
+    def split_kv_cache(
+        kv_cache: torch.Tensor,
+        num_kv_heads: int,
+        head_size: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        num_blocks = kv_cache.shape[1]
+        key_cache = kv_cache[0]
+        key_cache = key_cache.view(num_blocks, num_kv_heads, -1, head_size)
+        value_cache = kv_cache[1]
+        value_cache = value_cache.view(num_blocks, num_kv_heads, -1, head_size)
+        return key_cache, value_cache
+
+    @staticmethod
+    def split_write_to_paged_cache(
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        num_kv_heads: int,
+        head_size: int,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+        v_scale: torch.Tensor,
+    ) -> None:
+        # Split fused kv_cache [2, num_blocks, ...] into key_cache / value_cache
+        key_cache, value_cache = KunlunxinPagedAttention.split_kv_cache(
+            kv_cache,
+            num_kv_heads,
+            head_size,
+        )
+        xtorch_ops.reshape_and_cache(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping.flatten(),
+        )
+
+    def reshape_and_cache_flash(
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        k_max: torch.Tensor | None = None,
+        v_max: torch.Tensor | None = None,
+        quant_mode: int = 0,
+        force_sdnn: bool = False,
+        BLHD_LAYOUT: bool = True) -> int:
+        """
+        reshape and store key and value in cache_key, cache_value, respectively.
+
+        Args:
+            key (torch.Tensor): Shape [num_tokens, num_heads, head_size], dtype bf16/fp16/fp32.
+            value (torch.Tensor): Shape [num_tokens, num_heads, head_size], same dtype as key. 
+            Can be empty; quantization is not supported when value is empty.
+            slot_mapping (torch.Tensor): Maps tokens to position indices in the cache.
+            k_max (torch.Tensor, optional): Shape [num_heads] (quant_mode=0)
+                                    or [ctx->max_ptr_size()] (quant_mode=2). Defaults to None. Dtype is fp32.
+            v_max (torch.Tensor optional): Shape [num_heads] (quant_mode=0)
+                                    or [ctx->max_ptr_size()] (quant_mode=2). Defaults to None. Dtype is fp32.
+            quant_mode (int, optional): Quantization type. quant_mode=0:
+                                                quant_mode=2: Block-wise quantization by max_ptr_size().
+                                                Defaults to 0.
+            force_sdnn (bool, optional): Hardware type.
+            BLHD_LAYOUT (bool, optional): Whether to use BLHD_LAYOUT. Defaults to True (optimal performance).
+        Returns:
+            key_cache (torch.Tensor): Output cache for k, shape [num_blocks, block_size,  num_heads, head_size],
+                same dtype as key or int8.
+                When key is bfloat16, key_cache can be float16.
+            value_cache (torch.Tensor): Output cache for v, shape [num_blocks, block_size,  num_heads, head_size], 
+                same dtype as key.
+                Can be empty; quantization is not supported when value is empty.
+        """
+        if key_cache.dtype is torch.int8 and force_sdnn:
+            raise ValueError("reshape and cache flash use sdnn do not support quant")
+
+        if value is None or value_cache is None:
+            if key_cache.dtype is torch.int8:
+                raise ValueError("reshape and cache flash k only do not support quant")
+
+        return xtorch_ops.reshape_and_cache_flash(
+                    key,
+                    value,
+                    key_cache,
+                    value_cache,
+                    slot_mapping,
+                    k_max=k_max,
+                    v_max=v_max,
+                    quant_mode=quant_mode,
+                    force_sdnn=force_sdnn,
+                    BLHD_LAYOUT=BLHD_LAYOUT)
+
+    def forward_decode(
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        block_tables: torch.Tensor,
+        seq_lens: torch.Tensor,
+        seq_lens_host: torch.Tensor,
+        max_seq_len: int,
+        num_decode_tokens: int,
+        kv_cache_dtype: str,
+        num_kv_heads: int,
+        scale: float,
+        alibi_slopes: Optional[torch.Tensor],
+        k_scale: torch.Tensor,
+        v_scale: torch.Tensor,
+        max_window_size: int = -1,
+        output: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        if output is None:
+            output = torch.empty_like(query)
+        assert max_window_size == -1, "not support sliding window"
+        xtorch_ops.decode_paged_attention(
+            query[:num_decode_tokens],
+            key_cache,
+            value_cache,
+            seq_lens_host[:num_decode_tokens],
+            seq_lens[:num_decode_tokens],
+            block_tables,
+            output[:num_decode_tokens],
+            alpha=scale,
+            k_perchannel_scale=k_scale,
+            v_perchannel_scale=v_scale,
+            alibi_slopes=alibi_slopes,
+            sink=None,
+        )
+        return output
+
+class KunlunxinAttentionBackendImpl(AttentionImpl[KunlunxinMetadata]):
+    """
+    Kunlunxin attention implementation using xtorch_ops.
+    """
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: Optional[List[float]],
+        sliding_window: Optional[int],
+        kv_cache_dtype: str,
+        logits_soft_cap: Optional[float] = None,
+        attn_type: AttentionType = AttentionType.DECODER,
+        kv_sharing_target_layer_name: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        if not _KUNLUNXIN_OPS_AVAILABLE:
+            raise RuntimeError(
+                "xtorch_ops is required for Kunlunxin attention backend. "
+                "Please install xtorch_ops for Kunlunxin hardware support."
+            )
+
+        if logits_soft_cap is not None:
+            raise ValueError(
+                "kunlunxinAttention does not support attention logits soft capping.")
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = float(scale)
+        # specific atten_scale for attention kernel
+        self.adjusted_scale = self.scale * math.sqrt(self.head_size)
+        self.num_kv_heads = num_kv_heads
+        if alibi_slopes is not None:
+            alibi_slopes = torch.tensor(alibi_slopes, dtype=torch.float32)
+        self.alibi_slopes = alibi_slopes
+        self.sliding_window = sliding_window
+        self.kv_cache_dtype = kv_cache_dtype
+
+        assert self.num_heads % self.num_kv_heads == 0
+        self.num_queries_per_kv = self.num_heads // self.num_kv_heads
+
+        # 0.13.0 get_supported_head_size is not avaiable any more
+        suppored_head_sizes = KunlunxinAttentionBackend.get_supported_head_size()
+        if head_size not in suppored_head_sizes:
+            raise ValueError(
+                f"Head size {head_size} is not supported by KunlunxinAttentionBackend. "
+                f"Supported head sizes are: {suppored_head_sizes}.")
+
+    def _get_window_size(
+        self, attn_type: AttentionType
+    ) -> Optional[Tuple[int, int]]:
+        if self.sliding_window is None or self.sliding_window <= 0:
+            return None
+        if attn_type in (AttentionType.ENCODER, AttentionType.ENCODER_ONLY):
+            return (self.sliding_window, self.sliding_window)
+        return (self.sliding_window, 0)
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor],
+        value: Optional[torch.Tensor],
+        kv_cache: torch.Tensor,
+        attn_metadata: Optional[KunlunxinMetadata],
+        k_scale: Optional[torch.Tensor] = None,
+        v_scale: Optional[torch.Tensor] = None,
+        attn_type: AttentionType = AttentionType.DECODER,
+        output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
+        output_block_scale: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        query = query.view(-1, self.num_heads, self.head_size)
+        if output is None:
+            output = torch.empty_like(query)
+        if attn_metadata is None:
+            # Profiling run.
+
+            # make fake-meta-data, and let attn run during warmup period. In order to avoid cuda-graph fail risk
+            fake_meta = KunlunxinMetadata(seq_lens_tensor=None,
+                                       max_decode_seq_len=1,
+                                       block_tables=None,
+                                       num_prefills=1,
+                                       num_prefill_tokens=1,
+                                       num_decode_tokens=1,
+                                       slot_mapping=None,
+                                       enable_kv_scales_calculation=False,
+                                       max_prefill_seq_len=1,
+                                       num_actual_tokens=1,
+                                       use_cuda_graph=False, # up params is useless to context_forward
+                                       max_query_len=query.shape[0],
+                                       max_kv_len=query.shape[0],
+                                       query_start_loc=torch.tensor((0, query.shape[0]), dtype=torch.int32, device=query.device),
+                                       query_start_loc_host=torch.tensor((0, query.shape[0]), dtype=torch.int32, device="cpu"),
+                                       kv_prefix_start_loc=torch.tensor([0, query.shape[0]], dtype=torch.int32, device=query.device),
+                                       kv_prefix_start_loc_host=torch.tensor([0, query.shape[0]], dtype=torch.int32, device="cpu"))
+            self.context_forward(query, key, value, output, fake_meta, attn_type=attn_type)
+
+            return output.view(-1, self.num_heads * self.head_size)
+
+        if key is not None:
+            assert value is not None
+            key = key.view(-1, self.num_kv_heads, self.head_size)
+            value = value.view(-1, self.num_kv_heads, self.head_size)
+        else:
+            assert value is None
+
+        # Self-attention vs. cross-attention will impact
+        # which KV cache memory-mapping & which
+        # seqlen datastructures we utilize
+        # Encoder and encoder-only attention do not use KV cache
+        if (attn_type != AttentionType.ENCODER and
+            attn_type != AttentionType.ENCODER_ONLY and
+            kv_cache.numel() > 0):
+            # KV-cache during decoder-self- or
+            # encoder-decoder-cross-attention, but not
+            # during encoder attention.
+            #
+            # Even if there are no new key/value pairs to cache,
+            # we still need to break out key_cache and value_cache
+            # i.e. for later use by paged attention
+
+            updated_slot_mapping = attn_metadata.slot_mapping
+
+            # Reshape the input keys and values and store them in the cache.
+            # If kv_cache is not provided, the new key and value tensors are
+            # not cached. This happens during the initial memory
+            # profiling run.
+            if os.environ.get("USE_RESHAPE_AND_CACHE_FLASH", "0") == "1":
+                key_cache, value_cache = KunlunxinPagedAttention.split_kv_cache(
+                    kv_cache, self.num_kv_heads, self.head_size
+                )
+                key = key.contiguous()
+                value = value.contiguous()
+                KunlunxinPagedAttention.reshape_and_cache_flash(
+                    key,
+                    value,
+                    key_cache,
+                    value_cache,
+                    updated_slot_mapping,
+                    BLHD_LAYOUT=False,
+                )
+            else:
+                key = key.contiguous()
+                value = value.contiguous()
+                KunlunxinPagedAttention.split_write_to_paged_cache(
+                                                key,
+                                                value,
+                                                kv_cache,
+                                                self.num_kv_heads,
+                                                self.head_size,
+                                                updated_slot_mapping,
+                                                self.kv_cache_dtype,
+                                                k_scale, v_scale)
+                key_cache, value_cache = KunlunxinPagedAttention.split_kv_cache(
+                    kv_cache, self.num_kv_heads, self.head_size
+                )
+
+        # Handle encoder-only and encoder attention (e.g., BERT, BGE models)
+        if attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
+            # Encoder attention: use bidirectional attention without KV cache
+            num_actual_tokens = attn_metadata.num_actual_tokens
+            self.context_forward(
+                query[:num_actual_tokens],
+                key[:num_actual_tokens] if key is not None else None,
+                value[:num_actual_tokens] if value is not None else None,
+                output[:num_actual_tokens],
+                attn_metadata,
+                attn_type=attn_type,
+                key_cache=None,
+                value_cache=None,
+                is_causal=False  # Bidirectional attention for encoder
+            )
+            return output.view(-1, self.num_heads * self.head_size)
+
+        # Decoder self-attention supports chunked prefill.
+        assert attn_type == AttentionType.DECODER, \
+            f"Unsupported attention type: {attn_type}"
+        num_prefill_tokens = attn_metadata.num_prefill_tokens
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        # Only enforce this shape-constraint for decoder
+        # self-attention
+        if prefill_meta := attn_metadata.prefill_metadata:
+            # prefill
+            prefill_query = query[num_decode_tokens:attn_metadata.num_actual_tokens]
+            prefill_key = key[num_decode_tokens:attn_metadata.num_actual_tokens]
+            prefill_value = value[num_decode_tokens:attn_metadata.num_actual_tokens]
+            assert prefill_query.shape[0] == num_prefill_tokens
+            prefill_out = output[num_decode_tokens:attn_metadata.num_actual_tokens]
+            self.context_forward(
+                prefill_query,
+                prefill_key,
+                prefill_value,
+                prefill_out,
+                prefill_meta,
+                attn_type=attn_type,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                is_causal=True
+            )
+
+        if num_decode_tokens != 0:
+            decode_meta = attn_metadata.decode_metadata
+            if os.environ.get("USE_RESHAPE_AND_CACHE_FLASH", "0") == "1":
+                # For hybrid Attention (Qwen3-Next, Qwen3.5)
+                tmp_block_tables = (
+                    decode_meta.block_tables * 2
+                )
+            else:
+                tmp_block_tables = decode_meta.block_tables
+
+            if attn_metadata.decode_metadata.is_spec_decode:
+                # query_start_loc_host = decode_meta.query_start_loc_host.to(torch.int32)
+                # TODO: add MTP support
+                assert False, "speculative_attention_variable not implemented"
+
+            else:
+                max_window_size = -1
+                if self.sliding_window is not None and self.sliding_window > 0:
+                    max_window_size = self.sliding_window
+                KunlunxinPagedAttention.forward_decode(
+                    query,
+                    key_cache,
+                    value_cache,
+                    tmp_block_tables,
+                    attn_metadata.seq_lens_tensor,
+                    attn_metadata.seq_lens_tensor_host,
+                    attn_metadata.max_decode_seq_len,
+                    num_decode_tokens,
+                    self.kv_cache_dtype,
+                    self.num_kv_heads,
+                    self.scale,
+                    self.alibi_slopes,
+                    k_scale,
+                    v_scale,
+                    max_window_size=max_window_size,
+                    output=output
+                )
+        # Reshape the output tensor.
+        return output.view(-1, self.num_heads * self.head_size)
+
+    def context_forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        out: torch.Tensor,
+        attn_metadata: KunlunxinMetadata,
+        attn_type: AttentionType = AttentionType.DECODER,
+        key_cache: torch.Tensor = None,
+        value_cache: torch.Tensor = None,
+        is_causal=True
+    ):
+        if query is not None and not query.is_contiguous():
+            query = query.contiguous()
+        if key is not None and not key.is_contiguous():
+            key = key.contiguous()
+        if value is not None and not value.is_contiguous():
+            value = value.contiguous()
+
+        actual_query_start_loc = attn_metadata.query_start_loc
+        actual_query_start_loc_host = attn_metadata.query_start_loc_host
+        kv_prefix_start_loc = attn_metadata.kv_prefix_start_loc
+        kv_prefix_start_loc_host = attn_metadata.kv_prefix_start_loc_host
+        window_size = self._get_window_size(attn_type)
+        window_left = -1 if window_size is None else window_size[0]
+        window_right = -1 if window_size is None else window_size[1]
+
+        # prefix cache part
+        if actual_query_start_loc_host[-1] != kv_prefix_start_loc_host[-1]:
+            max_kv_len = attn_metadata.max_kv_len
+            if os.environ.get("USE_RESHAPE_AND_CACHE_FLASH", "0") == "1":
+                # For hybrid Attention (Qwen3-Next, Qwen3.5)
+                tmp_block_tables = (attn_metadata.block_tables * 2)
+            else:
+                tmp_block_tables = attn_metadata.block_tables
+            xtorch_ops.prefill_attention(
+                query,
+                key_cache,
+                value_cache,
+                out,
+                is_causal=is_causal,
+                is_prefix_cache=True,
+                alpha=self.adjusted_scale,
+                context_qlen_lod_cpu=actual_query_start_loc_host,
+                context_qlen_lod_xpu=actual_query_start_loc,
+                context_kvlen_lod_cpu=kv_prefix_start_loc_host,
+                context_kvlen_lod_xpu=kv_prefix_start_loc,
+                block_table=tmp_block_tables,
+                alibi_slopes=self.alibi_slopes,
+                swa_left=window_left,
+                swa_right=window_right,
+            )
+        # no prefix cache part
+        else:
+            max_kv_len = attn_metadata.max_query_len
+            xtorch_ops.prefill_attention(
+                query,
+                key,
+                value,
+                out,
+                is_causal=is_causal,
+                is_prefix_cache=False,
+                alpha=self.adjusted_scale,
+                context_qlen_lod_cpu=actual_query_start_loc_host,
+                context_qlen_lod_xpu=actual_query_start_loc,
+                alibi_slopes=self.alibi_slopes,
+                swa_left=window_left,
+                swa_right=window_right,
+            )
+
+
+__all__ = [
+    "KunlunxinAttentionBackend",
+    "KunlunxinAttentionBackendImpl",
+    "KunlunxinAttentionMetadataBuilder",
+    "KunlunxinMetadata",
+    "is_kunlunxin_ops_available",
+]

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/causal_conv1d.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/causal_conv1d.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Copyright (c) 2024, Tri Dao.
+# Adapted from https://github.com/Dao-AILab/causal-conv1d/blob/main/causal_conv1d/causal_conv1d_interface.py
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
+
+"""
+Kunlunxin implementation of causal_conv1d operators.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+from vllm.attention.backends.utils import PAD_SLOT_ID
+
+import xtorch_ops
+
+
+def causal_conv1d_fn_kunlunxin(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    activation: str | None = "silu",
+    pad_slot_id: int = PAD_SLOT_ID,
+    block_idx_first_scheduled_token: torch.Tensor | None = None,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    num_computed_tokens: torch.Tensor | None = None,
+    block_size_to_align=0,
+    metadata=None,
+    validate_data=False,
+) -> torch.Tensor:
+    """
+    Kunlunxin causal conv1d forward (prefill path).
+
+    Args:
+        x: input tensor (dim, cu_seqlen) for varlen
+        weight: (dim, width)
+        bias: (dim,) or None
+        activation: "silu", "swish", or None
+        conv_states: (num_cache_lines, dim, state_len)
+        has_initial_state: (batch,) bool
+        cache_indices: (batch,) int
+        query_start_loc: (batch+1,) int
+        metadata: optional metadata
+        pad_slot_id: padding slot id
+
+    Returns:
+        output tensor (same shape as x, modified in-place)
+    """
+    if activation not in [None, "silu", "swish"]:
+        raise NotImplementedError("activation must be None, silu, or swish")
+
+    x = x.contiguous()
+    bias = bias.contiguous() if bias is not None else None
+    query_start_loc_cpu = query_start_loc.cpu().tolist()
+
+    xtorch_ops.causal_conv1d_fwd(
+        x,
+        weight,
+        bias,
+        conv_states,
+        query_start_loc,
+        cache_indices,
+        has_initial_state,
+        activation in ["silu", "swish"],
+        False,          # is_ncw: x is (cu_seqlen, dim), conv_states is (N, state_len, dim)
+        query_start_loc_cpu,
+        pad_slot_id,
+    )
+
+    return x
+
+
+def causal_conv1d_update_kunlunxin(
+    x: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    activation: bool | str | None = None,
+    conv_state_indices: torch.Tensor | None = None,
+    cache_seqlens: torch.Tensor | None = None,
+    intermediate_conv_window: Optional[torch.Tensor] = None,
+    num_accepted_tokens: torch.Tensor | None = None,
+    query_start_loc: torch.Tensor | None = None,
+    max_query_len: int = -1,
+    pad_slot_id: int = PAD_SLOT_ID,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    validate_data=False,
+) -> torch.Tensor:
+    """
+    Kunlunxin causal conv1d update (decode path).
+
+    Args:
+        x: input tensor [batch, dim] or [batch, dim, seqlen]
+        conv_state: (num_cache_lines, dim, state_len)
+        weight: (dim, width)
+        bias: (dim,) or None
+        activation: "silu", "swish", or None
+        conv_state_indices: (batch,) state indices
+        num_accepted_tokens: (batch,) for speculative decoding
+        query_start_loc: (batch+1,) for varlen
+        max_query_len: max query length
+        pad_slot_id: padding slot id
+        block_idx_last_scheduled_token: (batch,) for APC
+        initial_state_idx: (batch,) for APC
+        validate_data: whether to validate inputs
+
+    Returns:
+        output tensor (same shape as input x)
+    """
+    if activation not in [None, "silu", "swish"]:
+        raise NotImplementedError(
+            f"activation must be None, silu, or swish, actual: {activation}"
+        )
+
+    activation_val = activation in ["silu", "swish"]
+
+    # check layout
+    unsqueeze = x.dim() == 2
+    if unsqueeze:
+        x = x.unsqueeze(1)
+    else:
+        x = x.transpose(1, 2)
+    x = x.contiguous()
+
+    xtorch_ops.causal_conv1d_update(
+        x,
+        conv_state,
+        weight,
+        bias,
+        activation_val,
+        cache_seqlens,
+        conv_state_indices,
+        intermediate_conv_window,
+        False,       # is_ncw
+        pad_slot_id,
+    )
+
+    # reverse layout
+    if unsqueeze:
+        x = x.squeeze(1)
+    else:
+        x = x.transpose(1, 2)
+
+    return x

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fla/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fla/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin FLA (Flash Linear Attention) operator implementations.
+"""

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fla/chunk.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fla/chunk.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
+
+"""
+Kunlunxin implementation of chunk_gated_delta_rule.
+
+Contains both the low-level kernel wrapper (chunk_gated_delta_rule_fwd) and
+the top-level entry (chunk_gated_delta_rule).
+
+The top-level ChunkGatedDeltaRuleFunction.forward **skips l2norm** because the
+Kunlunxin kernel handles it internally (use_qk_l2norm_in_kernel=True).
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Optional
+
+import torch
+from einops import rearrange
+
+import xtorch_ops
+
+
+def chunk_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+) -> tuple:
+    """
+    Kunlunxin chunked gated delta rule forward pass.
+
+    Args:
+        q: queries [B, T, H, K]
+        k: keys [B, T, H, K]
+        v: values [B, T, H, V]
+        g: decay gates (in log space)
+        beta: betas
+        scale: scale factor
+        initial_state: [N, H, V, K]
+        output_final_state: whether to output final state
+        cu_seqlens: cumulative sequence lengths
+
+    Returns:
+        7-tuple: (g, o, A, final_state, w, h, v_new)
+        to match the dispatch interface expected by vllm_fl
+    """
+    input_dtype = q.dtype
+
+    # check dtype
+    if input_dtype == torch.bfloat16:
+        g_input = g.float()
+        beta_input = beta.float()
+        state_input = initial_state.float()
+    else:
+        g_input = g
+        beta_input = beta
+        state_input = initial_state
+
+    cu_seqlens_cpu = cu_seqlens.cpu() if cu_seqlens is not None else None
+
+    final_state = torch.empty_like(state_input)
+    o = torch.empty_like(v)
+    xtorch_ops.chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        g_input,
+        beta_input,
+        -1,  # uses -1 for automatic scale
+        state_input,
+        o,
+        final_state,
+        cu_seqlens_cpu,
+        head_first=False,
+        use_qk_l2norm_in_kernel=True,  # always True in Kunlunxin
+    )
+
+    # Transpose final_state back to [N, H, K, V]
+    if final_state is not None:
+        final_state = final_state.transpose(2, 3).contiguous()
+
+    # Return 7-tuple to match the dispatch interface:
+    # (g, o, A, final_state, w, h, v_new)
+    return g, o, None, final_state, None, None, None
+
+
+class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float,
+        initial_state: torch.Tensor,
+        output_final_state: bool,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        use_qk_l2norm_in_kernel: bool = False,
+    ):
+        # klx diff: skip l2norm — kernel handles it internally
+        # (upstream would do l2norm_fwd(q), l2norm_fwd(k) here)
+
+        # [N, H, K, V] -> [N, H, V, K] for kunlunxin kernel
+        if initial_state is not None:
+            initial_state = initial_state.transpose(2, 3).contiguous()
+
+        g, o, A, final_state, w, h, v_new = chunk_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+        )
+        ctx.scale = scale
+        ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        return o.to(q.dtype), final_state
+
+
+@torch.compiler.disable
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    head_first: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+):
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]` if `head_first=False` else `[B, H, T, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+        g (torch.Tensor):
+            (forget) gating tensor (in log space!) of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+        beta (torch.Tensor):
+            betas of shape `[B, T, H]` if `head_first=False` else `[B, H, T]`.
+        scale (Optional[int]):
+            Scale factor for the RetNet attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape `[N, H, K, V]` for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+        head_first (Optional[bool]):
+            Whether the inputs are in the head-first format, which is not supported for variable-length inputs.
+            Default: `False`.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
+        final_state (torch.Tensor):
+            Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from fla.ops.gated_delta_rule import chunk_gated_delta_rule
+        # inputs with equal lengths
+        >>> B, T, H, K, V = 4, 2048, 4, 512, 512
+        >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
+        >>> k = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda'), p=2, dim=-1)
+        >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
+        >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
+        >>> g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
+        >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
+        >>> o, ht = chunk_gated_delta_rule(
+            q, k, v, g, beta,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, beta, g = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, beta, g))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o_var, ht_var = chunk_gated_delta_rule(
+            q, k, v, g, beta,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens
+        )
+    """
+    assert q.dtype == k.dtype == v.dtype
+    assert q.dtype != torch.float32, (
+        "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
+    )
+    assert len(beta.shape) == 3, (
+        "beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
+    )
+
+    if head_first:
+        raise DeprecationWarning(
+            "head_first is deprecated and will be removed in a future version. "
+            "Please use head_first=False for now instead.",
+            stacklevel=2,
+        )
+        q, k, v, beta, g = map(
+            lambda x: rearrange(x, "b h t ... -> b t h ..."), (q, k, v, beta, g)
+        )
+    if not head_first and q.shape[1] < q.shape[2]:
+        warnings.warn(
+            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
+            "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
+            "when head_first=False was specified. "
+            "Please verify your input tensor format matches the expected shape [B, T, H, ...].",
+            stacklevel=2,
+        )
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"Please flatten variable-length inputs before processing."
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
+            )
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale,
+        initial_state,
+        output_final_state,
+        cu_seqlens,
+        use_qk_l2norm_in_kernel,
+    )
+    if head_first:
+        o = rearrange(o, "b t h ... -> b h t ...")
+    return o, final_state

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fla/fused_recurrent.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fla/fused_recurrent.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
+
+"""
+Kunlunxin implementation of fused_recurrent_gated_delta_rule.
+
+Contains both the low-level kernel wrapper (fused_recurrent_gated_delta_rule_fwd)
+and the top-level entry (fused_recurrent_gated_delta_rule).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+import xtorch_ops
+
+
+def fused_recurrent_gated_delta_rule_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    inplace_final_state: bool = True,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    ssm_state_indices: Optional[torch.Tensor] = None,
+    num_accepted_tokens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Kunlunxin fused recurrent gated delta rule forward pass.
+
+    Args:
+        q: queries [B, T, H, K]
+        k: keys [B, T, H, K]
+        v: values [B, T, HV, V]
+        g: decay gates [B, T, HV]
+        beta: betas [B, T, HV]
+        scale: scale factor
+        initial_state: [N, HV, K, V]
+        inplace_final_state: whether to write final state in-place
+        cu_seqlens: cumulative sequence lengths [N+1]
+        ssm_state_indices: state index mapping
+        num_accepted_tokens: for speculative decoding
+        use_qk_l2norm_in_kernel: whether to L2-normalize q/k in kernel
+
+    Returns:
+        (output, final_state)
+    """
+    o, ht_output = xtorch_ops.fused_recurrent_gated_delta_rule_fwdv2(
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        g.contiguous(),
+        beta.contiguous(),
+        scale,
+        initial_state,
+        inplace_final_state,
+        cu_seqlens=cu_seqlens,
+        h0_indices=ssm_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        is_h0_transposed=True,
+    )
+
+    return o, ht_output
+
+
+class FusedRecurrentFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        scale: float,
+        initial_state: torch.Tensor,
+        inplace_final_state: bool = True,
+        cu_seqlens: Optional[torch.LongTensor] = None,
+        ssm_state_indices: Optional[torch.Tensor] = None,
+        num_accepted_tokens: Optional[torch.Tensor] = None,
+        use_qk_l2norm_in_kernel: bool = False,
+    ):
+        o, final_state = fused_recurrent_gated_delta_rule_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            initial_state=initial_state,
+            inplace_final_state=inplace_final_state,
+            cu_seqlens=cu_seqlens,
+            ssm_state_indices=ssm_state_indices,
+            num_accepted_tokens=num_accepted_tokens,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+
+        return o, final_state
+
+
+def fused_recurrent_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor = None,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    inplace_final_state: bool = True,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    ssm_state_indices: Optional[torch.Tensor] = None,
+    num_accepted_tokens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, HV, V]`.
+            GVA is applied if `HV > H`.
+        g (torch.Tensor):
+            g (decays) of shape `[B, T, HV]`.
+        beta (torch.Tensor):
+            betas of shape `[B, T, HV]`.
+        scale (Optional[int]):
+            Scale factor for the RetNet attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape `[N, HV, K, V]` for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        inplace_final_state: bool:
+            Whether to store the final state in-place to save memory.
+            Default: `True`.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+        ssm_state_indices (Optional[torch.Tensor]):
+            Indices to map the input sequences to the initial/final states.
+        num_accepted_tokens (Optional[torch.Tensor]):
+            Number of accepted tokens for each sequence during decoding.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, HV, V]`.
+        final_state (torch.Tensor):
+            Final state of shape `[N, HV, K, V]`.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from fla.ops.gated_delta_rule import fused_recurrent_gated_delta_rule
+        # inputs with equal lengths
+        >>> B, T, H, HV, K, V = 4, 2048, 4, 8, 512, 512
+        >>> q = torch.randn(B, T, H, K, device='cuda')
+        >>> k = F.normalize(torch.randn(B, T, H, K, device='cuda'), p=2, dim=-1)
+        >>> v = torch.randn(B, T, HV, V, device='cuda')
+        >>> g = F.logsigmoid(torch.rand(B, T, HV, device='cuda'))
+        >>> beta = torch.rand(B, T, HV, device='cuda').sigmoid()
+        >>> h0 = torch.randn(B, HV, K, V, device='cuda')
+        >>> o, ht = fused_gated_recurrent_delta_rule(
+            q, k, v, g, beta,
+            initial_state=h0,
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, g, beta = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, g, beta))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o_var, ht_var = fused_gated_recurrent_delta_rule(
+            q, k, v, g, beta,
+            initial_state=h0,
+            cu_seqlens=cu_seqlens
+        )
+    """
+    if cu_seqlens is not None and q.shape[0] != 1:
+        raise ValueError(
+            f"The batch size is expected to be 1 rather than {q.shape[0]} "
+            f"when using `cu_seqlens`. "
+            f"Please flatten variable-length inputs before processing."
+        )
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    else:
+        assert scale > 0, "scale must be positive"
+    if beta is None:
+        beta = torch.ones_like(q[..., 0])
+    o, final_state = FusedRecurrentFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale,
+        initial_state,
+        inplace_final_state,
+        cu_seqlens,
+        ssm_state_indices,
+        num_accepted_tokens,
+        use_qk_l2norm_in_kernel,
+    )
+    return o, final_state

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_gdn_gating.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_gdn_gating.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
+
+"""
+Kunlunxin implementation of fused_gdn_gating.
+"""
+
+from __future__ import annotations
+
+import torch
+import xtorch_ops
+
+
+def fused_gdn_gating_kunlunxin(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Kunlunxin fused GDN gating computation.
+
+    The xtorch_ops kernel computes g = -exp(A_log) * softplus(a + dt_bias).
+    beta_output = sigmoid(b) is computed separately in PyTorch.
+
+    Args:
+        A_log: log of A parameter [num_heads]
+        a: dt input [batch, num_heads]
+        b: beta input [batch, num_heads]
+        dt_bias: dt bias [num_heads]
+        beta: softplus beta parameter
+        threshold: softplus threshold parameter
+
+    Returns:
+        (g, beta_output) where:
+            g: [1, batch, num_heads] float32 gating values
+            beta_output: [1, batch, num_heads] sigmoid of b
+    """
+    org_shape = list(a.shape)
+
+    # xtorch_ops.fused_gdn_gating returns a new tensor (not in-place)
+    # It computes: output = -exp(A_log) * softplus(a + dt_bias, beta, threshold)
+    output = xtorch_ops.fused_gdn_gating(A_log, a, dt_bias, beta, threshold)
+
+    # Reshape to match expected output format [1, batch, num_heads]
+    g = output.view(*org_shape).unsqueeze(0)
+
+    # beta_output = sigmoid(b), computed separately
+    beta_output = b.sigmoid().unsqueeze(0)
+
+    return g, beta_output

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_moe/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_moe/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin FusedMoE implementations.
+"""
+
+from .experts_selector import (
+    fused_topk,
+    fused_topk_bias,
+    grouped_topk,
+    select_experts,
+)
+from .fused_moe import (
+    KunlunxinSharedFusedMoE,
+    fused_experts,
+    inplace_fused_experts,
+    outplace_fused_experts,
+)
+
+__all__ = [
+    "fused_experts",
+    "fused_topk",
+    "fused_topk_bias",
+    "grouped_topk",
+    "inplace_fused_experts",
+    "outplace_fused_experts",
+    "select_experts",
+    "KunlunxinSharedFusedMoE",
+]

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_moe/experts_selector.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_moe/experts_selector.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
+
+"""
+Kunlunxin expert routing functions: top-k selection, grouped top-k, and
+the unified select_experts entry point.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+import xtorch_ops
+
+
+def vllm_topk_softmax(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool,
+) -> tuple[torch.Tensor, ...]:
+    # moe_softmax_topk_norm: fused softmax + topk + renormalize
+    # moe_softmax_topk:      fused softmax + topk (no renormalize)
+    if renormalize:
+        xtorch_ops.moe_softmax_topk_norm(
+            gating_output,
+            topk_weights,
+            topk_indices,
+            None,  # block_statistic
+        )
+    else:
+        xtorch_ops.moe_softmax_topk(
+            gating_output,
+            topk_weights,
+            topk_indices,
+            None,  # block_statistic
+        )
+    return topk_weights, topk_indices
+
+
+def fused_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    indices_type: Optional[torch.dtype] = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused top-k selection with softmax."""
+    assert hidden_states.size(0) == gating_output.size(0), "Number of tokens mismatch"
+
+    M, _ = hidden_states.size()
+
+    topk_weights = torch.empty(
+        M, topk, dtype=torch.float32, device=hidden_states.device
+    )
+    topk_ids = torch.empty(
+        M,
+        topk,
+        dtype=torch.int32 if indices_type is None else indices_type,
+        device=hidden_states.device,
+    )
+    token_expert_indices = torch.empty(
+        M, topk, dtype=torch.int32, device=hidden_states.device
+    )
+
+    topk_weights, topk_ids = vllm_topk_softmax(
+        topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
+    )
+    return topk_weights, topk_ids, token_expert_indices
+
+
+def fused_topk_bias(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    e_score_correction_bias: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+):
+    n_routed_experts = gating_output.shape[-1]
+    scores = gating_output.softmax(dim=-1)
+    scores_for_choice = scores.view(
+        -1, n_routed_experts) + e_score_correction_bias.unsqueeze(0)
+    topk_indices = torch.topk(scores_for_choice, k=topk, dim=-1,
+                              sorted=False)[1]
+    topk_weights = scores.gather(1, topk_indices)
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+    return topk_weights.to(torch.float32), topk_indices.to(torch.int32)
+
+
+def grouped_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_expert_group: int = 0,
+    topk_group: int = 0,
+    scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Grouped top-k selection.
+    """
+    seq_num = gating_output.shape[0]
+
+    # scoring function
+    if scoring_func == "softmax":
+        scores = gating_output.softmax(dim=-1)
+    elif scoring_func == "sigmoid":
+        scores = gating_output.sigmoid()
+    else:
+        raise ValueError(f"Unsupported scoring_func: {scoring_func}")
+
+    if e_score_correction_bias is not None:
+        assert e_score_correction_bias.dtype == torch.float32
+        scores_for_choice = scores + e_score_correction_bias.unsqueeze(0)
+    else:
+        scores_for_choice = scores
+
+    # grouped topk
+    topk_weights = torch.empty(
+        (seq_num, topk), dtype=torch.float, device=gating_output.device
+    )
+    topk_ids = torch.empty(
+        (seq_num, topk), dtype=torch.int32, device=gating_output.device
+    )
+
+    xtorch_ops.moe_group_topk(
+        scores_for_choice,
+        num_expert_group,
+        topk_group,
+        topk_weights,
+        topk_ids,
+        None,  #block_statistic
+    )
+
+    # Use original unbiased scores for the routing weights
+    if e_score_correction_bias is not None:
+        topk_weights = scores.gather(1, topk_ids)
+
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+    return topk_weights, topk_ids
+
+
+def select_experts(
+    layer: FusedMoE,
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """
+    Route the input hidden states to the top-k experts based on the
+    router logits.
+
+    Returns:
+            (topk_weights, topk_ids, zero_expert_result)
+            (tuple[torch.Tensor, torch.Tensor, torch.Tensor]):
+            The weights, expert ids, and zero expert computation result.
+
+        **Compatibility**: When EPLB is not enabled, the returned ids are
+        equivalent to global logical ids, so should be compatible with
+        plain MoE implementations without redundant experts.
+    """
+
+    def valid_grouping() -> bool:
+        num_experts = router_logits.shape[-1]
+        if num_experts <= layer.num_expert_group:
+            return False
+        return num_experts % layer.num_expert_group == 0
+
+    indices_type = layer.quant_method.topk_indices_dtype
+
+    if layer.use_grouped_topk and valid_grouping():
+        assert layer.topk_group is not None
+        assert layer.num_expert_group is not None
+
+        topk_weights, topk_ids = grouped_topk(
+            hidden_states=hidden_states,
+            gating_output=router_logits,
+            topk=layer.top_k,
+            renormalize=layer.renormalize,
+            num_expert_group=layer.num_expert_group,
+            topk_group=layer.topk_group,
+            scoring_func=layer.scoring_func,
+            routed_scaling_factor=layer.routed_scaling_factor,
+            e_score_correction_bias=layer.e_score_correction_bias,
+        )
+    elif layer.e_score_correction_bias is not None:
+        topk_weights, topk_ids = fused_topk_bias(
+            hidden_states=hidden_states,
+            gating_output=router_logits,
+            e_score_correction_bias=layer.e_score_correction_bias.data,
+            topk=layer.top_k,
+            renormalize=layer.renormalize,
+        )
+        if layer.routed_scaling_factor != 1.0:
+            topk_weights *= layer.routed_scaling_factor
+    elif layer.custom_routing_function is None:
+        topk_weights, topk_ids, token_expert_indices = fused_topk(
+            hidden_states=hidden_states,
+            gating_output=router_logits,
+            topk=layer.top_k,
+            renormalize=layer.renormalize,
+            indices_type=indices_type,
+        )
+    else:
+        topk_weights, topk_ids = layer.custom_routing_function(
+            hidden_states=hidden_states,
+            gating_output=router_logits,
+            topk=layer.top_k,
+            renormalize=layer.renormalize,
+        )
+
+    # TODO: eplb
+    assert layer.enable_eplb == False
+
+    if indices_type is not None and topk_ids.dtype != indices_type:
+        topk_ids = topk_ids.to(dtype=indices_type)
+
+    return topk_weights, topk_ids, None

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_moe/fused_moe.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_moe/fused_moe.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
+
+"""
+Kunlunxin fused MoE kernel implementations and KunlunxinSharedFusedMoE layer.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Callable, Optional
+
+import torch
+
+from vllm.model_executor.layers.fused_moe import SharedFusedMoE
+from vllm.model_executor.layers.fused_moe.config import (
+    FUSED_MOE_UNQUANTIZED_CONFIG,
+    FusedMoEQuantConfig,
+)
+from vllm.utils.torch_utils import direct_register_custom_op
+
+import xtorch_ops
+
+# for kunlunxin vendor
+_KLX_MOE_BLOCK_NUM= 12
+
+
+def _klx_fused_experts(
+    hidden_states: torch.Tensor,
+    output: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    use_int8_w8a8: bool = False,
+    use_int8_w4a8: bool = False,
+    w1_scale: Optional[torch.Tensor] = None,
+    w2_scale: Optional[torch.Tensor] = None,
+) -> None:
+    """
+    Fused MoE expert computation using xtorch_ops (sorted path).
+
+    Pipeline: gen_block_statistic → moe_pre_sorted → moe_fc(w1) → swiglu → moe_fc(w2) → post (weight+sum)
+    """
+    if use_int8_w8a8 or use_int8_w4a8:
+        raise NotImplementedError("_klx_fused_experts is not supported for int8 w8a8 and w4a8.")
+
+    seq_num, hidden_dim = hidden_states.shape
+    moe_topk = topk_ids.shape[1]
+    expert_num = w1.shape[0]
+    double_ffn_hd = w1.shape[1]       # gate+up output dim (2 * intermediate_size for swiglu)
+    moe_input_num = seq_num * moe_topk
+
+    device = hidden_states.device
+    dtype = hidden_states.dtype
+
+    # Step 1: Generate block statistics for expert-parallel sorting
+    block_statistic = torch.zeros(
+        _KLX_MOE_BLOCK_NUM, expert_num,
+        dtype=torch.int32,
+        device=device,
+    )
+    xtorch_ops.gen_block_statistic(topk_ids, block_statistic)
+
+    # Step 2: Sort tokens by expert assignment (physical reorder)
+    moe_expand = torch.empty(moe_input_num, hidden_dim, dtype=dtype, device=device)
+    moe_index = torch.full((moe_input_num,), -1, dtype=torch.int32, device=device)
+    expert_m = torch.empty(expert_num, dtype=torch.int32, device=device)
+    sorted_tokens_num_lod = torch.empty(expert_num + 1, dtype=torch.int32, device=device)
+
+    xtorch_ops.moe_pre_sorted(
+        hidden_states, topk_ids, block_statistic,
+        moe_expand, moe_index, expert_m, sorted_tokens_num_lod
+    )
+
+    # Step 3: Inner FC (gate+up projection) — NO activation, NO topk_weights
+    # Output: [moe_input_num, double_ffn_hd] (will be split by swiglu)
+    inner_fc_out = torch.empty(moe_input_num, double_ffn_hd, dtype=dtype, device=device)
+
+    # leave it for other functions (e.g. w8a8)
+    moe_fc_w1_kwargs = {}
+
+    xtorch_ops.moe_fc_v3(
+        moe_expand,               # sorted input
+        w1,                       # weight
+        sorted_tokens_num_lod,
+        moe_index,                # sorted_tokens_idx
+        moe_topk,
+        inner_fc_out,             # output
+        sort_mode=True,
+        **moe_fc_w1_kwargs,
+    )
+
+    # Step 4: SwiGLU activation
+    swiglu_out = torch.empty(moe_input_num, double_ffn_hd // 2, dtype=dtype, device=device)
+    xtorch_ops.swiglu(inner_fc_out, swiglu_out)
+
+    # Step 5: Outer FC (down projection)
+    # leave it for other functions (e.g. w8a8)
+    moe_fc_w2_kwargs = {}
+
+    outer_fc_out = torch.empty(moe_input_num, hidden_dim, dtype=dtype, device=device)
+
+    xtorch_ops.moe_fc_v3(
+        swiglu_out,               # sorted intermediate
+        w2,                       # weight
+        sorted_tokens_num_lod,
+        moe_index,                # sorted_tokens_idx
+        moe_topk,
+        outer_fc_out,             # output
+        sort_mode=True,
+        **moe_fc_w2_kwargs,
+    )
+
+    # Step 6: Apply topk_weights and reduce across topk dimension (post fusion)
+    moe_index = moe_index.reshape(-1, moe_topk)
+    post_scale = torch.ones(seq_num, moe_topk, device=device, dtype=torch.float32)
+
+    xtorch_ops.moe_post(outer_fc_out,
+                        moe_index,
+                        topk_weights,
+                        post_scale,
+                        output,
+                        )
+
+
+def inplace_fused_experts(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: str = "silu",
+    apply_router_weight_on_input: bool = False,
+    use_fp8_w8a8: bool = False,
+    use_int8_w8a8: bool = False,
+    use_int8_w8a16: bool = False,
+    use_int4_w4a16: bool = False,
+    use_int8_w4a8: bool = False,
+    per_channel_quant: bool = False,
+    global_num_experts: int = -1,
+    expert_map: Optional[torch.Tensor] = None,
+    w1_scale: Optional[torch.Tensor] = None,
+    w2_scale: Optional[torch.Tensor] = None,
+    w1_zp: Optional[torch.Tensor] = None,
+    w2_zp: Optional[torch.Tensor] = None,
+    a1_scale: Optional[torch.Tensor] = None,
+    a2_scale: Optional[torch.Tensor] = None,
+) -> None:
+    """In-place fused expert computation."""
+    if use_int8_w8a8 and not per_channel_quant:
+        raise NotImplementedError(
+            f"Per-tensor quantization is not supported in int8-w8a8 mode. "
+            f"Current settings: use_int8_w8a8={use_int8_w8a8}, "
+            f"per_channel_quant={per_channel_quant}"
+        )
+    if use_int8_w4a8 and not per_channel_quant:
+        raise NotImplementedError(
+            f"Per-tensor quantization is not supported in int4-w4a8 mode. "
+            f"Current settings: use_int8_w4a8={use_int8_w4a8}, "
+            f"per_channel_quant={per_channel_quant}"
+        )
+    assert topk_weights.dtype == torch.float32
+    _klx_fused_experts(
+        hidden_states,
+        hidden_states,
+        w1,
+        w2,
+        topk_weights, topk_ids,
+        use_int8_w8a8=use_int8_w8a8,
+        use_int8_w4a8=use_int8_w4a8,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+    )
+
+
+
+def inplace_fused_experts_fake(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: str = "silu",
+    apply_router_weight_on_input: bool = False,
+    use_fp8_w8a8: bool = False,
+    use_int8_w8a8: bool = False,
+    use_int8_w8a16: bool = False,
+    use_int4_w4a16: bool = False,
+    use_int8_w4a8: bool = False,
+    per_channel_quant: bool = False,
+    global_num_experts: int = -1,
+    expert_map: Optional[torch.Tensor] = None,
+    w1_scale: Optional[torch.Tensor] = None,
+    w2_scale: Optional[torch.Tensor] = None,
+    w1_zp: Optional[torch.Tensor] = None,
+    w2_zp: Optional[torch.Tensor] = None,
+    a1_scale: Optional[torch.Tensor] = None,
+    a2_scale: Optional[torch.Tensor] = None,
+) -> None:
+    pass
+
+
+direct_register_custom_op(
+    op_name="kunlunxin_inplace_fused_experts",
+    op_func=inplace_fused_experts,
+    mutates_args=["hidden_states"],
+    fake_impl=inplace_fused_experts_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
+
+
+def outplace_fused_experts(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    activation: str = "silu",
+    apply_router_weight_on_input: bool = False,
+    use_fp8_w8a8: bool = False,
+    use_int8_w8a8: bool = False,
+    use_int8_w8a16: bool = False,
+    use_int4_w4a16: bool = False,
+    per_channel_quant: bool = False,
+    global_num_experts: int = -1,
+    expert_map: Optional[torch.Tensor] = None,
+    w1_scale: Optional[torch.Tensor] = None,
+    w2_scale: Optional[torch.Tensor] = None,
+    w1_zp: Optional[torch.Tensor] = None,
+    w2_zp: Optional[torch.Tensor] = None,
+    a1_scale: Optional[torch.Tensor] = None,
+    a2_scale: Optional[torch.Tensor] = None) -> torch.Tensor:
+
+    output = torch.empty_like(hidden_states)
+    if use_int8_w8a8 and not per_channel_quant:
+        raise NotImplementedError(
+            f"Per-tensor quantization is not supported in int8-w8a8 mode. "
+            f"Current settings: use_int8_w8a8={use_int8_w8a8}, "
+            f"per_channel_quant={per_channel_quant}"
+        )
+    assert topk_weights.dtype == torch.float32
+    _klx_fused_experts(
+        hidden_states,
+        output,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        use_int8_w8a8=use_int8_w8a8,
+        w1_scale=w1_scale,
+        w2_scale=w2_scale,
+    )
+    return output
+
+
+
+def outplace_fused_experts_fake(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    **kwargs,
+) -> torch.Tensor:
+    return torch.empty_like(hidden_states)
+
+
+direct_register_custom_op(
+    op_name="kunlunxin_outplace_fused_experts",
+    op_func=outplace_fused_experts,
+    mutates_args=[],
+    fake_impl=outplace_fused_experts_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
+
+
+def torch_vllm_inplace_fused_experts(**kwargs) -> torch.Tensor:
+    torch.ops.vllm.kunlunxin_inplace_fused_experts(**kwargs)
+    return kwargs["hidden_states"]
+
+
+def torch_vllm_outplace_fused_experts(**kwargs) -> torch.Tensor:
+    return torch.ops.vllm.kunlunxin_outplace_fused_experts(**kwargs)
+
+
+def dispatch_fused_experts_func(inplace: bool) -> Callable[..., torch.Tensor]:
+    if inplace:
+        return torch_vllm_inplace_fused_experts
+    return torch_vllm_outplace_fused_experts
+
+
+def fused_experts(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    output_input: Optional[torch.Tensor] = None,
+    inplace: bool = False,
+    activation: str = "silu",
+    apply_router_weight_on_input: bool = False,
+    per_channel_quant: bool = False,
+    global_num_experts: int = -1,
+    expert_map: Optional[torch.Tensor] = None,
+    quant_config: Optional[FusedMoEQuantConfig] = None,
+    allow_deep_gemm: bool = False,
+    allow_cutlass_block_scaled_grouped_gemm: bool = False,
+) -> torch.Tensor:
+    """High-level fused experts entry point."""
+    if quant_config is None:
+        quant_config = FUSED_MOE_UNQUANTIZED_CONFIG
+
+    assert allow_deep_gemm == False
+    assert quant_config.use_fp8_w8a8 == False
+
+    fn = dispatch_fused_experts_func(inplace)
+    return fn(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=activation,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        use_fp8_w8a8=quant_config.use_fp8_w8a8,
+        use_int8_w8a8=quant_config.use_int8_w8a8,
+        use_int8_w8a16=quant_config.use_int8_w8a16,
+        use_int4_w4a16=quant_config.use_int4_w4a16,
+        per_channel_quant=quant_config.per_act_token_quant,
+        global_num_experts=global_num_experts,
+        expert_map=expert_map,
+        w1_scale=quant_config.w1_scale,
+        w2_scale=quant_config.w2_scale,
+        w1_zp=quant_config.w1_zp,
+        w2_zp=quant_config.w2_zp,
+        a1_scale=quant_config.a1_scale,
+        a2_scale=quant_config.a2_scale,
+    )
+
+
+def _kunlunxin_quant_method_forward(
+    original_forward,
+    layer,
+    x: torch.Tensor,
+    router_logits: torch.Tensor,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Replacement forward for the quant_method that uses Kunlunxin kernels."""
+    from .experts_selector import select_experts
+
+    topk_weights, topk_ids, zero_expert_result = select_experts(
+        layer=layer,
+        hidden_states=x,
+        router_logits=router_logits,
+    )
+
+    result = fused_experts(
+        hidden_states=x,
+        w1=layer.w13_weight,
+        w2=layer.w2_weight,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=layer.activation,
+        apply_router_weight_on_input=layer.apply_router_weight_on_input,
+        global_num_experts=layer.global_num_experts,
+        expert_map=layer.expert_map,
+    )
+
+    if layer.zero_expert_num != 0 and layer.zero_expert_type is not None:
+        assert not isinstance(result, tuple), (
+            "Shared + zero experts are mutually exclusive not yet supported"
+        )
+        return result, zero_expert_result
+    else:
+        return result
+
+
+class KunlunxinSharedFusedMoE(SharedFusedMoE):
+    """SharedFusedMoE with Kunlunxin-optimized expert routing and computation.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Patch the quant_method to use Kunlunxin expert kernels
+        if self.quant_method is not None:
+            original_apply = self.quant_method.apply
+            self.quant_method.apply = functools.partial(
+                _kunlunxin_quant_method_forward,
+                original_apply,
+            )
+
+    def select_experts(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        from .experts_selector import select_experts
+
+        return select_experts(self, hidden_states, router_logits)

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/normalization.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/normalization.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin normalization operator implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import torch
+
+
+def rms_norm_kunlunxin(
+    obj,
+    x: torch.Tensor,
+    residual: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+    """
+    RMS normalization.
+
+    Args:
+        obj: The calling obj (e.g., RMSNorm layer)
+        x: Input tensor
+        residual: Optional residual tensor to add before normalization
+
+    Returns:
+        Normalized tensor, or tuple of (normalized, residual) if residual is provided
+    """
+    import xtorch_ops
+
+    weight = obj.weight
+    epsilon = obj.variance_epsilon
+
+    if residual is not None:
+        # fused_add_rms_norm: output = rmsnorm(x + residual), residual_output = x + residual
+        xtorch_ops.add_rmsnorm(
+            x=x,
+            y=residual,
+            weight=weight,
+            output=x,
+            eps=epsilon,
+            residual_output=residual,
+            store_output_before_norm=True,
+        )
+        return x, residual
+
+    # rms_norm_with_stride can handle strided 2D inputs
+    if x.dim() == 2 and x.stride(-2) != x.size(-1):
+        input_maybe_contiguous = x
+    else:
+        input_maybe_contiguous = x.contiguous()
+
+    out = torch.empty_like(x)
+    xtorch_ops.rmsnorm(input_maybe_contiguous, weight, out, epsilon)
+    return out

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/rotary.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/rotary.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin rotary embedding operator implementations.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def rotary_embedding_kunlunxin(
+    obj,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    rotary_interleaved: bool = False,
+    inplace: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Apply rotary position embedding.
+
+    The binding expects:
+    - positions: [num_tokens] int64 tensor
+    - query: [num_tokens, num_heads * head_size] flattened tensor (modified in-place)
+    - key: [num_tokens, num_kv_heads * head_size] flattened tensor (modified in-place)
+    - head_size: rotary dimension
+    - cos_sin_cache: [max_seq_len, rotary_dim] where first half is cos, second half is sin
+    - is_neox: bool (True for NeoX style, False for interleaved)
+
+    Args:
+        obj: The calling obj (for interface consistency)
+        query: Query tensor [num_tokens, num_heads, rotary_dim]
+        key: Key tensor [num_tokens, num_kv_heads, rotary_dim]
+        cos: Cosine cache [max_seq_len, rotary_dim // 2]
+        sin: Sine cache [max_seq_len, rotary_dim // 2]
+        position_ids: Position indices [num_tokens]
+        rotary_interleaved: Whether to use interleaved rotary (False = neox style)
+        inplace: Whether to modify tensors in-place
+
+    Returns:
+        Tuple of (embedded_query, embedded_key)
+    """
+    import xtorch_ops
+
+    num_tokens = query.shape[0]
+    rotary_dim = query.shape[-1]
+
+    # Reconstruct cos_sin_cache: [max_seq_len, rotary_dim]
+    # First half is cos, second half is sin
+    cos_sin_cache = torch.cat([cos, sin], dim=-1)
+
+    # Save original shapes
+    query_shape = query.shape
+    key_shape = key.shape
+
+    # Flatten query/key: [num_tokens, num_heads * rotary_dim]
+    query_flat = query.contiguous().view(num_tokens, -1)
+    key_flat = key.contiguous().view(num_tokens, -1)
+
+    # is_neox is the opposite of rotary_interleaved
+    is_neox = not rotary_interleaved
+
+    # Apply rotary embedding (in-place on query_flat / key_flat)
+    xtorch_ops.rotary_embedding(
+        position_ids,
+        query_flat,
+        key_flat,
+        rotary_dim,  # head_size = rotary_dim
+        cos_sin_cache,
+        is_neox,
+    )
+
+    # Restore original shapes
+    q_embed = query_flat.view(query_shape)
+    k_embed = key_flat.view(key_shape)
+
+    return q_embed, k_embed

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/kunlunxin.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/kunlunxin.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin backend implementation.
+
+This backend provides operator implementations for Kunlunxin hardware.
+Kunlunxin operators are exposed via xtorch_ops (primary). The Kunlunxin hardware masquerades as a CUDA device
+via torch_xmlir.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import torch
+
+from vllm_fl.dispatch.backends.base import Backend
+
+
+class KunlunxinBackend(Backend):
+    """
+    Kunlunxin backend for operator implementations.
+    """
+
+    _available: Optional[bool] = None
+
+    @property
+    def name(self) -> str:
+        return "kunlunxin"
+
+    @property
+    def vendor(self) -> Optional[str]:
+        return "kunlunxin"
+
+    def is_available(self) -> bool:
+        """Check if Kunlunxin hardware and libraries are available."""
+        if KunlunxinBackend._available is None:
+            try:
+                import torch_xmlir  # noqa: F401
+                # Kunlunxin hardware masquerades as CUDA device
+                if torch.cuda.is_available() and torch.cuda.device_count() > 0:
+                    KunlunxinBackend._available = True
+                else:
+                    KunlunxinBackend._available = False
+            except (ImportError, AttributeError):
+                KunlunxinBackend._available = False
+        return KunlunxinBackend._available
+
+    # ==================== Operator Implementations ====================
+
+    def silu_and_mul(self, obj, x: torch.Tensor) -> torch.Tensor:
+        """
+        SiLU activation followed by element-wise multiplication.
+
+        Args:
+            obj: The calling obj (for interface consistency)
+            x: Input tensor of shape [..., 2*d]
+
+        Returns:
+            Output tensor of shape [..., d]
+        """
+        from .impl.activation import silu_and_mul_kunlunxin
+
+        return silu_and_mul_kunlunxin(obj, x)
+
+    def rms_norm(
+        self,
+        obj,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        """
+        RMS normalization.
+
+        Args:
+            obj: The calling obj (e.g., RMSNorm layer)
+            x: Input tensor
+            residual: Optional residual tensor
+
+        Returns:
+            Normalized tensor, or tuple of (normalized, residual) if residual is provided
+        """
+        from .impl.normalization import rms_norm_kunlunxin
+
+        return rms_norm_kunlunxin(obj, x, residual)
+
+    def rotary_embedding(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        rotary_interleaved: bool = False,
+        inplace: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Apply rotary position embedding.
+
+        Args:
+            obj: The calling obj (for interface consistency)
+            query: Query tensor
+            key: Key tensor
+            cos: Cosine cache
+            sin: Sine cache
+            position_ids: Position indices
+            rotary_interleaved: Whether to use interleaved rotary
+            inplace: Whether to modify tensors in-place
+
+        Returns:
+            Tuple of (embedded_query, embedded_key)
+        """
+        from .impl.rotary import rotary_embedding_kunlunxin
+
+        return rotary_embedding_kunlunxin(
+            obj,
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            rotary_interleaved=rotary_interleaved,
+            inplace=inplace,
+        )
+
+    def attention_backend(self, use_mla: bool = False, use_sparse: bool = False) -> str:
+        """
+        Get the attention backend class path for Kunlunxin hardware.
+
+        Args:
+            use_mla: Whether to use Multi-head Latent Attention (MLA)
+            use_sparse: Whether to use Deepseek Sparse Attention (DSA)
+
+        Returns:
+            Fully qualified class path string
+        """
+        if use_mla:
+            if use_sparse:
+                raise NotImplementedError("MLA with sparse attention is not implemented for Kunlunxin yet.")
+            raise NotImplementedError("MLA attention is not implemented for Kunlunxin yet.")
+        return "vllm_fl.dispatch.backends.vendor.kunlunxin.impl.attention.KunlunxinAttentionBackend"
+
+    # ==================== FLA Operator Implementations ====================
+
+    def chunk_gated_delta_rule_fwd(self, *args, **kwargs):
+        """Chunk gated delta rule forward (prefill path)."""
+        from .impl.fla.chunk import chunk_gated_delta_rule_fwd
+
+        return chunk_gated_delta_rule_fwd(*args, **kwargs)
+
+    def fused_recurrent_gated_delta_rule_fwd(self, *args, **kwargs):
+        """Fused recurrent gated delta rule forward (decode path)."""
+        from .impl.fla.fused_recurrent import fused_recurrent_gated_delta_rule_fwd
+
+        return fused_recurrent_gated_delta_rule_fwd(*args, **kwargs)
+
+    # ==================== Causal Conv1d Implementations ====================
+
+    def causal_conv1d_fn(self, *args, **kwargs):
+        """Causal conv1d forward (prefill path)."""
+        from .impl.causal_conv1d import causal_conv1d_fn_kunlunxin
+
+        return causal_conv1d_fn_kunlunxin(*args, **kwargs)
+
+    def causal_conv1d_update(self, *args, **kwargs):
+        """Causal conv1d update (decode path)."""
+        from .impl.causal_conv1d import causal_conv1d_update_kunlunxin
+
+        return causal_conv1d_update_kunlunxin(*args, **kwargs)
+
+    # ==================== Fused GDN Gating ====================
+
+    def fused_gdn_gating(self, *args, **kwargs):
+        """Fused GDN gating."""
+        from .impl.fused_gdn_gating import fused_gdn_gating_kunlunxin
+
+        return fused_gdn_gating_kunlunxin(*args, **kwargs)

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/patch.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin platform monkey-patches.
+
+Follows the same pattern as ascend/patch.py — all Kunlunxin-specific
+overrides are applied here instead of scattering `if platform == "kunlunxin"`
+guards across shared code.
+
+Called once during plugin initialization (register_oot_ops).
+
+Note: patches/patch_fla_utils.py (ensure_fla_compat) is NOT called from here.
+It must run earlier — in register_model() — before any FLA module import,
+to prevent torch.xpu.get_device_name crash. See vllm_fl/__init__.py.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+_patches_applied = False
+
+
+def apply_kunlunxin_patches():
+    """Apply all Kunlunxin-specific patches. Idempotent."""
+    global _patches_applied
+    if _patches_applied:
+        return
+    _patches_applied = True
+
+    patch_causal_conv1d()
+    patch_fla_ops()
+    patch_fused_gdn_gating()
+    patch_op_cls()
+    patch_ssm_cache_update()
+    logger.info("Applied all Kunlunxin patches")
+
+
+# ── causal_conv1d ──
+def patch_causal_conv1d():
+    """Replace causal_conv1d_fn / causal_conv1d_update with Kunlunxin impls.
+
+    Upstream convention:
+        causal_conv1d_fn:  x=(dim, cu_seqlen), conv_states=(..., dim, state_len) — NCW
+        causal_conv1d_update: conv_state=(..., dim, state_len) — NCW
+    Kunlunxin kernel convention:
+        x=(cu_seqlen, dim), conv_states=(N, state_len, dim) — NWC, is_ncw=False
+
+    The wrappers bridge NCW ↔ NWC so the model code follows the upstream convention.
+    """
+    try:
+        import vllm.model_executor.layers.mamba.ops.causal_conv1d as _conv1d_lib
+        import vllm.model_executor.models.qwen3_next as _qwen3_next_lib
+
+        from vllm_fl.dispatch import resolve_op
+
+        _klx_conv1d_fn = resolve_op("causal_conv1d_fn")
+        _klx_conv1d_update = resolve_op("causal_conv1d_update")
+
+        def causal_conv1d_fn_adapter(
+            x, weight, bias, conv_states, query_start_loc, **kwargs
+        ):
+            # NCW → NWC: conv_states view, x transpose
+            conv_states_nwc = conv_states.transpose(-1, -2)
+            x_nwc = x.transpose(0, 1).contiguous()
+            out = _klx_conv1d_fn(
+                x_nwc, weight, bias, conv_states_nwc, query_start_loc, **kwargs
+            )
+            # NWC → NCW: transpose output back
+            return out.transpose(0, 1)
+
+        def causal_conv1d_update_adapter(
+            x, conv_state, weight, bias=None, activation=None, **kwargs
+        ):
+            # NCW → NWC: conv_state view
+            conv_state_nwc = conv_state.transpose(-1, -2)
+            return _klx_conv1d_update(
+                x, conv_state_nwc, weight, bias, activation, **kwargs
+            )
+
+        _conv1d_lib.causal_conv1d_fn = causal_conv1d_fn_adapter
+        _conv1d_lib.causal_conv1d_update = causal_conv1d_update_adapter
+        _qwen3_next_lib.causal_conv1d_fn = causal_conv1d_fn_adapter
+        _qwen3_next_lib.causal_conv1d_update = causal_conv1d_update_adapter
+        logger.info("Patched causal_conv1d ops for Kunlunxin")
+    except Exception as e:
+        logger.warning("Failed to patch causal_conv1d ops: %s", e)
+
+
+# ── FLA ops (chunk / fused_recurrent) ──
+def patch_fla_ops():
+    """Replace chunk_gated_delta_rule and fused_recurrent_gated_delta_rule
+    with Kunlunxin top-level implementations.
+    """
+    try:
+        import vllm.model_executor.layers.fla.ops as _fla_ops_lib
+        import vllm.model_executor.layers.fla.ops.chunk as _fla_chunk_lib
+        import vllm.model_executor.layers.fla.ops.fused_recurrent as _fla_recurrent_lib
+        import vllm.model_executor.models.qwen3_next as _qwen3_next_lib
+
+        from vllm_fl.dispatch.backends.vendor.kunlunxin.impl.fla.chunk import (
+            chunk_gated_delta_rule as klx_chunk_gated_delta_rule,
+        )
+        from vllm_fl.dispatch.backends.vendor.kunlunxin.impl.fla.fused_recurrent import (
+            fused_recurrent_gated_delta_rule as klx_fused_recurrent,
+        )
+
+        # Patch top-level chunk_gated_delta_rule
+        _fla_ops_lib.chunk_gated_delta_rule = klx_chunk_gated_delta_rule
+        _fla_chunk_lib.chunk_gated_delta_rule = klx_chunk_gated_delta_rule
+        _qwen3_next_lib.chunk_gated_delta_rule = klx_chunk_gated_delta_rule
+
+        # Patch top-level fused_recurrent_gated_delta_rule
+        _fla_ops_lib.fused_recurrent_gated_delta_rule = klx_fused_recurrent
+        _fla_recurrent_lib.fused_recurrent_gated_delta_rule = klx_fused_recurrent
+        _qwen3_next_lib.fused_recurrent_gated_delta_rule = klx_fused_recurrent
+
+        logger.info("Patched FLA ops for Kunlunxin")
+    except Exception as e:
+        logger.warning("Failed to patch FLA ops: %s", e)
+
+
+# ── fused_gdn_gating ──
+def patch_fused_gdn_gating():
+    """Replace the triton fused_gdn_gating kernel with Kunlunxin impl."""
+    try:
+        import vllm.model_executor.models.qwen3_next as _qwen3_next_lib
+
+        from vllm_fl.dispatch.backends.vendor.kunlunxin.impl.fused_gdn_gating import (
+            fused_gdn_gating_kunlunxin,
+        )
+
+        _qwen3_next_lib.fused_gdn_gating = fused_gdn_gating_kunlunxin
+        logger.info("Patched fused_gdn_gating for Kunlunxin")
+    except Exception as e:
+        logger.warning("Failed to patch fused_gdn_gating: %s", e)
+
+
+# ── SSM cache update (via _forward_core override) ──
+def patch_ssm_cache_update():
+    """Replace Qwen3NextGatedDeltaNet._forward_core with Kunlunxin version.
+    See patches/patch_forward_core.py for the implementation and diff markers.
+    """
+    try:
+        import vllm.model_executor.models.qwen3_next as _qwen3_next_lib
+
+        from vllm_fl.dispatch.backends.vendor.kunlunxin.patches.patch_Qwen3NextGatedDeltaNet_forward_core import _forward_core_kunlunxin
+
+        _qwen3_next_lib.Qwen3NextGatedDeltaNet._forward_core = _forward_core_kunlunxin
+        logger.info("Patched Qwen3NextGatedDeltaNet._forward_core for Kunlunxin")
+    except Exception as e:
+        logger.warning("Failed to patch _forward_core: %s", e)
+
+
+# ── SharedFusedMoE (via CustomOp.register_oot) ──
+def patch_op_cls():
+    """Register KunlunxinSharedFusedMoE as OOT replacement for SharedFusedMoE.
+    """
+    try:
+        from vllm.model_executor.custom_op import CustomOp
+
+        from vllm_fl.dispatch.backends.vendor.kunlunxin.impl.fused_moe import KunlunxinSharedFusedMoE
+
+        REGISTERED_KUNLUNXIN_OPS = {
+            "SharedFusedMoE": KunlunxinSharedFusedMoE,
+        }
+        for name, op_cls in REGISTERED_KUNLUNXIN_OPS.items():
+            CustomOp.register_oot(_decorated_op_cls=op_cls, name=name)
+        logger.info("Registered Kunlunxin OOT ops: %s",
+                     list(REGISTERED_KUNLUNXIN_OPS.keys()))
+    except Exception as e:
+        logger.warning("Failed to register Kunlunxin OOT ops: %s", e)

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/patches/patch_Qwen3NextGatedDeltaNet_forward_core.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/patches/patch_Qwen3NextGatedDeltaNet_forward_core.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
+
+"""
+Kunlunxin override of Qwen3NextGatedDeltaNet._forward_core.
+
+Copied from upstream vllm.model_executor.models.qwen3_next (installed package).
+The ONLY difference is the ssm_state cache write (marked with "# klx diff").
+
+This file is monkey-patched onto the class by
+``kunlunxin.patch.patch_ssm_cache_update()``.
+"""
+
+import torch
+
+from vllm.forward_context import get_forward_context
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+
+from vllm_fl.dispatch.backends.vendor.kunlunxin.impl.attention import (
+    KunlunxinPagedAttention,
+)
+
+
+def _kunlunxin_write_ssm_cache(
+    ssm_state: torch.Tensor,
+    last_recurrent_state: torch.Tensor,
+    indices: torch.Tensor,
+) -> None:
+    """Write recurrent state back into the paged ssm_state cache.
+
+    Upstream uses ``ssm_state[indices] = last_recurrent_state.to(dtype)``.
+    Kunlunxin requires ``KunlunxinPagedAttention.reshape_and_cache_flash``.
+    """
+    last_recurrent_state = (
+        last_recurrent_state.to(ssm_state.dtype)
+        .view(last_recurrent_state.shape[0], -1, last_recurrent_state.shape[-1])
+    )
+    cast_ssm_state = ssm_state.view(
+        ssm_state.shape[0], 1, -1, ssm_state.shape[-1]
+    )
+    KunlunxinPagedAttention.reshape_and_cache_flash(
+        last_recurrent_state,
+        None,
+        cast_ssm_state,
+        None,
+        indices,
+    )
+
+
+def _forward_core_kunlunxin(
+    self,
+    mixed_qkv: torch.Tensor,
+    b: torch.Tensor,
+    a: torch.Tensor,
+    core_attn_out: torch.Tensor,
+):
+    """
+    Core attention computation (called by custom op).
+
+    This is a copy of the upstream ``Qwen3NextGatedDeltaNet._forward_core``
+    with the ssm_state cache write replaced by ``_kunlunxin_write_ssm_cache``.
+    All other logic is identical to upstream.
+    """
+    # Resolve module-level refs from the upstream qwen3_next module at call time,
+    # so that other patches (causal_conv1d, fused_gdn_gating, etc.) take effect.
+    import vllm.model_executor.models.qwen3_next as _mod
+
+    causal_conv1d_fn = _mod.causal_conv1d_fn
+    causal_conv1d_update = _mod.causal_conv1d_update
+    fused_gdn_gating = _mod.fused_gdn_gating
+    chunk_gated_delta_rule = _mod.chunk_gated_delta_rule
+    fused_recurrent_gated_delta_rule = _mod.fused_recurrent_gated_delta_rule
+
+    forward_context = get_forward_context()
+    attn_metadata = forward_context.attn_metadata
+
+    if attn_metadata is None:
+        # V1 profile run
+        return
+
+    assert isinstance(attn_metadata, dict)
+    attn_metadata = attn_metadata[self.prefix]
+    assert isinstance(attn_metadata, GDNAttentionMetadata)
+    has_initial_state = attn_metadata.has_initial_state
+    spec_query_start_loc = attn_metadata.spec_query_start_loc
+    non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
+    spec_sequence_masks = attn_metadata.spec_sequence_masks
+    spec_token_indx = attn_metadata.spec_token_indx
+    non_spec_token_indx = attn_metadata.non_spec_token_indx
+    spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
+    non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+    self_kv_cache = self.kv_cache[forward_context.virtual_engine]
+    conv_state = self_kv_cache[0].transpose(-1, -2)
+    ssm_state = self_kv_cache[1]
+    num_actual_tokens = attn_metadata.num_actual_tokens
+    num_accepted_tokens = attn_metadata.num_accepted_tokens
+
+    mixed_qkv = mixed_qkv[:num_actual_tokens]
+    b = b[:num_actual_tokens]
+    a = a[:num_actual_tokens]
+
+    # 1. Convolution sequence transformation
+    conv_weights = self.conv1d.weight.view(
+        self.conv1d.weight.size(0), self.conv1d.weight.size(2)
+    )
+
+    if spec_sequence_masks is not None:
+        if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
+            mixed_qkv_spec = mixed_qkv
+            mixed_qkv_non_spec = None
+        else:
+            mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
+            mixed_qkv_non_spec = mixed_qkv.index_select(0, non_spec_token_indx)
+    else:
+        mixed_qkv_spec = None
+        mixed_qkv_non_spec = mixed_qkv
+
+    # 1.1: Process the multi-query part
+    if spec_sequence_masks is not None:
+        mixed_qkv_spec = causal_conv1d_update(
+            mixed_qkv_spec,
+            conv_state,
+            conv_weights,
+            self.conv1d.bias,
+            self.activation,
+            conv_state_indices=spec_state_indices_tensor[:, 0][
+                : attn_metadata.num_spec_decodes
+            ],
+            num_accepted_tokens=num_accepted_tokens,
+            query_start_loc=spec_query_start_loc,
+            max_query_len=spec_state_indices_tensor.size(-1),
+            validate_data=False,
+        )
+
+    # 1.2: Process the remaining part
+    if attn_metadata.num_prefills > 0:
+        mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
+        # - "cache_indices" updates the conv_state cache in positions
+        #   pointed to by "state_indices_tensor"
+        mixed_qkv_non_spec = causal_conv1d_fn(
+            mixed_qkv_non_spec_T,
+            conv_weights,
+            self.conv1d.bias,
+            activation=self.activation,
+            conv_states=conv_state,
+            has_initial_state=has_initial_state,
+            cache_indices=non_spec_state_indices_tensor,
+            query_start_loc=non_spec_query_start_loc,
+            metadata=attn_metadata,
+        ).transpose(0, 1)
+    elif attn_metadata.num_decodes > 0:
+        mixed_qkv_non_spec = causal_conv1d_update(
+            mixed_qkv_non_spec,
+            conv_state,
+            conv_weights,
+            self.conv1d.bias,
+            self.activation,
+            conv_state_indices=non_spec_state_indices_tensor[
+                : attn_metadata.num_actual_tokens
+            ],
+            validate_data=True,
+        )
+    else:
+        mixed_qkv_non_spec = None
+
+    query_spec, key_spec, value_spec = self.rearrange_mixed_qkv(mixed_qkv_spec)
+    query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(
+        mixed_qkv_non_spec
+    )
+
+    g, beta = fused_gdn_gating(self.A_log, a, b, self.dt_bias)
+
+    if spec_sequence_masks is not None:
+        if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
+            g_spec = g
+            beta_spec = beta
+            g_non_spec = None
+            beta_non_spec = None
+        else:
+            g_spec = g.index_select(1, spec_token_indx)
+            beta_spec = beta.index_select(1, spec_token_indx)
+            g_non_spec = g.index_select(1, non_spec_token_indx)
+            beta_non_spec = beta.index_select(1, non_spec_token_indx)
+    else:
+        g_spec = None
+        beta_spec = None
+        g_non_spec = g
+        beta_non_spec = beta
+
+    # 2. Recurrent attention
+
+    # 2.1: Process the multi-query part
+    if spec_sequence_masks is not None:
+        core_attn_out_spec, last_recurrent_state = fused_recurrent_gated_delta_rule(
+            q=query_spec,
+            k=key_spec,
+            v=value_spec,
+            g=g_spec,
+            beta=beta_spec,
+            initial_state=ssm_state,
+            inplace_final_state=True,
+            cu_seqlens=spec_query_start_loc[: attn_metadata.num_spec_decodes + 1],
+            ssm_state_indices=spec_state_indices_tensor,
+            num_accepted_tokens=num_accepted_tokens,
+            use_qk_l2norm_in_kernel=True,
+        )
+    else:
+        core_attn_out_spec, last_recurrent_state = None, None
+
+    # 2.2: Process the remaining part
+    if attn_metadata.num_prefills > 0:
+        initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
+        initial_state[~has_initial_state, ...] = 0
+        (
+            core_attn_out_non_spec,
+            last_recurrent_state,
+        ) = chunk_gated_delta_rule(
+            q=query_non_spec,
+            k=key_non_spec,
+            v=value_non_spec,
+            g=g_non_spec,
+            beta=beta_non_spec,
+            initial_state=initial_state,
+            output_final_state=True,
+            cu_seqlens=non_spec_query_start_loc,
+            head_first=False,
+            use_qk_l2norm_in_kernel=True,
+        )
+        # klx diff: use KunlunxinPagedAttention.reshape_and_cache_flash
+        # instead of ssm_state[indices] = value
+        _kunlunxin_write_ssm_cache(
+            ssm_state, last_recurrent_state, non_spec_state_indices_tensor
+        )
+    elif attn_metadata.num_decodes > 0:
+        core_attn_out_non_spec, last_recurrent_state = (
+            fused_recurrent_gated_delta_rule(
+                q=query_non_spec,
+                k=key_non_spec,
+                v=value_non_spec,
+                g=g_non_spec,
+                beta=beta_non_spec,
+                initial_state=ssm_state,
+                inplace_final_state=True,
+                cu_seqlens=non_spec_query_start_loc[
+                    : attn_metadata.num_decodes + 1
+                ],
+                ssm_state_indices=non_spec_state_indices_tensor,
+                use_qk_l2norm_in_kernel=True,
+            )
+        )
+    else:
+        core_attn_out_non_spec, last_recurrent_state = None, None
+
+    # 3. Merge core attention output
+    if spec_sequence_masks is not None and core_attn_out_non_spec is not None:
+        merged_out = torch.empty(
+            (1, num_actual_tokens, *core_attn_out_spec.shape[2:]),
+            dtype=core_attn_out_non_spec.dtype,
+            device=core_attn_out_non_spec.device,
+        )
+        merged_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
+        merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
+        core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
+    elif spec_sequence_masks is not None:
+        core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
+    else:
+        core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/patches/patch_fla_utils.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/patches/patch_fla_utils.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin compatibility: prevent torch.xpu.get_device_name crash in FLA utils.
+
+Problem
+-------
+Upstream ``vllm.model_executor.layers.fla.ops.utils`` at module level:
+
+    mapping = {"xpu": "intel", ...}          # line 132
+    is_intel = _check_platform() == "intel"  # line 147
+    is_intel_alchemist = is_intel and \
+        "Intel(R) Arc(TM) A" in torch.xpu.get_device_name(0)   # line 149
+
+On Kunlunxin, Triton backend reports "xpu" → maps to "intel" → line 149
+calls ``torch.xpu.get_device_name(0)`` → crashes with
+"Torch not compiled with XPU enabled".
+
+The preferred upstream fix is ``"xpu": "nvidia"`` (line 132) but we cannot
+modify installed packages.
+
+Fix
+---
+``ensure_fla_compat()`` does three things in one call:
+
+1. Wraps ``torch.xpu.get_device_name`` with try/except (prevents crash)
+2. Force-imports ``utils.py`` (so it loads NOW with the safe wrapper)
+3. Overwrites ``device_platform = "nvidia"`` and related flags
+
+After this, all subsequent imports that touch ``utils.py`` find it already
+in ``sys.modules`` with correct values.
+"""
+
+from __future__ import annotations
+
+import sys
+
+_FLA_UTILS_MOD = "vllm.model_executor.layers.fla.ops.utils"
+_patched = False
+
+
+def _fix_platform_vars() -> None:
+    """Correct platform flags in fla utils."""
+    mod = sys.modules.get(_FLA_UTILS_MOD)
+    if mod is None:
+        return
+    mod.device_platform = "nvidia"
+    mod.is_nvidia = True
+    mod.is_intel = False
+    mod.is_amd = False
+    mod.is_intel_alchemist = False
+    mod.is_nvidia_hopper = False
+    mod.is_tma_supported = False
+
+
+def ensure_fla_compat() -> None:
+    """One-shot fix. Call BEFORE any import that may load fla ops utils.
+
+    Safe to call multiple times (only the first call does real work).
+    """
+    global _patched
+    if _patched:
+        return
+    _patched = True
+
+    import torch
+
+    # Step 1: wrap torch.xpu.get_device_name so it never crashes
+    if hasattr(torch, "xpu") and hasattr(torch.xpu, "get_device_name"):
+        _orig = torch.xpu.get_device_name
+
+        def _safe_get_device_name(idx=0):
+            try:
+                return _orig(idx)
+            except Exception:
+                return ""
+
+        torch.xpu.get_device_name = _safe_get_device_name
+
+    # Step 2: force-import utils.py NOW (it loads safely with the wrapper)
+    try:
+        import vllm.model_executor.layers.fla.ops.utils  # noqa: F401
+    except Exception:
+        pass
+
+    # Step 3: overwrite platform vars → device_platform = "nvidia"
+    _fix_platform_vars()

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/register_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/register_ops.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026 Kunlunxin, Inc. All rights reserved.
+
+"""
+Kunlunxin backend operator registrations.
+
+This module registers all VENDOR (Kunlunxin) implementations.
+"""
+
+from __future__ import annotations
+
+import functools
+
+from vllm_fl.dispatch.types import OpImpl, BackendImplKind, BackendPriority
+
+
+def _bind_is_available(fn, is_available_fn):
+    """Wrap a function and bind _is_available attribute for OpImpl.is_available() check."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    wrapper._is_available = is_available_fn
+    return wrapper
+
+
+def register_builtins(registry) -> None:
+    """
+    Register all Kunlunxin (VENDOR) operator implementations.
+
+    Args:
+        registry: Registry to register into
+    """
+    from .kunlunxin import KunlunxinBackend
+
+    backend = KunlunxinBackend()
+    is_avail = backend.is_available
+
+    impls = [
+        # Activation
+        OpImpl(
+            op_name="silu_and_mul",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.silu_and_mul, is_avail),
+            vendor="kunlunxin",
+            priority=BackendPriority.VENDOR,
+        ),
+        # Normalization
+        OpImpl(
+            op_name="rms_norm",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.rms_norm, is_avail),
+            vendor="kunlunxin",
+            priority=BackendPriority.VENDOR,
+        ),
+        # Rotary Embedding
+        OpImpl(
+            op_name="rotary_embedding",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.rotary_embedding, is_avail),
+            vendor="kunlunxin",
+            priority=BackendPriority.VENDOR,
+        ),
+        # Attention Backend
+        OpImpl(
+            op_name="attention_backend",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.attention_backend, is_avail),
+            vendor="kunlunxin",
+            priority=BackendPriority.VENDOR,
+        ),
+        # FLA: Chunk Gated Delta Rule
+        OpImpl(
+            op_name="chunk_gated_delta_rule_fwd",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.chunk_gated_delta_rule_fwd, is_avail),
+            vendor="kunlunxin",
+            priority=BackendPriority.VENDOR,
+        ),
+        # FLA: Fused Recurrent Gated Delta Rule
+        OpImpl(
+            op_name="fused_recurrent_gated_delta_rule_fwd",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.fused_recurrent_gated_delta_rule_fwd, is_avail),
+            vendor="kunlunxin",
+            priority=BackendPriority.VENDOR,
+        ),
+        # Causal Conv1d Forward
+        OpImpl(
+            op_name="causal_conv1d_fn",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.causal_conv1d_fn, is_avail),
+            vendor="kunlunxin",
+            priority=BackendPriority.VENDOR,
+        ),
+        # Causal Conv1d Update
+        OpImpl(
+            op_name="causal_conv1d_update",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.causal_conv1d_update, is_avail),
+            vendor="kunlunxin",
+            priority=BackendPriority.VENDOR,
+        ),
+        # Fused GDN Gating
+        OpImpl(
+            op_name="fused_gdn_gating",
+            impl_id="vendor.kunlunxin",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.fused_gdn_gating, is_avail),
+            vendor="kunlunxin",
+            priority=BackendPriority.VENDOR,
+        ),
+    ]
+
+    registry.register_many(impls)

--- a/vllm_fl/dispatch/config/kunlunxin.yaml
+++ b/vllm_fl/dispatch/config/kunlunxin.yaml
@@ -1,0 +1,91 @@
+# vLLM-FL Dispatch Configuration for Kunlunxin vendor
+# Auto-loaded when running on Kunlunxin hardware
+
+# Preferred default backend type: flaggems, vendor, reference
+prefer: flagos
+
+# Strict Mode:
+#   true  = Raise an error immediately on failure; do not attempt other backends.
+#   false = Attempt the next available backend in sequence upon failure (Default).
+strict: false
+
+# Vendor Whitelist (Optional, allows all if not set)
+# allow_vendors:
+#  - kunlunxin
+#  - cuda
+
+# Vendor Blacklist (Optional)
+# deny_vendors:
+#   - cuda
+
+# Per-operator backend execution order (Optional)
+# Only the backends listed here will be attempted, in the order specified.
+#
+# Supported tokens:
+#   - flagos        : FlagOS implementation
+#   - reference     : PyTorch reference implementation
+#   - vendor        : Any available vendor backend (auto-detected)
+#   - vendor:kunlunxin : Kunlunxin-specific vendor backend
+op_backends:
+  # attention_backend: prioritize flagos (FlagGems Triton) implementation
+  attention_backend:
+    - flagos
+    - vendor
+    - reference
+
+  # rms_norm: prioritize vendor (Kunlunxin) implementation
+  rms_norm:
+    - flagos
+    - vendor
+    - reference
+
+  # silu_and_mul: prioritize vendor (Kunlunxin) implementation
+  silu_and_mul:
+    - flagos
+    - vendor
+    - reference
+
+  # rotary_embedding: prioritize vendor (Kunlunxin) implementation
+  rotary_embedding:
+    - flagos
+    - vendor
+    - reference
+
+  # FLA chunk gated delta rule: vendor (Kunlunxin) implementation
+  chunk_gated_delta_rule_fwd:
+    - vendor
+    - reference
+
+  # FLA fused recurrent gated delta rule: vendor (Kunlunxin) implementation
+  fused_recurrent_gated_delta_rule_fwd:
+    - vendor
+    - reference
+
+  # Causal conv1d forward: vendor (Kunlunxin) implementation
+  causal_conv1d_fn:
+    - vendor
+    - reference
+
+  # Causal conv1d update: vendor (Kunlunxin) implementation
+  causal_conv1d_update:
+    - vendor
+    - reference
+
+  # Fused GDN gating: vendor (Kunlunxin) implementation
+  fused_gdn_gating:
+    - vendor
+    - reference
+
+# FlagOS operator blacklist
+# These operators will NOT use FlagOS implementation even if FlagOS is enabled.
+flagos_blacklist:
+  - chunk_gated_delta_rule_fwd
+  - fused_recurrent_gated_delta_rule_fwd
+  - causal_conv1d_fn
+  - causal_conv1d_update
+  - fused_gdn_gating
+
+# OOT (Out-of-Tree) operator blacklist
+# These operators will NOT be registered as OOT replacements.
+# oot_blacklist:
+#   - fused_moe

--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
 
 import logging
 from typing import Optional, List
@@ -76,10 +78,16 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
         op_cls, registration_name = OOT_OPS[op_name]
         logger.info(f"Registering oot op: {op_name} as '{registration_name}'")
         CustomOp.register_oot(_decorated_op_cls=op_cls, name=registration_name)
-        # Apply Ascend NPU monkey-patches if running on NPU.
+        # Apply vendor-specific monkey-patches after all OOT ops are registered.
         # These replace upstream module-level functions (e.g. in qwen3_next) with
-        # Ascend implementations that bypass the CustomOp/dispatch path.
+        # vendor implementations that bypass the CustomOp/dispatch path.
+        # Each apply_*_patches() is idempotent (guarded by _patches_applied flag).
         from vllm.platforms import current_platform
         if current_platform.device_type == "npu":
             from vllm_fl.dispatch.backends.vendor.ascend.patch import apply_ascend_patches
             apply_ascend_patches()
+
+    from vllm_fl.dispatch.config.utils import get_platform_name
+    if get_platform_name() == "kunlunxin":
+        from vllm_fl.dispatch.backends.vendor.kunlunxin.patch import apply_kunlunxin_patches
+        apply_kunlunxin_patches()

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -3,6 +3,8 @@
 # Below is the original copyright:
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
 
 import os
 from typing import TYPE_CHECKING, Optional, TypeVar
@@ -153,6 +155,9 @@ class PlatformFL(Platform):
             elif cls.device_type == "musa":
                 cache_config.block_size = 64
                 logger.info("Setting kv cache block size to 64 for MUSA.")
+            elif cls.vendor_name == "kunlunxin":
+                cache_config.block_size = 128
+                logger.info("Setting kv cache block size to 128 for Kunlunxin.")
             else:
                 cache_config.block_size = 16
 
@@ -291,7 +296,7 @@ class PlatformFL(Platform):
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:
-        if cls.vendor_name in ["nvidia", "ascend", "metax"]:
+        if cls.vendor_name in ["nvidia", "ascend", "metax", "kunlunxin"]:
             return True
         return False
 

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -1,4 +1,6 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
+#
+# 2026 - Modified by Kunlunxin, Inc. All Rights Reserved.
 
 import json
 import os
@@ -25,7 +27,7 @@ _OP_CONFIG: Optional[dict[str, str]] = None
 #   Source: runtime platform detection (current_platform.device_name).
 #
 # Values are normalized to lowercase and matched against available backend
-# subdirectories (for example, cuda/ascend/metax/iluvatar/mthreads).
+# subdirectories (for example, cuda/ascend/metax/iluvatar/mthreads/kunlunxin).
 VENDOR_DEVICE_MAP: dict[str, dict[str, str]] = {
     # Registered backend: vendor/cuda
     "nvidia": {"device_type": "cuda", "device_name": "nvidia"},
@@ -37,6 +39,8 @@ VENDOR_DEVICE_MAP: dict[str, dict[str, str]] = {
     "metax": {"device_type": "cuda", "device_name": "metax"},
     # Registered backend: vendor/musa
     "mthreads": {"device_type": "musa", "device_name": "musa"},
+    # Registered backend: vendor/kunlunxin
+    "kunlunxin": {"device_type": "cuda", "device_name": "kunlunxin"},
 }
 
 
@@ -205,7 +209,7 @@ _load_op_config_from_env()
 class DeviceInfo:
     def __init__(self):
         self.device = DeviceDetector()
-        self.supported_device = ["nvidia", "ascend", "metax", "mthreads"]
+        self.supported_device = ["nvidia", "ascend", "metax", "mthreads", "kunlunxin"]
         backend.set_torch_backend_device_fn(self.device.vendor_name)
 
     @property


### PR DESCRIPTION
### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->
Vendor: add kunlunxin vendor

### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->
New Features

### Description
<!-- Describe what this PR does and why. -->
  Add Kunlunxin hardware vendor backend for vllm-plugin-FL dispatch system, enabling inference on Kunlunxin accelerators.

  #### Supported operators

  | Category | Operators |
  |----------|-----------|
  | Attention | paged attention (prefill + decode) | 
  | Activation | silu_and_mul |
  | Normalization | rms_norm |
  | Positional encoding | rotary_embedding |
  | Conv | causal_conv1d (forward + update) |
  | FLA (linear attention) | chunk_gated_delta_rule, fused_recurrent_gated_delta_rule |
  | GDN | fused_gdn_gating |
  | MoE | shared_fused_moe|

 #### Supported models
  - Qwen3.5-MoE

  #### Integration approach

  Following the existing vendor integration pattern (same as Ascend/MetaX/MUSA):
  1. Vendor operator implementations under `dispatch/backends/vendor/kunlunxin/`
  2. Monkey-patches for model-specific forward passes (Qwen3Next GDN)
  3. `torch.xpu` (Intel device) compatibility shim for FLA utils (avoids "Torch not compiled with XPU enabled" crash)
  4. All handmade vendor operators delegate to `xtorch_ops` (Kunlunxin's inference kernel library)

### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->

### Changes
<!-- List the key changes made in this PR. -->


### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->


### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
