### PR TITLE
Add Gemma4 support and fix MoE backend selection for vLLM v0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
 | MiniCPM-o 4.5 | Supported | [example](./examples/minicpm/) |
 | GLM-5 | Supported | [example](./examples/glm_5_offline_inference.py) |
 | Qwen3.5-35B-A3B | Supported | [example](./examples/glm_5_offline_inference.py)  |
+| Gemma4-26B-A4B | Supported | [example](./examples/gemma4_offline_inference.py) |
 | BAAI/bge-m3 | Supported | [implementation](./vllm_fl/models/bge_m3.py) |
 
 ### Supported Chips

--- a/examples/gemma4_offline_inference.py
+++ b/examples/gemma4_offline_inference.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+# Adapted from https://github.com/vllm-project/vllm/blob/v0.11.0/examples/offline_inference/basic/basic.py
+# Below is the original copyright:
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+
+# Enable FlagGems operators
+os.environ["USE_FLAGGEMS"] = "1"
+# Blacklist FlagGems operators that are incompatible with MoE models
+os.environ["VLLM_FL_FLAGOS_BLACKLIST"] = (
+    "one_hot,_to_copy,moe_align_block_size,topk,gather,sort,sort_stable"
+)
+
+from vllm import LLM, SamplingParams
+
+if __name__ == "__main__":
+    prompts = [
+        "Hello, my name is",
+    ]
+
+    # Create a sampling params object.
+    sampling_params = SamplingParams(max_tokens=10, temperature=0.0)
+    # Create an LLM.
+    llm = LLM(
+        model="google/gemma-4-26B-A4B-it",
+        tensor_parallel_size=2,
+        max_model_len=8192,
+        enforce_eager=False,
+        trust_remote_code=True,
+    )
+
+    # Generate texts from the prompts.
+    outputs = llm.generate(prompts, sampling_params)
+
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

--- a/vllm_fl/ops/fused_moe/layer.py
+++ b/vllm_fl/ops/fused_moe/layer.py
@@ -49,13 +49,11 @@ class UnquantizedFusedMoEMethodFL(UnquantizedFusedMoEMethod):
         self,
         layer: "FusedMoE",  # type: ignore[name-defined] # noqa: F821
         x: torch.Tensor,
-        router_logits: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        topk_weights, topk_ids, zero_expert_result = layer.select_experts(
-            hidden_states=x,
-            router_logits=router_logits,
-        )
-        result = fused_experts(
+        return fused_experts(
             hidden_states=x,
             w1=layer.w13_weight,
             w2=layer.w2_weight,
@@ -67,14 +65,6 @@ class UnquantizedFusedMoEMethodFL(UnquantizedFusedMoEMethod):
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,
         )
-
-        if layer.zero_expert_num != 0 and layer.zero_expert_type is not None:
-            assert not isinstance(result, tuple), (
-                "Shared + zero experts are mutually exclusive not yet supported"
-            )
-            return result, zero_expert_result
-        else:
-            return result
 
     def forward_native(
         self,
@@ -119,7 +109,7 @@ class FusedMoEFL(FusedMoE):
 
         if self.shared_experts is None:
             fused_output = torch.ops.vllm.moe_forward(
-                hidden_states, router_logits, self.layer_name
+                hidden_states, router_logits, None, self.layer_name
             )
             return fused_output[..., :og_hidden_states]
         else:

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -146,8 +146,38 @@ class PlatformFL(Platform):
             except Exception as e:
                 logger.warning(f"Failed to import maca patches: {e}")
 
+    _moe_backend_patched = False
+
+    @classmethod
+    def _patch_moe_backend_selection(cls):
+        if cls._moe_backend_patched:
+            return
+        cls._moe_backend_patched = True
+        if not cls.is_cuda_alike(cls):
+            return
+        from vllm.model_executor.layers.fused_moe.oracle import (
+            unquantized as _uq,
+        )
+        import vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method as _ufm
+        _orig = _uq.select_unquantized_moe_backend
+
+        def _patched(moe_config, use_ep, use_dp):
+            backend = _orig(moe_config, use_ep, use_dp)
+            if backend == _uq.UnquantizedMoeBackend.OOT:
+                return _uq.UnquantizedMoeBackend.TRITON
+            return backend
+
+        _uq.select_unquantized_moe_backend = _patched
+        _ufm.select_unquantized_moe_backend = _patched
+
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        # Fix: vLLM's select_unquantized_moe_backend uses non-exclusive
+        # `if` checks, so is_out_of_tree() overrides the TRITON backend
+        # set by is_cuda(). Patch it to fall back to TRITON on CUDA-alike
+        # OOT platforms so the modular MoE kernel is created correctly.
+        cls._patch_moe_backend_selection()
+
         parallel_config = vllm_config.parallel_config
         model_config = vllm_config.model_config
 

--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -231,6 +231,10 @@ class WorkerFL(WorkerBase):
 
         register_oot_ops()
 
+        # Apply MoE backend patch in worker process (spawned separately)
+        from vllm_fl.platform import PlatformFL
+        PlatformFL._patch_moe_backend_selection()
+
         if fl_envs.USE_FLAGGEMS:
             import flag_gems
 


### PR DESCRIPTION
### PR Category
Core

### PR Type
New Feature & Bug Fixes

### Description
Add Gemma4 (google/gemma-4-26B-A4B-it) as a supported model and fix MoE models failing on CUDA-alike OOT platforms after the v0.19.0 upgrade.

#### New Feature
- Add Gemma4 offline inference example (`examples/gemma4_offline_inference.py`)
- Add Gemma4-26B-A4B to the supported models table in README

#### Bug Fixes
Two bugs fixed that broke **all** MoE models (Gemma4, Qwen3.5-MoE, GLM-5, etc.) on CUDA-alike OOT platforms:

1. **MoE backend selection override**: `select_unquantized_moe_backend()` uses non-exclusive `if` checks, so `is_out_of_tree()` overrides the TRITON backend set by `is_cuda()`. This causes `make_unquantized_moe_kernel()` to return None, breaking all MoE models on CUDA-alike OOT platforms.
2. **`forward_native` signature mismatch**: The v0.19.0 upgrade changed the signature to receive pre-computed `topk_weights`/`topk_ids` instead of `router_logits`, but the plugin was not updated to match.

### Changes
- `vllm_fl/platform.py`: Add `_patch_moe_backend_selection()` to redirect OOT -> TRITON on CUDA-alike platforms
- `vllm_fl/worker/worker.py`: Apply patch in spawned worker processes
- `vllm_fl/ops/fused_moe/layer.py`: Update `forward_native` signature and `moe_forward` call to match vLLM v0.19.0 API
- `examples/gemma4_offline_inference.py`: Add Gemma4 offline inference example
- `README.md`: Add Gemma4-26B-A4B to supported models table

### Testing
- Tested with Gemma4 (google/gemma-4-26B-A4B-it) MoE model on 2x NVIDIA GPUs (TP=2)
- Model loads and generates correctly with FlagGems operators enabled