### PR TITLE
[Vendor] Add MiniMax-M2.7 support on Sunrise

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -23,6 +23,8 @@ def apply_sunrise_patches():
     patch_distributed_runtime()
     patch_op_cls()
     patch_accelerator_empty_cache()
+    patch_memory_profiling_for_plain_allocator()
+    patch_fused_topk_bias_router()
 
 
 def patch_flagcx_stream_adapter():
@@ -208,3 +210,169 @@ def patch_accelerator_empty_cache():
         logger.info("Patched torch.accelerator.empty_cache for Sunrise/PTPU")
     except Exception as e:
         logger.warning("Failed to patch torch.accelerator.empty_cache: %s", e)
+
+
+def patch_fused_topk_bias_router():
+    """Replace CUDA-only ``vllm_topk_{sigmoid,softmax}`` with a native
+    implementation on Sunrise/PTPU.
+    """
+
+    try:
+        from vllm.platforms import current_platform
+
+        if getattr(current_platform, "device_type", None) != "ptpu":
+            return
+
+        import vllm.envs as envs
+        from vllm.model_executor.layers.fused_moe.router import (
+            fused_topk_bias_router as router_mod,
+        )
+
+        if getattr(router_mod, "_sunrise_topk_patched", False):
+            return
+
+        def _native_topk_with_bias(
+            topk_weights: torch.Tensor,
+            topk_indices: torch.Tensor,
+            token_expert_indices: torch.Tensor,
+            gating_output: torch.Tensor,
+            renormalize: bool,
+            e_score_correction_bias: torch.Tensor | None,
+            scoring_func: str,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            if scoring_func == "softmax":
+                scores = gating_output.softmax(dim=-1)
+            elif scoring_func == "sigmoid":
+                scores = gating_output.sigmoid()
+            else:
+                raise ValueError(
+                    f"Unsupported scoring function: {scoring_func}"
+                )
+
+            if e_score_correction_bias is not None:
+                scores_for_choice = scores + e_score_correction_bias.to(
+                    scores.dtype
+                ).unsqueeze(0)
+            else:
+                scores_for_choice = scores
+
+            topk = topk_weights.shape[-1]
+            use_sorted = getattr(envs, "VLLM_BATCH_INVARIANT", False)
+            chosen_indices = torch.topk(
+                scores_for_choice, k=topk, dim=-1, sorted=use_sorted
+            ).indices
+            chosen_weights = scores.gather(dim=-1, index=chosen_indices)
+            if renormalize:
+                chosen_weights = chosen_weights / chosen_weights.sum(
+                    dim=-1, keepdim=True
+                )
+
+            topk_weights.copy_(chosen_weights.to(topk_weights.dtype))
+            topk_indices.copy_(chosen_indices.to(topk_indices.dtype))
+            return topk_weights, topk_indices
+
+        def _patched_vllm_topk_sigmoid(
+            topk_weights, topk_indices, token_expert_indices,
+            gating_output, renormalize=False, e_score_correction_bias=None,
+        ):
+            return _native_topk_with_bias(
+                topk_weights, topk_indices, token_expert_indices,
+                gating_output, renormalize, e_score_correction_bias,
+                scoring_func="sigmoid",
+            )
+
+        def _patched_vllm_topk_softmax(
+            topk_weights, topk_indices, token_expert_indices,
+            gating_output, renormalize=False, e_score_correction_bias=None,
+        ):
+            return _native_topk_with_bias(
+                topk_weights, topk_indices, token_expert_indices,
+                gating_output, renormalize, e_score_correction_bias,
+                scoring_func="softmax",
+            )
+
+        router_mod.vllm_topk_sigmoid = _patched_vllm_topk_sigmoid
+        router_mod.vllm_topk_softmax = _patched_vllm_topk_softmax
+        router_mod._sunrise_topk_patched = True
+
+        logger.info(
+            "Patched fused_topk_bias_router to use native topk on PTPU"
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to patch fused_topk_bias_router for Sunrise: %s", e
+        )
+
+
+def patch_memory_profiling_for_plain_allocator():
+    """Fix KV-cache OOM caused by weights being double-counted on PTPU.
+    since ``torch_ptpu`` ships a "plain"-style device allocator that does not register
+    with PyTorch's caching allocator, ``torch.memory_reserved()`` is always ~0 on PTPU. 
+    """
+    try:
+        from vllm.platforms import current_platform
+
+        if getattr(current_platform, "device_type", None) != "ptpu":
+            return
+    except Exception as e:
+        logger.warning("Skip PTPU memory profiling patch: %s", e)
+        return
+
+    try:
+        from contextlib import contextmanager
+
+        from vllm_fl.worker import worker as worker_mod
+
+        original = worker_mod.memory_profiling_fl
+        if getattr(original, "_sunrise_mem_profile_patched", False):
+            return
+
+        gib = float(2**30)
+        _logged = {"once": False}
+
+        @contextmanager
+        def memory_profiling_fl_ptpu(baseline_snapshot, weights_memory):
+            with original(
+                baseline_snapshot, weights_memory=weights_memory
+            ) as result:
+                yield result
+
+            if (
+                result.after_profile.torch_memory == 0
+                and result.weights_memory > 0
+            ):
+                actual_used = (
+                    result.after_profile.cuda_memory
+                    - result.before_create.cuda_memory
+                )
+                corrected_non_torch = max(0, actual_used - result.weights_memory)
+                result.non_torch_increase = corrected_non_torch
+                result.non_kv_cache_memory = (
+                    corrected_non_torch
+                    + result.torch_peak_increase
+                    + result.weights_memory
+                )
+
+                if not _logged["once"]:
+                    _logged["once"] = True
+                    logger.info(
+                        "PTPU plain-allocator memory accounting fix applied: "
+                        "weights=%.2f GiB peak_act=%.2f GiB actual_used=%.2f GiB "
+                        "-> non_torch=%.2f GiB non_kv_cache=%.2f GiB",
+                        result.weights_memory / gib,
+                        result.torch_peak_increase / gib,
+                        actual_used / gib,
+                        corrected_non_torch / gib,
+                        result.non_kv_cache_memory / gib,
+                    )
+
+        memory_profiling_fl_ptpu._sunrise_mem_profile_patched = True
+        worker_mod.memory_profiling_fl = memory_profiling_fl_ptpu
+        logger.info(
+            "Patched memory_profiling_fl for PTPU plain allocator "
+            "(prevents weights double-counting in KV cache sizing)"
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to patch memory_profiling_fl for Sunrise/PTPU: %s", e
+        )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -306,8 +306,15 @@ def patch_fused_topk_bias_router():
 
 def patch_memory_profiling_for_plain_allocator():
     """Fix KV-cache OOM caused by weights being double-counted on PTPU.
-    since ``torch_ptpu`` ships a "plain"-style device allocator that does not register
-    with PyTorch's caching allocator, ``torch.memory_reserved()`` is always ~0 on PTPU. 
+
+    ``torch_ptpu`` ships a "plain"-style device allocator that does not register
+    with PyTorch's caching allocator, so ``torch.memory_reserved()`` is always
+    ~0 on PTPU. The shared :func:`memory_profiling_fl` computes
+    ``non_torch = cuda_used - torch_reserved``; with ``torch_reserved == 0``
+    this leaks the model weights into ``non_torch``. The final
+    ``non_kv_cache = weights + peak_act + non_torch`` then counts weights
+    twice, yielding a phantom OOM in ``determine_available_memory`` even when
+    the device has plenty of free memory.
     """
     try:
         from vllm.platforms import current_platform


### PR DESCRIPTION
### PR Category
Vendor 

### PR Type
New Features

### Description
This PR add BF16 MiniMax-M2.7 support on Sunrise, meanwhile patch memory_profiling_fl to fix a count-weights-twice bug that may trigger on Sunrise and cause unexpected kv-cache OOM


### Testing
vllm serve /models/MiniMax-M2.7-nvidia-FlagOS
--served-model-name "MiniMax-M2.7"
--host 0.0.0.0
--port 7529
--tensor-parallel-size 8
--gpu-memory-utilization 0.9
--enforce-eager
--no-enable-prefix-caching
--trust-remote-code
--max-num-batched-tokens 4096
--max-num-seqs 1
--max-model-len 8192


### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
