### PR TITLE
Fix MUSA cuda graph custom ops performance regression

### DIFF
--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -226,6 +226,7 @@ class WorkerFL(WorkerBase):
         for k, v in sorted(os.environ.items()):
             logger.debug("%s=%r", k, v)
 
+        self._preserve_musa_custom_ops_for_compile()
         register_oot_ops()
 
         if fl_envs.USE_FLAGGEMS:
@@ -260,6 +261,28 @@ class WorkerFL(WorkerBase):
                 flag_gems.enable(
                     record=should_record, once=True, path=fl_envs.FLAGGEMS_ENABLE_OPLIST_PATH
                 )
+
+    def _preserve_musa_custom_ops_for_compile(self) -> None:
+        """Keep FL OOT custom ops enabled for MUSA compile/cudagraph mode."""
+        from vllm.platforms import current_platform
+
+        if current_platform.device_type != "musa":
+            return
+
+        custom_ops = self.vllm_config.compilation_config.custom_ops
+        if "all" in custom_ops:
+            return
+
+        if "none" in custom_ops:
+            custom_ops.remove("none")
+
+        custom_ops.append("all")
+        print(
+            "[FL_MUSA_CUSTOM_OPS] enabled custom_ops=all to preserve "
+            "FL OOT dispatch under compile/cudagraph mode.",
+            flush=True,
+        )
+
 
     # def sleep(self, level: int = 1) -> None:
     #     TODO(lms): rewrite CuMemAllocator


### PR DESCRIPTION
### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->
Vendor

### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->
Bug Fixes, Performance

### Description
<!-- Describe what this PR does and why. -->
This PR fixes a MUSA cuda graph performance regression in vllm-plugin-FL.

In MUSA + FL cuda graph/compile mode, vLLM may use `custom_ops=["none"]` by default. This prevents FL OOT custom ops from taking the `default.flagos` dispatch path, causing key ops such as `rms_norm`, `rotary_embedding`, and `silu_and_mul` to fall back to unfused paths.

This PR preserves custom ops for MUSA compile/cuda graph mode, so users do not need to manually pass:

```bash
--compilation-config '{"custom_ops":["all"]}'
```

### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->
N/A


### Changes
<!-- List the key changes made in this PR. -->
- Preserve custom ops for MUSA compile/cuda graph mode before registering FL OOT ops.
- Remove none from compilation_config.custom_ops on MUSA when needed.
- Append all to keep FL OOT custom op dispatch enabled.
- Add a runtime log to indicate that MUSA custom ops preservation is enabled.

### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->
Tested with Qwen3-4B on MUSA single-card cuda graph mode.
Verified:
- Service starts without explicitly passing custom_ops=["all"].
- cuda graph capture succeeds.
- [FL_MUSA_CUSTOM_OPS] enabled custom_ops=all ... appears in logs.
- rms_norm, rotary_embedding, and silu_and_mul hit default.flagos.
- Benchmark performance recovers from the degraded graph path to near eager / manual custom_ops=["all"] level.

**Benchmark result**:

Multi-concurrency C8, Qwen3-4B, input/output 128/128:
- Eager output token throughput: `126.92 tok/s`
- Patched cuda graph output token throughput: `127.41 tok/s`
- Failed requests: `0`
- Patched cuda graph recovers to near eager level and avoids the previous degraded graph path.

Single-concurrency C1, Qwen3-4B, input/output 128/128:
- Eager output token throughput: `19.63 tok/s`
- Patched cuda graph output token throughput: `19.26 tok/s`
- Failed requests: `0`
- Patched cuda graph remains close to eager level.

