### PR TITLE
New Feature: Add FlagCX-based KV connector for vLLM V1 disaggregated prefill-decode (PD) serving

### DIFF
--- a/examples/disaggregated_serving_xpyd/router.py
+++ b/examples/disaggregated_serving_xpyd/router.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# 1P1D disaggregated serving proxy for FlagcxConnector
+#
+# Usage:
+#   python3 router.py \
+#     --host 0.0.0.0 --port 8000 \
+#     --prefill http://<prefill_host>:<vllm_port> <VLLM_FLAGCX_BOOTSTRAP_PORT> \
+#     --decode  http://<decode_host>:<vllm_port>
+#
+# VLLM_FLAGCX_BOOTSTRAP_PORT is the ZMQ side-channel BASE port (default 8998).
+
+import argparse
+import asyncio
+import itertools
+import os
+import urllib.parse
+import uuid
+from contextlib import asynccontextmanager
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+global_args = None
+
+
+async def wait_for_prefill_health(prefill_clients, ready):
+    for client_info in prefill_clients:
+        while True:
+            try:
+                response = await client_info["client"].get("/health")
+                response.raise_for_status()
+                break
+            except Exception as exc:
+                print(f"Waiting for prefill {client_info['url']}/health: {exc}")
+                await asyncio.sleep(1)
+        print(f"Prefill {client_info['url']} is healthy.")
+    ready.set()
+    print("All prefill instances are ready.")
+
+
+@asynccontextmanager
+async def lifespan(app):
+    app.state.prefill_clients = []
+    app.state.decode_clients = []
+    app.state.ready = asyncio.Event()
+
+    for url, side_channel_port in global_args.prefill:
+        parsed_url = urllib.parse.urlparse(url)
+        app.state.prefill_clients.append({
+            "client": httpx.AsyncClient(
+                timeout=None, base_url=url,
+                limits=httpx.Limits(max_connections=None, max_keepalive_connections=None),
+            ),
+            "url": url,
+            "remote_host": parsed_url.hostname,
+            "side_channel_port": side_channel_port,
+        })
+
+    for url in global_args.decode:
+        app.state.decode_clients.append({
+            "client": httpx.AsyncClient(
+                timeout=None, base_url=url,
+                limits=httpx.Limits(max_connections=None, max_keepalive_connections=None),
+            ),
+        })
+
+    asyncio.create_task(wait_for_prefill_health(app.state.prefill_clients, app.state.ready))
+    app.state.prefill_iterator = itertools.cycle(range(len(app.state.prefill_clients)))
+    app.state.decode_iterator = itertools.cycle(range(len(app.state.decode_clients)))
+    print(f"Got {len(app.state.prefill_clients)} prefill clients and {len(app.state.decode_clients)} decode clients.")
+
+    yield
+
+    for c in app.state.prefill_clients:
+        await c["client"].aclose()
+    for c in app.state.decode_clients:
+        await c["client"].aclose()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+async def send_to_prefill(prefill_client, endpoint, req_data, request_id):
+    data = req_data.copy()
+    data["kv_transfer_params"] = {"do_remote_decode": True, "do_remote_prefill": False}
+    data["stream"] = False
+    data["max_tokens"] = 1
+    if "max_completion_tokens" in data:
+        data["max_completion_tokens"] = 1
+    data.pop("stream_options", None)
+    headers = {"X-Request-Id": request_id}
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        response = await prefill_client["client"].post(endpoint, json=data, headers=headers)
+        response.raise_for_status()
+        await response.aclose()
+    except Exception as exc:
+        print(f"Prefill request {request_id} error: {exc}")
+
+
+async def stream_from_decode(prefill_client, decode_client, endpoint, req_data, request_id):
+    data = req_data.copy()
+    data["kv_transfer_params"] = {
+        "do_remote_prefill": True,
+        "do_remote_decode": False,
+        "remote_host": prefill_client["remote_host"],
+        "remote_port": prefill_client["side_channel_port"],
+    }
+    headers = {"X-Request-Id": request_id}
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    async with decode_client["client"].stream("POST", endpoint, json=data, headers=headers) as response:
+        response.raise_for_status()
+        async for chunk in response.aiter_bytes():
+            yield chunk
+
+
+async def _handle_completions(api, request):
+    if not app.state.ready.is_set():
+        raise HTTPException(status_code=503, detail="Service Unavailable")
+    try:
+        req_data = await request.json()
+        request_id = str(uuid.uuid4())
+        prefill_client = app.state.prefill_clients[next(app.state.prefill_iterator)]
+        decode_client = app.state.decode_clients[next(app.state.decode_iterator)]
+        asyncio.create_task(send_to_prefill(prefill_client, api, req_data, request_id))
+
+        async def generate():
+            async for chunk in stream_from_decode(prefill_client, decode_client, api, req_data, request_id):
+                yield chunk
+
+        return StreamingResponse(generate(), media_type="application/json")
+    except Exception as e:
+        import sys, traceback
+        print(f"Error in proxy [{api}]: {e}")
+        print("".join(traceback.format_exception(*sys.exc_info())))
+        raise
+
+
+@app.post("/v1/completions")
+async def handle_completions(request: Request):
+    return await _handle_completions("/v1/completions", request)
+
+
+@app.post("/v1/chat/completions")
+async def handle_chat_completions(request: Request):
+    return await _handle_completions("/v1/chat/completions", request)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="1P1D proxy for FlagcxConnector (ZMQ side-channel)")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--prefill", nargs="+", action="append", dest="prefill_raw",
+        metavar=("URL", "ZMQ_PORT"),
+        help="Prefill URL and ZMQ side-channel base port (= VLLM_FLAGCX_BOOTSTRAP_PORT, default 8998)")
+    parser.add_argument("--decode", nargs=1, action="append", dest="decode_raw",
+        metavar="URL", help="Decode vllm URL")
+
+    args = parser.parse_args()
+    args.prefill = []
+    for item in (args.prefill_raw or []):
+        url = item[0]
+        port = int(item[1]) if len(item) >= 2 else 8998
+        args.prefill.append((url, port))
+    args.decode = [item[0] for item in (args.decode_raw or [])]
+
+    if not args.prefill:
+        parser.error("At least one --prefill URL is required.")
+    if not args.decode:
+        parser.error("At least one --decode URL is required.")
+    return args
+
+
+if __name__ == "__main__":
+    global_args = parse_args()
+    import uvicorn
+    uvicorn.run(app, host=global_args.host, port=global_args.port)

--- a/examples/disaggregated_serving_xpyd/router.py
+++ b/examples/disaggregated_serving_xpyd/router.py
@@ -135,7 +135,8 @@ async def _handle_completions(api, request):
 
         return StreamingResponse(generate(), media_type="application/json")
     except Exception as e:
-        import sys, traceback
+        import sys
+        import traceback
         print(f"Error in proxy [{api}]: {e}")
         print("".join(traceback.format_exception(*sys.exc_info())))
         raise

--- a/examples/disaggregated_serving_xpyd/router.py
+++ b/examples/disaggregated_serving_xpyd/router.py
@@ -24,7 +24,7 @@ from fastapi.responses import StreamingResponse
 global_args = None
 
 
-async def wait_for_prefill_health(prefill_clients, ready):
+async def wait_for_health(prefill_clients, decode_clients, ready):
     for client_info in prefill_clients:
         while True:
             try:
@@ -35,8 +35,18 @@ async def wait_for_prefill_health(prefill_clients, ready):
                 print(f"Waiting for prefill {client_info['url']}/health: {exc}")
                 await asyncio.sleep(1)
         print(f"Prefill {client_info['url']} is healthy.")
+    for client_info in decode_clients:
+        while True:
+            try:
+                response = await client_info["client"].get("/health")
+                response.raise_for_status()
+                break
+            except Exception as exc:
+                print(f"Waiting for decode {client_info['url']}/health: {exc}")
+                await asyncio.sleep(1)
+        print(f"Decode {client_info['url']} is healthy.")
     ready.set()
-    print("All prefill instances are ready.")
+    print("All prefill and decode instances are ready.")
 
 
 @asynccontextmanager
@@ -47,28 +57,45 @@ async def lifespan(app):
 
     for url, side_channel_port in global_args.prefill:
         parsed_url = urllib.parse.urlparse(url)
-        app.state.prefill_clients.append({
-            "client": httpx.AsyncClient(
-                timeout=None, base_url=url,
-                limits=httpx.Limits(max_connections=None, max_keepalive_connections=None),
-            ),
-            "url": url,
-            "remote_host": parsed_url.hostname,
-            "side_channel_port": side_channel_port,
-        })
+        app.state.prefill_clients.append(
+            {
+                "client": httpx.AsyncClient(
+                    timeout=None,
+                    base_url=url,
+                    limits=httpx.Limits(
+                        max_connections=None, max_keepalive_connections=None
+                    ),
+                ),
+                "url": url,
+                "remote_host": parsed_url.hostname,
+                "side_channel_port": side_channel_port,
+            }
+        )
 
     for url in global_args.decode:
-        app.state.decode_clients.append({
-            "client": httpx.AsyncClient(
-                timeout=None, base_url=url,
-                limits=httpx.Limits(max_connections=None, max_keepalive_connections=None),
-            ),
-        })
+        app.state.decode_clients.append(
+            {
+                "client": httpx.AsyncClient(
+                    timeout=None,
+                    base_url=url,
+                    limits=httpx.Limits(
+                        max_connections=None, max_keepalive_connections=None
+                    ),
+                ),
+                "url": url,
+            }
+        )
 
-    asyncio.create_task(wait_for_prefill_health(app.state.prefill_clients, app.state.ready))
+    asyncio.create_task(
+        wait_for_health(
+            app.state.prefill_clients, app.state.decode_clients, app.state.ready
+        )
+    )
     app.state.prefill_iterator = itertools.cycle(range(len(app.state.prefill_clients)))
     app.state.decode_iterator = itertools.cycle(range(len(app.state.decode_clients)))
-    print(f"Got {len(app.state.prefill_clients)} prefill clients and {len(app.state.decode_clients)} decode clients.")
+    print(
+        f"Got {len(app.state.prefill_clients)} prefill clients and {len(app.state.decode_clients)} decode clients."
+    )
 
     yield
 
@@ -94,14 +121,18 @@ async def send_to_prefill(prefill_client, endpoint, req_data, request_id):
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     try:
-        response = await prefill_client["client"].post(endpoint, json=data, headers=headers)
+        response = await prefill_client["client"].post(
+            endpoint, json=data, headers=headers
+        )
         response.raise_for_status()
         await response.aclose()
     except Exception as exc:
         print(f"Prefill request {request_id} error: {exc}")
 
 
-async def stream_from_decode(prefill_client, decode_client, endpoint, req_data, request_id):
+async def stream_from_decode(
+    prefill_client, decode_client, endpoint, req_data, request_id
+):
     data = req_data.copy()
     data["kv_transfer_params"] = {
         "do_remote_prefill": True,
@@ -113,7 +144,9 @@ async def stream_from_decode(prefill_client, decode_client, endpoint, req_data, 
     api_key = os.environ.get("OPENAI_API_KEY", "")
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
-    async with decode_client["client"].stream("POST", endpoint, json=data, headers=headers) as response:
+    async with decode_client["client"].stream(
+        "POST", endpoint, json=data, headers=headers
+    ) as response:
         response.raise_for_status()
         async for chunk in response.aiter_bytes():
             yield chunk
@@ -130,13 +163,16 @@ async def _handle_completions(api, request):
         asyncio.create_task(send_to_prefill(prefill_client, api, req_data, request_id))
 
         async def generate():
-            async for chunk in stream_from_decode(prefill_client, decode_client, api, req_data, request_id):
+            async for chunk in stream_from_decode(
+                prefill_client, decode_client, api, req_data, request_id
+            ):
                 yield chunk
 
         return StreamingResponse(generate(), media_type="application/json")
     except Exception as e:
         import sys
         import traceback
+
         print(f"Error in proxy [{api}]: {e}")
         print("".join(traceback.format_exception(*sys.exc_info())))
         raise
@@ -153,18 +189,31 @@ async def handle_chat_completions(request: Request):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="1P1D proxy for FlagcxConnector (ZMQ side-channel)")
+    parser = argparse.ArgumentParser(
+        description="1P1D proxy for FlagcxConnector (ZMQ side-channel)"
+    )
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--host", type=str, default="0.0.0.0")
-    parser.add_argument("--prefill", nargs="+", action="append", dest="prefill_raw",
+    parser.add_argument(
+        "--prefill",
+        nargs="+",
+        action="append",
+        dest="prefill_raw",
         metavar=("URL", "ZMQ_PORT"),
-        help="Prefill URL and ZMQ side-channel base port (= FLAGCX_BOOTSTRAP_PORT, default 8998)")
-    parser.add_argument("--decode", nargs=1, action="append", dest="decode_raw",
-        metavar="URL", help="Decode vllm URL")
+        help="Prefill URL and ZMQ side-channel base port (= FLAGCX_BOOTSTRAP_PORT, default 8998)",
+    )
+    parser.add_argument(
+        "--decode",
+        nargs=1,
+        action="append",
+        dest="decode_raw",
+        metavar="URL",
+        help="Decode vllm URL",
+    )
 
     args = parser.parse_args()
     args.prefill = []
-    for item in (args.prefill_raw or []):
+    for item in args.prefill_raw or []:
         url = item[0]
         port = int(item[1]) if len(item) >= 2 else 8998
         args.prefill.append((url, port))
@@ -180,4 +229,5 @@ def parse_args():
 if __name__ == "__main__":
     global_args = parse_args()
     import uvicorn
+
     uvicorn.run(app, host=global_args.host, port=global_args.port)

--- a/examples/disaggregated_serving_xpyd/router.py
+++ b/examples/disaggregated_serving_xpyd/router.py
@@ -4,10 +4,10 @@
 # Usage:
 #   python3 router.py \
 #     --host 0.0.0.0 --port 8000 \
-#     --prefill http://<prefill_host>:<vllm_port> <VLLM_FLAGCX_BOOTSTRAP_PORT> \
+#     --prefill http://<prefill_host>:<vllm_port> <FLAGCX_BOOTSTRAP_PORT> \
 #     --decode  http://<decode_host>:<vllm_port>
 #
-# VLLM_FLAGCX_BOOTSTRAP_PORT is the ZMQ side-channel BASE port (default 8998).
+# FLAGCX_BOOTSTRAP_PORT is the ZMQ side-channel BASE port (default 8998).
 
 import argparse
 import asyncio
@@ -158,7 +158,7 @@ def parse_args():
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--prefill", nargs="+", action="append", dest="prefill_raw",
         metavar=("URL", "ZMQ_PORT"),
-        help="Prefill URL and ZMQ side-channel base port (= VLLM_FLAGCX_BOOTSTRAP_PORT, default 8998)")
+        help="Prefill URL and ZMQ side-channel base port (= FLAGCX_BOOTSTRAP_PORT, default 8998)")
     parser.add_argument("--decode", nargs=1, action="append", dest="decode_raw",
         metavar="URL", help="Decode vllm URL")
 

--- a/examples/disaggregated_serving_xpyd/run_flagcx_connector.md
+++ b/examples/disaggregated_serving_xpyd/run_flagcx_connector.md
@@ -1,0 +1,162 @@
+# FlagCX Connector Disaggregated Serving (1P1D)
+
+This guide walks through setting up disaggregated prefill-decode serving with the **FlagCXConnector** on two nodes (one Prefill, one Decode).
+
+## Prerequisites
+
+- Two nodes with RDMA (InfiniBand) connectivity
+- NVIDIA GPUs with CUDA toolkit installed
+- vLLM (v1 architecture) installed
+- Python 3.10+
+
+## 1. Build FlagCX
+
+On **both** Prefill and Decode nodes:
+
+```bash
+git clone https://github.com/FlagOpen/FlagCX.git
+cd FlagCX
+
+# Build with NVIDIA backend
+make USE_NVIDIA=1 -j$(nproc)
+
+# Verify the shared library is built
+ls build/lib/libflagcx.so
+```
+
+Set environment variables (add to your shell profile or export before running):
+
+```bash
+export FLAGCX_PATH=/path/to/FlagCX
+# FLAGCX_LIB_PATH is optional; defaults to ${FLAGCX_PATH}/build/lib/libflagcx.so
+```
+
+## 2. Install vllm-plugin-FL
+
+On **both** Prefill and Decode nodes:
+
+```bash
+git clone https://github.com/flagos-ai/vllm-plugin-FL.git
+cd vllm-plugin-FL
+pip install --no-build-isolation -e .
+```
+
+## 3. Start the Prefill Instance
+
+Run on the **Prefill node** (e.g. `10.8.2.168`):
+
+```bash
+# ---- Network / RDMA settings (adjust to your cluster) ----
+export NCCL_SOCKET_IFNAME=bond0
+export GLOO_SOCKET_IFNAME=bond0
+export NCCL_DEBUG=version
+export NCCL_IB_HCA==mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7
+export NCCL_NVLS_ENABLE=0
+export NCCL_IB_GID_INDEX=3
+
+# ---- FlagCX settings ----
+export FLAGCX_USE_HETERO_COMM=1
+export FLAGCX_PATH=/path/to/FlagCX
+
+# ---- vLLM settings ----
+export VLLM_RPC_TIMEOUT=600000
+export VLLM_ENGINE_ITERATION_TIMEOUT_S=600
+export VLLM_PLUGINS=fl
+
+vllm serve <model_path> \
+    --host 0.0.0.0 \
+    --port 20001 \
+    --tensor-parallel-size 8 \
+    --seed 1024 \
+    --max-model-len 40960 \
+    --served-model-name base_model \
+    --max-num-batched-tokens 65536 \
+    --max-num-seqs 256 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config \
+    '{"kv_connector":"FlagCXConnector","kv_role":"kv_producer"}'
+```
+
+## 4. Start the Decode Instance
+
+Run on the **Decode node** (e.g. `10.8.2.169`):
+
+```bash
+# ---- Network / RDMA settings (same as Prefill) ----
+export NCCL_SOCKET_IFNAME=bond0
+export GLOO_SOCKET_IFNAME=bond0
+export NCCL_DEBUG=version
+export NCCL_IB_HCA==mlx5_0,mlx5_1,mlx5_2,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7
+export NCCL_NVLS_ENABLE=0
+export NCCL_IB_GID_INDEX=3
+
+# ---- FlagCX settings ----
+export FLAGCX_USE_HETERO_COMM=1
+export FLAGCX_PATH=/path/to/FlagCX
+
+# ---- vLLM settings ----
+export VLLM_RPC_TIMEOUT=600000
+export VLLM_ENGINE_ITERATION_TIMEOUT_S=600
+export VLLM_PLUGINS=fl
+
+vllm serve <model_path> \
+    --host 0.0.0.0 \
+    --port 20002 \
+    --tensor-parallel-size 8 \
+    --seed 1024 \
+    --max-model-len 40960 \
+    --served-model-name base_model \
+    --max-num-batched-tokens 65536 \
+    --max-num-seqs 256 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.8 \
+    --kv-transfer-config \
+    '{"kv_connector":"FlagCXConnector","kv_role":"kv_consumer"}'
+```
+
+## 5. Start the Router
+
+The router is a FastAPI proxy that coordinates Prefill and Decode instances. Run it on **any** node that can reach both:
+
+```bash
+cd vllm-plugin-FL/examples/disaggregated_serving_xpyd
+
+python3 router.py \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --prefill http://<prefill_host>:20001 8998 \
+  --decode http://<decode_host>:20002
+```
+
+- The second argument after the Prefill URL is the **ZMQ side-channel base port** (`FLAGCX_BOOTSTRAP_PORT`, default `8998`).
+- You can specify multiple `--prefill` / `--decode` for xPyD topologies.
+
+## 6. Send Requests
+
+```bash
+curl -s http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "base_model",
+    "prompt": "Hello, world!",
+    "max_tokens": 64
+  }'
+```
+
+## 7. Benchmarking
+
+```bash
+vllm bench serve \
+  --base-url http://<router_host>:8000 \
+  --endpoint /v1/completions \
+  --model <model_path> \
+  --served-model-name base_model \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 1024 \
+  --request-rate 70 \
+  --num-prompts 350 \
+  --percentile-metrics ttft,tpot,itl,e2el \
+  --metric-percentiles 50,90,99
+```

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -29,6 +29,20 @@ def _patch_transformers_compat():
         )
 
 
