### PR TITLE
feat(ascend): add split_qkv_rmsnorm_mrope fused kernel for Qwen3.5/3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
 | MiniCPM-o 4.5 | Supported | [example](./examples/minicpm/) |
 | GLM-5 | Supported | [example](./examples/glm_5_offline_inference.py) |
 | Qwen3.5-35B-A3B | Supported | [example](./examples/glm_5_offline_inference.py)  |
-| Qwen3.6-27B | Supported | [Ascend patch](./vllm_fl/dispatch/backends/vendor/ascend/patches/patch_qwen3_5.py) |
 | BAAI/bge-m3 | Supported | [implementation](./vllm_fl/models/bge_m3.py) |
 
 ### Supported Chips

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
 | MiniCPM-o 4.5 | Supported | [example](./examples/minicpm/) |
 | GLM-5 | Supported | [example](./examples/glm_5_offline_inference.py) |
 | Qwen3.5-35B-A3B | Supported | [example](./examples/glm_5_offline_inference.py)  |
+| Qwen3.6-27B | Supported | [Ascend patch](./vllm_fl/dispatch/backends/vendor/ascend/patches/patch_qwen3_5.py) |
 | BAAI/bge-m3 | Supported | [implementation](./vllm_fl/models/bge_m3.py) |
 
 ### Supported Chips

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/linearnorm/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/linearnorm/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026 BAAI. All rights reserved.

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/linearnorm/split_qkv_rmsnorm_mrope.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/linearnorm/split_qkv_rmsnorm_mrope.py
@@ -1,0 +1,429 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+# Copyright (c) 2026 BAAI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Adapted from https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/ops/triton/linearnorm/split_qkv_rmsnorm_mrope.py
+# mypy: ignore-errors
+
+import torch
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+from ..triton_utils import extract_slice, get_vectorcore_num, insert_slice
+
+
+@triton.jit(
+    do_not_specialize=["num_tokens", "front_core_num", "num_tokens_each_front_core", "num_tokens_each_tail_core"]
+)
+def split_qkv_rmsnorm_mrope_kernel(
+    in_qkv_ptr: torch.Tensor,
+    q_weight_ptr: torch.Tensor,
+    q_bias_ptr: torch.Tensor,
+    k_weight_ptr: torch.Tensor,
+    k_bias_ptr: torch.Tensor,
+    cos_sin_ptr: torch.Tensor,
+    out_q_ptr: torch.Tensor,
+    out_k_ptr: torch.Tensor,
+    out_v_ptr: torch.Tensor,
+    out_gate_ptr: torch.Tensor,
+    num_tokens,
+    front_core_num,
+    num_tokens_each_front_core,
+    num_tokens_each_tail_core,
+    num_q_heads: tl.constexpr,
+    num_kv_heads: tl.constexpr,
+    head_size: tl.constexpr,
+    q_size: tl.constexpr,
+    kv_size: tl.constexpr,
+    eps: tl.constexpr,
+    mrope_section_t,
+    mrope_section_h,
+    mrope_section_w,
+    has_bias: tl.constexpr,
+    is_interleaved: tl.constexpr,
+    rope_dim: tl.constexpr,
+    half_rope_dim: tl.constexpr,
+    IS_PARTIAL_ROPE: tl.constexpr,
+    gate_size: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+
+    loop_num = num_tokens_each_front_core
+    if block_idx >= front_core_num:
+        loop_num = num_tokens_each_tail_core
+
+    block_offset = num_tokens_each_front_core * block_idx
+    if block_idx >= front_core_num:
+        block_offset = (
+            num_tokens_each_front_core * front_core_num + (block_idx - front_core_num) * num_tokens_each_tail_core
+        )
+
+    q_rmsnorm_weight = tl.load(q_weight_ptr + tl.arange(0, head_size))
+    k_rmsnorm_weight = tl.load(k_weight_ptr + tl.arange(0, head_size))
+
+    if has_bias:
+        q_bias = tl.load(q_bias_ptr + tl.arange(0, head_size))
+        k_bias = tl.load(k_bias_ptr + tl.arange(0, head_size))
+
+    for index in range(loop_num):
+        ## load ##
+        # q
+        in_q_offset = in_qkv_ptr + (block_offset + index) * (q_size + gate_size + 2 * kv_size)
+        if gate_size > 0:
+            in_q_gate_tensor = (
+                tl.load(in_q_offset + tl.arange(0, q_size + gate_size))
+                .to(tl.float32)
+                .reshape(num_q_heads, head_size * 2)
+            )
+            in_q_tensor = extract_slice(
+                in_q_gate_tensor,
+                offsets=(0, 0),
+                sizes=(num_q_heads, head_size),
+                strides=(1, 1),
+            )
+            in_gate_tensor = extract_slice(
+                in_q_gate_tensor,
+                offsets=(0, head_size),
+                sizes=(num_q_heads, head_size),
+                strides=(1, 1),
+            ).reshape(q_size)
+        else:
+            in_q_tensor = tl.load(in_q_offset + tl.arange(0, q_size)).to(tl.float32).reshape(num_q_heads, head_size)
+
+        # k
+        in_k_offset = in_q_offset + q_size + gate_size
+        in_k_tensor = tl.load(in_k_offset + tl.arange(0, kv_size)).to(tl.float32).reshape(num_kv_heads, head_size)
+        # v
+        in_v_offset = in_k_offset + kv_size
+        in_v_tensor = tl.load(in_v_offset + tl.arange(0, kv_size))
+
+        # cos, sin
+        cos_offsets = tl.arange(0, half_rope_dim)
+        if is_interleaved:
+            h_mask = ((cos_offsets % 3) == 1) & (cos_offsets <= 3 * mrope_section_h)
+            w_mask = ((cos_offsets % 3) == 2) & (cos_offsets <= 3 * mrope_section_w)
+            t_mask = ~(h_mask | w_mask)
+        else:
+            t_mask = cos_offsets < mrope_section_t
+            h_mask = (mrope_section_t - 1 < cos_offsets) & (cos_offsets < mrope_section_t + mrope_section_h)
+            w_mask = (mrope_section_t + mrope_section_h - 1 < cos_offsets) & (
+                cos_offsets < mrope_section_t + mrope_section_h + mrope_section_w
+            )
+
+        t_cos_offset = cos_sin_ptr + (block_offset + index) * rope_dim
+        h_cos_offset = t_cos_offset + num_tokens * rope_dim
+        w_cos_offset = h_cos_offset + num_tokens * rope_dim
+
+        t_sin_offset = cos_sin_ptr + (block_offset + index) * rope_dim + half_rope_dim
+        h_sin_offset = t_sin_offset + num_tokens * rope_dim
+        w_sin_offset = h_sin_offset + num_tokens * rope_dim
+
+        t_cos_tensor = tl.load(t_cos_offset + cos_offsets, mask=t_mask, other=0)
+        h_cos_tensor = tl.load(h_cos_offset + cos_offsets, mask=h_mask, other=0)
+        w_cos_tensor = tl.load(w_cos_offset + cos_offsets, mask=w_mask, other=0)
+        t_sin_tensor = tl.load(t_sin_offset + cos_offsets, mask=t_mask, other=0)
+        h_sin_tensor = tl.load(h_sin_offset + cos_offsets, mask=h_mask, other=0)
+        w_sin_tensor = tl.load(w_sin_offset + cos_offsets, mask=w_mask, other=0)
+
+        cos_tensor = (t_cos_tensor + h_cos_tensor + w_cos_tensor).to(tl.float32).reshape(1, half_rope_dim)
+        cos_tensor = tl.broadcast_to(cos_tensor, (2, half_rope_dim)).reshape(1, rope_dim)
+
+        sin_tensor = (t_sin_tensor + h_sin_tensor + w_sin_tensor).to(tl.float32).reshape(1, half_rope_dim)
+        sin_tensor = tl.broadcast_to(sin_tensor, (2, half_rope_dim)).reshape(1, rope_dim)
+
+        ## compute ##
+        # q-rmsnorm
+        squares = in_q_tensor * in_q_tensor
+        variances = tl.sum(squares, axis=1) / head_size
+        reciprocal_std = (1 / tl.sqrt(variances + eps)).reshape(num_q_heads, 1)
+        q_normalized = in_q_tensor * reciprocal_std
+        q_normalized = q_normalized * q_rmsnorm_weight
+        if has_bias:
+            q_normalized = q_normalized + q_bias
+
+        # k-rmsnorm
+        squares = in_k_tensor * in_k_tensor
+        variances = tl.sum(squares, axis=1) / head_size
+        reciprocal_std = (1 / tl.sqrt(variances + eps)).reshape(num_kv_heads, 1)
+        k_normalized = in_k_tensor * reciprocal_std
+        k_normalized = k_normalized * k_rmsnorm_weight
+        if has_bias:
+            k_normalized = k_normalized + k_bias
+
+        # q-mrope
+        x1 = extract_slice(
+            q_normalized,
+            offsets=(0, 0),
+            sizes=(num_q_heads, half_rope_dim),
+            strides=(1, 1),
+        )
+        x2 = extract_slice(
+            q_normalized,
+            offsets=(0, half_rope_dim),
+            sizes=(num_q_heads, half_rope_dim),
+            strides=(1, 1),
+        )
+        cat_x = tl.zeros((num_q_heads, rope_dim), dtype=tl.float32)
+        cat_x = insert_slice(
+            cat_x,
+            -x2,
+            offsets=(0, 0),
+            sizes=(num_q_heads, half_rope_dim),
+            strides=(1, 1),
+        )
+        cat_x = insert_slice(
+            cat_x,
+            x1,
+            offsets=(0, half_rope_dim),
+            sizes=(num_q_heads, half_rope_dim),
+            strides=(1, 1),
+        )
+        if IS_PARTIAL_ROPE:
+            orig_qk = extract_slice(
+                q_normalized,
+                offsets=(0, 0),
+                sizes=(num_q_heads, rope_dim),
+                strides=(1, 1),
+            )
+        else:
+            orig_qk = q_normalized
+        roped_q = cat_x * sin_tensor + orig_qk * cos_tensor
+
+        # k-mrope
+        y1 = extract_slice(
+            k_normalized,
+            offsets=(0, 0),
+            sizes=(num_kv_heads, half_rope_dim),
+            strides=(1, 1),
+        )
+        y2 = extract_slice(
+            k_normalized,
+            offsets=(0, half_rope_dim),
+            sizes=(num_kv_heads, half_rope_dim),
+            strides=(1, 1),
+        )
+        cat_y = tl.zeros((num_kv_heads, rope_dim), dtype=tl.float32)
+        cat_y = insert_slice(
+            cat_y,
+            -y2,
+            offsets=(0, 0),
+            sizes=(num_kv_heads, half_rope_dim),
+            strides=(1, 1),
+        )
+        cat_y = insert_slice(
+            cat_y,
+            y1,
+            offsets=(0, half_rope_dim),
+            sizes=(num_kv_heads, half_rope_dim),
+            strides=(1, 1),
+        )
+        if IS_PARTIAL_ROPE:
+            orig_qk = extract_slice(
+                k_normalized,
+                offsets=(0, 0),
+                sizes=(num_kv_heads, rope_dim),
+                strides=(1, 1),
+            )
+        else:
+            orig_qk = k_normalized
+        roped_k = cat_y * sin_tensor + orig_qk * cos_tensor
+
+        if IS_PARTIAL_ROPE:
+            q_normalized = insert_slice(
+                q_normalized,
+                roped_q,
+                offsets=(0, 0),
+                sizes=(num_q_heads, rope_dim),
+                strides=(1, 1),
+            )
+            k_normalized = insert_slice(
+                k_normalized,
+                roped_k,
+                offsets=(0, 0),
+                sizes=(num_kv_heads, rope_dim),
+                strides=(1, 1),
+            )
+        else:
+            q_normalized = roped_q
+            k_normalized = roped_k
+
+        ## store ##
+        # out_q
+        out_q_offset = out_q_ptr + (block_offset + index) * q_size
+        out_q_indices = tl.arange(0, q_size)
+        tl.store(out_q_offset + out_q_indices, q_normalized.reshape(q_size))
+
+        # out_k
+        out_k_offset = out_k_ptr + (block_offset + index) * kv_size
+        out_k_indices = tl.arange(0, kv_size)
+        tl.store(out_k_offset + out_k_indices, k_normalized.reshape(kv_size))
+
+        # out_v
+        out_v_offset = out_v_ptr + (block_offset + index) * kv_size
+        tl.store(out_v_offset + tl.arange(0, kv_size), in_v_tensor)
+
+        # out_gate
+        if gate_size > 0:
+            out_gate_offset = out_gate_ptr + (block_offset + index) * gate_size
+            tl.store(out_gate_offset + tl.arange(0, gate_size), in_gate_tensor)
+
+
+def triton_split_qkv_rmsnorm_mrope(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin: torch.Tensor,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    eps: float,
+    mrope_section: list[int],
+    is_interleaved: bool,
+    rope_dim: int | None = None,
+    q_bias: torch.Tensor | None = None,
+    k_bias: torch.Tensor | None = None,
+    has_gate: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    core_num = get_vectorcore_num()
+
+    q_size = num_q_heads * head_size
+    kv_size = num_kv_heads * head_size
+    num_tokens = qkv.shape[0]
+
+    gate_size = q_size if has_gate else 0
+
+    if rope_dim is None:
+        rope_dim = head_size
+    IS_PARTIAL_ROPE = rope_dim != head_size
+
+    front_core_num = core_num
+    if num_tokens % core_num != 0:
+        front_core_num = num_tokens % core_num
+
+    num_tokens_each_front_core = (num_tokens + core_num - 1) // core_num
+
+    tail_core_num = 0
+    if num_tokens > core_num:
+        tail_core_num = core_num - front_core_num
+
+    num_tokens_each_tail_core = num_tokens // core_num
+
+    q_output = torch.empty(num_tokens, q_size, device=qkv.device, dtype=qkv.dtype)
+    k_output = torch.empty(num_tokens, kv_size, device=qkv.device, dtype=qkv.dtype)
+    v_output = torch.empty(num_tokens, kv_size, device=qkv.device, dtype=qkv.dtype)
+    gate_output = torch.empty(num_tokens, gate_size, device=qkv.device, dtype=qkv.dtype)
+
+    total_core = front_core_num + tail_core_num
+    block_dim = core_num
+    if total_core < core_num:
+        block_dim = total_core
+
+    has_bias = q_bias is not None
+
+    split_qkv_rmsnorm_mrope_kernel[(block_dim,)](
+        qkv,
+        q_weight,
+        q_bias,
+        k_weight,
+        k_bias,
+        cos_sin,
+        q_output,
+        k_output,
+        v_output,
+        gate_output,
+        num_tokens,
+        front_core_num,
+        num_tokens_each_front_core,
+        num_tokens_each_tail_core,
+        num_q_heads,
+        num_kv_heads,
+        head_size,
+        q_size,
+        kv_size,
+        eps,
+        mrope_section[0],
+        mrope_section[1],
+        mrope_section[2],
+        has_bias,
+        is_interleaved,
+        rope_dim,
+        rope_dim // 2,
+        IS_PARTIAL_ROPE,
+        gate_size,
+    )
+
+    return q_output, k_output, v_output, gate_output
+
+
+def triton_split_qkv_rmsnorm_mrope_fake(
+    qkv: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin: torch.Tensor,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    eps: float,
+    mrope_section: list[int],
+    is_interleaved: bool,
+    rope_dim: int | None = None,
+    q_bias: torch.Tensor | None = None,
+    k_bias: torch.Tensor | None = None,
+    has_gate: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_tokens = qkv.shape[0]
+    q_size = num_q_heads * head_size
+    kv_size = num_kv_heads * head_size
+    gate_size = q_size if has_gate else 0
+
+    q_output = torch.empty(
+        num_tokens,
+        q_size,
+        device=qkv.device,
+        dtype=qkv.dtype,
+    )
+
+    k_output = torch.empty(
+        num_tokens,
+        kv_size,
+        device=qkv.device,
+        dtype=qkv.dtype,
+    )
+
+    v_output = torch.empty(
+        num_tokens,
+        kv_size,
+        device=qkv.device,
+        dtype=qkv.dtype,
+    )
+
+    gate_output = torch.empty(
+        num_tokens,
+        gate_size,
+        device=qkv.device,
+        dtype=qkv.dtype,
+    )
+
+    return q_output, k_output, v_output, gate_output
+
+
+if not hasattr(torch.ops.vllm, "triton_split_qkv_rmsnorm_mrope"):
+    direct_register_custom_op(
+        op_name="triton_split_qkv_rmsnorm_mrope",
+        op_func=triton_split_qkv_rmsnorm_mrope,
+        fake_impl=triton_split_qkv_rmsnorm_mrope_fake,
+        mutates_args=[],
+        dispatch_key="PrivateUse1",
+    )

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/triton_utils.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/triton_utils.py
@@ -4,10 +4,48 @@
 from typing import Any, Dict
 
 import torch
-from vllm.triton_utils import HAS_TRITON, triton
+from vllm.triton_utils import HAS_TRITON, tl, triton
 
 _NUM_AICORE = -1
 _NUM_VECTORCORE = -1
+_extension_module = None
+
+if HAS_TRITON:
+    try:
+        import triton.language.extra.cann.extension as _extension_module  # type: ignore
+    except ImportError:
+        _extension_module = None
+
+
+def _resolve_triton_ascend_op(op_name: str):
+    if not HAS_TRITON:
+        raise RuntimeError(
+            f"Triton op '{op_name}' cannot be resolved because HAS_TRITON is False"
+        )
+
+    if _extension_module is not None:
+        extension_op = getattr(_extension_module, op_name, None)
+        if extension_op is not None:
+            return extension_op
+
+    tl_op = getattr(tl, op_name, None)
+    if tl_op is not None:
+        return tl_op
+
+    raise RuntimeError(
+        f"Failed to resolve Triton op '{op_name}': "
+        "neither triton.language.extra.cann.extension nor triton.language provides it."
+    )
+
+
+if HAS_TRITON:
+    insert_slice = _resolve_triton_ascend_op("insert_slice")
+    extract_slice = _resolve_triton_ascend_op("extract_slice")
+    get_element = _resolve_triton_ascend_op("get_element")
+else:
+    insert_slice = None
+    extract_slice = None
+    get_element = None
 
 
 def init_device_properties_triton():

--- a/vllm_fl/dispatch/backends/vendor/ascend/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/patch.py
@@ -18,6 +18,7 @@ def apply_ascend_patches():
     patch_fla_ops()
     patch_op_cls()
     patch_fused_moe()
+    patch_qwen3_5_attention()
 
 def patch_mamba_config():
     """Patch HybridAttentionMambaModelConfig for Ascend."""
@@ -55,6 +56,16 @@ def patch_fused_moe():
         logger.info("Patched fused_moe for Ascend")
     except Exception as e:
         logger.warning("Failed to patch fused_moe ops: %s", e)
+
+def patch_qwen3_5_attention():
+    """Patch Qwen3.5/Qwen3.6 attention to use the fused Ascend kernel."""
+    try:
+        from .patches.patch_qwen3_5 import patch_qwen3_5_attention as _do_patch
+
+        _do_patch()
+    except Exception as e:
+        logger.warning("Failed to patch Qwen3NextAttention for Ascend: %s", e)
+
 
 def patch_fla_ops():
     """Patch FLA ops and fused_gdn_gating with Ascend implementations."""

--- a/vllm_fl/dispatch/backends/vendor/ascend/patches/README.md
+++ b/vllm_fl/dispatch/backends/vendor/ascend/patches/README.md
@@ -1,0 +1,20 @@
+# Ascend-specific patches
+
+This directory contains runtime monkey-patches that adapt upstream vLLM model
+code for Huawei Ascend NPUs. These patches are applied automatically when the
+`fl` plugin is loaded on an Ascend platform (`VLLM_FL_PLATFORM=ascend`).
+
+## Patch list
+
+| File | Target | Purpose |
+|------|--------|---------|
+| `patch_mamba_config.py` | `HybridAttentionMambaModelConfig.verify_and_update_config` | Aligns attention/mamba block sizes with Ascend requirements. |
+| `patch_multimodal_merge.py` | `vllm.model_executor.models.utils.merge_multimodal_embeddings` | In-place merge of multimodal embeddings on NPU. |
+| `patch_qwen3_5.py` | `vllm.model_executor.models.qwen3_next.Qwen3NextAttention.forward` | Fuses the Q/K/V split, RMSNorm and M-RoPE of Qwen3.5/Qwen3.6 full-attention layers into a single Triton kernel (`torch.ops.vllm.triton_split_qkv_rmsnorm_mrope`). |
+
+## Adding a new patch
+
+1. Create `patches/patch_<name>.py`.
+2. Expose an idempotent `patch_<name>()` function.
+3. Register the function in `../patch.py::apply_ascend_patches()`.
+4. Update this README with the new entry.

--- a/vllm_fl/dispatch/backends/vendor/ascend/patches/patch_qwen3_5.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/patches/patch_qwen3_5.py
@@ -1,0 +1,105 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+# Copyright (c) 2026 BAAI. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# mypy: ignore-errors
+
+"""Ascend-specific patch for Qwen3.5/Qwen3.6 attention.
+
+Replaces the upstream ``Qwen3NextAttention.forward`` with a fused
+``triton_split_qkv_rmsnorm_mrope`` implementation on Ascend NPUs.
+"""
+
+import logging
+
+import torch
+
+from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
+
+# Importing this module registers ``torch.ops.vllm.triton_split_qkv_rmsnorm_mrope``
+# if it has not been registered by another backend (e.g. vllm-ascend).
+from ..impl.linearnorm import split_qkv_rmsnorm_mrope  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+
+class AscendQwen3NextAttention(Qwen3NextAttention):
+    def forward(
+        self,
+        positions: torch.Tensor,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ):
+        qkv, _ = self.qkv_proj(hidden_states)
+
+        if "qwen3_5" in self.config.model_type:
+            cos_sin = self.rotary_emb.cos_sin_cache[positions]
+            if cos_sin.device != qkv.device:
+                cos_sin = cos_sin.to(qkv.device)
+            if cos_sin.dtype != qkv.dtype:
+                cos_sin = cos_sin.to(qkv.dtype)
+
+            q, k, v, gate = torch.ops.vllm.triton_split_qkv_rmsnorm_mrope(
+                qkv=qkv,
+                q_weight=1.0 + self.q_norm.weight,
+                k_weight=1.0 + self.k_norm.weight,
+                cos_sin=cos_sin,
+                num_q_heads=self.num_heads,
+                num_kv_heads=self.num_kv_heads,
+                head_size=self.head_dim,
+                eps=self.config.rms_norm_eps,
+                mrope_section=self.rotary_emb.mrope_section,
+                is_interleaved=self.rotary_emb.mrope_interleaved,
+                rope_dim=self.rotary_emb.rotary_dim,
+                has_gate=self.attn_output_gate,
+            )
+        else:
+            if self.attn_output_gate:
+                q_gate, k, v = qkv.split(
+                    [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
+                )
+                orig_shape = q_gate.shape[:-1]
+                q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
+                q, gate = torch.chunk(q_gate, 2, dim=-1)
+                q = q.reshape(*orig_shape, -1)
+                gate = gate.reshape(*orig_shape, -1)
+            else:
+                q, k, v = qkv.split(
+                    [self.q_size, self.kv_size, self.kv_size], dim=-1
+                )
+                gate = None
+
+            q = self.q_norm(q.view(-1, self.num_heads, self.head_dim)).view(
+                -1, self.num_heads * self.head_dim
+            )
+            k = self.k_norm(k.view(-1, self.num_kv_heads, self.head_dim)).view(
+                -1, self.num_kv_heads * self.head_dim
+            )
+
+            q, k = self.rotary_emb(positions, q, k)
+
+        attn_output = self.attn(q, k, v)
+
+        if self.attn_output_gate:
+            gate = torch.sigmoid(gate)
+            attn_output = attn_output * gate
+
+        output[:], _ = self.o_proj(attn_output)
+
+
+def patch_qwen3_5_attention() -> None:
+    """Apply the Ascend Qwen3.5/Qwen3.6 attention patch."""
+    Qwen3NextAttention.forward = AscendQwen3NextAttention.forward
+    logger.info("Patched Qwen3NextAttention for Ascend (split_qkv_rmsnorm_mrope)")


### PR DESCRIPTION
- Add Ascend Triton implementation of triton_split_qkv_rmsnorm_mrope.
- Patch Qwen3NextAttention.forward to use the fused kernel on qwen3_5 model_type.
- Register the op via torch custom op (PrivateUse1) with fallback guard.
- Extend triton_utils with extract_slice/insert_slice helpers.
- Update README and add patches README.

Tested on Qwen3.6-27B with graph + chunked prefill; all benchmark cases pass.

### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->

### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->

### Description
<!-- Describe what this PR does and why. -->

### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->

### Changes
<!-- List the key changes made in this PR. -->
-

### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->
-

### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
