### PR TITLE
fix some bugs in adaptation of the hygon device

### DIFF
--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -8,6 +8,8 @@ from .layernorm import *  # noqa F403 F401
 from .activation import *  # noqa F403 F401
 from .rotary_embedding import *  # noqa F403 F401
 from .fused_moe import *  # noqa F403 F401
+from .gdn_chunk import *  # noqa F403 F401
+from .gdn_recurrent import *  # noqa F403 F401
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +26,8 @@ OOT_OPS = {
     "rotary_embedding": (RotaryEmbeddingFL, "RotaryEmbedding"),  # noqa F405
     "fused_moe": (FusedMoEFL, "FusedMoE"),  # noqa F405
     "shared_fused_moe": (SharedFusedMoEFL, "SharedFusedMoE"),  # noqa F405
+    "chunk_gated_delta_rule": (ChunkGatedDeltaRuleFL, "ChunkGatedDeltaRule"),  # noqa F405
+    "fused_recurrent_gated_delta_rule": (FusedRecurrentGatedDeltaRuleFL, "FusedRecurrentGatedDeltaRuleOp"), # noqa F405
     "unquantized_fused_moe_method": (
         UnquantizedFusedMoEMethodFL,  # noqa F405
         "UnquantizedFusedMoEMethod",
@@ -79,6 +83,10 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
             PluggableLayer.register_oot(_decorated_layer_cls=op_cls, name=registration_name)
         else:
             CustomOp.register_oot(_decorated_op_cls=op_cls, name=registration_name)
+
+        if op_name == "fused_recurrent_gated_delta_rule":
+            patch_gdn_recurrent_decode()  # noqa F405
+
         # Apply Ascend NPU monkey-patches if running on NPU.
         # These replace upstream module-level functions (e.g. in qwen3_next) with
         # Ascend implementations that bypass the CustomOp/dispatch path.

--- a/vllm_fl/ops/fla/chunk.py
+++ b/vllm_fl/ops/fla/chunk.py
@@ -4,7 +4,7 @@ import warnings
 import os
 import torch
 
-from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.custom_op import CustomOp, op_registry
 from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd
 from .utils import input_guard
 from vllm_fl.utils import use_flaggems_op
@@ -13,6 +13,13 @@ if use_flaggems_op("chunk_gated_delta_rule_fwd"):
     from flag_gems.fused.FLA import chunk_gated_delta_rule_fwd
 else:
     from vllm.model_executor.layers.fla.ops.chunk import chunk_gated_delta_rule_fwd
+
+
+def register_chunk_gated_delta_rule_op(op_cls):
+    if "chunk_gated_delta_rule" in op_registry:
+        op_cls.name = "chunk_gated_delta_rule"
+        return op_cls
+    return CustomOp.register("chunk_gated_delta_rule")(op_cls)
 
 
 class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
@@ -51,7 +58,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         return o.to(q.dtype), final_state
 
 
-@CustomOp.register("chunk_gated_delta_rule")
+@register_chunk_gated_delta_rule_op
 class ChunkGatedDeltaRuleOp(CustomOp):
     def __init__(
         self,
@@ -77,7 +84,9 @@ class ChunkGatedDeltaRuleOp(CustomOp):
         beta: torch.Tensor,
         scale: float = None,
         initial_state: torch.Tensor = None,
+        output_final_state: bool | None = None,
         cu_seqlens: torch.LongTensor | None = None,
+        use_qk_l2norm_in_kernel: bool | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         r"""
         Args:
@@ -139,6 +148,10 @@ class ChunkGatedDeltaRuleOp(CustomOp):
                 )
         if scale is None:
             scale = k.shape[-1] ** -0.5
+        if output_final_state is None:
+            output_final_state = self.output_final_state
+        if use_qk_l2norm_in_kernel is None:
+            use_qk_l2norm_in_kernel = self.use_qk_l2norm_in_kernel
         o, final_state = ChunkGatedDeltaRuleFunction.apply(
             q,
             k,
@@ -147,8 +160,8 @@ class ChunkGatedDeltaRuleOp(CustomOp):
             beta,
             scale,
             initial_state,
-            self.output_final_state,
+            output_final_state,
             cu_seqlens,
-            self.use_qk_l2norm_in_kernel,
+            use_qk_l2norm_in_kernel,
         )
         return o, final_state

--- a/vllm_fl/ops/gdn_chunk.py
+++ b/vllm_fl/ops/gdn_chunk.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.layers.mamba.gdn_linear_attn import ChunkGatedDeltaRule
+from vllm_fl.ops.fla.chunk import ChunkGatedDeltaRuleOp
+
+logger = init_logger(__name__)
+
+
+class ChunkGatedDeltaRuleFL(ChunkGatedDeltaRule):
+    """OOT adapter that routes vLLM 0.19 GDN prefill through vllm_fl FLA."""
+
+    def __init__(self) -> None:
+        CustomOp.__init__(self)
+        self._forward_method = self.forward_native
+        self._chunk_gated_delta_rule = ChunkGatedDeltaRuleOp()
+        logger.info_once(
+            "Using FL OOT ChunkGatedDeltaRule adapter for GDN prefill.",
+            scope="local",
+        )
+
+    def forward_native(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        initial_state: torch.Tensor,
+        output_final_state: bool,
+        cu_seqlens: torch.Tensor | None = None,
+        use_qk_l2norm_in_kernel: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self._chunk_gated_delta_rule.forward_native(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+
+    def forward_cuda(self, *args, **kwargs):
+        return self.forward_native(*args, **kwargs)
+
+    def forward_hip(self, *args, **kwargs):
+        return self.forward_native(*args, **kwargs)
+
+    def forward_oot(self, *args, **kwargs):
+        return self.forward_native(*args, **kwargs)

--- a/vllm_fl/ops/gdn_recurrent.py
+++ b/vllm_fl/ops/gdn_recurrent.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.mamba.gdn_linear_attn import fused_gdn_gating
+
+from vllm_fl.ops.fla import FusedRecurrentGatedDeltaRuleOp
+
+logger = init_logger(__name__)
+
+
+class FusedRecurrentGatedDeltaRuleFL(FusedRecurrentGatedDeltaRuleOp):
+    """Adapter that routes vLLM 0.19 GDN decode through vllm_fl FLA."""
+
+    def __init__(
+        self,
+        inplace_final_state: bool = True,
+        use_qk_l2norm_in_kernel: bool = True,
+    ) -> None:
+        # Decode patches instantiate this adapter from model forward, where
+        # vLLM's CustomOp config context is no longer active.
+        torch.nn.Module.__init__(self)
+        self._forward_method = self.forward_native
+        self.inplace_final_state = inplace_final_state
+        self.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        logger.info_once(
+            "Using FL OOT FusedRecurrentGatedDeltaRule adapter for GDN decode.",
+            scope="local",
+        )
+
+    def forward_sigmoid_gating(
+        self,
+        A_log: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        dt_bias: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: float = 1.0,
+        threshold: float = 20.0,
+        scale: float | None = None,
+        initial_state: torch.Tensor | None = None,
+        cu_seqlens: torch.Tensor | None = None,
+        ssm_state_indices: torch.Tensor | None = None,
+        num_accepted_tokens: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        g, beta_out = fused_gdn_gating(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            beta=beta,
+            threshold=threshold,
+        )
+        return self.forward_native(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta_out,
+            scale=scale,
+            initial_state=initial_state,
+            cu_seqlens=cu_seqlens,
+            ssm_state_indices=ssm_state_indices,
+            num_accepted_tokens=num_accepted_tokens,
+        )
+
+    def forward_packed_decode(
+        self,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        scale: float,
+        initial_state: torch.Tensor,
+        out: torch.Tensor,
+        ssm_state_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        q, k, v = _unpack_mixed_qkv(mixed_qkv, initial_state)
+        cu_seqlens = torch.arange(
+            mixed_qkv.shape[0] + 1,
+            device=mixed_qkv.device,
+            dtype=ssm_state_indices.dtype,
+        )
+        recurrent_out, final_state = self.forward_sigmoid_gating(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=q,
+            k=k,
+            v=v,
+            scale=scale,
+            initial_state=initial_state,
+            cu_seqlens=cu_seqlens,
+            ssm_state_indices=ssm_state_indices,
+        )
+        out.copy_(recurrent_out.squeeze(0).unsqueeze(1))
+        return out, final_state
+
+    def forward_cuda(self, *args, **kwargs):
+        return self.forward_native(*args, **kwargs)
+
+    def forward_hip(self, *args, **kwargs):
+        return self.forward_native(*args, **kwargs)
+
+    def forward_oot(self, *args, **kwargs):
+        return self.forward_native(*args, **kwargs)
+
+
+_PATCHED = False
+_OPS: dict[tuple[bool, bool], FusedRecurrentGatedDeltaRuleFL] = {}
+
+
+def _get_op(
+    inplace_final_state: bool,
+    use_qk_l2norm_in_kernel: bool,
+) -> FusedRecurrentGatedDeltaRuleFL:
+    key = (inplace_final_state, use_qk_l2norm_in_kernel)
+    if key not in _OPS:
+        _OPS[key] = FusedRecurrentGatedDeltaRuleFL(
+            inplace_final_state=inplace_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+    return _OPS[key]
+
+
+def _unpack_mixed_qkv(
+    mixed_qkv: torch.Tensor,
+    initial_state: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    hv, v_dim, k_dim = initial_state.shape[-3:]
+    qkv_dim = mixed_qkv.shape[1]
+    qk_dim = qkv_dim - hv * v_dim
+    if qk_dim <= 0 or qk_dim % 2 != 0:
+        raise ValueError(f"Invalid mixed_qkv last dim={qkv_dim} for HV={hv}, V={v_dim}.")
+
+    q_dim = qk_dim // 2
+    if q_dim % k_dim != 0:
+        raise ValueError(f"Invalid Q dim={q_dim}; expected divisible by K={k_dim}.")
+
+    num_q_heads = q_dim // k_dim
+    q_raw, k_raw, v_raw = torch.split(mixed_qkv, [q_dim, q_dim, hv * v_dim], dim=-1)
+    q = q_raw.view(1, mixed_qkv.shape[0], num_q_heads, k_dim).contiguous()
+    k = k_raw.view(1, mixed_qkv.shape[0], num_q_heads, k_dim).contiguous()
+    v = v_raw.view(1, mixed_qkv.shape[0], hv, v_dim).contiguous()
+    return q, k, v
+
+
+def _fl_fused_sigmoid_gating_delta_rule_update(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    inplace_final_state: bool = True,
+    cu_seqlens: torch.Tensor | None = None,
+    ssm_state_indices: torch.Tensor | None = None,
+    num_accepted_tokens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    is_kda: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if is_kda:
+        raise NotImplementedError("FL GDN recurrent replacement does not handle KDA.")
+
+    return _get_op(
+        inplace_final_state,
+        use_qk_l2norm_in_kernel,
+    ).forward_sigmoid_gating(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        threshold=threshold,
+        scale=scale,
+        initial_state=initial_state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_accepted_tokens=num_accepted_tokens,
+    )
+
+
+def _fl_fused_recurrent_gated_delta_rule_packed_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _get_op(
+        True,
+        use_qk_l2norm_in_kernel,
+    ).forward_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=initial_state,
+        out=out,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+
+def patch_gdn_recurrent_decode() -> None:
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    import vllm.model_executor.layers.fla.ops as fla_ops
+    import vllm.model_executor.layers.fla.ops.fused_recurrent as fused_recurrent
+    import vllm.model_executor.layers.fla.ops.fused_sigmoid_gating as fused_sigmoid
+    import vllm.model_executor.layers.mamba.gdn_linear_attn as gdn_linear_attn
+
+    fused_sigmoid.fused_sigmoid_gating_delta_rule_update = (
+        _fl_fused_sigmoid_gating_delta_rule_update
+    )
+    fla_ops.fused_sigmoid_gating_delta_rule_update = (
+        _fl_fused_sigmoid_gating_delta_rule_update
+    )
+    gdn_linear_attn.fused_sigmoid_gating_delta_rule_update = (
+        _fl_fused_sigmoid_gating_delta_rule_update
+    )
+
+    fused_recurrent.fused_recurrent_gated_delta_rule_packed_decode = (
+        _fl_fused_recurrent_gated_delta_rule_packed_decode
+    )
+    fla_ops.fused_recurrent_gated_delta_rule_packed_decode = (
+        _fl_fused_recurrent_gated_delta_rule_packed_decode
+    )
+    gdn_linear_attn.fused_recurrent_gated_delta_rule_packed_decode = (
+        _fl_fused_recurrent_gated_delta_rule_packed_decode
+    )
+
+    _PATCHED = True
+    logger.info_once(
+        "Using FL FusedRecurrentGatedDeltaRuleOp for GDN decode recurrent update.",
+        scope="local",
+    )

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -36,6 +36,8 @@ VENDOR_DEVICE_MAP: dict[str, dict[str, str]] = {
     "metax": {"device_type": "cuda", "device_name": "metax"},
     # Registered backend: vendor/musa
     "mthreads": {"device_type": "musa", "device_name": "musa"},
+    #Registered backend: vendor/musa
+    "hygon":{"device_type": "cuda", "device_name": "rocm"},
 }
 
 

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -444,6 +444,8 @@ class ModelRunnerFL(
         self.cache_config = vllm_config.cache_config
         self.offload_config = vllm_config.offload_config
         self.compilation_config = vllm_config.compilation_config
+        if self.compilation_config.max_cudagraph_capture_size is None:
+            self.compilation_config.max_cudagraph_capture_size = 0
         self.lora_config = vllm_config.lora_config
         self.load_config = vllm_config.load_config
         self.parallel_config = vllm_config.parallel_config


### PR DESCRIPTION
### Description
fix some bugs in adaptation of the hygon device

### Related Issues
1、Add hygon vendor，Block the issue of the hygon equipment being wrongly identified as AMD.
2、In vllm, the sampler `topk_topp_kernel` triggered a HSA VMFault on the hygon platform. Disabled the `topk_topp_kernel` in the triton form within vllm.
3、The implementation of chunk_gated_delta_rule in vLLM resulted in an error due to the FLA Triton kernel in hygon device. Using the OOT operator for registration enables the chunk_gated_delta_rule to execute using FlagGems.
4、The implementation of fused_recurrent_gated_delta_rule in vLLM resulted in an error due to the FLA Triton kernel in hygon device. Using the OOT operator for registration enables the fused_recurrent_gated_delta_rule to execute using FlagGems.


### Test
Qwen-3.5-35B-A3B  TEST PASS 