### PR TITLE
update vllm version for test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ test = [
     "requests",
     "openai",
     "decorator",
-    "vllm[audio]==0.19.0",
+    "vllm[audio]==0.20.2",
     "modelscope>=1.18.1",
 ]
 


### PR DESCRIPTION
### PR Category
CICD

### PR Type
Tests

### Description
bump vllm version to 0.20.2 in CI images

### Related Issues
CI keeps failing due to unit test failure

### Changes
- Upgrade CUDA driver on host machine and install vLLM v0.20.2

### Testing

- Workflow

### Checklist
- [x] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
