### PR TITLE
fix(moe): use valid_grouping closure in GroupedTopKRouterFL

### DIFF
--- a/vllm_fl/ops/fused_moe/router.py
+++ b/vllm_fl/ops/fused_moe/router.py
@@ -169,7 +169,17 @@ class GroupedTopKRouterFL(GroupedTopKRouter):
         *,
         input_ids: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if not self._valid_grouping(router_logits):
+        # Mirror upstream GroupedTopKRouter._compute_routing, which checks
+        # expert/grouping validity via an inner `valid_grouping()` closure
+        # rather than a `_valid_grouping` method. The earlier port called a
+        # non-existent `self._valid_grouping`, raising AttributeError.
+        def valid_grouping() -> bool:
+            num_experts = router_logits.shape[-1]
+            if num_experts <= self.num_expert_group:
+                return False
+            return num_experts % self.num_expert_group == 0
+
+        if not valid_grouping():
             if self.e_score_correction_bias is not None:
                 topk_weights, topk_ids = fused_topk_bias(
                     hidden_states=hidden_states,


### PR DESCRIPTION
### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->
Core
### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->
Bug Fixes
### Description
<!-- Describe what this PR does and why. -->
GroupedTopKRouterFL._compute_routing calls self._valid_grouping(router_logits), but no such method exists on GroupedTopKRouter, BaseRouter, or GroupedTopKRouterFL. Upstream
  GroupedTopKRouter._compute_routing (vllm 0.20.2) validates the expert/grouping layout through an inner closure valid_grouping(), not a method.

  As a result, serving any model that uses the grouped top-k router (DeepSeek-V2/V3, Hy3, Qwen3-MoE, …) crashes at startup during the profile run:

AttributeError: 'GroupedTopKRouterFL' object has no attribute '_valid_grouping'
RuntimeError: Worker failed with error ''GroupedTopKRouterFL' object has no attribute '_valid_grouping''
  EngineCore failed to start.

  This PR restores the upstream closure-based check so the FL router no longer references a non-existent method.

### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->
None
### Changes
<!-- List the key changes made in this PR. -->
-
In vllm_fl/ops/fused_moe/router.py, GroupedTopKRouterFL._compute_routing: replace the non-existent self._valid_grouping(router_logits) call with the inner valid_grouping()
  closure, mirroring upstream GroupedTopKRouter._compute_routing exactly — reads router_logits.shape[-1], returns False when num_experts <= num_expert_group or when num_experts is
  not divisible by num_expert_group, otherwise True.

### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->
-
verified hy3_preview model on nvidia and mthreads

### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
