### PR TITLE
fix: make mcoplib._C pre-load unconditional in register_op_schemas

### DIFF
--- a/vllm_fl/ops/_C_ops_registry.py
+++ b/vllm_fl/ops/_C_ops_registry.py
@@ -57,10 +57,12 @@ def register_op_schemas():
     # Pre-load mcoplib._C (MetaX) so its TORCH_LIBRARY registrations land
     # before our FRAGMENT definitions.  The hasattr check below will then
     # skip any ops already registered by mcoplib, avoiding c10::Error.
-    try:
-        import mcoplib._C  # noqa: F401
-    except ImportError:
-        pass
+    import importlib.util
+    if importlib.util.find_spec("mcoplib") is not None:
+        try:
+            import mcoplib._C  # noqa: F401
+        except ImportError:
+            logger.warning("Failed to import mcoplib._C")
 
     from vllm_fl.ops._C_ops_schemas import SCHEMAS as schemas
 

--- a/vllm_fl/ops/_C_ops_registry.py
+++ b/vllm_fl/ops/_C_ops_registry.py
@@ -57,12 +57,10 @@ def register_op_schemas():
     # Pre-load mcoplib._C (MetaX) so its TORCH_LIBRARY registrations land
     # before our FRAGMENT definitions.  The hasattr check below will then
     # skip any ops already registered by mcoplib, avoiding c10::Error.
-    from vllm.platforms import current_platform
-    if getattr(current_platform, 'vendor_name', None) == "metax":
-        try:
-            import mcoplib._C  # noqa: F401
-        except ImportError:
-            logger.warning("Failed to import mcoplib._C")
+    try:
+        import mcoplib._C  # noqa: F401
+    except ImportError:
+        pass
 
     from vllm_fl.ops._C_ops_schemas import SCHEMAS as schemas
 


### PR DESCRIPTION
## Summary
At schema registration time, `current_platform` has not yet been replaced by the FL subclass, so `vendor_name` is unavailable. The previous guard (`vendor_name == "metax"`) caused mcoplib._C to never load, leading to:
```
RuntimeError: operator _C::scaled_fp4_quant does not exist
```

## Changes
- Remove the platform guard and use a simple `try/except ImportError` — harmless no-op on non-MetaX environments.

## Testing
- Verified on MetaX C550: model loads and CUDA graph capture proceeds without the `scaled_fp4_quant` error.