+def _register_flagcx_connector():
+    from vllm.distributed.kv_transfer.kv_connector.factory import (
+        KVConnectorFactory,
+    )
+
+    for _alias in ("FlagCXConnector", "FlagcxConnector"):
+        if _alias not in KVConnectorFactory._registry:
+            KVConnectorFactory.register_connector(
+                _alias,
+                "vllm_fl.distributed.kv_transfer.flagcx_connector",
+                "FlagCXConnector",
+            )
+
+
 def register():
     """Register the FL platform."""
     _patch_transformers_compat()
@@ -37,15 +51,8 @@ def register():
     from vllm_fl.patches.glm_moe_dsa import apply_platform_patches as glm5_platform
     glm5_platform()
 
-    # Register FlagCX KV connector
-    from vllm.distributed.kv_transfer.kv_connector.factory import (
-        KVConnectorFactory,
-    )
-    KVConnectorFactory.register_connector(
-        "FlagCXConnector",
-        "vllm_fl.distributed.kv_transfer.flagcx_connector",
-        "FlagCXConnector",
-    )
+    # Register FlagCX KV connector (idempotent across processes).
+    _register_flagcx_connector()
 
     multiproc_method = os.environ.get("VLLM_WORKER_MULTIPROC_METHOD")
     if multiproc_method is None:
@@ -56,6 +63,8 @@ def register():
 
 def register_model():
     """Register FL-specific models not yet upstream."""
+    _register_flagcx_connector()
+
     # Models now upstream in vLLM v0.18.1 (no longer need plugin registration):
     #   BGE-M3, Qwen3NextForCausalLM, Qwen3_5MoeForConditionalGeneration,
     #   MiniCPMO, KimiK25ForConditionalGeneration, Qwen3_5MoeConfig
@@ -70,4 +79,3 @@ def register_model():
         #glm5_model()
     except Exception as e:
         logger.error(f"Register GlmMoeDsa model error: {str(e)}")
-

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -37,6 +37,16 @@ def register():
     from vllm_fl.patches.glm_moe_dsa import apply_platform_patches as glm5_platform
     glm5_platform()
 
+    # Register FlagCX KV connector
+    from vllm.distributed.kv_transfer.kv_connector.factory import (
+        KVConnectorFactory,
+    )
+    KVConnectorFactory.register_connector(
+        "FlagCXConnector",
+        "vllm_fl.distributed.kv_transfer.flagcx_connector",
+        "FlagCXConnector",
+    )
+
     multiproc_method = os.environ.get("VLLM_WORKER_MULTIPROC_METHOD")
     if multiproc_method is None:
         os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -1,0 +1,933 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
