### PR TITLE
support cuda_graph on iluvatar

### DIFF
--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -410,7 +410,7 @@ class PlatformFL(Platform):
 
     @classmethod
     def use_custom_op_collectives(cls) -> bool:
-        return cls.vendor_name in ("nvidia", "thead")
+        return cls.vendor_name in ("nvidia", "thead", "iluvatar")
 
     @classmethod
     def num_compute_units(cls, device_id: int = 0) -> int:

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -199,10 +199,8 @@ class PlatformFL(Platform):
         from vllm.config import CUDAGraphMode
 
         compilation_config = vllm_config.compilation_config
-        # NOTE: Do NOT set compile_sizes to [] here.
-        # Leaving it as None allows vllm's optimization level defaults
-        # and _set_cudagraph_sizes() to auto-populate compile_sizes
-        # based on cudagraph_capture_sizes for proper graph capture.
+        if compilation_config.compile_sizes is None:
+            compilation_config.compile_sizes = []
 
         if (
             cls.device_type == "musa"

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -199,8 +199,10 @@ class PlatformFL(Platform):
         from vllm.config import CUDAGraphMode
 
         compilation_config = vllm_config.compilation_config
-        if compilation_config.compile_sizes is None:
-            compilation_config.compile_sizes = []
+        # NOTE: Do NOT set compile_sizes to [] here.
+        # Leaving it as None allows vllm's optimization level defaults
+        # and _set_cudagraph_sizes() to auto-populate compile_sizes
+        # based on cudagraph_capture_sizes for proper graph capture.
 
         if (
             cls.device_type == "musa"
@@ -329,7 +331,7 @@ class PlatformFL(Platform):
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:
-        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon", "mthreads"]:
+        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon", "mthreads", "iluvatar"]:
             return True
         return False
 


### PR DESCRIPTION
### PR Category
Others

### PR Type
Bug Fixes 

### Description
Support CUDA Graph on iluvatar, enabling CUDA Graphs can improve performance. Has been verified Qwen3.6-27B and Qwen3.6-35B-A3B models.
Note:  If use the default `compilation-config` parameter, maybe OOM.


### Testing
export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=7200
vllm serve /models/Qwen3.6-35B-A3B/ -tp 8 --served-model-name qwen --port 8070 --max-model-len 131072 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'

### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
