### PR TITLE
add hygon backends

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/hygon/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon vendor backend for vLLM native fallback implementations."""
+
+from .hygon import HygonBackend
+
+__all__ = ["HygonBackend"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/hygon.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/hygon.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+Hygon backend implementation.
+
+Hygon devices in this environment are exposed through a ROCm/HIP-compatible
+runtime stack. Some Python layers may still use CUDA-style compatibility entry
+points such as ``torch.cuda`` on ROCm builds, but this backend should be treated
+as Hygon/ROCm rather than NVIDIA CUDA.
+
+This backend only performs platform detection for now; concrete operator methods
+should be added once profiling identifies which FlagGems replacements need a
+Hygon-specific fallback or override.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Optional, Union
+
+import torch
+
+from vllm_fl.dispatch.backends.base import Backend
+
+
+class HygonBackend(Backend):
+    """Hygon backend for vendor-specific operator implementations."""
+
+    _available: Optional[bool] = None
+
+    @property
+    def name(self) -> str:
+        return "hygon"
+
+    @property
+    def vendor(self) -> Optional[str]:
+        return "hygon"
+
+    def is_available(self) -> bool:
+        """
+        Check whether the current runtime appears to be a Hygon environment.
+
+        Detection follows the same loose style as the other vendor backends:
+        prefer vLLM platform metadata when available, then fall back to the
+        environment hints already used by ``vllm_fl.utils``.
+        """
+        if HygonBackend._available is not None:
+            return HygonBackend._available
+
+        try:
+            from vllm.platforms import current_platform
+
+            vendor_name = getattr(current_platform, "vendor_name", None)
+            if isinstance(vendor_name, str) and vendor_name.lower() == "hygon":
+                HygonBackend._available = True
+                return True
+        except Exception:
+            pass
+
+        gems_vendor = os.environ.get("GEMS_VENDOR", "").strip().lower()
+        if gems_vendor == "hygon":
+            HygonBackend._available = True
+            return True
+
+        # Hygon deployments in this project expose both management tools.
+        if shutil.which("hy-smi") and shutil.which("rocm-smi"):
+            HygonBackend._available = True
+            return True
+
+        HygonBackend._available = False
+        return HygonBackend._available
+
+    # ==================== Operator Implementations ====================
+
+    def silu_and_mul(self, obj, x: torch.Tensor) -> torch.Tensor:
+        from .impl.activation import silu_and_mul_hygon
+
+        return silu_and_mul_hygon(obj, x)
+
+    def gelu_and_mul(self, obj, x: torch.Tensor) -> torch.Tensor:
+        from .impl.activation import gelu_and_mul_hygon
+
+        return gelu_and_mul_hygon(obj, x)
+
+    def rms_norm(
+        self,
+        obj,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        from .impl.normalization import rms_norm_hygon
+
+        return rms_norm_hygon(obj, x, residual)
+
+    def rotary_embedding(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        rotary_interleaved: bool = False,
+        inplace: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from .impl.rotary import rotary_embedding_hygon
+
+        return rotary_embedding_hygon(
+            obj,
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            rotary_interleaved=rotary_interleaved,
+            inplace=inplace,
+        )
+
+    def attention_backend(self, use_mla: bool = False, use_sparse: bool = False) -> str:
+        """
+        Get the vLLM native attention backend path for Hygon.
+
+        Hygon deployments use a HIP/ROCm-compatible stack, so the vendor
+        fallback should follow the adapted vLLM ROCm platform priorities rather
+        than CUDA FlashAttention paths.
+        """
+        from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        if use_mla:
+            if use_sparse:
+                return AttentionBackendEnum.ROCM_AITER_MLA_SPARSE.get_path()
+
+            from vllm._aiter_ops import rocm_aiter_ops
+
+            if rocm_aiter_ops.is_mla_enabled():
+                return AttentionBackendEnum.ROCM_AITER_MLA.get_path()
+            return AttentionBackendEnum.TRITON_MLA.get_path()
+
+        if use_sparse:
+            raise ValueError("use_sparse=True requires use_mla=True.")
+
+        return AttentionBackendEnum.ROCM_ATTN.get_path()
+
+    def moe_align_block_size(
+        self,
+        topk_ids: torch.Tensor,
+        block_size: int,
+        num_experts: int,
+        expert_map: Optional[torch.Tensor] = None,
+        pad_sorted_ids: bool = False,
+        ignore_invalid_experts: bool = False,
+    ):
+        from .impl.fused_moe import moe_align_block_size_hygon
+
+        return moe_align_block_size_hygon(
+            topk_ids,
+            block_size,
+            num_experts,
+            expert_map,
+            pad_sorted_ids,
+            ignore_invalid_experts,
+        )
+
+    def moe_sum(self, inp, out):
+        from .impl.fused_moe import moe_sum_hygon
+
+        moe_sum_hygon(inp, out)
+
+    def topk_softmax(
+        self,
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize=False,
+    ):
+        from .impl.fused_moe import topk_softmax_hygon
+
+        return topk_softmax_hygon(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+        )
+
+    def invoke_fused_moe_triton_kernel(
+        self,
+        A,
+        B,
+        C,
+        A_scale,
+        B_scale,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        mul_routed_weight,
+        top_k,
+        config,
+        compute_type,
+        use_fp8_w8a8,
+        use_int8_w8a8,
+        use_int8_w8a16,
+        use_int4_w4a16,
+        per_channel_quant,
+        block_shape=None,
+        B_bias=None,
+    ):
+        from .impl.fused_moe import invoke_fused_moe_triton_kernel_hygon
+
+        invoke_fused_moe_triton_kernel_hygon(
+            A,
+            B,
+            C,
+            A_scale,
+            B_scale,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight,
+            top_k,
+            config,
+            compute_type,
+            use_fp8_w8a8,
+            use_int8_w8a8,
+            use_int8_w8a16,
+            use_int4_w4a16,
+            per_channel_quant,
+            block_shape=block_shape,
+            B_bias=B_bias,
+        )
+
+    def grouped_topk(
+        self,
+        scores,
+        n_group,
+        topk_group,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        bias,
+        scoring_func=0,
+    ):
+        from .impl.fused_moe import grouped_topk_hygon
+
+        return grouped_topk_hygon(
+            scores,
+            n_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+            bias,
+            scoring_func,
+        )

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon vendor operator implementations."""

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/activation.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/activation.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon activation operator fallbacks backed by vLLM native ops."""
+
+from __future__ import annotations
+
+import torch
+
+
+def silu_and_mul_hygon(obj, x: torch.Tensor) -> torch.Tensor:
+    """SiLU activation followed by element-wise multiplication."""
+    d = x.shape[-1] // 2
+    out = torch.empty(*x.shape[:-1], d, dtype=x.dtype, device=x.device)
+    torch.ops._C.silu_and_mul(out, x)
+    return out
+
+
+def gelu_and_mul_hygon(obj, x: torch.Tensor) -> torch.Tensor:
+    """GELU activation followed by element-wise multiplication."""
+    approximate = getattr(obj, "approximate", "none") if obj is not None else "none"
+    d = x.shape[-1] // 2
+    out = torch.empty(*x.shape[:-1], d, dtype=x.dtype, device=x.device)
+    if approximate == "tanh":
+        torch.ops._C.gelu_tanh_and_mul(out, x)
+    else:
+        torch.ops._C.gelu_and_mul(out, x)
+    return out

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/fused_moe.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/fused_moe.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon MoE operator fallbacks backed by vLLM native ops."""
+
+from __future__ import annotations
+
+import torch
+from vllm.triton_utils import triton
+from vllm.utils.math_utils import round_up
+
+
+def moe_align_block_size_hygon(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    expert_map: torch.Tensor | None = None,
+    pad_sorted_ids: bool = False,
+    ignore_invalid_experts: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    from vllm._custom_ops import moe_align_block_size
+
+    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
+    if pad_sorted_ids:
+        max_num_tokens_padded = round_up(max_num_tokens_padded, block_size)
+    if topk_ids.numel() < num_experts:
+        max_num_tokens_padded = min(
+            topk_ids.numel() * block_size, max_num_tokens_padded
+        )
+
+    sorted_ids = torch.empty(
+        (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device
+    )
+    max_num_m_blocks = triton.cdiv(max_num_tokens_padded, block_size)
+    expert_ids = torch.empty(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+    num_tokens_post_pad = torch.empty((1,), dtype=torch.int32, device=topk_ids.device)
+
+    moe_align_block_size(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_ids,
+        expert_ids,
+        num_tokens_post_pad,
+        expert_map if ignore_invalid_experts else None,
+    )
+
+    if expert_map is not None and not ignore_invalid_experts:
+        expert_ids = expert_map[expert_ids]
+
+    return sorted_ids, expert_ids, num_tokens_post_pad
+
+
+def moe_sum_hygon(inp, out):
+    from vllm._custom_ops import moe_sum
+
+    moe_sum(inp, out)
+
+
+def topk_softmax_hygon(
+    topk_weights,
+    topk_indices,
+    token_expert_indices,
+    gating_output,
+    renormalize=False,
+):
+    from vllm._custom_ops import topk_softmax
+
+    topk_softmax(
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+    )
+    return topk_weights, topk_indices
+
+
+def invoke_fused_moe_triton_kernel_hygon(
+    A,
+    B,
+    C,
+    A_scale,
+    B_scale,
+    topk_weights,
+    sorted_token_ids,
+    expert_ids,
+    num_tokens_post_padded,
+    mul_routed_weight,
+    top_k,
+    config,
+    compute_type,
+    use_fp8_w8a8,
+    use_int8_w8a8,
+    use_int8_w8a16,
+    use_int4_w4a16,
+    per_channel_quant,
+    block_shape=None,
+    B_bias=None,
+):
+    from vllm.model_executor.layers.fused_moe.fused_moe import (
+        invoke_fused_moe_triton_kernel,
+    )
+
+    invoke_fused_moe_triton_kernel(
+        A,
+        B,
+        C,
+        A_scale,
+        B_scale,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        mul_routed_weight,
+        top_k,
+        config,
+        compute_type,
+        use_fp8_w8a8,
+        use_int8_w8a8,
+        use_int8_w8a16,
+        use_int4_w4a16,
+        per_channel_quant,
+        block_shape=block_shape,
+        B_bias=B_bias,
+    )
+
+
+def grouped_topk_hygon(
+    scores,
+    n_group,
+    topk_group,
+    topk,
+    renormalize,
+    routed_scaling_factor,
+    bias,
+    scoring_func=0,
+):
+    from vllm._custom_ops import grouped_topk
+
+    return grouped_topk(
+        scores,
+        n_group,
+        topk_group,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        bias,
+        scoring_func,
+    )

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/normalization.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/normalization.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon normalization operator fallbacks backed by vLLM native ops."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import torch
+
+
+def rms_norm_hygon(
+    obj,
+    x: torch.Tensor,
+    residual: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+    """RMS normalization using vLLM custom ops."""
+    from vllm._custom_ops import fused_add_rms_norm as vllm_fused_add_rms_norm
+    from vllm._custom_ops import rms_norm as vllm_rms_norm
+
+    weight = obj.weight
+    epsilon = obj.variance_epsilon
+
+    if residual is not None:
+        vllm_fused_add_rms_norm(x, residual, weight, epsilon)
+        return x, residual
+
+    out = torch.empty_like(x)
+    vllm_rms_norm(out, x, weight, epsilon)
+    return out

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/rotary.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/rotary.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon rotary embedding fallback backed by vLLM native ops."""
+
+from __future__ import annotations
+
+import torch
+
+
+def rotary_embedding_hygon(
+    obj,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    rotary_interleaved: bool = False,
+    inplace: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply rotary position embedding using vLLM custom ops."""
+    from vllm._custom_ops import rotary_embedding as vllm_rotary_embedding
+
+    if not inplace:
+        query = query.clone()
+        key = key.clone()
+
+    vllm_rotary_embedding(
+        position_ids,
+        query,
+        key,
+        cos,
+        sin,
+        rotary_interleaved,
+    )
+    return query, key

--- a/vllm_fl/dispatch/backends/vendor/hygon/register_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/register_ops.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon backend operator registrations."""
+
+from __future__ import annotations
+
+import functools
+
+from vllm_fl.dispatch.types import OpImpl, BackendImplKind, BackendPriority
+
+
+def _bind_is_available(fn, is_available_fn):
+    """Wrap a function and bind _is_available for OpImpl.is_available()."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    wrapper._is_available = is_available_fn
+    return wrapper
+
+
+def register_builtins(registry) -> None:
+    """
+    Register Hygon vendor operator implementations.
+
+    Args:
+        registry: Registry to register into.
+    """
+    from .hygon import HygonBackend
+
+    backend = HygonBackend()
+    is_avail = backend.is_available
+
+    impls: list[OpImpl] = [
+        OpImpl(
+            op_name="silu_and_mul",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.silu_and_mul, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="gelu_and_mul",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.gelu_and_mul, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="rms_norm",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.rms_norm, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="rotary_embedding",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.rotary_embedding, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="attention_backend",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.attention_backend, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="moe_align_block_size",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.moe_align_block_size, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="moe_sum",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.moe_sum, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="topk_softmax",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.topk_softmax, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="invoke_fused_moe_triton_kernel",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.invoke_fused_moe_triton_kernel, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="grouped_topk",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.grouped_topk, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+    ]
+
+    registry.register_many(impls)
+
+
+__all__ = [
+    "BackendImplKind",
+    "BackendPriority",
+    "OpImpl",
+    "_bind_is_available",
+    "register_builtins",
+]

--- a/vllm_fl/dispatch/config/hygon.yaml
+++ b/vllm_fl/dispatch/config/hygon.yaml
@@ -1,5 +1,5 @@
 # vLLM-FL Dispatch Configuration for hygon GPU
-# Auto-loaded when running on hygon hardware
+# Auto-loaded when running on hygons hardware
 
 # Preferred default backend type: flagos, vendor, reference
 prefer: flagos
@@ -43,7 +43,37 @@ op_backends:
     - vendor:hygon
     - reference
 
+  gelu_and_mul:
+    - flagos
+    - vendor:hygon
+    - reference
+
   rotary_embedding:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  moe_align_block_size:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  moe_sum:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  topk_softmax:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  invoke_fused_moe_triton_kernel:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  grouped_topk:
     - flagos
     - vendor:hygon
     - reference

--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -67,11 +67,6 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
             logger.warning(f"OOT op '{op_name}' not found in OOT_OPS, skipping.")
             continue
 
-        # unquantized_fused_moe_method only registers when use_flaggems_op is True
-        if op_name == "unquantized_fused_moe_method" and not use_flaggems_op(op_name):
-            logger.debug(f"Skipping '{op_name}': use_flaggems_op returned False")
-            continue
-
         op_cls, registration_name = OOT_OPS[op_name]
         logger.info(f"Registering oot op: {op_name} as '{registration_name}'")
         if issubclass(op_cls, PluggableLayer):

--- a/vllm_fl/ops/fused_moe/fused_moe_utils.py
+++ b/vllm_fl/ops/fused_moe/fused_moe_utils.py
@@ -83,7 +83,7 @@ def select_unquantized_moe_backend_oot(moe_config: FusedMoEConfig,
     if current_platform.is_tpu():
         return UnquantizedMoeBackend.TPU, None
     
-    if current_platform.is_out_of_tree() and use_flaggems():
+    if current_platform.is_out_of_tree():
         return UnquantizedMoeBackend.TRITON, TritonExpertsFL
 
     if moe_config.is_lora_enabled:


### PR DESCRIPTION
### PR Type
New Features

### Description
1、 Add codes of hygon backends in vllm-plugin-FL/vllm_fl/dispatch/backends/vendor/hygon.
2、Fix bugs: when we use USE_FLAGGEMS=0,  unquantized_fused_moe_method OP may cause operational errors.

### Testing
Run qwen3.6-35b-a3b qwen3.6-27b pass.