+import ctypes
+import os
+import sys
+import threading
+import time
+import uuid
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+import msgspec
+import numpy as np
+import torch
+import zmq
+import zmq.asyncio
+
+from vllm import envs
+from vllm.attention.backends.abstract import AttentionMetadata
+from vllm.attention.selector import get_attn_backend
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.utils import TpKVTopology
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.distributed.parallel_state import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    get_tp_group,
+)
+from vllm.forward_context import ForwardContext
+from vllm.logger import init_logger
+from vllm.utils.network_utils import get_ip, make_zmq_path, make_zmq_socket
+from vllm.v1.attention.backends.utils import get_kv_cache_layout
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.request import RequestStatus
+
+if TYPE_CHECKING:
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+_flagcx_path = os.getenv("FLAGCX_PATH")
+if _flagcx_path and os.path.isdir(_flagcx_path):
+    if _flagcx_path not in sys.path:
+        sys.path.append(_flagcx_path)
+
+try:
+    from plugin.interservice.flagcx_wrapper import (
+        FLAGCXLibrary,
+        buffer_type,
+        flagcxComm_t,
+        flagcxStream_t,
+        flagcxUniqueId,
+        flagcxOneSideRegister,
+        flagcxOneSideSignalRegister
+    )
+except ImportError as e:
+    raise ImportError(
+        "Cannot import FlagCX wrapper. Set FLAGCX_PATH to the FlagCX repo "
+        "root (containing plugin/interservice/flagcx_wrapper.py)."
+    ) from e
+
+EngineId = str
+ReqId = str
+
+TRANS_DONE = b"trans_done"
+TRANS_ERROR = b"trans_error"
+
+logger = init_logger(__name__)
+
+class FlagCXAgentMetadata(
+    msgspec.Struct,
+    omit_defaults=True,  # type: ignore[call-arg]
+    dict=True,
+):
+    """Sent from Decode → Prefill over ZMQ to request a KV transfer."""
+    remote_hostname: str
+    remote_port: int
+    request_ids: list[ReqId]
+    kv_caches_base_addr: list[int]
+    block_ids: list[list[int]]
+    uid_bytes: Optional[bytes] = None  # set on first contact to init pair comm
+
+@dataclass
+class RecvReqMeta:
+    local_block_ids: list[int]
+    remote_host: str
+    remote_port: int
+
+@dataclass
+class SendBlockMeta:
+    local_block_ids: list[int]
+    ready: threading.Event
+    expire_time: float = float("inf")
+
+@dataclass
+class SendReqMeta:
+    reqs: dict[ReqId, SendBlockMeta]
+    lock: threading.Lock
+
+@dataclass
+class FinishedSendReqSet:
+    set: set[ReqId]
+    lock: threading.Lock
+
+@dataclass
+class FinishedReceiveReqSet:
+    set: set[ReqId]
+    lock: asyncio.Lock
+
+class FlagCXConnectorMetadata(KVConnectorMetadata):
+    def __init__(self):
+        self.reqs_to_recv: dict[ReqId, RecvReqMeta] = {}
+        self.reqs_to_send: dict[ReqId, list[int]] = {}
+
+    def add_new_req(
+        self,
+        request_id: ReqId,
+        local_block_ids: list[int],
+        kv_transfer_params: dict[str, Any],
+        load_remote_cache: bool = True,
+    ):
+        if load_remote_cache:
+            self.reqs_to_recv[request_id] = RecvReqMeta(
+                local_block_ids=local_block_ids,
+                remote_host=kv_transfer_params["remote_host"],
+                remote_port=kv_transfer_params["remote_port"],
+            )
+        else:
+            self.reqs_to_send[request_id] = local_block_ids
+
+class FlagCXConnector(KVConnectorBase_V1):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: Optional["KVCacheConfig"] = None,
+    ):
+        super().__init__(vllm_config, role, kv_cache_config)
+
+        assert vllm_config.kv_transfer_config is not None
+        assert vllm_config.kv_transfer_config.engine_id is not None
+        self.engine_id: EngineId = vllm_config.kv_transfer_config.engine_id
+
+        if role == KVConnectorRole.SCHEDULER:
+            self.connector_scheduler: FlagCXConnectorScheduler | None = (
+                FlagCXConnectorScheduler(vllm_config, self.engine_id)
+            )
+            self.connector_worker: FlagCXConnectorWorker | None = None
+        elif role == KVConnectorRole.WORKER:
+            self.connector_scheduler = None
+            self.connector_worker = FlagCXConnectorWorker(
+                vllm_config, self.engine_id
+            )
+
+    # ---- Scheduler-side ----
+    def get_num_new_matched_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int, bool]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.get_num_new_matched_tokens(
+            request, num_computed_tokens
+        )
+
+    def update_state_after_alloc(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        num_external_tokens: int,
+    ):
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.update_state_after_alloc(
+            request, blocks, num_external_tokens
+        )
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.build_connector_meta(scheduler_output)
+
+    def request_finished(
+        self, request: "Request", block_ids: list[int]
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request, block_ids)
+
+    # ---- Worker-side ----
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        assert self.connector_worker is not None
+        self.connector_worker.register_kv_caches(kv_caches)
+
+    def get_finished(
+        self, finished_req_ids: set[str]
+    ) -> tuple[set[str] | None, set[str] | None]:
+        assert self.connector_worker is not None
+        return self.connector_worker.get_finished()
+
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+        assert self.connector_worker is not None
+        assert isinstance(self._connector_metadata, FlagCXConnectorMetadata)
+        self.connector_worker.start_load_kv(self._connector_metadata)
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        pass
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs,
+    ) -> None:
+        pass
+
+    def wait_for_save(self):
+        pass
+
+class FlagCXConnectorScheduler:
+    def __init__(self, vllm_config: VllmConfig, engine_id: str):
+        self.vllm_config = vllm_config
+        self.engine_id: EngineId = engine_id
+        self.side_channel_host = get_ip()
+        self.side_channel_port = _get_side_channel_port(vllm_config)
+
+        assert vllm_config.kv_transfer_config
+        self.kv_role = vllm_config.kv_transfer_config.kv_role
+        logger.info("FlagCX Connector Scheduler init: %s", engine_id)
+
+        self._reqs_need_recv: dict[ReqId, tuple["Request", list[int]]] = {}
+        self._reqs_need_send: dict[ReqId, list[int]] = {}
+
+    def get_num_new_matched_tokens(
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int, bool]:
+        params = request.kv_transfer_params
+        if params is not None and params.get("do_remote_prefill"):
+            token_ids = request.prompt_token_ids or []
+            count = len(token_ids) - num_computed_tokens
+            if count > 0:
+                return count, True
+        return 0, False
+
+    def update_state_after_alloc(
+        self,
+        request: "Request",
+        blocks: "KVCacheBlocks",
+        num_external_tokens: int,
+    ):
+        params = request.kv_transfer_params
+        if not params:
+            return
+
+        if params.get("do_remote_prefill"):
+            assert self.kv_role != "kv_producer"
+            if all(
+                p in params for p in ("remote_host", "remote_port")
+            ):
+                local_block_ids = (
+                    blocks.get_unhashed_block_ids()
+                    if num_external_tokens > 0
+                    else []
+                )
+                self._reqs_need_recv[request.request_id] = (
+                    request,
+                    local_block_ids,
+                )
+            else:
+                logger.warning("Invalid KVTransferParams: %s", params)
+            params["do_remote_prefill"] = False
+
+        elif params.get("do_remote_decode"):
+            self._reqs_need_send[request.request_id] = []
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        meta = FlagCXConnectorMetadata()
+
+        if self.kv_role != "kv_producer":
+            for req_id, (req, block_ids) in self._reqs_need_recv.items():
+                assert req.kv_transfer_params is not None
+                meta.add_new_req(
+                    request_id=req_id,
+                    local_block_ids=block_ids,
+                    kv_transfer_params=req.kv_transfer_params,
+                )
+            self._reqs_need_recv.clear()
+
+        if self.kv_role != "kv_consumer":
+            for req_id, block_ids in self._reqs_need_send.items():
+                meta.add_new_req(
+                    request_id=req_id,
+                    local_block_ids=block_ids,
+                    kv_transfer_params={},
+                    load_remote_cache=False,
+                )
+            self._reqs_need_send.clear()
+
+        return meta
+
+    def request_finished(
+        self, request: "Request", block_ids: list[int]
+    ) -> tuple[bool, dict[str, Any] | None]:
+        params = request.kv_transfer_params
+        if not params:
+            return False, None
+
+        if params.get("do_remote_prefill"):
+            assert self.kv_role != "kv_producer"
+            self._reqs_need_recv[request.request_id] = (request, [])
+            params["do_remote_prefill"] = False
+            return False, None
+
+        if (
+            not params.get("do_remote_decode")
+            or request.status != RequestStatus.FINISHED_LENGTH_CAPPED
+        ):
+            return False, None
+
+        assert self.kv_role != "kv_consumer"
+        delay_free_blocks = len(block_ids) > 0
+
+        if delay_free_blocks:
+            self._reqs_need_send[request.request_id] = block_ids
+
+        return delay_free_blocks, dict(
+            do_remote_prefill=True,
+            do_remote_decode=False,
+            remote_host=self.side_channel_host,
+            remote_port=self.side_channel_port,
+        )
+
+class FlagCXConnectorWorker:
+    def __init__(self, vllm_config: VllmConfig, engine_id: str):
+        logger.info("FlagCX Connector Worker init: %s", engine_id)
+
+        self.vllm_config = vllm_config
+        self.engine_id: EngineId = engine_id
+        self.hostname = get_ip()
+
+        # ---- FlagCX library ----
+        library_path = os.getenv("FLAGCX_LIB_PATH")
+        if library_path is None:
+            flagcx_path = os.getenv("FLAGCX_PATH", "")
+            library_path = os.path.join(flagcx_path, "build/lib/libflagcx.so")
+        self.flagcx = FLAGCXLibrary(library_path)
+
+        # ---- Per-pair comms (lazily created on first transfer with each peer) ----
+        # key: remote ZMQ address "host:port+tp_rank", value: (comm, my_rank_in_pair)
+        self.pair_comms: dict[str, Any] = {}
+        self.pair_comms_lock = threading.Lock()
+        # KV tensor metadata (base_addr, size) — collected in register_kv_caches,
+        # used to call flagcxOneSideRegister once per pair comm creation.
+        self.kv_tensors_meta: list[tuple[int, int]] = []
+
+        # ---- Side-channel ZMQ port (for block-id metadata) ----
+        self.side_channel_port: int = _get_side_channel_port(vllm_config)
+
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.world_size = get_tensor_model_parallel_world_size()
+        self.tp_group = get_tp_group()
+        self.num_blocks = 0
+
+        assert vllm_config.kv_transfer_config
+        self.kv_role = vllm_config.kv_transfer_config.kv_role
+        self.num_workers = (
+            vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+                "num_workers", 10
+            )
+        )
+
+        self.kv_caches_base_addr: list[int] = []
+        self.device_kv_caches: dict[str, torch.Tensor] = {}
+        self.reqs_need_send: SendReqMeta = SendReqMeta(
+            reqs={}, lock=threading.Lock()
+        )
+
+        # Signal buffer (GPU memory, will be allocated in register_kv_caches)
+        self.signal_buffer: torch.Tensor | None = None
+        self.signal_counter: int = 0  # monotonically increasing
+
+        # Background threads
+        if self.kv_role != "kv_consumer":
+            self._sender_t: threading.Thread | None = None
+            self._sender_executor = ThreadPoolExecutor(
+                max_workers=self.num_workers,
+                thread_name_prefix="vllm-flagcx-sender",
+            )
+        if self.kv_role != "kv_producer":
+            self.receiver_loop = asyncio.new_event_loop()
+            self._receiver_t = threading.Thread(
+                target=self._receiver_loop_fn,
+                args=(self.receiver_loop,),
+                daemon=True,
+            )
+            self._receiver_t.start()
+
+        self.finished_sending_reqs = FinishedSendReqSet(
+            set(), threading.Lock()
+        )
+        self.finished_recving_reqs = FinishedReceiveReqSet(
+            set(), asyncio.Lock()
+        )
+
+        # Attention backend detection
+        self.block_size = vllm_config.cache_config.block_size
+        self.model_config = vllm_config.model_config
+        self.cache_config = vllm_config.cache_config
+        self.use_mla = self.model_config.use_mla
+
+        backend = get_attn_backend(
+            self.model_config.get_head_size(),
+            self.model_config.dtype,
+            self.cache_config.cache_dtype,
+            self.block_size,
+            use_mla=self.use_mla,
+        )
+        self.backend_name = backend.get_name()
+        self.kv_cache_layout = get_kv_cache_layout()
+
+        self._tp_size: dict[EngineId, int] = {self.engine_id: self.world_size}
+        self._block_size: dict[EngineId, int] = {
+            self.engine_id: self.block_size
+        }
+        self.kv_topo = TpKVTopology(
+            tp_rank=self.tp_rank,
+            engine_id=self.engine_id,
+            remote_tp_size=self._tp_size,
+            remote_block_size=self._block_size,
+            is_mla=self.use_mla,
+            total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
+            attn_backend=backend,
+        )
+
+        self.zmq_ctx = zmq.Context()
+        self.async_zmq_ctx = zmq.asyncio.Context()
+        self._encoder = msgspec.msgpack.Encoder()
+        self._decoder = msgspec.msgpack.Decoder(FlagCXAgentMetadata)
+
+    def _register_kv_for_comm(self, comm: Any) -> None:
+        """Register all KV tensors + signal buffer with a newly created
+        per-pair comm.  Both sides call this right after flagcxCommInitRank;
+        the internal AllGather in flagcxOneSideRegister ensures rendezvous."""
+        for base_addr, size in self.kv_tensors_meta:
+            self.flagcx.flagcxOneSideRegister(comm, base_addr, size)
+        assert self.signal_buffer is not None
+        self.flagcx.flagcxOneSideSignalRegister(
+            comm, self.signal_buffer.data_ptr(), self.signal_buffer.nbytes
+        )
+        logger.info(
+            "Registered %d KV MRs + signal buffer for pair comm",
+            len(self.kv_tensors_meta),
+        )
+
+    def _init_pair_comm_responder(
+        self, uid_bytes: bytes, remote_zmq_addr: str
+    ) -> Any:
+        """Prefill side: given uid_bytes from Decode, init pair comm as rank=1.
+        Blocks until both sides have completed CommInitRank + OneSideRegister."""
+        with self.pair_comms_lock:
+            if remote_zmq_addr in self.pair_comms:
+                return self.pair_comms[remote_zmq_addr][0]
+        uid = self.flagcx.unique_id_from_bytes(uid_bytes)
+        uid_ptr = ctypes.POINTER(flagcxUniqueId)(uid)
+        comm = self.flagcx.flagcxCommInitRank(2, uid_ptr, 1)
+        self._register_kv_for_comm(comm)
+        with self.pair_comms_lock:
+            self.pair_comms[remote_zmq_addr] = (comm, 1)
+        logger.info("Pair comm ready (responder/rank=1) ↔ %s", remote_zmq_addr)
+        return comm
+
+    def _finalize_pair_comm_initiator(
+        self, uid: Any, remote_zmq_addr: str
+    ) -> Any:
+        """Decode side: called in executor thread after uid has been sent to
+        Prefill.  Blocks on CommInitRank(rank=0) + OneSideRegister so both
+        sides rendezvous before any PutSignal is issued."""
+        comm = self.flagcx.flagcxCommInitRank(2, uid, 0)
+        self._register_kv_for_comm(comm)
+        with self.pair_comms_lock:
+            self.pair_comms[remote_zmq_addr] = (comm, 0)
+        logger.info("Pair comm ready (initiator/rank=0) ↔ %s", remote_zmq_addr)
+        return comm
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        """Collect KV cache tensor metadata for later per-pair registration.
+
+        flagcxOneSideRegister is NOT called here — it is deferred to
+        _register_kv_for_comm, which is called when each per-pair comm is
+        established so the collective AllGather happens within that pair.
+        """
+        logger.info("Registering KV caches. use_mla: %s", self.use_mla)
+
+        seen_base_addresses: list[int] = []
+        split_k_and_v = self.kv_topo.split_k_and_v
+        tensor_size_bytes = None
+
+        for layer_name, cache_or_caches in kv_caches.items():
+            cache_list = cache_or_caches if split_k_and_v else [cache_or_caches]
+            for cache in cache_list:
+                base_addr = cache.data_ptr()
+                if base_addr in seen_base_addresses:
+                    continue
+                seen_base_addresses.append(base_addr)
+                curr_size = cache.nbytes
+
+                if tensor_size_bytes is None:
+                    tensor_size_bytes = curr_size
+                    self.num_blocks = cache.shape[0]
+
+                assert tensor_size_bytes == curr_size
+                kernel_block_size = cache.shape[-2 if self.use_mla else -3]
+                assert self.block_size == kernel_block_size
+
+                # Defer collective MR registration to per-pair comm creation
+                self.kv_tensors_meta.append((base_addr, curr_size))
+
+        self.kv_caches_base_addr = seen_base_addresses
+
+        assert tensor_size_bytes is not None
+        assert self.num_blocks != 0
+        assert tensor_size_bytes % self.num_blocks == 0
+        self.block_len = tensor_size_bytes // self.num_blocks
+        self.device_kv_caches = kv_caches
+
+        # Allocate signal buffer once; it is registered per pair comm inside
+        # _register_kv_for_comm (one uint64 slot is enough per pair).
+        self.signal_buffer = torch.zeros(1, dtype=torch.int64, device="cuda")
+
+        logger.info(
+            "KV cache metadata collected: %d tensors, num_blocks=%d, "
+            "block_len=%d. flagcxOneSideRegister deferred to pair comm init.",
+            len(seen_base_addresses),
+            self.num_blocks,
+            self.block_len,
+        )
+
+        # Launch sender thread for P nodes
+        if self.kv_role == "kv_consumer":
+            return
+
+        ready_event = threading.Event()
+        self._sender_t = threading.Thread(
+            target=self._sender_thread,
+            args=(ready_event, self.side_channel_port, self.tp_rank),
+            daemon=True,
+            name="flagcx_sender",
+        )
+        self._sender_t.start()
+        ready_event.wait()
+
+    def _sender_thread(
+        self, ready_event: threading.Event, base_port: int, tp_rank: int
+    ):
+        frontend_path = make_zmq_path("tcp", self.hostname, base_port + tp_rank)
+        frontend = make_zmq_socket(self.zmq_ctx, frontend_path, zmq.ROUTER)
+
+        backend_path = make_zmq_path("inproc", str(uuid.uuid4()))
+        backend = make_zmq_socket(self.zmq_ctx, backend_path, zmq.PULL)
+
+        poller = zmq.Poller()
+        poller.register(frontend, zmq.POLLIN)
+        poller.register(backend, zmq.POLLIN)
+
+        ready_event.set()
+
+        try:
+            while True:
+                sockets = dict(poller.poll())
+                if frontend in sockets:
+                    identity, _, metadata_bytes = frontend.recv_multipart()
+                    self._sender_executor.submit(
+                        self._sender_worker, identity, metadata_bytes,
+                        backend_path,
+                    )
+                if backend in sockets:
+                    identity, status = backend.recv_multipart()
+                    frontend.send_multipart((identity, b"", status))
+        except zmq.ContextTerminated:
+            pass
+        except Exception as e:
+            logger.error("FlagCX sender thread error: %s", e)
+        finally:
+            frontend.close()
+            backend.close()
+
+    def _sender_worker(
+        self, identity: bytes, metadata_bytes: bytes,
+        worker_channel_path: str,
+    ):
+        status = TRANS_ERROR
+        try:
+            metadata = self._decoder.decode(metadata_bytes)
+            # First contact from this Decode TP rank: init pair comm before
+            # transferring.  CommInitRank(rank=1) blocks until Decode (rank=0)
+            # also enters it — they rendezvous naturally.
+            if metadata.uid_bytes is not None:
+                remote_zmq_addr = (
+                    f"{metadata.remote_hostname}:"
+                    f"{metadata.remote_port + self.tp_rank}"
+                )
+                self._init_pair_comm_responder(
+                    metadata.uid_bytes, remote_zmq_addr
+                )
+            self._send_kv_to_decode(metadata)
+            status = TRANS_DONE
+        except Exception as e:
+            logger.error("FlagCX sender worker error: %s", e)
+        finally:
+            pusher = make_zmq_socket(
+                self.zmq_ctx, worker_channel_path, zmq.PUSH
+            )
+            try:
+                pusher.send_multipart((identity, status))
+            except zmq.ZMQError as e:
+                logger.warning("ZMQ push error: %s", e)
+            finally:
+                pusher.close()
+
+    def _send_kv_to_decode(self, meta: FlagCXAgentMetadata):
+        send_reqs: list[tuple[ReqId, SendBlockMeta]] = []
+        with self.reqs_need_send.lock:
+            for req_id in meta.request_ids:
+                send_meta = self.reqs_need_send.reqs.get(req_id)
+                if send_meta is None:
+                    logger.warning("Request %s not in reqs_need_send", req_id)
+                    return
+                send_meta.expire_time = float("inf")
+                send_reqs.append((req_id, send_meta))
+
+        self._send_blocks(send_reqs, meta)
+
+        with self.reqs_need_send.lock:
+            for req_id in meta.request_ids:
+                del self.reqs_need_send.reqs[req_id]
+
+        with self.finished_sending_reqs.lock:
+            self.finished_sending_reqs.set.update(meta.request_ids)
+
+    def _send_blocks(
+        self,
+        send_reqs: list[tuple[ReqId, SendBlockMeta]],
+        agent_meta: FlagCXAgentMetadata,
+    ):
+        """RDMA WRITE KV blocks to the remote Decode node using
+        flagcxPutSignal.
+
+        Each layer × block-group → one flagcxPutSignal call.
+        The last call carries a signal increment so the receiver's
+        flagcxWaitSignal unblocks.
+        """
+        local_base_addr = self.kv_caches_base_addr
+        remote_base_addr = agent_meta.kv_caches_base_addr
+        block_len = self.block_len
+
+        # Look up the per-pair comm for this Decode TP rank.
+        remote_zmq_addr = (
+            f"{agent_meta.remote_hostname}:"
+            f"{agent_meta.remote_port + self.tp_rank}"
+        )
+        pair_info = self.pair_comms.get(remote_zmq_addr)
+        if pair_info is None:
+            raise RuntimeError(
+                f"No pair comm for {remote_zmq_addr}; "
+                "uid_bytes must be included in the first metadata message"
+            )
+        comm, my_rank = pair_info
+        peer_rank = 1 - my_rank  # Prefill is rank=1 → peer (Decode) is rank=0
+
+        # Collect (src_offset, dst_offset, size) tuples per layer
+        xfer_list: list[tuple[int, int, int, int, int]] = []
+        # (layer_local_base, layer_remote_base, local_block_start,
+        #  remote_block_start, num_blocks)
+
+        assert len(send_reqs) == len(agent_meta.block_ids)
+        for (req_id, send_meta), remote_block_ids in zip(
+            send_reqs, agent_meta.block_ids
+        ):
+            send_meta.ready.wait()
+
+            num_remote_blocks = len(remote_block_ids)
+            if num_remote_blocks == 0:
+                continue
+
+            local_block_ids = send_meta.local_block_ids
+            num_local_blocks = len(local_block_ids)
+            assert num_local_blocks >= num_remote_blocks
+            if num_local_blocks > num_remote_blocks:
+                local_block_ids = local_block_ids[-num_remote_blocks:]
+
+            group_local, group_remote = _group_contiguous(
+                local_block_ids, remote_block_ids
+            )
+
+            for local_layer_addr, remote_layer_addr in zip(
+                local_base_addr, remote_base_addr
+            ):
+                for grp_local, grp_remote in zip(group_local, group_remote):
+                    xfer_list.append((
+                        local_layer_addr,
+                        remote_layer_addr,
+                        grp_local[0],
+                        grp_remote[0],
+                        len(grp_local),
+                    ))
+
+        if not xfer_list:
+            return
+
+        # Issue PutSignal calls; only the last one carries a signal bump
+        self.signal_counter += 1
+        expected_signal = self.signal_counter
+
+        start_time = time.perf_counter()
+        for i, (
+            local_layer_addr, remote_layer_addr,
+            local_start, remote_start, n_blocks
+        ) in enumerate(xfer_list):
+            src_offset = local_start * block_len
+            dst_offset = remote_start * block_len
+            size = n_blocks * block_len
+            is_last = (i == len(xfer_list) - 1)
+
+            # signal_offset = 0: per-pair signal buffer has a single uint64 slot
+            signal_offset = 0
+            signal_value = expected_signal if is_last else 0
+
+            # For PutSignal we need to express offsets relative to the
+            # registered MR base. Since each layer is a separate MR slot,
+            # we find its mr_index.
+            src_mr_idx = local_base_addr.index(local_layer_addr)
+            dst_mr_idx = remote_base_addr.index(remote_layer_addr)
+
+            self.flagcx.flagcxPutSignal(
+                comm, peer_rank,
+                src_offset, dst_offset, size,
+                signal_offset, src_mr_idx, dst_mr_idx,
+                signal_value,
+            )
+
+        logger.debug(
+            "Sent %d xfers to rank %d, took %.4f s",
+            len(xfer_list),
+            peer_rank,
+            time.perf_counter() - start_time,
+        )
+
+    def _receiver_loop_fn(self, loop: asyncio.AbstractEventLoop):
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    async def _receive_kv(
+        self, path: str, req_blocks: list[tuple[str, list[int]]]
+    ):
+        """Send metadata to Prefiller via ZMQ, requesting it to RDMA-write
+        the KV blocks.  On first contact, includes uid_bytes so Prefill can
+        init the per-pair comm; Decode concurrently calls CommInitRank in an
+        executor so both sides rendezvous without blocking the event loop."""
+        req_ids, block_ids = map(list, zip(*req_blocks))
+
+        # Check if this is the first contact with this Prefill TP rank.
+        with self.pair_comms_lock:
+            need_init = path not in self.pair_comms
+
+        uid: Any = None
+        uid_bytes_to_send: Optional[bytes] = None
+        if need_init:
+            # Generate uid BEFORE sending — Prefill needs it to enter
+            # CommInitRank.  The uid is embedded in the metadata message;
+            # we then immediately kick off CommInitRank(rank=0) in an executor.
+            uid = self.flagcx.flagcxGetUniqueId()
+            uid_bytes_to_send = bytes(uid.contents.internal)
+
+        metadata = FlagCXAgentMetadata(
+            remote_hostname=self.hostname,
+            remote_port=self.side_channel_port,
+            request_ids=req_ids,
+            kv_caches_base_addr=self.kv_caches_base_addr,
+            block_ids=block_ids,
+            uid_bytes=uid_bytes_to_send,
+        )
+
+        encoded_data = self._encoder.encode(metadata)
+
+        sock: zmq.asyncio.Socket = make_zmq_socket(
+            self.async_zmq_ctx, path, zmq.REQ, bind=False, linger=0
+        )
+        sock.setsockopt(zmq.RCVTIMEO, 60000)
+        comm_future = None
+        try:
+            await sock.send(encoded_data)
+            if need_init:
+                # Kick off CommInitRank(rank=0) in a thread pool so the event
+                # loop stays responsive while Prefill's worker thread also
+                # enters CommInitRank(rank=1) upon receiving the message above.
+                loop = asyncio.get_event_loop()
+                comm_future = loop.run_in_executor(
+                    None,
+                    self._finalize_pair_comm_initiator,
+                    uid,
+                    path,
+                )
+            ret_msg = await sock.recv()
+            if ret_msg != TRANS_DONE:
+                logger.error(
+                    "KV transfer error for %s, see prefiller logs", req_ids
+                )
+                return
+            if comm_future is not None:
+                await comm_future  # ensure Decode side also finished registering
+        except zmq.ContextTerminated:
+            return
+        except Exception as e:
+            logger.error("FlagCX receive_kv failed for %s: %s", req_ids, e)
+            return
+        finally:
+            sock.close()
+
+        async with self.finished_recving_reqs.lock:
+            self.finished_recving_reqs.set.update(req_ids)
+
+    def start_load_kv(self, metadata: FlagCXConnectorMetadata):
+        if self.kv_role != "kv_producer":
+            kv_pulls = self._group_kv_pull(metadata)
+            for path, req_blocks in kv_pulls.items():
+                asyncio.run_coroutine_threadsafe(
+                    self._receive_kv(path, req_blocks), self.receiver_loop
+                )
+
+        if self.kv_role != "kv_consumer":
+            with self.reqs_need_send.lock:
+                for req_id, block_ids in metadata.reqs_to_send.items():
+                    if block_ids:
+                        send_meta = self.reqs_need_send.reqs[req_id]
+                        send_meta.local_block_ids = block_ids
+                        send_meta.ready.set()
+                        send_meta.expire_time = (
+                            time.perf_counter()
+                            + envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT
+                        )
+                    else:
+                        self.reqs_need_send.reqs[req_id] = SendBlockMeta(
+                            local_block_ids=[], ready=threading.Event()
+                        )
+
+    def _group_kv_pull(self, metadata: FlagCXConnectorMetadata):
+        kv_pulls: dict[str, list[tuple[str, list[int]]]] = defaultdict(list)
+        for req_id, meta in metadata.reqs_to_recv.items():
+            path = make_zmq_path(
+                "tcp", meta.remote_host, meta.remote_port + self.tp_rank
+            )
+            kv_pulls[path].append((req_id, meta.local_block_ids))
+        return kv_pulls
+
+    async def _fetch_finished_recving(self) -> set[ReqId]:
+        async with self.finished_recving_reqs.lock:
+            result = self.finished_recving_reqs.set
+            self.finished_recving_reqs.set = set()
+        return result
+
+    def get_finished(self) -> tuple[set[str] | None, set[str] | None]:
+        fut = None
+        if self.kv_role != "kv_producer":
+            fut = asyncio.run_coroutine_threadsafe(
+                self._fetch_finished_recving(), self.receiver_loop
+            )
+
+        if self.kv_role != "kv_consumer":
+            with self.finished_sending_reqs.lock:
+                finished_sending = self.finished_sending_reqs.set
+                self.finished_sending_reqs.set = set()
+        else:
+            finished_sending = set()
+
+        finished_recving = fut.result() if fut else set()
+
+        # Expire stale sends
+        now = time.perf_counter()
+        with self.reqs_need_send.lock:
+            expired = [
+                rid
+                for rid, sm in self.reqs_need_send.reqs.items()
+                if sm.expire_time < now
+            ]
+            for rid in expired:
+                logger.warning("Request %s send timed out, freeing blocks", rid)
+                del self.reqs_need_send.reqs[rid]
+            if expired:
+                finished_sending.update(expired)
+
+        return finished_sending or None, finished_recving or None
+
+    def __del__(self):
+        self.shutdown()
+
+    def shutdown(self):
+        self.zmq_ctx.term()
+        self.async_zmq_ctx.term()
+        if self.kv_role != "kv_consumer":
+            self._sender_executor.shutdown(wait=False)
+            if self._sender_t:
+                self._sender_t.join(timeout=2)
+        if self.kv_role != "kv_producer" and self.receiver_loop.is_running():
+            self.receiver_loop.call_soon_threadsafe(self.receiver_loop.stop)
+            self._receiver_t.join(timeout=2)
+
+def _group_contiguous(
+    src_indices: list[int], dst_indices: list[int]
+) -> tuple[list[list[int]], list[list[int]]]:
+    if len(src_indices) == 0:
+        return [], []
+    brk = np.where(
+        (np.diff(src_indices) != 1) | (np.diff(dst_indices) != 1)
+    )[0] + 1
+    src_groups = [g.tolist() for g in np.split(src_indices, brk)]
+    dst_groups = [g.tolist() for g in np.split(dst_indices, brk)]
+    return src_groups, dst_groups
+
+
+def _get_side_channel_port(vllm_config: VllmConfig) -> int:
+    base_port = int(os.getenv("FLAGCX_BOOTSTRAP_PORT", "9998"))
+    return (
+        base_port
+        + vllm_config.parallel_config.data_parallel_rank
+        * vllm_config.parallel_config.tensor_parallel_size
+    )

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -9,7 +9,7 @@ import time
 import uuid
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
 import msgspec
@@ -57,8 +57,6 @@ try:
         flagcxComm_t,
         flagcxStream_t,
         flagcxUniqueId,
