### PR TITLE
Add benchmark code for serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
 | Iluvatar | Supported | - |
 | Tsingmicro | Merging | [PR #52](https://github.com/flagos-ai/vllm-plugin-FL/pull/52) |
 | Moore Threads | Supported | - |
-| Hygon | Merging | [PR #78](https://github.com/flagos-ai/vllm-plugin-FL/pull/78) |
+| Hygon | Supported | - |
 | Sunrise | Supported | - |
 
 ## Quick Start
 
 ### Setup
 
-1. Install vllm from the official [v0.20.2](https://github.com/vllm-project/vllm/tree/v0.20.2) (optional if the correct version is installed) or from the fork [vllm-FL](https://github.com/flagos-ai/vllm-FL).
+1. Install vllm from the official [v0.20.2](https://github.com/vllm-project/vllm/tree/v0.20.2) (optional if the correct version is installed)
 
 
 2. Install vllm-plugin-FL

--- a/benchmarks/benchmark_throughput_serve.py
+++ b/benchmarks/benchmark_throughput_serve.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+
+# Usage:
+#  1. Start the server as follows (adjust model path and args as needed):
+# vllm serve /models/Qwen3.6-27B --tensor-parallel-size 2 --max-model-len 262144 --no-enable-log-requests --no-enable-prefix-caching
+
+#  2. Run this benchmark script (default: 4 test cases):
+# python benchmarks/benchmark_throughput_serve.py
+#
+# [Optional] Run all 10 test cases:
+# python benchmarks/benchmark_throughput_serve.py --enable-all
+
+
+import argparse
+import csv
+import os
+import re
+import subprocess
+import time
+from datetime import datetime
+from statistics import mean
+
+MODEL = "/models/Qwen3.6-27B"
+
+# total runs for each case
+RUNS = 4
+
+# skip first N runs
+SKIP_FIRST = 1
+
+COMMON_ARGS = [
+    "vllm",
+    "bench",
+    "serve",
+    "--backend",
+    "vllm",
+    "--model",
+    MODEL,
+    "--endpoint",
+    "/v1/completions",
+    "--host",
+    "localhost",
+    "--port",
+    "8000",
+    "--dataset-name",
+    "random",
+    "--ignore-eos",
+]
+
+# Baseline cases used when --enable-all is not set.
+# Each case is a tuple:
+# (random_input_len, random_output_len, max_concurrency, num_prompts)
+DEFAULT_TEST_CASES = [
+    (1024, 1024, 64, 256),
+    (4096, 1024, 64, 256),
+    (16384, 1024, 64, 256),
+    (65536, 1024, 64, 256),
+]
+
+ALL_TEST_CASES = [
+    *DEFAULT_TEST_CASES,
+    (4096, 1024, 1, 256),
+    (4096, 1024, 4, 256),
+    (4096, 1024, 16, 256),
+    (4096, 1024, 256, 256),
+    (131072, 1024, 64, 64),
+    (262144, 1024, 64, 64),
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--enable-all",
+        action="store_true",
+        help="Enable all 10 test cases. If not set, run default 4 cases.",
+    )
+
+    return parser.parse_args()
+
+
+PATTERNS = {
+    "successful_requests": r"Successful requests:\s+([0-9.]+)",
+    "benchmark_duration": r"Benchmark duration \(s\):\s+([0-9.]+)",
+    "total_input_tokens": r"Total input tokens:\s+([0-9.]+)",
+    "total_output_tokens": r"Total generated tokens:\s+([0-9.]+)",
+    "request_throughput": r"Request throughput \(req/s\):\s+([0-9.]+)",
+    "output_throughput": r"Output token throughput \(tok/s\):\s+([0-9.]+)",
+    "peak_output_throughput": r"Peak output token throughput \(tok/s\):\s+([0-9.]+)",
+    "total_token_throughput": r"Total token throughput \(tok/s\):\s+([0-9.]+)",
+    "mean_ttft_ms": r"Mean TTFT \(ms\):\s+([0-9.]+)",
+    "median_ttft_ms": r"Median TTFT \(ms\):\s+([0-9.]+)",
+    "p99_ttft_ms": r"P99 TTFT \(ms\):\s+([0-9.]+)",
+    "mean_tpot_ms": r"Mean TPOT \(ms\):\s+([0-9.]+)",
+    "median_tpot_ms": r"Median TPOT \(ms\):\s+([0-9.]+)",
+    "p99_tpot_ms": r"P99 TPOT \(ms\):\s+([0-9.]+)",
+    "mean_itl_ms": r"Mean ITL \(ms\):\s+([0-9.]+)",
+    "median_itl_ms": r"Median ITL \(ms\):\s+([0-9.]+)",
+    "p99_itl_ms": r"P99 ITL \(ms\):\s+([0-9.]+)",
+}
+
+CSV_COLUMNS = [
+    "Prefill",
+    "Decode",
+    "Conc",
+    "Num Prompts",
+    "Successful Requests",
+    "Benchmark Duration (s)",
+    "Total Input Tokens",
+    "Total Output Tokens",
+    "Req/s",
+    "Output tok/s",
+    "Peak Output tok/s",
+    "Total tok/s",
+    "Mean TTFT (ms)",
+    "Median TTFT (ms)",
+    "P99 TTFT (ms)",
+    "Mean TPOT (ms)",
+    "Median TPOT (ms)",
+    "P99 TPOT (ms)",
+    "Mean ITL (ms)",
+    "Median ITL (ms)",
+    "P99 ITL (ms)",
+]
+
+
+def extract_metrics(output_text):
+    result = {}
+
+    for key, pattern in PATTERNS.items():
+        match = re.search(
+            pattern,
+            output_text,
+            re.IGNORECASE,
+        )
+
+        result[key] = float(match.group(1)) if match else None
+
+    return result
+
+
+def format_result(case, metrics):
+    input_len, output_len, concurrency, num_prompts = case
+
+    return {
+        "Prefill": input_len,
+        "Decode": output_len,
+        "Conc": concurrency,
+        "Num Prompts": num_prompts,
+        "Successful Requests": metrics.get("successful_requests"),
+        "Benchmark Duration (s)": metrics.get("benchmark_duration"),
+        "Total Input Tokens": metrics.get("total_input_tokens"),
+        "Total Output Tokens": metrics.get("total_output_tokens"),
+        "Req/s": metrics.get("request_throughput"),
+        "Output tok/s": metrics.get("output_throughput"),
+        "Peak Output tok/s": metrics.get("peak_output_throughput"),
+        "Total tok/s": metrics.get("total_token_throughput"),
+        "Mean TTFT (ms)": metrics.get("mean_ttft_ms"),
+        "Median TTFT (ms)": metrics.get("median_ttft_ms"),
+        "P99 TTFT (ms)": metrics.get("p99_ttft_ms"),
+        "Mean TPOT (ms)": metrics.get("mean_tpot_ms"),
+        "Median TPOT (ms)": metrics.get("median_tpot_ms"),
+        "P99 TPOT (ms)": metrics.get("p99_tpot_ms"),
+        "Mean ITL (ms)": metrics.get("mean_itl_ms"),
+        "Median ITL (ms)": metrics.get("median_itl_ms"),
+        "P99 ITL (ms)": metrics.get("p99_itl_ms"),
+    }
+
+
+def append_csv(row, filename):
+    file_exists = os.path.exists(filename)
+
+    with open(filename, "a", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=CSV_COLUMNS,
+        )
+
+        if not file_exists:
+            writer.writeheader()
+
+        writer.writerow(row)
+
+
+def run_once(case, run_id):
+    input_len, output_len, concurrency, num_prompts = case
+
+    name = f"{input_len}_{output_len}_c{concurrency}"
+
+    print("=" * 80)
+    print(f"Running: {name} | Run {run_id}/{RUNS}")
+    print("=" * 80)
+
+    cmd = COMMON_ARGS + [
+        "--random-input-len",
+        str(input_len),
+        "--random-output-len",
+        str(output_len),
+        "--max-concurrency",
+        str(concurrency),
+        "--num-prompts",
+        str(num_prompts),
+    ]
+
+    print(" ".join(cmd))
+    print()
+
+    start_time = time.time()
+
+    process = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    elapsed = time.time() - start_time
+
+    output = process.stdout
+
+    print(output)
+
+    metrics = extract_metrics(output)
+
+    metrics["elapsed_sec"] = round(elapsed, 2)
+
+    return metrics
+
+
+def average_metrics(results):
+    avg_result = {}
+
+    keys = results[0].keys()
+
+    for key in keys:
+        values = [r[key] for r in results if isinstance(r.get(key), (int, float))]
+
+        if values:
+            avg_result[key] = round(mean(values), 2)
+
+    return avg_result
+
+
+def run_test_case(case, raw_csv):
+    all_runs = []
+
+    for run_id in range(1, RUNS + 1):
+        metrics = run_once(case, run_id)
+
+        raw_row = format_result(case, metrics)
+
+        append_csv(raw_row, raw_csv)
+
+        all_runs.append(metrics)
+
+    valid_runs = all_runs[SKIP_FIRST:]
+
+    avg_metrics = average_metrics(valid_runs)
+
+    summary_row = format_result(case, avg_metrics)
+
+    return summary_row
+
+
+def print_summary(results):
+    print()
+    print("=" * 80)
+    print("Summary")
+    print("=" * 80)
+
+    for r in results:
+        print(
+            f"Prefill={r['Prefill']} "
+            f"Decode={r['Decode']} "
+            f"Conc={r['Conc']} "
+            f"NumPrompts={r['Num Prompts']} "
+            f"Req/s={r['Req/s']} "
+            f"Total tok/s={r['Total tok/s']} "
+            f"TTFT={r['Mean TTFT (ms)']}ms"
+        )
+
+
+def main():
+    args = parse_args()
+
+    test_cases = ALL_TEST_CASES if args.enable_all else DEFAULT_TEST_CASES
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    raw_csv = f"raw_runs_{timestamp}.csv"
+    summary_csv = f"summary_{timestamp}.csv"
+
+    all_summary = []
+
+    print()
+    print(f"RUNS={RUNS}")
+    print(f"SKIP_FIRST={SKIP_FIRST}")
+    print(f"ENABLE_ALL={args.enable_all}")
+    print(f"TOTAL_CASES={len(test_cases)}")
+    print(f"TEST_CASES={test_cases}")
+    print()
+
+    for case in test_cases:
+        try:
+            summary_row = run_test_case(
+                case,
+                raw_csv,
+            )
+
+            append_csv(
+                summary_row,
+                summary_csv,
+            )
+
+            all_summary.append(summary_row)
+
+        except Exception as e:
+            print(f"ERROR: {e}")
+
+    print_summary(all_summary)
+
+    print()
+    print(f"Raw CSV: {raw_csv}")
+    print(f"Summary CSV: {summary_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_throughput_serve.py
+++ b/benchmarks/benchmark_throughput_serve.py
@@ -100,12 +100,36 @@ PATTERNS = {
     "p99_itl_ms": r"P99 ITL \(ms\):\s+([0-9.]+)",
 }
 
-CSV_COLUMNS = [
+RAW_CSV_COLUMNS = [
     "Prefill",
     "Decode",
     "Conc",
     "Num Prompts",
     "Successful Requests",
+    "Run Status",
+    "Benchmark Duration (s)",
+    "Total Input Tokens",
+    "Total Output Tokens",
+    "Req/s",
+    "Output tok/s",
+    "Peak Output tok/s",
+    "Total tok/s",
+    "Mean TTFT (ms)",
+    "Median TTFT (ms)",
+    "P99 TTFT (ms)",
+    "Mean TPOT (ms)",
+    "Median TPOT (ms)",
+    "P99 TPOT (ms)",
+    "Mean ITL (ms)",
+    "Median ITL (ms)",
+    "P99 ITL (ms)",
+]
+
+SUMMARY_CSV_COLUMNS = [
+    "Prefill",
+    "Decode",
+    "Conc",
+    "Num Prompts",
     "Benchmark Duration (s)",
     "Total Input Tokens",
     "Total Output Tokens",
@@ -140,15 +164,14 @@ def extract_metrics(output_text):
     return result
 
 
-def format_result(case, metrics):
+def format_result(case, metrics, include_successful_requests=True):
     input_len, output_len, concurrency, num_prompts = case
 
-    return {
+    result = {
         "Prefill": input_len,
         "Decode": output_len,
         "Conc": concurrency,
         "Num Prompts": num_prompts,
-        "Successful Requests": metrics.get("successful_requests"),
         "Benchmark Duration (s)": metrics.get("benchmark_duration"),
         "Total Input Tokens": metrics.get("total_input_tokens"),
         "Total Output Tokens": metrics.get("total_output_tokens"),
@@ -167,14 +190,19 @@ def format_result(case, metrics):
         "P99 ITL (ms)": metrics.get("p99_itl_ms"),
     }
 
+    if include_successful_requests:
+        result["Successful Requests"] = metrics.get("successful_requests")
 
-def append_csv(row, filename):
+    return result
+
+
+def append_csv(row, filename, columns):
     file_exists = os.path.exists(filename)
 
     with open(filename, "a", newline="") as f:
         writer = csv.DictWriter(
             f,
-            fieldnames=CSV_COLUMNS,
+            fieldnames=columns,
         )
 
         if not file_exists:
@@ -248,19 +276,35 @@ def run_test_case(case, raw_csv):
     for run_id in range(1, RUNS + 1):
         metrics = run_once(case, run_id)
 
-        raw_row = format_result(case, metrics)
+        raw_row = format_result(case, metrics, include_successful_requests=True)
+        expected_successful_requests = case[3]
+        raw_row["Run Status"] = (
+            "SUCCESS"
+            if metrics.get("successful_requests") == expected_successful_requests
+            else "FAILED"
+        )
 
-        append_csv(raw_row, raw_csv)
+        append_csv(raw_row, raw_csv, RAW_CSV_COLUMNS)
 
         all_runs.append(metrics)
 
     valid_runs = all_runs[SKIP_FIRST:]
 
+    expected_successful_requests = case[3]
+    has_failed_run = any(
+        run.get("successful_requests") != expected_successful_requests
+        for run in valid_runs
+    )
+
     avg_metrics = average_metrics(valid_runs)
 
-    summary_row = format_result(case, avg_metrics)
+    summary_row = format_result(
+        case,
+        avg_metrics,
+        include_successful_requests=False,
+    )
 
-    return summary_row
+    return summary_row, has_failed_run
 
 
 def print_summary(results):
@@ -303,15 +347,16 @@ def main():
 
     for case in test_cases:
         try:
-            summary_row = run_test_case(
+            summary_row, has_failed_run = run_test_case(
                 case,
                 raw_csv,
             )
 
-            append_csv(
-                summary_row,
-                summary_csv,
-            )
+            if has_failed_run:
+                print(f"SKIP SUMMARY ROW (failed case): {case}")
+                continue
+
+            append_csv(summary_row, summary_csv, SUMMARY_CSV_COLUMNS)
 
             all_summary.append(summary_row)
 

--- a/benchmarks/benchmark_throughput_serve.py
+++ b/benchmarks/benchmark_throughput_serve.py
@@ -332,8 +332,10 @@ def main():
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-    raw_csv = f"raw_runs_{timestamp}.csv"
-    summary_csv = f"summary_{timestamp}.csv"
+    output_dir = "benchmark_results"
+    os.makedirs(output_dir, exist_ok=True)
+    raw_csv = os.path.join(output_dir, f"raw_runs_{timestamp}.csv")
+    summary_csv = os.path.join(output_dir, f"summary_{timestamp}.csv")
 
     all_summary = []
 


### PR DESCRIPTION
### PR Category
Tools

### PR Type
Performance

### Description

This benchmark script runs throughput/latency tests against a running vLLM serve endpoint and exports both raw and averaged metrics to CSV files.

**How to use**

1. Start the vLLM server

Use a command like:

```bash
vllm serve /models/Qwen3.6-27B --tensor-parallel-size 2 --max-model-len 262144 --no-enable-log-requests --no-enable-prefix-caching
```

2. Run benchmark with default cases

```bash
python benchmarks/benchmark_throughput_serve.py
```

Each test case is:

`(random_input_len, random_output_len, max_concurrency, num_prompts)`

- `random_input_len`: prefill token length per request
- `random_output_len`: generated token length per request
- `max_concurrency`: max concurrent requests
- `num_prompts`: total requests for that benchmark run

Output files

- `raw_runs_<timestamp>.csv`: one row per run
- `summary_<timestamp>.csv`: averaged row per test case (after warmup skip)

```
# cat summary_20260522_094402.csv 
Prefill,Decode,Conc,Num Prompts,Benchmark Duration (s),Total Input Tokens,Total Output Tokens,Req/s,Output tok/s,Peak Output tok/s,Total tok/s,Mean TTFT (ms),Median TTFT (ms),P99 TTFT (ms),Mean TPOT (ms),Median TPOT (ms),P99 TPOT (ms),Mean ITL (ms),Median ITL (ms),P99 ITL (ms)
1024,1024,64,256,73.59,262144.0,262144.0,3.48,3562.08,4288.0,7124.16,940.97,981.23,2154.05,17.05,17.1,17.9,17.05,16.13,17.89
4096,1024,64,256,107.21,1048576.0,262144.0,2.39,2445.2,3840.0,12225.99,2117.0,1347.29,8819.76,24.08,25.08,25.93,24.08,17.99,269.88
``` 


