### PR TITLE
Support Qwen3.6 for hygon adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
     pip install --no-build-isolation -e .
     ```
     Note: if on Sunrize platform, depends on FlagGems [PR #2949](https://github.com/flagos-ai/FlagGems/pull/2949)
+          if on Hygon platform, depends on FlagGems [PR #3477](https://github.com/flagos-ai/FlagGems/pull/3477)
 
 4. (Optional) Install [FlagCX](https://github.com/flagos-ai/FlagCX/blob/main/docs/getting_started.md#build-and-installation)
 

--- a/vllm_fl/dispatch/config/hygon.yaml
+++ b/vllm_fl/dispatch/config/hygon.yaml
@@ -1,0 +1,59 @@
+# vLLM-FL Dispatch Configuration for hygon GPU
+# Auto-loaded when running on hygon hardware
+
+# Preferred default backend type: flagos, vendor, reference
+prefer: flagos
+
+# Strict Mode:
+#   true  = Raise an error immediately on failure; do not attempt other backends.
+#   false = Attempt the next available backend in sequence upon failure (Default).
+strict: false
+
+# Vendor Whitelist (Optional, allows all if not set)
+# allow_vendors:
+#   - hygon
+
+# Vendor Blacklist (Optional)
+# deny_vendors:
+#   - cuda
+
+
+# Per-operator backend execution order (Optional)
+# Only the backends listed here will be attempted, in the order specified.
+#
+# Supported tokens:
+#   - flagos      : Default FlagGems implementation (Triton)
+#   - reference   : PyTorch reference implementation
+#   - vendor      : Any available vendor backend (auto-detected)
+#   - vendor:hygon : hygon-specific vendor backend
+op_backends:
+  # All operators: prioritize FlagGems (Triton), fallback to vendor, then reference
+  attention_backend:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  rms_norm:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  silu_and_mul:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  rotary_embedding:
+    - flagos
+    - vendor:hygon
+    - reference
+
+# FlagOS operator blacklist
+# Blacklist only ops that are known to have issues
+flagos_blacklist:
+  - cat
+
+# OOT (Out-of-Tree) operator blacklist
+# These operators will NOT be registered as OOT replacements.
+# oot_blacklist:
+#   - fused_moe

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -38,6 +38,8 @@ VENDOR_DEVICE_MAP: dict[str, dict[str, str]] = {
     "mthreads": {"device_type": "musa", "device_name": "musa"},
     # Registered backend: vendor/sunrise
     "sunrise": {"device_type": "ptpu", "device_name": "ptpu"},
+    # Registered backend: vendor/hygon
+    "hygon": {"device_type": "cuda", "device_name": "cuda"},    
 }
 
 


### PR DESCRIPTION
### Description
Support for hygon adap, You must set the FlagCX path in bash before you use vllm-plugin-FL,
such as:  export FLAGCX_PATH=/workspace/FlagCX/
Note: This modification and test depends on FlagGems [PR #3477](https://github.com/flagos-ai/FlagGems/pull/3477)

### Changes
Add  hygon device in VENDOR_DEVICE_MAP
Add hygon.yaml in vllm_fl/dispatch/config

### Testing
Run Qwen3.5-35B-A3B、Qwen3.6-35B-A3B、Qwen3.6-27B  success。