-        flagcxOneSideRegister,
-        flagcxOneSideSignalRegister
     )
 except ImportError as e:
     raise ImportError(
@@ -113,6 +111,25 @@ class FinishedSendReqSet:
 class FinishedReceiveReqSet:
     set: set[ReqId]
     lock: asyncio.Lock
+
+@dataclass
+class PendingSignalWait:
+    req_ids: list[ReqId]
+    comm: Any = None
+    peer_rank: int = -1
+    signal_value: int = 0
+    ready: threading.Event = field(default_factory=threading.Event)
+
+@dataclass
+class PairCommInfo:
+    """Per-pair comm state.  Each (Prefill TP rank, Decode TP rank) pair
+    gets its own flagcxComm, signal buffer, and monotonic signal counter
+    so that RDMA signals from different pairs never interfere."""
+    comm: Any
+    my_rank: int
+    signal_counter: int = 0
+    # GPU signal buffer – per-pair to avoid cross-pair RDMA write races.
+    signal_buffer: Optional[torch.Tensor] = None
 
 class FlagCXConnectorMetadata(KVConnectorMetadata):
     def __init__(self):
@@ -208,7 +225,8 @@ class FlagCXConnector(KVConnectorBase_V1):
         self.connector_worker.start_load_kv(self._connector_metadata)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
-        pass
+        if self.connector_worker is not None:
+            self.connector_worker.wait_for_layer_load()
 
     def save_kv_layer(
         self,
@@ -353,8 +371,8 @@ class FlagCXConnectorWorker:
         self.flagcx = FLAGCXLibrary(library_path)
 
         # ---- Per-pair comms (lazily created on first transfer with each peer) ----
-        # key: remote ZMQ address "host:port+tp_rank", value: (comm, my_rank_in_pair)
-        self.pair_comms: dict[str, Any] = {}
+        # key: remote ZMQ address "host:port+tp_rank", value: PairCommInfo
+        self.pair_comms: dict[str, PairCommInfo] = {}
         self.pair_comms_lock = threading.Lock()
         # KV tensor metadata (base_addr, size) — collected in register_kv_caches,
         # used to call flagcxOneSideRegister once per pair comm creation.
@@ -382,10 +400,6 @@ class FlagCXConnectorWorker:
             reqs={}, lock=threading.Lock()
         )
 
-        # Signal buffer (GPU memory, will be allocated in register_kv_caches)
-        self.signal_buffer: torch.Tensor | None = None
-        self.signal_counter: int = 0  # monotonically increasing
-
         # Background threads
         if self.kv_role != "kv_consumer":
             self._sender_t: threading.Thread | None = None
@@ -408,6 +422,10 @@ class FlagCXConnectorWorker:
         self.finished_recving_reqs = FinishedReceiveReqSet(
             set(), asyncio.Lock()
         )
+
+        # Pending GPU-side signal waits for incoming RDMA transfers
+        self._active_signal_waits: list[PendingSignalWait] = []
+        self._active_signal_waits_lock = threading.Lock()
 
         # Attention backend detection
         self.block_size = vllm_config.cache_config.block_size
@@ -444,20 +462,27 @@ class FlagCXConnectorWorker:
         self._encoder = msgspec.msgpack.Encoder()
         self._decoder = msgspec.msgpack.Decoder(FlagCXAgentMetadata)
 
-    def _register_kv_for_comm(self, comm: Any) -> None:
-        """Register all KV tensors + signal buffer with a newly created
-        per-pair comm.  Both sides call this right after flagcxCommInitRank;
-        the internal AllGather in flagcxOneSideRegister ensures rendezvous."""
+    def _register_kv_for_comm(self, comm: Any) -> torch.Tensor:
+        """Register all KV tensors + a fresh per-pair signal buffer with a
+        newly created pair comm.  Both sides call this right after
+        flagcxCommInitRank; the internal AllGather in flagcxOneSideRegister
+        ensures rendezvous.
+
+        Returns the newly allocated per-pair GPU signal buffer (caller must
+        keep a reference to prevent GC)."""
         for base_addr, size in self.kv_tensors_meta:
             self.flagcx.flagcxOneSideRegister(comm, base_addr, size)
-        assert self.signal_buffer is not None
+        # Allocate a *per-pair* signal buffer so different Prefill peers
+        # writing via RDMA never stomp on each other.
+        signal_buffer = torch.zeros(1, dtype=torch.int64, device="cuda")
         self.flagcx.flagcxOneSideSignalRegister(
-            comm, self.signal_buffer.data_ptr(), self.signal_buffer.nbytes
+            comm, signal_buffer.data_ptr(), signal_buffer.nbytes
         )
         logger.info(
-            "Registered %d KV MRs + signal buffer for pair comm",
+            "Registered %d KV MRs + per-pair signal buffer for pair comm",
             len(self.kv_tensors_meta),
         )
+        return signal_buffer
 
     def _init_pair_comm_responder(
         self, uid_bytes: bytes, remote_zmq_addr: str
@@ -466,13 +491,15 @@ class FlagCXConnectorWorker:
         Blocks until both sides have completed CommInitRank + OneSideRegister."""
         with self.pair_comms_lock:
             if remote_zmq_addr in self.pair_comms:
-                return self.pair_comms[remote_zmq_addr][0]
+                return self.pair_comms[remote_zmq_addr].comm
         uid = self.flagcx.unique_id_from_bytes(uid_bytes)
         uid_ptr = ctypes.POINTER(flagcxUniqueId)(uid)
         comm = self.flagcx.flagcxCommInitRank(2, uid_ptr, 1)
-        self._register_kv_for_comm(comm)
+        signal_buffer = self._register_kv_for_comm(comm)
         with self.pair_comms_lock:
-            self.pair_comms[remote_zmq_addr] = (comm, 1)
+            self.pair_comms[remote_zmq_addr] = PairCommInfo(
+                comm=comm, my_rank=1, signal_buffer=signal_buffer,
+            )
         logger.info("Pair comm ready (responder/rank=1) ↔ %s", remote_zmq_addr)
         return comm
 
@@ -483,9 +510,11 @@ class FlagCXConnectorWorker:
         Prefill.  Blocks on CommInitRank(rank=0) + OneSideRegister so both
         sides rendezvous before any PutSignal is issued."""
         comm = self.flagcx.flagcxCommInitRank(2, uid, 0)
-        self._register_kv_for_comm(comm)
+        signal_buffer = self._register_kv_for_comm(comm)
         with self.pair_comms_lock:
-            self.pair_comms[remote_zmq_addr] = (comm, 0)
+            self.pair_comms[remote_zmq_addr] = PairCommInfo(
+                comm=comm, my_rank=0, signal_buffer=signal_buffer,
+            )
         logger.info("Pair comm ready (initiator/rank=0) ↔ %s", remote_zmq_addr)
         return comm
 
@@ -529,10 +558,6 @@ class FlagCXConnectorWorker:
         assert tensor_size_bytes % self.num_blocks == 0
         self.block_len = tensor_size_bytes // self.num_blocks
         self.device_kv_caches = kv_caches
-
-        # Allocate signal buffer once; it is registered per pair comm inside
-        # _register_kv_for_comm (one uint64 slot is enough per pair).
-        self.signal_buffer = torch.zeros(1, dtype=torch.int64, device="cuda")
 
         logger.info(
             "KV cache metadata collected: %d tensors, num_blocks=%d, "
@@ -609,8 +634,8 @@ class FlagCXConnectorWorker:
                 self._init_pair_comm_responder(
                     metadata.uid_bytes, remote_zmq_addr
                 )
-            self._send_kv_to_decode(metadata)
-            status = TRANS_DONE
+            signal = self._send_kv_to_decode(metadata)
+            status = TRANS_DONE + signal.to_bytes(8, 'little')
         except Exception as e:
             logger.error("FlagCX sender worker error: %s", e)
         finally:
@@ -631,11 +656,11 @@ class FlagCXConnectorWorker:
                 send_meta = self.reqs_need_send.reqs.get(req_id)
                 if send_meta is None:
                     logger.warning("Request %s not in reqs_need_send", req_id)
-                    return
+                    return 0
                 send_meta.expire_time = float("inf")
                 send_reqs.append((req_id, send_meta))
 
-        self._send_blocks(send_reqs, meta)
+        signal = self._send_blocks(send_reqs, meta)
 
         with self.reqs_need_send.lock:
             for req_id in meta.request_ids:
@@ -643,6 +668,8 @@ class FlagCXConnectorWorker:
 
         with self.finished_sending_reqs.lock:
             self.finished_sending_reqs.set.update(meta.request_ids)
+
+        return signal
 
     def _send_blocks(
         self,
@@ -671,7 +698,8 @@ class FlagCXConnectorWorker:
                 f"No pair comm for {remote_zmq_addr}; "
                 "uid_bytes must be included in the first metadata message"
             )
-        comm, my_rank = pair_info
+        comm = pair_info.comm
+        my_rank = pair_info.my_rank
         peer_rank = 1 - my_rank  # Prefill is rank=1 → peer (Decode) is rank=0
 
         # Collect (src_offset, dst_offset, size) tuples per layer
@@ -712,11 +740,13 @@ class FlagCXConnectorWorker:
                     ))
 
         if not xfer_list:
-            return
+            return 0
 
-        # Issue PutSignal calls; only the last one carries a signal bump
-        self.signal_counter += 1
-        expected_signal = self.signal_counter
+        # Issue PutSignal calls; only the last one carries a signal bump.
+        # PutSignal is async (queued to rmaProxy); the Decode side will
+        # call flagcxWaitSignal to GPU-wait for the final signal value.
+        pair_info.signal_counter += 1
+        expected_signal = pair_info.signal_counter
 
         start_time = time.perf_counter()
         for i, (
@@ -746,18 +776,22 @@ class FlagCXConnectorWorker:
             )
 
         logger.debug(
-            "Sent %d xfers to rank %d, took %.4f s",
+            "Queued %d async xfers to rank %d (signal=%d), took %.4f s",
             len(xfer_list),
             peer_rank,
+            expected_signal,
             time.perf_counter() - start_time,
         )
+
+        return expected_signal
 
     def _receiver_loop_fn(self, loop: asyncio.AbstractEventLoop):
         asyncio.set_event_loop(loop)
         loop.run_forever()
 
     async def _receive_kv(
-        self, path: str, req_blocks: list[tuple[str, list[int]]]
+        self, path: str, req_blocks: list[tuple[str, list[int]]],
+        pending_wait: PendingSignalWait,
     ):
         """Send metadata to Prefiller via ZMQ, requesting it to RDMA-write
         the KV blocks.  On first contact, includes uid_bytes so Prefill can
@@ -808,13 +842,24 @@ class FlagCXConnectorWorker:
                     path,
                 )
             ret_msg = await sock.recv()
-            if ret_msg != TRANS_DONE:
+            if not ret_msg.startswith(TRANS_DONE):
                 logger.error(
                     "KV transfer error for %s, see prefiller logs", req_ids
                 )
                 return
+            # Parse expected signal value appended by sender
+            signal_bytes = ret_msg[len(TRANS_DONE):]
+            expected_signal = (
+                int.from_bytes(signal_bytes, "little") if signal_bytes else 0
+            )
             if comm_future is not None:
                 await comm_future  # ensure Decode side also finished registering
+            # Fill pending wait so wait_for_layer_load can issue WaitSignal
+            pair_info = self.pair_comms.get(path)
+            if pair_info and expected_signal > 0:
+                pending_wait.comm = pair_info.comm
+                pending_wait.peer_rank = 1 - pair_info.my_rank
+                pending_wait.signal_value = expected_signal
         except zmq.ContextTerminated:
             return
         except Exception as e:
@@ -822,6 +867,7 @@ class FlagCXConnectorWorker:
             return
         finally:
             sock.close()
+            pending_wait.ready.set()
 
         async with self.finished_recving_reqs.lock:
             self.finished_recving_reqs.set.update(req_ids)
@@ -830,8 +876,14 @@ class FlagCXConnectorWorker:
         if self.kv_role != "kv_producer":
             kv_pulls = self._group_kv_pull(metadata)
             for path, req_blocks in kv_pulls.items():
+                pending_wait = PendingSignalWait(
+                    req_ids=[rb[0] for rb in req_blocks],
+                )
+                with self._active_signal_waits_lock:
+                    self._active_signal_waits.append(pending_wait)
                 asyncio.run_coroutine_threadsafe(
-                    self._receive_kv(path, req_blocks), self.receiver_loop
+                    self._receive_kv(path, req_blocks, pending_wait),
+                    self.receiver_loop,
                 )
 
         if self.kv_role != "kv_consumer":
@@ -849,6 +901,30 @@ class FlagCXConnectorWorker:
                         self.reqs_need_send.reqs[req_id] = SendBlockMeta(
                             local_block_ids=[], ready=threading.Event()
                         )
+
+    def wait_for_layer_load(self) -> None:
+        """Issue GPU-side WaitSignal for all pending RDMA receives.
+
+        Called once per forward step from FlagCXConnector.wait_for_layer_load.
+        Drains the active-wait list so subsequent layer calls are no-ops.
+        """
+        with self._active_signal_waits_lock:
+            waits = self._active_signal_waits
+            self._active_signal_waits = []
+        if not waits:
+            return
+        torch_stream = torch.cuda.current_stream()
+        flagcx_stream = self.flagcx.adaptor_stream_copy(torch_stream)
+        try:
+            for w in waits:
+                w.ready.wait(timeout=60)
+                if w.comm is not None and w.signal_value > 0:
+                    self.flagcx.flagcxWaitSignal(
+                        w.comm, w.peer_rank, 0,
+                        w.signal_value, flagcx_stream,
+                    )
+        finally:
+            self.flagcx.adaptor_stream_free(flagcx_stream)
 
     def _group_kv_pull(self, metadata: FlagCXConnectorMetadata):
         kv_pulls: dict[str, list[tuple[str, list[int]]]] = defaultdict(list)

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -18,7 +18,6 @@ import torch
 import zmq
 import zmq.asyncio
 
-from vllm import envs
 from vllm.attention.backends.abstract import AttentionMetadata
 from vllm.attention.selector import get_attn_backend
 from vllm.config import VllmConfig
@@ -130,6 +129,9 @@ class PairCommInfo:
     signal_counter: int = 0
     # GPU signal buffer – per-pair to avoid cross-pair RDMA write races.
     signal_buffer: Optional[torch.Tensor] = None
+    # Serialises counter-increment + PutSignal enqueue so that signal
+    # values always land in monotonic order on the remote signal buffer.
+    send_lock: threading.Lock = field(default_factory=threading.Lock)
 
 class FlagCXConnectorMetadata(KVConnectorMetadata):
     def __init__(self):
@@ -415,6 +417,9 @@ class FlagCXConnectorWorker:
                 daemon=True,
             )
             self._receiver_t.start()
+            # Persistent PUSH sockets keyed by Prefill ZMQ path.
+            # Avoids per-request socket creation + linger=0 message loss.
+            self._push_sockets: dict[str, zmq.asyncio.Socket] = {}
 
         self.finished_sending_reqs = FinishedSendReqSet(
             set(), threading.Lock()
@@ -585,42 +590,24 @@ class FlagCXConnectorWorker:
         self, ready_event: threading.Event, base_port: int, tp_rank: int
     ):
         frontend_path = make_zmq_path("tcp", self.hostname, base_port + tp_rank)
-        frontend = make_zmq_socket(self.zmq_ctx, frontend_path, zmq.ROUTER)
-
-        backend_path = make_zmq_path("inproc", str(uuid.uuid4()))
-        backend = make_zmq_socket(self.zmq_ctx, backend_path, zmq.PULL)
-
-        poller = zmq.Poller()
-        poller.register(frontend, zmq.POLLIN)
-        poller.register(backend, zmq.POLLIN)
+        frontend = make_zmq_socket(self.zmq_ctx, frontend_path, zmq.PULL)
 
         ready_event.set()
 
         try:
             while True:
-                sockets = dict(poller.poll())
-                if frontend in sockets:
-                    identity, _, metadata_bytes = frontend.recv_multipart()
-                    self._sender_executor.submit(
-                        self._sender_worker, identity, metadata_bytes,
-                        backend_path,
-                    )
-                if backend in sockets:
-                    identity, status = backend.recv_multipart()
-                    frontend.send_multipart((identity, b"", status))
+                metadata_bytes = frontend.recv()
+                self._sender_executor.submit(
+                    self._sender_worker, metadata_bytes,
+                )
         except zmq.ContextTerminated:
             pass
         except Exception as e:
             logger.error("FlagCX sender thread error: %s", e)
         finally:
             frontend.close()
-            backend.close()
 
-    def _sender_worker(
-        self, identity: bytes, metadata_bytes: bytes,
-        worker_channel_path: str,
-    ):
-        status = TRANS_ERROR
+    def _sender_worker(self, metadata_bytes: bytes):
         try:
             metadata = self._decoder.decode(metadata_bytes)
             # First contact from this Decode TP rank: init pair comm before
@@ -634,33 +621,38 @@ class FlagCXConnectorWorker:
                 self._init_pair_comm_responder(
                     metadata.uid_bytes, remote_zmq_addr
                 )
-            signal = self._send_kv_to_decode(metadata)
-            status = TRANS_DONE + signal.to_bytes(8, 'little')
+            self._send_kv_to_decode(metadata)
         except Exception as e:
             logger.error("FlagCX sender worker error: %s", e)
-        finally:
-            pusher = make_zmq_socket(
-                self.zmq_ctx, worker_channel_path, zmq.PUSH
-            )
-            try:
-                pusher.send_multipart((identity, status))
-            except zmq.ZMQError as e:
-                logger.warning("ZMQ push error: %s", e)
-            finally:
-                pusher.close()
 
     def _send_kv_to_decode(self, meta: FlagCXAgentMetadata):
         send_reqs: list[tuple[ReqId, SendBlockMeta]] = []
-        with self.reqs_need_send.lock:
-            for req_id in meta.request_ids:
-                send_meta = self.reqs_need_send.reqs.get(req_id)
-                if send_meta is None:
-                    logger.warning("Request %s not in reqs_need_send", req_id)
-                    return 0
-                send_meta.expire_time = float("inf")
-                send_reqs.append((req_id, send_meta))
+        # The Decode ZMQ request may arrive before the scheduler metadata
+        # reaches start_load_kv(), so poll with a timeout instead of
+        # returning immediately.
+        deadline = time.perf_counter() + 30  # 30s timeout
+        while True:
+            with self.reqs_need_send.lock:
+                all_found = True
+                for req_id in meta.request_ids:
+                    if req_id not in self.reqs_need_send.reqs:
+                        all_found = False
+                        break
+                if all_found:
+                    for req_id in meta.request_ids:
+                        send_meta = self.reqs_need_send.reqs[req_id]
+                        send_meta.expire_time = float("inf")
+                        send_reqs.append((req_id, send_meta))
+                    break
+            if time.perf_counter() > deadline:
+                logger.warning(
+                    "Timed out waiting for reqs_need_send: %s",
+                    meta.request_ids,
+                )
+                return 0
+            time.sleep(0.01)
 
-        signal = self._send_blocks(send_reqs, meta)
+        self._send_blocks(send_reqs, meta)
 
         with self.reqs_need_send.lock:
             for req_id in meta.request_ids:
@@ -668,8 +660,6 @@ class FlagCXConnectorWorker:
 
         with self.finished_sending_reqs.lock:
             self.finished_sending_reqs.set.update(meta.request_ids)
-
-        return signal
 
     def _send_blocks(
         self,
@@ -742,38 +732,41 @@ class FlagCXConnectorWorker:
         if not xfer_list:
             return 0
 
-        # Issue PutSignal calls; only the last one carries a signal bump.
-        # PutSignal is async (queued to rmaProxy); the Decode side will
-        # call flagcxWaitSignal to GPU-wait for the final signal value.
-        pair_info.signal_counter += 1
-        expected_signal = pair_info.signal_counter
+        # Serialise counter-increment AND all PutSignal enqueues under the
+        # per-pair send_lock.  This guarantees that RDMA signal writes land
+        # in monotonic order on the remote signal buffer — otherwise a
+        # higher signal value could be overwritten by a lower one from a
+        # concurrent thread, causing cuStreamWaitValue64(GEQ) to deadlock.
+        with pair_info.send_lock:
+            pair_info.signal_counter += 1
+            expected_signal = pair_info.signal_counter
 
-        start_time = time.perf_counter()
-        for i, (
-            local_layer_addr, remote_layer_addr,
-            local_start, remote_start, n_blocks
-        ) in enumerate(xfer_list):
-            src_offset = local_start * block_len
-            dst_offset = remote_start * block_len
-            size = n_blocks * block_len
-            is_last = (i == len(xfer_list) - 1)
+            start_time = time.perf_counter()
+            for i, (
+                local_layer_addr, remote_layer_addr,
+                local_start, remote_start, n_blocks
+            ) in enumerate(xfer_list):
+                src_offset = local_start * block_len
+                dst_offset = remote_start * block_len
+                size = n_blocks * block_len
+                is_last = (i == len(xfer_list) - 1)
 
-            # signal_offset = 0: per-pair signal buffer has a single uint64 slot
-            signal_offset = 0
-            signal_value = expected_signal if is_last else 0
+                # signal_offset = 0: per-pair signal buffer has a single uint64 slot
+                signal_offset = 0
+                signal_value = expected_signal if is_last else 0
 
-            # For PutSignal we need to express offsets relative to the
-            # registered MR base. Since each layer is a separate MR slot,
-            # we find its mr_index.
-            src_mr_idx = local_base_addr.index(local_layer_addr)
-            dst_mr_idx = remote_base_addr.index(remote_layer_addr)
+                # For PutSignal we need to express offsets relative to the
+                # registered MR base. Since each layer is a separate MR slot,
+                # we find its mr_index.
+                src_mr_idx = local_base_addr.index(local_layer_addr)
+                dst_mr_idx = remote_base_addr.index(remote_layer_addr)
 
-            self.flagcx.flagcxPutSignal(
-                comm, peer_rank,
-                src_offset, dst_offset, size,
-                signal_offset, src_mr_idx, dst_mr_idx,
-                signal_value,
-            )
+                self.flagcx.flagcxPutSignal(
+                    comm, peer_rank,
+                    src_offset, dst_offset, size,
+                    signal_offset, src_mr_idx, dst_mr_idx,
+                    signal_value,
+                )
 
         logger.debug(
             "Queued %d async xfers to rank %d (signal=%d), took %.4f s",
@@ -823,10 +816,16 @@ class FlagCXConnectorWorker:
 
         encoded_data = self._encoder.encode(metadata)
 
-        sock: zmq.asyncio.Socket = make_zmq_socket(
-            self.async_zmq_ctx, path, zmq.REQ, bind=False, linger=0
-        )
-        sock.setsockopt(zmq.RCVTIMEO, 60000)
+        # Use a persistent PUSH socket per Prefill peer.  Creating a new
+        # socket per request with linger=0 risks dropping messages if the
+        # TCP connection hasn't been established before the socket is closed.
+        sock = self._push_sockets.get(path)
+        if sock is None:
+            sock = make_zmq_socket(
+                self.async_zmq_ctx, path, zmq.PUSH, bind=False
+            )
+            self._push_sockets[path] = sock
+
         comm_future = None
         try:
             await sock.send(encoded_data)
@@ -841,32 +840,23 @@ class FlagCXConnectorWorker:
                     uid,
                     path,
                 )
-            ret_msg = await sock.recv()
-            if not ret_msg.startswith(TRANS_DONE):
-                logger.error(
-                    "KV transfer error for %s, see prefiller logs", req_ids
-                )
-                return
-            # Parse expected signal value appended by sender
-            signal_bytes = ret_msg[len(TRANS_DONE):]
-            expected_signal = (
-                int.from_bytes(signal_bytes, "little") if signal_bytes else 0
-            )
             if comm_future is not None:
                 await comm_future  # ensure Decode side also finished registering
-            # Fill pending wait so wait_for_layer_load can issue WaitSignal
+            # Decode tracks signal counter locally — no need to wait for
+            # Prefill's ZMQ reply.  flagcxWaitSignal on the GPU side will
+            # block until the RDMA PutSignal from Prefill lands.
             pair_info = self.pair_comms.get(path)
-            if pair_info and expected_signal > 0:
+            if pair_info:
+                pair_info.signal_counter += 1
                 pending_wait.comm = pair_info.comm
                 pending_wait.peer_rank = 1 - pair_info.my_rank
-                pending_wait.signal_value = expected_signal
+                pending_wait.signal_value = pair_info.signal_counter
         except zmq.ContextTerminated:
             return
         except Exception as e:
             logger.error("FlagCX receive_kv failed for %s: %s", req_ids, e)
             return
         finally:
-            sock.close()
             pending_wait.ready.set()
 
         async with self.finished_recving_reqs.lock:
@@ -895,7 +885,7 @@ class FlagCXConnectorWorker:
                         send_meta.ready.set()
                         send_meta.expire_time = (
                             time.perf_counter()
-                            + envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT
+                            + 480
                         )
                     else:
                         self.reqs_need_send.reqs[req_id] = SendBlockMeta(
@@ -977,6 +967,9 @@ class FlagCXConnectorWorker:
         self.shutdown()
 
     def shutdown(self):
+        if self.kv_role != "kv_producer":
+            for sock in getattr(self, '_push_sockets', {}).values():
+                sock.close()
         self.zmq_ctx.term()
         self.async_zmq_ctx.term()
         if self.kv_role != "kv_consumer":
@@ -1001,7 +994,7 @@ def _group_contiguous(
 
 
 def _get_side_channel_port(vllm_config: VllmConfig) -> int:
-    base_port = int(os.getenv("FLAGCX_BOOTSTRAP_PORT", "9998"))
+    base_port = int(os.getenv("FLAGCX_BOOTSTRAP_PORT", "8998"))
     return (
         base_port
         + vllm_config.parallel_config.data_parallel_rank

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -19,6 +19,7 @@ import zmq
 import zmq.asyncio
 
 from vllm.attention.backends.abstract import AttentionMetadata
+from vllm.utils.torch_utils import current_stream
 from vllm.attention.selector import get_attn_backend
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import TpKVTopology
@@ -68,6 +69,10 @@ ReqId = str
 
 logger = init_logger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# ZMQ message: Decode → Prefill (request KV transfer)
+# ---------------------------------------------------------------------------
 class FlagCXAgentMetadata(
     msgspec.Struct,
     omit_defaults=True,  # type: ignore[call-arg]
@@ -79,13 +84,17 @@ class FlagCXAgentMetadata(
     request_ids: list[ReqId]
     kv_caches_base_addr: list[int]
     block_ids: list[list[int]]
-    uid_bytes: Optional[bytes] = None  # set on first contact to init pair comm
 
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
 @dataclass
 class RecvReqMeta:
     local_block_ids: list[int]
     remote_host: str
     remote_port: int
+
 
 @dataclass
 class SendBlockMeta:
@@ -93,20 +102,24 @@ class SendBlockMeta:
     ready: threading.Event
     expire_time: float = float("inf")
 
+
 @dataclass
 class SendReqMeta:
     reqs: dict[ReqId, SendBlockMeta]
     lock: threading.Lock
+
 
 @dataclass
 class FinishedSendReqSet:
     set: set[ReqId]
     lock: threading.Lock
 
+
 @dataclass
 class FinishedReceiveReqSet:
     set: set[ReqId]
     lock: asyncio.Lock
+
 
 @dataclass
 class PendingSignalWait:
@@ -116,20 +129,20 @@ class PendingSignalWait:
     signal_value: int = 0
     ready: threading.Event = field(default_factory=threading.Event)
 
+
 @dataclass
 class PairCommInfo:
-    """Per-pair comm state.  Each (Prefill TP rank, Decode TP rank) pair
-    gets its own flagcxComm, signal buffer, and monotonic signal counter
-    so that RDMA signals from different pairs never interfere."""
+    """Per-pair comm state."""
     comm: Any
     my_rank: int
     signal_counter: int = 0
-    # GPU signal buffer – per-pair to avoid cross-pair RDMA write races.
     signal_buffer: Optional[torch.Tensor] = None
-    # Serialises counter-increment + PutSignal enqueue so that signal
-    # values always land in monotonic order on the remote signal buffer.
     send_lock: threading.Lock = field(default_factory=threading.Lock)
 
+
+# ---------------------------------------------------------------------------
+# Connector metadata
+# ---------------------------------------------------------------------------
 class FlagCXConnectorMetadata(KVConnectorMetadata):
     def __init__(self):
         self.reqs_to_recv: dict[ReqId, RecvReqMeta] = {}
@@ -151,6 +164,10 @@ class FlagCXConnectorMetadata(KVConnectorMetadata):
         else:
             self.reqs_to_send[request_id] = local_block_ids
 
+
+# ===================================================================
+# FlagCXConnector  (thin delegation layer — unchanged)
+# ===================================================================
 class FlagCXConnector(KVConnectorBase_V1):
     def __init__(
         self,
@@ -239,6 +256,10 @@ class FlagCXConnector(KVConnectorBase_V1):
     def wait_for_save(self):
         pass
 
+
+# ===================================================================
+# FlagCXConnectorScheduler  (unchanged)
+# ===================================================================
 class FlagCXConnectorScheduler:
     def __init__(self, vllm_config: VllmConfig, engine_id: str):
         self.vllm_config = vllm_config
@@ -354,7 +375,23 @@ class FlagCXConnectorScheduler:
             remote_port=self.side_channel_port,
         )
 
+
+# ===================================================================
+# FlagCXConnectorWorker  (REWRITTEN — NCCL-style comm init)
+# ===================================================================
 class FlagCXConnectorWorker:
+    """Worker-side logic for FlagCX PD disaggregation.
+
+    Comm init follows the P2pNccl "endpoint" pattern:
+      - Prefill (sender) is the initiator: on first send to a Decode peer,
+        generates a uid, sends it via ZMQ DEALER→ROUTER, then both sides
+        call flagcxCommInitRank(2, uid, rank) simultaneously.
+      - Decode (receiver) runs a ROUTER listener thread that handles the
+        "NEW" handshake command.
+    This avoids the previous Decode-initiated async comm init that could
+    deadlock and leave requests stuck in WAITING_FOR_REMOTE_KVS.
+    """
+
     def __init__(self, vllm_config: VllmConfig, engine_id: str):
         logger.info("FlagCX Connector Worker init: %s", engine_id)
 
@@ -370,20 +407,12 @@ class FlagCXConnectorWorker:
         self.flagcx = FLAGCXLibrary(library_path)
         self.cuda_device_index = torch.cuda.current_device()
 
-        # ---- Per-pair comms (lazily created on first transfer with each peer) ----
-        # key: remote ZMQ address "host:port+tp_rank", value: PairCommInfo
+        # ---- Per-pair comms (lazily created on first transfer) ----
         self.pair_comms: dict[str, PairCommInfo] = {}
         self.pair_comms_lock = threading.Lock()
-        # Guards against concurrent pair-comm init for the same path.
-        # Prefill (sync threads) uses threading.Event barriers;
-        # Decode (async coroutines) uses asyncio.Event barriers.
-        self._pair_comm_init_barriers: dict[str, threading.Event] = {}
-        self._pair_comm_init_events: dict[str, asyncio.Event] = {}
-        # KV tensor metadata (base_addr, size) — collected in register_kv_caches,
-        # used to call flagcxOneSideRegister once per pair comm creation.
         self.kv_tensors_meta: list[tuple[int, int]] = []
 
-        # ---- Side-channel ZMQ port (for block-id metadata) ----
+        # ---- Side-channel ZMQ port ----
         self.side_channel_port: int = _get_side_channel_port(vllm_config)
 
         self.tp_rank = get_tensor_model_parallel_rank()
@@ -405,14 +434,21 @@ class FlagCXConnectorWorker:
             reqs={}, lock=threading.Lock()
         )
 
-        # Background threads
+        # ---- Prefill (sender) background threads ----
         if self.kv_role != "kv_consumer":
             self._sender_t: threading.Thread | None = None
             self._sender_executor = ThreadPoolExecutor(
                 max_workers=self.num_workers,
                 thread_name_prefix="vllm-flagcx-sender",
+                initializer=torch.cuda.set_device,
+                initargs=(self.cuda_device_index,),
             )
+
+        # ---- Decode (receiver) background threads ----
         if self.kv_role != "kv_producer":
+            # Listener thread for comm init handshake from Prefill
+            self._decode_listener_t: threading.Thread | None = None
+            # Async event loop for _receive_kv coroutines
             self.receiver_loop = asyncio.new_event_loop()
             self._receiver_t = threading.Thread(
                 target=self._receiver_loop_fn,
@@ -420,9 +456,6 @@ class FlagCXConnectorWorker:
                 daemon=True,
             )
             self._receiver_t.start()
-            # Persistent PUSH sockets keyed by Prefill ZMQ path.
-            # Avoids per-request socket creation + linger=0 message loss.
-            self._push_sockets: dict[str, zmq.asyncio.Socket] = {}
 
         self.finished_sending_reqs = FinishedSendReqSet(
             set(), threading.Lock()
@@ -431,11 +464,10 @@ class FlagCXConnectorWorker:
             set(), asyncio.Lock()
         )
 
-        # Pending GPU-side signal waits for incoming RDMA transfers
         self._active_signal_waits: list[PendingSignalWait] = []
         self._active_signal_waits_lock = threading.Lock()
 
-        # Attention backend detection
+        # ---- Attention backend detection ----
         self.block_size = vllm_config.cache_config.block_size
         self.model_config = vllm_config.model_config
         self.cache_config = vllm_config.cache_config
@@ -470,17 +502,15 @@ class FlagCXConnectorWorker:
         self._encoder = msgspec.msgpack.Encoder()
         self._decoder = msgspec.msgpack.Decoder(FlagCXAgentMetadata)
 
+    # ------------------------------------------------------------------
+    # Utility
+    # ------------------------------------------------------------------
     def _ensure_cuda_device(self) -> None:
-        """Background threads start with their own CUDA current-device state.
-
-        Pair-comm init and signal-buffer allocation must happen on the same
-        device as the worker process, otherwise later stream waits may target a
-        signal address from another GPU.
-        """
         current = torch.cuda.current_device()
         if current != self.cuda_device_index:
             logger.warning(
-                "Switching CUDA device in background thread: current=%d target=%d",
+                "Switching CUDA device in background thread: "
+                "current=%d target=%d",
                 current,
                 self.cuda_device_index,
             )
@@ -492,99 +522,141 @@ class FlagCXConnectorWorker:
         return hex(value) if value is not None else "0x0"
 
     def _register_kv_for_comm(self, comm: Any) -> torch.Tensor:
-        """Register all KV tensors + a fresh per-pair signal buffer with a
-        newly created pair comm.  Both sides call this right after
-        flagcxCommInitRank; the internal AllGather in flagcxOneSideRegister
-        ensures rendezvous.
-
-        Returns the newly allocated per-pair GPU signal buffer (caller must
-        keep a reference to prevent GC)."""
+        """Register KV MRs + signal buffer. Both sides must call this
+        after flagcxCommInitRank (internal AllGather for rendezvous)."""
         self._ensure_cuda_device()
         for base_addr, size in self.kv_tensors_meta:
             self.flagcx.flagcxOneSideRegister(comm, base_addr, size)
-        # Allocate a *per-pair* signal buffer so different Prefill peers
-        # writing via RDMA never stomp on each other.
         signal_buffer = torch.zeros(1, dtype=torch.int64, device="cuda")
         self.flagcx.flagcxOneSideSignalRegister(
             comm, signal_buffer.data_ptr(), signal_buffer.nbytes
         )
         logger.info(
-            "Registered %d KV MRs + per-pair signal buffer for pair comm=%s "
-            "(signal_ptr=%s, signal_device=%s, current_device=%d)",
+            "Registered %d KV MRs + signal buffer for comm=%s "
+            "(signal_ptr=%s, device=%s)",
             len(self.kv_tensors_meta),
             self._comm_repr(comm),
             hex(signal_buffer.data_ptr()),
             signal_buffer.device,
-            torch.cuda.current_device(),
         )
         return signal_buffer
 
-    def _init_pair_comm_responder(
-        self, uid_bytes: bytes, remote_zmq_addr: str
-    ) -> Any:
-        """Prefill side: given uid_bytes from Decode, init pair comm as rank=1.
-        Blocks until both sides have completed CommInitRank + OneSideRegister.
-        Only the first caller per remote_zmq_addr creates the comm; concurrent
-        callers block on a barrier until init finishes."""
+    # ------------------------------------------------------------------
+    # Comm init: Prefill side (initiator, rank=0)
+    # Called from _sender_worker on first send to a Decode peer.
+    # Pattern: P2pNcclEngine.create_connect
+    # ------------------------------------------------------------------
+    def _create_pair_comm(self, decode_listener_addr: str) -> PairCommInfo:
+        """Prefill side: create pair comm to a Decode peer.
+        Sends uid via ZMQ DEALER→ROUTER, then both sides call
+        flagcxCommInitRank simultaneously."""
         with self.pair_comms_lock:
-            if remote_zmq_addr in self.pair_comms:
-                return self.pair_comms[remote_zmq_addr].comm
-            barrier = self._pair_comm_init_barriers.get(remote_zmq_addr)
-            if barrier is not None:
-                # Another thread is already initializing — wait for it.
-                is_initializer = False
-            else:
-                is_initializer = True
-                barrier = threading.Event()
-                self._pair_comm_init_barriers[remote_zmq_addr] = barrier
+            existing = self.pair_comms.get(decode_listener_addr)
+            if existing is not None:
+                return existing
 
-        if not is_initializer:
-            barrier.wait()
-            with self.pair_comms_lock:
-                return self.pair_comms[remote_zmq_addr].comm
-
-        try:
-            self._ensure_cuda_device()
-            uid = self.flagcx.unique_id_from_bytes(uid_bytes)
-            uid_ptr = ctypes.POINTER(flagcxUniqueId)(uid)
-            comm = self.flagcx.flagcxCommInitRank(2, uid_ptr, 1)
-            signal_buffer = self._register_kv_for_comm(comm)
-            with self.pair_comms_lock:
-                self.pair_comms[remote_zmq_addr] = PairCommInfo(
-                    comm=comm, my_rank=1, signal_buffer=signal_buffer,
-                )
-            logger.info(
-                "Pair comm ready (responder/rank=1) ↔ %s", remote_zmq_addr
-            )
-            return comm
-        finally:
-            barrier.set()
-            with self.pair_comms_lock:
-                self._pair_comm_init_barriers.pop(remote_zmq_addr, None)
-
-    def _finalize_pair_comm_initiator(
-        self, uid: Any, remote_zmq_addr: str
-    ) -> Any:
-        """Decode side: called in executor thread after uid has been sent to
-        Prefill.  Blocks on CommInitRank(rank=0) + OneSideRegister so both
-        sides rendezvous before any PutSignal is issued."""
         self._ensure_cuda_device()
+
+        # 1. Generate uid
+        uid = self.flagcx.flagcxGetUniqueId()
+        uid_bytes = bytes(uid.contents.internal)
+
+        # 2. Send NEW handshake to Decode listener via ZMQ DEALER
+        my_identity = (
+            f"{self.hostname}:{self.side_channel_port + self.tp_rank}"
+        )
+        sock = self.zmq_ctx.socket(zmq.DEALER)
+        sock.setsockopt_string(zmq.IDENTITY, my_identity)
+        sock.connect(f"tcp://{decode_listener_addr}")
+        sock.send(msgspec.msgpack.encode({
+            "cmd": "NEW",
+            "uid": uid_bytes,
+        }))
+
+        # 3. flagcxCommInitRank(rank=0) — blocks until Decode also calls
         comm = self.flagcx.flagcxCommInitRank(2, uid, 0)
         signal_buffer = self._register_kv_for_comm(comm)
+
+        # 4. Wait for Decode to confirm registration is done
+        reply = sock.recv()
+        sock.close()
+
+        pair_info = PairCommInfo(
+            comm=comm, my_rank=0, signal_buffer=signal_buffer,
+        )
         with self.pair_comms_lock:
-            self.pair_comms[remote_zmq_addr] = PairCommInfo(
-                comm=comm, my_rank=0, signal_buffer=signal_buffer,
-            )
-        logger.info("Pair comm ready (initiator/rank=0) ↔ %s", remote_zmq_addr)
-        return comm
+            self.pair_comms[decode_listener_addr] = pair_info
 
+        logger.info(
+            "Pair comm ready (Prefill/rank=0) ↔ %s", decode_listener_addr
+        )
+        return pair_info
+
+    # ------------------------------------------------------------------
+    # Comm init: Decode side (responder, rank=1)
+    # Runs in _decode_listener_thread, handles NEW from Prefill.
+    # Pattern: P2pNcclEngine.listen_for_requests (NEW branch)
+    # ------------------------------------------------------------------
+    def _decode_listener_thread(
+        self, ready_event: threading.Event, base_port: int, tp_rank: int
+    ):
+        """Decode side: ROUTER listener for comm init handshakes."""
+        listen_path = make_zmq_path(
+            "tcp", self.hostname, base_port + tp_rank
+        )
+        router = make_zmq_socket(self.zmq_ctx, listen_path, zmq.ROUTER)
+        logger.info("Decode listener started on %s", listen_path)
+        ready_event.set()
+
+        poller = zmq.Poller()
+        poller.register(router, zmq.POLLIN)
+
+        try:
+            while True:
+                socks = dict(poller.poll())
+                if router not in socks:
+                    continue
+
+                identity, msg = router.recv_multipart()
+                data = msgspec.msgpack.decode(msg)
+
+                if data.get(b"cmd") == b"NEW" or data.get("cmd") == "NEW":
+                    uid_bytes = data.get(b"uid") or data.get("uid")
+                    self._ensure_cuda_device()
+
+                    uid = self.flagcx.unique_id_from_bytes(uid_bytes)
+                    uid_ptr = ctypes.POINTER(flagcxUniqueId)(uid)
+                    comm = self.flagcx.flagcxCommInitRank(2, uid_ptr, 1)
+                    signal_buffer = self._register_kv_for_comm(comm)
+
+                    remote_addr = identity.decode()
+                    pair_info = PairCommInfo(
+                        comm=comm, my_rank=1, signal_buffer=signal_buffer,
+                    )
+                    with self.pair_comms_lock:
+                        self.pair_comms[remote_addr] = pair_info
+
+                    # Reply OK so Prefill knows registration is done
+                    router.send_multipart([identity, b"OK"])
+                    logger.info(
+                        "Pair comm ready (Decode/rank=1) ↔ %s", remote_addr
+                    )
+                else:
+                    logger.warning(
+                        "Decode listener: unknown cmd from %s: %s",
+                        identity, data,
+                    )
+        except zmq.ContextTerminated:
+            pass
+        except Exception as e:
+            logger.error("Decode listener error: %s", e)
+        finally:
+            router.close()
+
+    # ------------------------------------------------------------------
+    # register_kv_caches
+    # ------------------------------------------------------------------
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        """Collect KV cache tensor metadata for later per-pair registration.
-
-        flagcxOneSideRegister is NOT called here — it is deferred to
-        _register_kv_for_comm, which is called when each per-pair comm is
-        established so the collective AllGather happens within that pair.
-        """
         logger.info("Registering KV caches. use_mla: %s", self.use_mla)
 
         seen_base_addresses: list[int] = []
@@ -592,7 +664,9 @@ class FlagCXConnectorWorker:
         tensor_size_bytes = None
 
         for layer_name, cache_or_caches in kv_caches.items():
-            cache_list = cache_or_caches if split_k_and_v else [cache_or_caches]
+            cache_list = (
+                cache_or_caches if split_k_and_v else [cache_or_caches]
+            )
             for cache in cache_list:
                 base_addr = cache.data_ptr()
                 if base_addr in seen_base_addresses:
@@ -605,10 +679,10 @@ class FlagCXConnectorWorker:
                     self.num_blocks = cache.shape[0]
 
                 assert tensor_size_bytes == curr_size
-                kernel_block_size = cache.shape[-2 if self.use_mla else -3]
+                kernel_block_size = cache.shape[
+                    -2 if self.use_mla else -3
+                ]
                 assert self.block_size == kernel_block_size
-
-                # Defer collective MR registration to per-pair comm creation
                 self.kv_tensors_meta.append((base_addr, curr_size))
 
         self.kv_caches_base_addr = seen_base_addresses
@@ -621,79 +695,125 @@ class FlagCXConnectorWorker:
 
         logger.info(
             "KV cache metadata collected: %d tensors, num_blocks=%d, "
-            "block_len=%d. flagcxOneSideRegister deferred to pair comm init.",
+            "block_len=%d.",
             len(seen_base_addresses),
             self.num_blocks,
             self.block_len,
         )
 
-        # Launch sender thread for P nodes
-        if self.kv_role == "kv_consumer":
-            return
+        # Launch Prefill sender thread (PULL socket for Decode requests)
+        if self.kv_role != "kv_consumer":
+            ready_event = threading.Event()
+            self._sender_t = threading.Thread(
+                target=self._sender_thread,
+                args=(ready_event, self.side_channel_port, self.tp_rank),
+                daemon=True,
+                name="flagcx_sender",
+            )
+            self._sender_t.start()
+            ready_event.wait()
 
-        ready_event = threading.Event()
-        self._sender_t = threading.Thread(
-            target=self._sender_thread,
-            args=(ready_event, self.side_channel_port, self.tp_rank),
-            daemon=True,
-            name="flagcx_sender",
-        )
-        self._sender_t.start()
-        ready_event.wait()
+        # Launch Decode listener thread (ROUTER for comm init handshakes)
+        if self.kv_role != "kv_producer":
+            ready_event = threading.Event()
+            self._decode_listener_t = threading.Thread(
+                target=self._decode_listener_thread,
+                args=(ready_event, self.side_channel_port, self.tp_rank),
+                daemon=True,
+                name="flagcx_decode_listener",
+            )
+            self._decode_listener_t.start()
+            ready_event.wait()
 
+    # ------------------------------------------------------------------
+    # Prefill sender thread + worker
+    # ------------------------------------------------------------------
     def _sender_thread(
         self, ready_event: threading.Event, base_port: int, tp_rank: int
     ):
-        frontend_path = make_zmq_path("tcp", self.hostname, base_port + tp_rank)
-        frontend = make_zmq_socket(self.zmq_ctx, frontend_path, zmq.PULL)
+        """Prefill sender: ROUTER socket receives requests from Decode,
+        dispatches to thread pool, and relays replies (signal value)."""
+        frontend_path = make_zmq_path(
+            "tcp", self.hostname, base_port + tp_rank
+        )
+        frontend = make_zmq_socket(
+            self.zmq_ctx, frontend_path, zmq.ROUTER
+        )
+
+        backend_path = make_zmq_path("inproc", str(uuid.uuid4()))
+        backend = make_zmq_socket(self.zmq_ctx, backend_path, zmq.PULL)
+
+        poller = zmq.Poller()
+        poller.register(frontend, zmq.POLLIN)
+        poller.register(backend, zmq.POLLIN)
 
         ready_event.set()
 
         try:
             while True:
-                metadata_bytes = frontend.recv()
-                self._sender_executor.submit(
-                    self._sender_worker, metadata_bytes,
-                )
+                sockets = dict(poller.poll())
+
+                if frontend in sockets:
+                    identity, _, metadata_bytes = frontend.recv_multipart()
+                    self._sender_executor.submit(
+                        self._sender_worker,
+                        identity,
+                        metadata_bytes,
+                        backend_path,
+                    )
+
+                if backend in sockets:
+                    # Relay reply from worker thread back to Decode
+                    identity, reply = backend.recv_multipart()
+                    frontend.send_multipart([identity, b"", reply])
+
         except zmq.ContextTerminated:
             pass
         except Exception as e:
             logger.error("FlagCX sender thread error: %s", e)
         finally:
             frontend.close()
+            backend.close()
 
-    def _sender_worker(self, metadata_bytes: bytes):
+    def _sender_worker(
+        self,
+        identity: bytes,
+        metadata_bytes: bytes,
+        worker_channel_path: str,
+    ):
+        reply = b"ERR"
         try:
             metadata = self._decoder.decode(metadata_bytes)
-            remote_zmq_addr = (
+            decode_listener_addr = (
                 f"{metadata.remote_hostname}:"
                 f"{metadata.remote_port + self.tp_rank}"
             )
-            if metadata.uid_bytes is not None:
-                # First contact from this Decode TP rank: init pair comm.
-                # _init_pair_comm_responder deduplicates concurrent callers
-                # via barriers — only the first one creates the comm.
-                self._init_pair_comm_responder(
-                    metadata.uid_bytes, remote_zmq_addr
-                )
-            else:
-                # Subsequent message — wait for any in-progress init to finish.
-                with self.pair_comms_lock:
-                    barrier = self._pair_comm_init_barriers.get(
-                        remote_zmq_addr
-                    )
-                if barrier is not None:
-                    barrier.wait()
-            self._send_kv_to_decode(metadata)
+
+            # Lazy comm init (NCCL-style: Prefill initiates on first send)
+            with self.pair_comms_lock:
+                pair_info = self.pair_comms.get(decode_listener_addr)
+            if pair_info is None:
+                self._create_pair_comm(decode_listener_addr)
+
+            expected_signal = self._send_kv_to_decode(metadata)
+            # Reply with the signal value so Decode knows what to wait for
+            reply = str(expected_signal).encode()
         except Exception as e:
             logger.error("FlagCX sender worker error: %s", e)
+        finally:
+            pusher = make_zmq_socket(
+                self.zmq_ctx, worker_channel_path, zmq.PUSH
+            )
+            try:
+                pusher.send_multipart([identity, reply])
+            except zmq.ZMQError as e:
+                logger.warning("Internal reply error: %s", e)
+            finally:
+                pusher.close()
 
     def _send_kv_to_decode(self, meta: FlagCXAgentMetadata):
         send_reqs: list[tuple[ReqId, SendBlockMeta]] = []
-        # The Decode ZMQ request may arrive before the scheduler metadata
-        # reaches start_load_kv(), so poll with a timeout instead of
-        # returning immediately.
-        deadline = time.perf_counter() + 30  # 30s timeout
+        deadline = time.perf_counter() + 30
         while True:
             with self.reqs_need_send.lock:
                 all_found = True
@@ -715,7 +835,7 @@ class FlagCXConnectorWorker:
                 return 0
             time.sleep(0.01)
 
-        self._send_blocks(send_reqs, meta)
+        expected_signal = self._send_blocks(send_reqs, meta)
 
         with self.reqs_need_send.lock:
             for req_id in meta.request_ids:
@@ -724,42 +844,32 @@ class FlagCXConnectorWorker:
         with self.finished_sending_reqs.lock:
             self.finished_sending_reqs.set.update(meta.request_ids)
 
+        return expected_signal
+
     def _send_blocks(
         self,
         send_reqs: list[tuple[ReqId, SendBlockMeta]],
         agent_meta: FlagCXAgentMetadata,
     ):
-        """RDMA WRITE KV blocks to the remote Decode node using
-        flagcxPutSignal.
-
-        Each layer × block-group → one flagcxPutSignal call.
-        The last call carries a signal increment so the receiver's
-        flagcxWaitSignal unblocks.
-        """
         self._ensure_cuda_device()
         local_base_addr = self.kv_caches_base_addr
         remote_base_addr = agent_meta.kv_caches_base_addr
         block_len = self.block_len
 
-        # Look up the per-pair comm for this Decode TP rank.
-        remote_zmq_addr = (
+        decode_listener_addr = (
             f"{agent_meta.remote_hostname}:"
             f"{agent_meta.remote_port + self.tp_rank}"
         )
-        pair_info = self.pair_comms.get(remote_zmq_addr)
+        pair_info = self.pair_comms.get(decode_listener_addr)
         if pair_info is None:
             raise RuntimeError(
-                f"No pair comm for {remote_zmq_addr}; "
-                "uid_bytes must be included in the first metadata message"
+                f"No pair comm for {decode_listener_addr}"
             )
         comm = pair_info.comm
         my_rank = pair_info.my_rank
-        peer_rank = 1 - my_rank  # Prefill is rank=1 → peer (Decode) is rank=0
+        peer_rank = 1 - my_rank
 
-        # Collect (src_offset, dst_offset, size) tuples per layer
         xfer_list: list[tuple[int, int, int, int, int]] = []
-        # (layer_local_base, layer_remote_base, local_block_start,
-        #  remote_block_start, num_blocks)
 
         assert len(send_reqs) == len(agent_meta.block_ids)
         for (req_id, send_meta), remote_block_ids in zip(
@@ -784,7 +894,9 @@ class FlagCXConnectorWorker:
             for local_layer_addr, remote_layer_addr in zip(
                 local_base_addr, remote_base_addr
             ):
-                for grp_local, grp_remote in zip(group_local, group_remote):
+                for grp_local, grp_remote in zip(
+                    group_local, group_remote
+                ):
                     xfer_list.append((
                         local_layer_addr,
                         remote_layer_addr,
@@ -796,12 +908,6 @@ class FlagCXConnectorWorker:
         if not xfer_list:
             return 0
 
-        # Serialise PutSignal enqueues under the per-pair send_lock so that
-        # the atomic-add signals land in order on the remote signal buffer.
-        # flagcxPutSignal does an atomic ADD of signal_value on the remote
-        # signal slot, so we always pass 1 for the last transfer in a batch
-        # (and 0 for all others).  The remote signal thus accumulates as
-        # 1, 2, 3, ... matching the Decode side's monotonic expected values.
         with pair_info.send_lock:
             pair_info.signal_counter += 1
             expected_signal = pair_info.signal_counter
@@ -815,9 +921,6 @@ class FlagCXConnectorWorker:
                 dst_offset = remote_start * block_len
                 size = n_blocks * block_len
                 is_last = (i == len(xfer_list) - 1)
-
-                signal_offset = 0
-                # Atomic add: always +1 on the last xfer, 0 on others.
                 signal_value = 1 if is_last else 0
 
                 src_mr_idx = local_base_addr.index(local_layer_addr)
@@ -826,20 +929,22 @@ class FlagCXConnectorWorker:
                 self.flagcx.flagcxPutSignal(
                     comm, peer_rank,
                     src_offset, dst_offset, size,
-                    signal_offset, src_mr_idx, dst_mr_idx,
+                    0, src_mr_idx, dst_mr_idx,
                     signal_value,
                 )
 
         logger.debug(
-            "Queued %d async xfers to rank %d (signal=%d), took %.4f s",
+            "Queued %d xfers to rank %d (signal=%d), took %.4f s",
             len(xfer_list),
             peer_rank,
             expected_signal,
             time.perf_counter() - start_time,
         )
-
         return expected_signal
 
+    # ------------------------------------------------------------------
+    # Decode receiver
+    # ------------------------------------------------------------------
     def _receiver_loop_fn(self, loop: asyncio.AbstractEventLoop):
         asyncio.set_event_loop(loop)
         loop.run_forever()
@@ -848,39 +953,12 @@ class FlagCXConnectorWorker:
         self, path: str, req_blocks: list[tuple[str, list[int]]],
         pending_wait: PendingSignalWait,
     ):
-        """Send metadata to Prefiller via ZMQ, requesting it to RDMA-write
-        the KV blocks.  On first contact, includes uid_bytes so Prefill can
-        init the per-pair comm; Decode concurrently calls CommInitRank in an
-        executor so both sides rendezvous without blocking the event loop.
+        """Send block metadata to Prefill via ZMQ REQ, wait for Prefill
+        to complete RDMA write and reply with the signal value.
 
-        Concurrent first-contact coroutines for the same path are serialised
-        via _pair_comm_init_events: only the first one generates a uid and
-        creates the comm; the rest wait for that to finish."""
+        The signal value comes from Prefill (the single source of truth),
+        so Decode never maintains its own counter — no desync possible."""
         req_ids, block_ids = map(list, zip(*req_blocks))
-
-        # Determine init responsibility under lock.
-        need_init = False
-        must_wait_init = False
-        with self.pair_comms_lock:
-            if path not in self.pair_comms:
-                gate = self._pair_comm_init_events.get(path)
-                if gate is not None:
-                    # Another coroutine is already initializing.
-                    must_wait_init = True
-                else:
-                    need_init = True
-                    gate = asyncio.Event()
-                    self._pair_comm_init_events[path] = gate
-
-        if must_wait_init:
-            # Wait for the initializer to finish, then send without uid.
-            await gate  # type: ignore[arg-type]
-
-        uid: Any = None
-        uid_bytes_to_send: Optional[bytes] = None
-        if need_init:
-            uid = self.flagcx.flagcxGetUniqueId()
-            uid_bytes_to_send = bytes(uid.contents.internal)
 
         metadata = FlagCXAgentMetadata(
             remote_hostname=self.hostname,
@@ -888,55 +966,69 @@ class FlagCXConnectorWorker:
             request_ids=req_ids,
             kv_caches_base_addr=self.kv_caches_base_addr,
             block_ids=block_ids,
-            uid_bytes=uid_bytes_to_send,
         )
 
         encoded_data = self._encoder.encode(metadata)
 
-        sock = self._push_sockets.get(path)
-        if sock is None:
-            sock = make_zmq_socket(
-                self.async_zmq_ctx, path, zmq.PUSH, bind=False
-            )
-            self._push_sockets[path] = sock
+        # Use REQ socket (per-request, with timeout) so we get a reply
+        # containing the signal value from Prefill.
+        sock: zmq.asyncio.Socket = make_zmq_socket(
+            self.async_zmq_ctx, path, zmq.REQ, bind=False, linger=0
+        )
+        sock.setsockopt(zmq.RCVTIMEO, 120000)  # 120s timeout
 
         try:
             await sock.send(encoded_data)
-            if need_init:
-                loop = asyncio.get_event_loop()
-                await loop.run_in_executor(
-                    None,
-                    self._finalize_pair_comm_initiator,
-                    uid,
-                    path,
-                )
-                # Unblock waiters and clean up the gate.
-                with self.pair_comms_lock:
-                    self._pair_comm_init_events.pop(path, None)
-                gate.set()  # type: ignore[union-attr]
+            reply = await sock.recv()
 
-            pair_info = self.pair_comms.get(path)
-            if pair_info:
-                pair_info.signal_counter += 1
-                pending_wait.comm = pair_info.comm
-                pending_wait.peer_rank = 1 - pair_info.my_rank
-                pending_wait.signal_value = pair_info.signal_counter
+            if reply == b"ERR":
+                logger.error(
+                    "Prefill reported error for %s", req_ids
+                )
+                return
+
+            expected_signal = int(reply)
+
+            # Look up pair comm (created by Decode listener thread
+            # during Prefill's _create_pair_comm handshake).
+            pair_info = None
+            with self.pair_comms_lock:
+                if self.pair_comms:
+                    pair_info = next(iter(self.pair_comms.values()))
+
+            if pair_info is None:
+                logger.error(
+                    "Pair comm not found after Prefill reply for %s",
+                    req_ids,
+                )
+                return
+
+            pending_wait.comm = pair_info.comm
+            pending_wait.peer_rank = 1 - pair_info.my_rank
+            pending_wait.signal_value = expected_signal
+
         except zmq.ContextTerminated:
             return
+        except zmq.Again:
+            logger.error(
+                "Timeout waiting for Prefill reply for %s", req_ids
+            )
+            return
         except Exception as e:
-            logger.error("FlagCX receive_kv failed for %s: %s", req_ids, e)
-            # If we were the initializer, unblock waiters even on failure.
-            if need_init:
-                with self.pair_comms_lock:
-                    self._pair_comm_init_events.pop(path, None)
-                gate.set()  # type: ignore[union-attr]
+            logger.error(
+                "FlagCX receive_kv failed for %s: %s", req_ids, e
+            )
             return
         finally:
+            sock.close()
             pending_wait.ready.set()
 
         async with self.finished_recving_reqs.lock:
             self.finished_recving_reqs.set.update(req_ids)
 
+    # ------------------------------------------------------------------
+    # start_load_kv / wait_for_layer_load
+    # ------------------------------------------------------------------
     def start_load_kv(self, metadata: FlagCXConnectorMetadata):
         if self.kv_role != "kv_producer":
             kv_pulls = self._group_kv_pull(metadata)
@@ -959,8 +1051,7 @@ class FlagCXConnectorWorker:
                         send_meta.local_block_ids = block_ids
                         send_meta.ready.set()
                         send_meta.expire_time = (
-                            time.perf_counter()
-                            + 480
+                            time.perf_counter() + 480
                         )
                     else:
                         self.reqs_need_send.reqs[req_id] = SendBlockMeta(
@@ -968,45 +1059,50 @@ class FlagCXConnectorWorker:
                         )
 
     def wait_for_layer_load(self) -> None:
-        """Issue GPU-side WaitSignal for all pending RDMA receives.
-
-        Called once per forward step from FlagCXConnector.wait_for_layer_load.
-        Drains the active-wait list so subsequent layer calls are no-ops.
-        """
         with self._active_signal_waits_lock:
             waits = self._active_signal_waits
             self._active_signal_waits = []
         if not waits:
             return
+
+        for w in waits:
+            w.ready.wait(timeout=60)
+
+        # Filter out waits that have no valid comm/signal (e.g. errors).
+        valid_waits = [
+            w for w in waits
+            if w.comm is not None and w.signal_value > 0
+        ]
+        if not valid_waits:
+            return
+        valid_waits.sort(key=lambda w: w.signal_value)
+        max_wait = valid_waits[-1]
+
         self._ensure_cuda_device()
-        torch_stream = torch.cuda.current_stream()
+        torch_stream = current_stream()
         flagcx_stream = self.flagcx.adaptor_stream_copy(torch_stream)
         try:
-            for w in waits:
-                w.ready.wait(timeout=60)
-                if w.comm is not None and w.signal_value > 0:
-                    try:
-                        self.flagcx.flagcxWaitSignal(
-                            w.comm, w.peer_rank, 0,
-                            w.signal_value, flagcx_stream,
-                        )
-                    except Exception:
-                        logger.exception(
-                            "flagcxWaitSignal failed: comm=%s peer=%d "
-                            "signal_offset=0 expected=%d current_device=%d "
-                            "torch_stream=%s flagcx_stream=%s reqs=%s",
-                            self._comm_repr(w.comm),
-                            w.peer_rank,
-                            w.signal_value,
-                            torch.cuda.current_device(),
-                            hex(torch_stream.cuda_stream),
-                            self._comm_repr(flagcx_stream),
-                            w.req_ids,
-                        )
-                        raise
+            self.flagcx.flagcxWaitSignal(
+                max_wait.comm, max_wait.peer_rank, 0,
+                max_wait.signal_value, flagcx_stream,
+            )
+        except Exception:
+            logger.exception(
+                "flagcxWaitSignal failed: comm=%s peer=%d "
+                "expected=%d device=%d reqs=%s",
+                self._comm_repr(max_wait.comm),
+                max_wait.peer_rank,
+                max_wait.signal_value,
+                torch.cuda.current_device(),
+                [r for w in valid_waits for r in w.req_ids],
+            )
+            raise
         finally:
             self.flagcx.adaptor_stream_free(flagcx_stream)
 
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
     def _group_kv_pull(self, metadata: FlagCXConnectorMetadata):
         kv_pulls: dict[str, list[tuple[str, list[int]]]] = defaultdict(list)
         for req_id, meta in metadata.reqs_to_recv.items():
@@ -1038,7 +1134,6 @@ class FlagCXConnectorWorker:
 
         finished_recving = fut.result() if fut else set()
 
-        # Expire stale sends
         now = time.perf_counter()
         with self.reqs_need_send.lock:
             expired = [
@@ -1047,7 +1142,9 @@ class FlagCXConnectorWorker:
                 if sm.expire_time < now
             ]
             for rid in expired:
-                logger.warning("Request %s send timed out, freeing blocks", rid)
+                logger.warning(
+                    "Request %s send timed out, freeing blocks", rid
+                )
                 del self.reqs_need_send.reqs[rid]
             if expired:
                 finished_sending.update(expired)
@@ -1058,19 +1155,23 @@ class FlagCXConnectorWorker:
         self.shutdown()
 
     def shutdown(self):
-        if self.kv_role != "kv_producer":
-            for sock in getattr(self, '_push_sockets', {}).values():
-                sock.close()
         self.zmq_ctx.term()
         self.async_zmq_ctx.term()
         if self.kv_role != "kv_consumer":
             self._sender_executor.shutdown(wait=False)
             if self._sender_t:
                 self._sender_t.join(timeout=2)
-        if self.kv_role != "kv_producer" and self.receiver_loop.is_running():
-            self.receiver_loop.call_soon_threadsafe(self.receiver_loop.stop)
-            self._receiver_t.join(timeout=2)
+        if self.kv_role != "kv_producer":
+            if hasattr(self, 'receiver_loop') and self.receiver_loop.is_running():
+                self.receiver_loop.call_soon_threadsafe(
+                    self.receiver_loop.stop
+                )
+                self._receiver_t.join(timeout=2)
 
+
+# ===================================================================
+# Module-level helpers (unchanged)
+# ===================================================================
 def _group_contiguous(
     src_indices: list[int], dst_indices: list[int]
 ) -> tuple[list[list[int]], list[list[int]]]:

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -53,9 +53,6 @@ if _flagcx_path and os.path.isdir(_flagcx_path):
 try:
     from plugin.interservice.flagcx_wrapper import (
         FLAGCXLibrary,
-        buffer_type,
-        flagcxComm_t,
-        flagcxStream_t,
         flagcxUniqueId,
     )
 except ImportError as e:
@@ -541,11 +538,6 @@ class FlagCXConnectorWorker:
         )
         return signal_buffer
 
-    # ------------------------------------------------------------------
-    # Comm init: Prefill side (initiator, rank=0)
-    # Called from _sender_worker on first send to a Decode peer.
-    # Pattern: P2pNcclEngine.create_connect
-    # ------------------------------------------------------------------
     def _create_pair_comm(self, decode_listener_addr: str) -> PairCommInfo:
         """Prefill side: create pair comm to a Decode peer.
         Sends uid via ZMQ DEALER→ROUTER, then both sides call
@@ -567,6 +559,10 @@ class FlagCXConnectorWorker:
         )
         sock = self.zmq_ctx.socket(zmq.DEALER)
         sock.setsockopt_string(zmq.IDENTITY, my_identity)
+        # Fail fast if the Decode listener isn't reachable / hangs, so a
+        # ThreadPoolExecutor worker doesn't get stuck forever.
+        sock.setsockopt(zmq.RCVTIMEO, 120000)  # 120s
+        sock.setsockopt(zmq.LINGER, 0)
         sock.connect(f"tcp://{decode_listener_addr}")
         sock.send(msgspec.msgpack.encode({
             "cmd": "NEW",
@@ -578,8 +574,22 @@ class FlagCXConnectorWorker:
         signal_buffer = self._register_kv_for_comm(comm)
 
         # 4. Wait for Decode to confirm registration is done
-        reply = sock.recv()
-        sock.close()
+        try:
+            reply = sock.recv()
+        except zmq.Again as e:
+            sock.close()
+            raise RuntimeError(
+                f"Timed out waiting for Decode registration reply "
+                f"from {decode_listener_addr}"
+            ) from e
+        finally:
+            sock.close()
+
+        if reply != b"OK":
+            raise RuntimeError(
+                f"Decode handshake with {decode_listener_addr} failed: "
+                f"unexpected reply {reply!r}"
+            )
 
         pair_info = PairCommInfo(
             comm=comm, my_rank=0, signal_buffer=signal_buffer,
@@ -592,11 +602,6 @@ class FlagCXConnectorWorker:
         )
         return pair_info
 
-    # ------------------------------------------------------------------
-    # Comm init: Decode side (responder, rank=1)
-    # Runs in _decode_listener_thread, handles NEW from Prefill.
-    # Pattern: P2pNcclEngine.listen_for_requests (NEW branch)
-    # ------------------------------------------------------------------
     def _decode_listener_thread(
         self, ready_event: threading.Event, base_port: int, tp_rank: int
     ):
@@ -625,8 +630,11 @@ class FlagCXConnectorWorker:
                     self._ensure_cuda_device()
 
                     uid = self.flagcx.unique_id_from_bytes(uid_bytes)
-                    uid_ptr = ctypes.POINTER(flagcxUniqueId)(uid)
-                    comm = self.flagcx.flagcxCommInitRank(2, uid_ptr, 1)
+                    # Match style used by device_communicators/flagcx.py:
+                    # pass a pointer via ctypes.byref to flagcxCommInitRank.
+                    comm = self.flagcx.flagcxCommInitRank(
+                        2, ctypes.byref(uid), 1
+                    )
                     signal_buffer = self._register_kv_for_comm(comm)
 
                     remote_addr = identity.decode()
@@ -686,6 +694,11 @@ class FlagCXConnectorWorker:
                 self.kv_tensors_meta.append((base_addr, curr_size))
 
         self.kv_caches_base_addr = seen_base_addresses
+        # Precompute addr→layer-index map to avoid O(L) list.index() in the
+        # per-transfer inner loop of _send_blocks.
+        self._local_mr_idx: dict[int, int] = {
+            addr: i for i, addr in enumerate(seen_base_addresses)
+        }
 
         assert tensor_size_bytes is not None
         assert self.num_blocks != 0
@@ -855,6 +868,10 @@ class FlagCXConnectorWorker:
         local_base_addr = self.kv_caches_base_addr
         remote_base_addr = agent_meta.kv_caches_base_addr
         block_len = self.block_len
+        local_mr_idx = self._local_mr_idx
+        remote_mr_idx = {
+            addr: i for i, addr in enumerate(remote_base_addr)
+        }
 
         decode_listener_addr = (
             f"{agent_meta.remote_hostname}:"
@@ -923,8 +940,8 @@ class FlagCXConnectorWorker:
                 is_last = (i == len(xfer_list) - 1)
                 signal_value = 1 if is_last else 0
 
-                src_mr_idx = local_base_addr.index(local_layer_addr)
-                dst_mr_idx = remote_base_addr.index(remote_layer_addr)
+                src_mr_idx = local_mr_idx[local_layer_addr]
+                dst_mr_idx = remote_mr_idx[remote_layer_addr]
 
                 self.flagcx.flagcxPutSignal(
                     comm, peer_rank,
@@ -991,15 +1008,20 @@ class FlagCXConnectorWorker:
 
             # Look up pair comm (created by Decode listener thread
             # during Prefill's _create_pair_comm handshake).
-            pair_info = None
+            # The pair_comms key is the Prefill identity, which is
+            # "{prefill_host}:{prefill_side_channel_port + prefill_tp_rank}".
+            # Since we connect symmetrically (same tp_rank on both sides),
+            # stripping the tcp:// prefix from `path` yields that key.
+            prefill_key = path[len("tcp://"):] if path.startswith(
+                "tcp://"
+            ) else path
             with self.pair_comms_lock:
-                if self.pair_comms:
-                    pair_info = next(iter(self.pair_comms.values()))
+                pair_info = self.pair_comms.get(prefill_key)
 
             if pair_info is None:
                 logger.error(
-                    "Pair comm not found after Prefill reply for %s",
-                    req_ids,
+                    "Pair comm not found for %s after Prefill reply for %s",
+                    prefill_key, req_ids,
                 )
                 return
 

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -397,10 +397,8 @@ class FlagCXConnectorWorker:
         self.hostname = get_ip()
 
         # ---- FlagCX library ----
-        library_path = os.getenv("FLAGCX_LIB_PATH")
-        if library_path is None:
-            flagcx_path = os.getenv("FLAGCX_PATH", "")
-            library_path = os.path.join(flagcx_path, "build/lib/libflagcx.so")
+        flagcx_path = os.getenv("FLAGCX_PATH", "")
+        library_path = os.path.join(flagcx_path, "build/lib/libflagcx.so")
         self.flagcx = FLAGCXLibrary(library_path)
         self.cuda_device_index = torch.cuda.current_device()
 

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -66,9 +66,6 @@ except ImportError as e:
 EngineId = str
 ReqId = str
 
-TRANS_DONE = b"trans_done"
-TRANS_ERROR = b"trans_error"
-
 logger = init_logger(__name__)
 
 class FlagCXAgentMetadata(
@@ -371,11 +368,17 @@ class FlagCXConnectorWorker:
             flagcx_path = os.getenv("FLAGCX_PATH", "")
             library_path = os.path.join(flagcx_path, "build/lib/libflagcx.so")
         self.flagcx = FLAGCXLibrary(library_path)
+        self.cuda_device_index = torch.cuda.current_device()
 
         # ---- Per-pair comms (lazily created on first transfer with each peer) ----
         # key: remote ZMQ address "host:port+tp_rank", value: PairCommInfo
         self.pair_comms: dict[str, PairCommInfo] = {}
         self.pair_comms_lock = threading.Lock()
+        # Guards against concurrent pair-comm init for the same path.
+        # Prefill (sync threads) uses threading.Event barriers;
+        # Decode (async coroutines) uses asyncio.Event barriers.
+        self._pair_comm_init_barriers: dict[str, threading.Event] = {}
+        self._pair_comm_init_events: dict[str, asyncio.Event] = {}
         # KV tensor metadata (base_addr, size) — collected in register_kv_caches,
         # used to call flagcxOneSideRegister once per pair comm creation.
         self.kv_tensors_meta: list[tuple[int, int]] = []
@@ -467,6 +470,27 @@ class FlagCXConnectorWorker:
         self._encoder = msgspec.msgpack.Encoder()
         self._decoder = msgspec.msgpack.Decoder(FlagCXAgentMetadata)
 
+    def _ensure_cuda_device(self) -> None:
+        """Background threads start with their own CUDA current-device state.
+
+        Pair-comm init and signal-buffer allocation must happen on the same
+        device as the worker process, otherwise later stream waits may target a
+        signal address from another GPU.
+        """
+        current = torch.cuda.current_device()
+        if current != self.cuda_device_index:
+            logger.warning(
+                "Switching CUDA device in background thread: current=%d target=%d",
+                current,
+                self.cuda_device_index,
+            )
+            torch.cuda.set_device(self.cuda_device_index)
+
+    @staticmethod
+    def _comm_repr(comm: Any) -> str:
+        value = getattr(comm, "value", None)
+        return hex(value) if value is not None else "0x0"
+
     def _register_kv_for_comm(self, comm: Any) -> torch.Tensor:
         """Register all KV tensors + a fresh per-pair signal buffer with a
         newly created pair comm.  Both sides call this right after
@@ -475,6 +499,7 @@ class FlagCXConnectorWorker:
 
         Returns the newly allocated per-pair GPU signal buffer (caller must
         keep a reference to prevent GC)."""
+        self._ensure_cuda_device()
         for base_addr, size in self.kv_tensors_meta:
             self.flagcx.flagcxOneSideRegister(comm, base_addr, size)
         # Allocate a *per-pair* signal buffer so different Prefill peers
@@ -484,8 +509,13 @@ class FlagCXConnectorWorker:
             comm, signal_buffer.data_ptr(), signal_buffer.nbytes
         )
         logger.info(
-            "Registered %d KV MRs + per-pair signal buffer for pair comm",
+            "Registered %d KV MRs + per-pair signal buffer for pair comm=%s "
+            "(signal_ptr=%s, signal_device=%s, current_device=%d)",
             len(self.kv_tensors_meta),
+            self._comm_repr(comm),
+            hex(signal_buffer.data_ptr()),
+            signal_buffer.device,
+            torch.cuda.current_device(),
         )
         return signal_buffer
 
@@ -493,20 +523,44 @@ class FlagCXConnectorWorker:
         self, uid_bytes: bytes, remote_zmq_addr: str
     ) -> Any:
         """Prefill side: given uid_bytes from Decode, init pair comm as rank=1.
-        Blocks until both sides have completed CommInitRank + OneSideRegister."""
+        Blocks until both sides have completed CommInitRank + OneSideRegister.
+        Only the first caller per remote_zmq_addr creates the comm; concurrent
+        callers block on a barrier until init finishes."""
         with self.pair_comms_lock:
             if remote_zmq_addr in self.pair_comms:
                 return self.pair_comms[remote_zmq_addr].comm
-        uid = self.flagcx.unique_id_from_bytes(uid_bytes)
-        uid_ptr = ctypes.POINTER(flagcxUniqueId)(uid)
-        comm = self.flagcx.flagcxCommInitRank(2, uid_ptr, 1)
-        signal_buffer = self._register_kv_for_comm(comm)
-        with self.pair_comms_lock:
-            self.pair_comms[remote_zmq_addr] = PairCommInfo(
-                comm=comm, my_rank=1, signal_buffer=signal_buffer,
+            barrier = self._pair_comm_init_barriers.get(remote_zmq_addr)
+            if barrier is not None:
+                # Another thread is already initializing — wait for it.
+                is_initializer = False
+            else:
+                is_initializer = True
+                barrier = threading.Event()
+                self._pair_comm_init_barriers[remote_zmq_addr] = barrier
+
+        if not is_initializer:
+            barrier.wait()
+            with self.pair_comms_lock:
+                return self.pair_comms[remote_zmq_addr].comm
+
+        try:
+            self._ensure_cuda_device()
+            uid = self.flagcx.unique_id_from_bytes(uid_bytes)
+            uid_ptr = ctypes.POINTER(flagcxUniqueId)(uid)
+            comm = self.flagcx.flagcxCommInitRank(2, uid_ptr, 1)
+            signal_buffer = self._register_kv_for_comm(comm)
+            with self.pair_comms_lock:
+                self.pair_comms[remote_zmq_addr] = PairCommInfo(
+                    comm=comm, my_rank=1, signal_buffer=signal_buffer,
+                )
+            logger.info(
+                "Pair comm ready (responder/rank=1) ↔ %s", remote_zmq_addr
             )
-        logger.info("Pair comm ready (responder/rank=1) ↔ %s", remote_zmq_addr)
-        return comm
+            return comm
+        finally:
+            barrier.set()
+            with self.pair_comms_lock:
+                self._pair_comm_init_barriers.pop(remote_zmq_addr, None)
 
     def _finalize_pair_comm_initiator(
         self, uid: Any, remote_zmq_addr: str
@@ -514,6 +568,7 @@ class FlagCXConnectorWorker:
         """Decode side: called in executor thread after uid has been sent to
         Prefill.  Blocks on CommInitRank(rank=0) + OneSideRegister so both
         sides rendezvous before any PutSignal is issued."""
+        self._ensure_cuda_device()
         comm = self.flagcx.flagcxCommInitRank(2, uid, 0)
         signal_buffer = self._register_kv_for_comm(comm)
         with self.pair_comms_lock:
@@ -610,17 +665,25 @@ class FlagCXConnectorWorker:
     def _sender_worker(self, metadata_bytes: bytes):
         try:
             metadata = self._decoder.decode(metadata_bytes)
-            # First contact from this Decode TP rank: init pair comm before
-            # transferring.  CommInitRank(rank=1) blocks until Decode (rank=0)
-            # also enters it — they rendezvous naturally.
+            remote_zmq_addr = (
+                f"{metadata.remote_hostname}:"
+                f"{metadata.remote_port + self.tp_rank}"
+            )
             if metadata.uid_bytes is not None:
-                remote_zmq_addr = (
-                    f"{metadata.remote_hostname}:"
-                    f"{metadata.remote_port + self.tp_rank}"
-                )
+                # First contact from this Decode TP rank: init pair comm.
+                # _init_pair_comm_responder deduplicates concurrent callers
+                # via barriers — only the first one creates the comm.
                 self._init_pair_comm_responder(
                     metadata.uid_bytes, remote_zmq_addr
                 )
+            else:
+                # Subsequent message — wait for any in-progress init to finish.
+                with self.pair_comms_lock:
+                    barrier = self._pair_comm_init_barriers.get(
+                        remote_zmq_addr
+                    )
+                if barrier is not None:
+                    barrier.wait()
             self._send_kv_to_decode(metadata)
         except Exception as e:
             logger.error("FlagCX sender worker error: %s", e)
@@ -673,6 +736,7 @@ class FlagCXConnectorWorker:
         The last call carries a signal increment so the receiver's
         flagcxWaitSignal unblocks.
         """
+        self._ensure_cuda_device()
         local_base_addr = self.kv_caches_base_addr
         remote_base_addr = agent_meta.kv_caches_base_addr
         block_len = self.block_len
@@ -732,11 +796,12 @@ class FlagCXConnectorWorker:
         if not xfer_list:
             return 0
 
-        # Serialise counter-increment AND all PutSignal enqueues under the
-        # per-pair send_lock.  This guarantees that RDMA signal writes land
-        # in monotonic order on the remote signal buffer — otherwise a
-        # higher signal value could be overwritten by a lower one from a
-        # concurrent thread, causing cuStreamWaitValue64(GEQ) to deadlock.
+        # Serialise PutSignal enqueues under the per-pair send_lock so that
+        # the atomic-add signals land in order on the remote signal buffer.
+        # flagcxPutSignal does an atomic ADD of signal_value on the remote
+        # signal slot, so we always pass 1 for the last transfer in a batch
+        # (and 0 for all others).  The remote signal thus accumulates as
+        # 1, 2, 3, ... matching the Decode side's monotonic expected values.
         with pair_info.send_lock:
             pair_info.signal_counter += 1
             expected_signal = pair_info.signal_counter
@@ -751,13 +816,10 @@ class FlagCXConnectorWorker:
                 size = n_blocks * block_len
                 is_last = (i == len(xfer_list) - 1)
 
-                # signal_offset = 0: per-pair signal buffer has a single uint64 slot
                 signal_offset = 0
-                signal_value = expected_signal if is_last else 0
+                # Atomic add: always +1 on the last xfer, 0 on others.
+                signal_value = 1 if is_last else 0
 
-                # For PutSignal we need to express offsets relative to the
-                # registered MR base. Since each layer is a separate MR slot,
-                # we find its mr_index.
                 src_mr_idx = local_base_addr.index(local_layer_addr)
                 dst_mr_idx = remote_base_addr.index(remote_layer_addr)
 
@@ -789,19 +851,34 @@ class FlagCXConnectorWorker:
         """Send metadata to Prefiller via ZMQ, requesting it to RDMA-write
         the KV blocks.  On first contact, includes uid_bytes so Prefill can
         init the per-pair comm; Decode concurrently calls CommInitRank in an
-        executor so both sides rendezvous without blocking the event loop."""
+        executor so both sides rendezvous without blocking the event loop.
+
+        Concurrent first-contact coroutines for the same path are serialised
+        via _pair_comm_init_events: only the first one generates a uid and
+        creates the comm; the rest wait for that to finish."""
         req_ids, block_ids = map(list, zip(*req_blocks))
 
-        # Check if this is the first contact with this Prefill TP rank.
+        # Determine init responsibility under lock.
+        need_init = False
+        must_wait_init = False
         with self.pair_comms_lock:
-            need_init = path not in self.pair_comms
+            if path not in self.pair_comms:
+                gate = self._pair_comm_init_events.get(path)
+                if gate is not None:
+                    # Another coroutine is already initializing.
+                    must_wait_init = True
+                else:
+                    need_init = True
+                    gate = asyncio.Event()
+                    self._pair_comm_init_events[path] = gate
+
+        if must_wait_init:
+            # Wait for the initializer to finish, then send without uid.
+            await gate  # type: ignore[arg-type]
 
         uid: Any = None
         uid_bytes_to_send: Optional[bytes] = None
         if need_init:
-            # Generate uid BEFORE sending — Prefill needs it to enter
-            # CommInitRank.  The uid is embedded in the metadata message;
-            # we then immediately kick off CommInitRank(rank=0) in an executor.
             uid = self.flagcx.flagcxGetUniqueId()
             uid_bytes_to_send = bytes(uid.contents.internal)
 
@@ -816,9 +893,6 @@ class FlagCXConnectorWorker:
 
         encoded_data = self._encoder.encode(metadata)
 
-        # Use a persistent PUSH socket per Prefill peer.  Creating a new
-        # socket per request with linger=0 risks dropping messages if the
-        # TCP connection hasn't been established before the socket is closed.
         sock = self._push_sockets.get(path)
         if sock is None:
             sock = make_zmq_socket(
@@ -826,25 +900,21 @@ class FlagCXConnectorWorker:
             )
             self._push_sockets[path] = sock
 
-        comm_future = None
         try:
             await sock.send(encoded_data)
             if need_init:
-                # Kick off CommInitRank(rank=0) in a thread pool so the event
-                # loop stays responsive while Prefill's worker thread also
-                # enters CommInitRank(rank=1) upon receiving the message above.
                 loop = asyncio.get_event_loop()
-                comm_future = loop.run_in_executor(
+                await loop.run_in_executor(
                     None,
                     self._finalize_pair_comm_initiator,
                     uid,
                     path,
                 )
-            if comm_future is not None:
-                await comm_future  # ensure Decode side also finished registering
-            # Decode tracks signal counter locally — no need to wait for
-            # Prefill's ZMQ reply.  flagcxWaitSignal on the GPU side will
-            # block until the RDMA PutSignal from Prefill lands.
+                # Unblock waiters and clean up the gate.
+                with self.pair_comms_lock:
+                    self._pair_comm_init_events.pop(path, None)
+                gate.set()  # type: ignore[union-attr]
+
             pair_info = self.pair_comms.get(path)
             if pair_info:
                 pair_info.signal_counter += 1
@@ -855,6 +925,11 @@ class FlagCXConnectorWorker:
             return
         except Exception as e:
             logger.error("FlagCX receive_kv failed for %s: %s", req_ids, e)
+            # If we were the initializer, unblock waiters even on failure.
+            if need_init:
+                with self.pair_comms_lock:
+                    self._pair_comm_init_events.pop(path, None)
+                gate.set()  # type: ignore[union-attr]
             return
         finally:
             pending_wait.ready.set()
@@ -903,16 +978,32 @@ class FlagCXConnectorWorker:
             self._active_signal_waits = []
         if not waits:
             return
+        self._ensure_cuda_device()
         torch_stream = torch.cuda.current_stream()
         flagcx_stream = self.flagcx.adaptor_stream_copy(torch_stream)
         try:
             for w in waits:
                 w.ready.wait(timeout=60)
                 if w.comm is not None and w.signal_value > 0:
-                    self.flagcx.flagcxWaitSignal(
-                        w.comm, w.peer_rank, 0,
-                        w.signal_value, flagcx_stream,
-                    )
+                    try:
+                        self.flagcx.flagcxWaitSignal(
+                            w.comm, w.peer_rank, 0,
+                            w.signal_value, flagcx_stream,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "flagcxWaitSignal failed: comm=%s peer=%d "
+                            "signal_offset=0 expected=%d current_device=%d "
+                            "torch_stream=%s flagcx_stream=%s reqs=%s",
+                            self._comm_repr(w.comm),
+                            w.peer_rank,
+                            w.signal_value,
+                            torch.cuda.current_device(),
+                            hex(torch_stream.cuda_stream),
+                            self._comm_repr(flagcx_stream),
+                            w.req_ids,
+                        )
+                        raise
         finally:
             self.flagcx.adaptor_stream_free(flagcx_stream)
 


### PR DESCRIPTION
### PR Category
Core

### PR Type
New Features

### Description
Add FlagCX-based KV connector for vLLM V1 disaggregated prefill-decode (PD) serving, along with a lightweight proxy router.

1. FlagCXConnector (flagcx_connector.py) implements KVConnectorBase_V1 to enable RDMA-based KV cache transfer between separate Prefill and Decode vLLM instances via the FlagCX one-sided communication API (flagcxPutSignal / flagcxWaitSignal). Key design choices:

* Pair comm init: Prefill (rank 0) initiates communicator creation by generating a flagcxUniqueId, sending it to Decode via ZMQ DEALER→ROUTER, then both sides call flagcxCommInitRank(2, uid, rank) simultaneously — avoiding the previous Decode-initiated async init that could deadlock.

* One-sided RDMA transfer: Prefill registers all KV cache tensors as Memory Regions and uses flagcxPutSignal to write blocks directly into Decode's GPU memory. Decode calls flagcxWaitSignal on the CUDA stream to synchronize without CPU-side polling.
Contiguous block grouping: Adjacent block IDs are coalesced into single RDMA writes to minimize the number of operations.

* Thread pool sender: Prefill uses a ThreadPoolExecutor with configurable num_workers for concurrent KV transfers, with each worker thread pinned to the correct CUDA device.
Scheduler/Worker split: Scheduler side handles token matching and block allocation tracking; Worker side handles actual data movement in background threads.

2. Router (router.py) is a FastAPI-based 1P1D disaggregated serving proxy that:

* Round-robins requests across multiple Prefill and Decode instances.
* Injects kv_transfer_params into requests: do_remote_decode=True for Prefill, do_remote_prefill=True (with remote_host/remote_port) for Decode.
* Fire-and-forgets the Prefill request (non-streaming, max_tokens=1) while streaming the Decode response back to the client.

### Related Issues
N/A

### Changes
vllm_fl/distributed/kv_transfer/flagcx_connector.py: New FlagCXConnector
examples/disaggregated_serving_xpyd/router.py: New disaggregated serving proxy that coordinates Prefill and Decode vLLM instances.
-

### Testing
Please refer to vllm-plugin-FL/examples/disaggregated_serving_xpyd/run_flagcx_connector.md
-

### Test results
```txt
========================================
Testing input=1024 output=1024 rps=75 num_prompts=375
========================================
============ Serving Benchmark Result ============
Successful requests:                     375       
Failed requests:                         0         
Request rate configured (RPS):           75.00     
Benchmark duration (s):                  33.71     
Total input tokens:                      384000    
Total generated tokens:                  384000    
Request throughput (req/s):              11.12     
Output token throughput (tok/s):         11390.52  
Peak output token throughput (tok/s):    16256.00  
Peak concurrent requests:                375.00    
Total token throughput (tok/s):          22781.05  
---------------Time to First Token----------------
Mean TTFT (ms):                          5473.75   
Median TTFT (ms):                        1325.64   
P50 TTFT (ms):                           1325.64   
P90 TTFT (ms):                           15588.28  
P99 TTFT (ms):                           16978.99  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.09     
Median TPOT (ms):                        17.55     
P50 TPOT (ms):                           17.55     
P90 TPOT (ms):                           17.88     
P99 TPOT (ms):                           18.07     
---------------Inter-token Latency----------------
Mean ITL (ms):                           16.10     
Median ITL (ms):                         17.31     
P50 ITL (ms):                            17.31     
P90 ITL (ms):                            19.13     
P99 ITL (ms):                            36.55     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          21931.51  
Median E2EL (ms):                        19545.41  
P50 E2EL (ms):                           19545.41  
P90 E2EL (ms):                           28727.77  
P99 E2EL (ms):                           29347.81  
================================================== 


========================================
Testing input=4096 output=1024 rps=70 num_prompts=350
========================================
============ Serving Benchmark Result ============
Successful requests:                     350       
Failed requests:                         0         
Request rate configured (RPS):           70.00     
Benchmark duration (s):                  45.31     
Total input tokens:                      1433600   
Total generated tokens:                  358400    
Request throughput (req/s):              7.72      
Output token throughput (tok/s):         7909.98   
Peak output token throughput (tok/s):    10752.00  
Peak concurrent requests:                350.00    
Total token throughput (tok/s):          39549.89  
---------------Time to First Token----------------
Mean TTFT (ms):                          10740.83  
Median TTFT (ms):                        9750.43   
P50 TTFT (ms):                           9750.43   
P90 TTFT (ms):                           21938.61  
P99 TTFT (ms):                           24081.32  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.59     
Median TPOT (ms):                        22.12     
P50 TPOT (ms):                           22.12     
P90 TPOT (ms):                           23.29     
P99 TPOT (ms):                           23.30     
---------------Inter-token Latency----------------
Mean ITL (ms):                           20.60     
Median ITL (ms):                         22.52     
P50 ITL (ms):                            22.52     
P90 ITL (ms):                            24.26     
P99 ITL (ms):                            41.28     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          31805.05  
Median E2EL (ms):                        33559.57  
P50 E2EL (ms):                           33559.57  
P90 E2EL (ms):                           39582.37  
P99 E2EL (ms):                           40164.55  
==================================================

========================================
Testing input=8192 output=1024 rps=65 num_prompts=325
========================================
============ Serving Benchmark Result ============
Successful requests:                     325       
Failed requests:                         0         
Request rate configured (RPS):           65.00     
Benchmark duration (s):                  77.86     
Total input tokens:                      2662400   
Total generated tokens:                  332800    
Request throughput (req/s):              4.17      
Output token throughput (tok/s):         4274.51   
Peak output token throughput (tok/s):    8169.00   
Peak concurrent requests:                325.00    
Total token throughput (tok/s):          38470.57  
---------------Time to First Token----------------
Mean TTFT (ms):                          17627.05  
Median TTFT (ms):                        18422.39  
P50 TTFT (ms):                           18422.39  
P90 TTFT (ms):                           43084.28  
P99 TTFT (ms):                           52515.24  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          43.23     
Median TPOT (ms):                        50.26     
P50 TPOT (ms):                           50.26     
P90 TPOT (ms):                           50.50     
P99 TPOT (ms):                           53.09     
---------------Inter-token Latency----------------
Mean ITL (ms):                           43.28     
Median ITL (ms):                         30.31     
P50 ITL (ms):                            30.31     
P90 ITL (ms):                            31.70     
P99 ITL (ms):                            45.35     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          61847.01  
Median E2EL (ms):                        69936.04  
P50 E2EL (ms):                           69936.04  
P90 E2EL (ms):                           71427.72  
P99 E2EL (ms):                           72849.58  
==================================================

========================================
Testing input=16384 output=1024 rps=60 num_prompts=300
========================================
============ Serving Benchmark Result ============
Successful requests:                     300       
Failed requests:                         0         
Request rate configured (RPS):           60.00     
Benchmark duration (s):                  209.64    
Total input tokens:                      4915200   
Total generated tokens:                  307200    
Request throughput (req/s):              1.43      
Output token throughput (tok/s):         1465.39   
Peak output token throughput (tok/s):    4199.00   
Peak concurrent requests:                300.00    
Total token throughput (tok/s):          24911.58  
---------------Time to First Token----------------
Mean TTFT (ms):                          101052.15 
Median TTFT (ms):                        75863.80  
P50 TTFT (ms):                           75863.80  
P90 TTFT (ms):                           143580.24 
P99 TTFT (ms):                           154169.75 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          47.27     
Median TPOT (ms):                        53.23     
P50 TPOT (ms):                           53.23     
P90 TPOT (ms):                           53.30     
P99 TPOT (ms):                           90.35     
---------------Inter-token Latency----------------
Mean ITL (ms):                           48.65     
Median ITL (ms):                         35.16     
P50 ITL (ms):                            35.16     
P90 ITL (ms):                            36.21     
P99 ITL (ms):                            98.39     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          149412.47 
Median E2EL (ms):                        115202.33 
P50 E2EL (ms):                           115202.33 
P90 E2EL (ms):                           198107.15 
P99 E2EL (ms):                           201133.53 
==================================================

========================================
Testing input=32768 output=1024 rps=45 num_prompts=225
========================================
============ Serving Benchmark Result ============
Successful requests:                     225       
Failed requests:                         0         
Request rate configured (RPS):           45.00     
Benchmark duration (s):                  232.85    
Total input tokens:                      7372800   
Total generated tokens:                  230400    
Request throughput (req/s):              0.97      
Output token throughput (tok/s):         989.48    
Peak output token throughput (tok/s):    1539.00   
Peak concurrent requests:                225.00    
Total token throughput (tok/s):          32652.97  
---------------Time to First Token----------------
Mean TTFT (ms):                          110839.50 
Median TTFT (ms):                        108659.65 
P50 TTFT (ms):                           108659.65 
P90 TTFT (ms):                           197732.90 
P99 TTFT (ms):                           219034.11 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          8.66      
Median TPOT (ms):                        8.00      
P50 TPOT (ms):                           8.00      
P90 TPOT (ms):                           11.35     
P99 TPOT (ms):                           11.93     
---------------Inter-token Latency----------------
Mean ITL (ms):                           8.90      
Median ITL (ms):                         7.99      
P50 ITL (ms):                            7.99      
P90 ITL (ms):                            11.61     
P99 ITL (ms):                            13.63     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          119698.57 
Median E2EL (ms):                        120704.38 
P50 E2EL (ms):                           120704.38 
P90 E2EL (ms):                           205656.03 
P99 E2EL (ms):                           226633.85 
==================================================
```

### Checklist
- [x] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
