### PR TITLE
Fix is_monolithic missing when setting VLLM_FL_PREFER_ENABLED=0

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -93,6 +93,77 @@ def _patch_custom_ops():
     register_op_schemas()
 
 
+def _patch_moe_backend_selection():
+    """Patch select_unquantized_moe_backend to fall through to CUDA backends
+    when no OOT FusedMoE pluggable layer is registered.
+
+    Upstream returns (OOT, None) for any is_out_of_tree() platform.  When
+    FusedMoEFL is registered, the OOT path delegates correctly.  When it is
+    not (VLLM_FL_PREFER_ENABLED=0 or whitelist filtering), experts_cls=None
+    triggers AttributeError.  This patch skips the is_out_of_tree() early
+    return in that case so native CUDA backends (flashinfer/triton) are used.
+
+    Implementation note: importing oracle.unquantized triggers the parent
+    fused_moe/__init__.py which imports unquantized_fused_moe_method, binding
+    the original function via `from ... import`.  We must patch BOTH module
+    namespaces AFTER the import chain is fully resolved.
+
+    NOTE: This function must NOT be called from register() (platform plugin)
+    because it triggers a circular import (vllm.config not yet ready).
+    It must be called from register_model() (general plugin) instead.
+    """
+    import vllm.model_executor.layers.fused_moe.oracle.unquantized as oracle_mod
+    from vllm.model_executor.custom_op import op_registry_oot
+    from vllm.platforms import current_platform
+
+    _orig = oracle_mod.select_unquantized_moe_backend
+
+    def _patched(moe_config):
+        # When FusedMoE is registered OOT, let upstream handle it normally
+        if not current_platform.is_out_of_tree() or "FusedMoE" in op_registry_oot:
+            return _orig(moe_config)
+        # No OOT FusedMoE registered — select CUDA backends directly,
+        # reusing upstream's _get_priority_backends logic
+        from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+            _get_priority_backends, backend_to_kernel_cls)
+        from vllm.model_executor.layers.fused_moe import modular_kernel as mk
+        from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+            UnquantizedMoeBackend,)
+
+        if moe_config.is_lora_enabled:
+            return UnquantizedMoeBackend.TRITON, backend_to_kernel_cls(
+                UnquantizedMoeBackend.TRITON)
+
+        AVAILABLE_BACKENDS = _get_priority_backends(moe_config)
+
+        activation_format = (
+            mk.FusedMoEActivationFormat.BatchedExperts
+            if moe_config.moe_parallel_config.use_batched_activation_format
+            else mk.FusedMoEActivationFormat.Standard
+        )
+
+        for backend in AVAILABLE_BACKENDS:
+            k_cls = backend_to_kernel_cls(backend)
+            supported, reason = k_cls.is_supported_config(
+                k_cls, moe_config, None, None, activation_format)
+            if supported:
+                logger.info(
+                    f"Using {backend.value} Unquantized MoE backend "
+                    f"(FL fallback, no OOT FusedMoE registered).")
+                return backend, k_cls
+
+        raise NotImplementedError(
+            "No Unquantized MoE backend supports the deployment configuration.")
+
+    # Patch the oracle module (source of truth)
+    oracle_mod.select_unquantized_moe_backend = _patched
+
+    # Also patch the consumer module which already bound the original via
+    # `from ... import` during the import chain triggered above.
+    import vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method as uqm
+    uqm.select_unquantized_moe_backend = _patched
+
+
 def register():
     """Register the FL platform."""
     _patch_custom_ops()
@@ -128,11 +199,15 @@ def register_router():
     # fused_moe import chain triggers cutlass_scaled_mm_supports_fp8 on MUSA
     if current_platform.device_type == "musa":
         return
+    from vllm_fl.utils import is_oot_enabled
+    if not is_oot_enabled():
+        return
     from vllm_fl.ops.fused_moe.router import replace_router_with_fl
     replace_router_with_fl()
 
 def register_model():
     """Register FL-specific models not yet upstream."""
+    _patch_moe_backend_selection()
     _register_flagcx_connector()
 
     # Register OOT quant kernels so kernel selection can find them

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -93,77 +93,6 @@ def _patch_custom_ops():
     register_op_schemas()
 
 
-def _patch_moe_backend_selection():
-    """Patch select_unquantized_moe_backend to fall through to CUDA backends
-    when no OOT FusedMoE pluggable layer is registered.
-
-    Upstream returns (OOT, None) for any is_out_of_tree() platform.  When
-    FusedMoEFL is registered, the OOT path delegates correctly.  When it is
-    not (VLLM_FL_PREFER_ENABLED=0 or whitelist filtering), experts_cls=None
-    triggers AttributeError.  This patch skips the is_out_of_tree() early
-    return in that case so native CUDA backends (flashinfer/triton) are used.
-
-    Implementation note: importing oracle.unquantized triggers the parent
-    fused_moe/__init__.py which imports unquantized_fused_moe_method, binding
-    the original function via `from ... import`.  We must patch BOTH module
-    namespaces AFTER the import chain is fully resolved.
-
-    NOTE: This function must NOT be called from register() (platform plugin)
-    because it triggers a circular import (vllm.config not yet ready).
-    It must be called from register_model() (general plugin) instead.
-    """
-    import vllm.model_executor.layers.fused_moe.oracle.unquantized as oracle_mod
-    from vllm.model_executor.custom_op import op_registry_oot
-    from vllm.platforms import current_platform
-
-    _orig = oracle_mod.select_unquantized_moe_backend
-
-    def _patched(moe_config):
-        # When FusedMoE is registered OOT, let upstream handle it normally
-        if not current_platform.is_out_of_tree() or "FusedMoE" in op_registry_oot:
-            return _orig(moe_config)
-        # No OOT FusedMoE registered — select CUDA backends directly,
-        # reusing upstream's _get_priority_backends logic
-        from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
-            _get_priority_backends, backend_to_kernel_cls)
-        from vllm.model_executor.layers.fused_moe import modular_kernel as mk
-        from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
-            UnquantizedMoeBackend,)
-
-        if moe_config.is_lora_enabled:
-            return UnquantizedMoeBackend.TRITON, backend_to_kernel_cls(
-                UnquantizedMoeBackend.TRITON)
-
-        AVAILABLE_BACKENDS = _get_priority_backends(moe_config)
-
-        activation_format = (
-            mk.FusedMoEActivationFormat.BatchedExperts
-            if moe_config.moe_parallel_config.use_batched_activation_format
-            else mk.FusedMoEActivationFormat.Standard
-        )
-
-        for backend in AVAILABLE_BACKENDS:
-            k_cls = backend_to_kernel_cls(backend)
-            supported, reason = k_cls.is_supported_config(
-                k_cls, moe_config, None, None, activation_format)
-            if supported:
-                logger.info(
-                    f"Using {backend.value} Unquantized MoE backend "
-                    f"(FL fallback, no OOT FusedMoE registered).")
-                return backend, k_cls
-
-        raise NotImplementedError(
-            "No Unquantized MoE backend supports the deployment configuration.")
-
-    # Patch the oracle module (source of truth)
-    oracle_mod.select_unquantized_moe_backend = _patched
-
-    # Also patch the consumer module which already bound the original via
-    # `from ... import` during the import chain triggered above.
-    import vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method as uqm
-    uqm.select_unquantized_moe_backend = _patched
-
-
 def register():
     """Register the FL platform."""
     _patch_custom_ops()
@@ -207,7 +136,6 @@ def register_router():
 
 def register_model():
     """Register FL-specific models not yet upstream."""
-    _patch_moe_backend_selection()
     _register_flagcx_connector()
 
     # Register OOT quant kernels so kernel selection can find them

--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -40,10 +40,26 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
 
     Operators in VLLM_FL_OOT_BLACKLIST or platform config oot_blacklist
     will be excluded from registration.
+
+    Note: fused_moe is ALWAYS registered regardless of is_oot_enabled(),
+    whitelist, or blacklist. Upstream vLLM assumes is_out_of_tree() implies
+    an OOT FusedMoE PluggableLayer exists. FusedMoEFL handles the "no FL
+    ops" case internally by delegating to native CUDA backends.
     """
     from vllm_fl.utils import get_oot_blacklist, get_oot_whitelist, is_oot_enabled, use_flaggems_op
+    from vllm.model_executor.custom_op import op_registry_oot
 
-    # Check if OOT registration is enabled
+    # Always register fused_moe to satisfy upstream's OOT FusedMoE assumption.
+    # FusedMoEFL delegates to native backends when FL ops are disabled.
+    _always_register = ["fused_moe"]
+    for op_name in _always_register:
+        if op_name in OOT_OPS:
+            op_cls, registration_name = OOT_OPS[op_name]
+            if registration_name not in op_registry_oot:
+                logger.info(f"Registering oot op (always): {op_name} as '{registration_name}'")
+                PluggableLayer.register_oot(_decorated_layer_cls=op_cls, name=registration_name)
+
+    # Check if OOT registration is enabled for remaining ops
     if not is_oot_enabled():
         return
 
@@ -59,8 +75,9 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
     else:
         ops_to_register = list(OOT_OPS.keys())
 
-    # Apply blacklist
-    ops_to_register = [op for op in ops_to_register if op not in blacklist]
+    # Apply blacklist and exclude always-registered ops
+    ops_to_register = [op for op in ops_to_register
+                       if op not in blacklist and op not in _always_register]
 
     for op_name in ops_to_register:
         if op_name not in OOT_OPS:

--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -66,7 +66,6 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
     so it picks native CUDA backends instead of returning (OOT, None).
     """
     from vllm_fl.utils import get_oot_blacklist, get_oot_whitelist, is_oot_enabled, use_flaggems_op
-    from vllm.model_executor.custom_op import op_registry_oot
 
     # Check if OOT registration is enabled
     if not is_oot_enabled():

--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -43,8 +43,11 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
 
     Note: fused_moe is ALWAYS registered regardless of is_oot_enabled(),
     whitelist, or blacklist. Upstream vLLM assumes is_out_of_tree() implies
-    an OOT FusedMoE PluggableLayer exists. FusedMoEFL handles the "no FL
-    ops" case internally by delegating to native CUDA backends.
+    an OOT FusedMoE PluggableLayer exists (the upstream
+    select_unquantized_moe_backend returns OOT/None which crashes).
+    When VLLM_FL_PREFER_ENABLED=0, FusedMoEFL acts as a thin shim: it
+    fixes the backend selection but skips router replacement and FL dispatch
+    paths, resulting in pure native CUDA execution.
     """
     from vllm_fl.utils import get_oot_blacklist, get_oot_whitelist, is_oot_enabled, use_flaggems_op
     from vllm.model_executor.custom_op import op_registry_oot

--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -29,6 +29,26 @@ OOT_OPS = {
     ),
 }
 
+def _patch_unquantized_moe_oracle() -> None:
+    """
+    Monkey-patch the upstream select_unquantized_moe_backend so it does not
+    short-circuit to (OOT, None) on our platform.  Instead it falls through
+    to the normal CUDA/ROCm backend priority selection — the same logic that
+    select_unquantized_moe_backend_oot uses.
+
+    This is needed when FusedMoEFL is NOT registered (PREFER_ENABLED=0 or
+    fused_moe blacklisted): without the patch, the in-tree UnquantizedFusedMoEMethod
+    would get (OOT, None), skip _setup_kernel, and crash at inference time.
+    """
+    import vllm.model_executor.layers.fused_moe.oracle.unquantized as _oracle_mod
+    from vllm_fl.ops.fused_moe.fused_moe_utils import select_unquantized_moe_backend_oot
+    _oracle_mod.select_unquantized_moe_backend = select_unquantized_moe_backend_oot
+    # Also patch the import in unquantized_fused_moe_method module
+    import vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method as _method_mod
+    _method_mod.select_unquantized_moe_backend = select_unquantized_moe_backend_oot
+    logger.info("Patched select_unquantized_moe_backend to bypass OOT short-circuit")
+
+
 def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
     """
     Register OOT (out-of-tree) custom operators.
@@ -41,29 +61,17 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
     Operators in VLLM_FL_OOT_BLACKLIST or platform config oot_blacklist
     will be excluded from registration.
 
-    Note: fused_moe is ALWAYS registered regardless of is_oot_enabled(),
-    whitelist, or blacklist. Upstream vLLM assumes is_out_of_tree() implies
-    an OOT FusedMoE PluggableLayer exists (the upstream
-    select_unquantized_moe_backend returns OOT/None which crashes).
-    When VLLM_FL_PREFER_ENABLED=0, FusedMoEFL acts as a thin shim: it
-    fixes the backend selection but skips router replacement and FL dispatch
-    paths, resulting in pure native CUDA execution.
+    When fused_moe is not registered (PREFER_ENABLED=0 or blacklisted),
+    the upstream select_unquantized_moe_backend oracle is monkey-patched
+    so it picks native CUDA backends instead of returning (OOT, None).
     """
     from vllm_fl.utils import get_oot_blacklist, get_oot_whitelist, is_oot_enabled, use_flaggems_op
     from vllm.model_executor.custom_op import op_registry_oot
 
-    # Always register fused_moe to satisfy upstream's OOT FusedMoE assumption.
-    # FusedMoEFL delegates to native backends when FL ops are disabled.
-    _always_register = ["fused_moe"]
-    for op_name in _always_register:
-        if op_name in OOT_OPS:
-            op_cls, registration_name = OOT_OPS[op_name]
-            if registration_name not in op_registry_oot:
-                logger.info(f"Registering oot op (always): {op_name} as '{registration_name}'")
-                PluggableLayer.register_oot(_decorated_layer_cls=op_cls, name=registration_name)
-
-    # Check if OOT registration is enabled for remaining ops
+    # Check if OOT registration is enabled
     if not is_oot_enabled():
+        # Patch the upstream oracle so in-tree FusedMoE works on this platform.
+        _patch_unquantized_moe_oracle()
         return
 
     # Get blacklist (from env var or platform config)
@@ -78,9 +86,13 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
     else:
         ops_to_register = list(OOT_OPS.keys())
 
-    # Apply blacklist and exclude always-registered ops
-    ops_to_register = [op for op in ops_to_register
-                       if op not in blacklist and op not in _always_register]
+    # Apply blacklist
+    ops_to_register = [op for op in ops_to_register if op not in blacklist]
+
+    # If fused_moe is excluded (blacklisted or not in whitelist), patch the
+    # upstream oracle so the in-tree FusedMoE doesn't crash on OOT platforms.
+    if "fused_moe" not in ops_to_register:
+        _patch_unquantized_moe_oracle()
 
     for op_name in ops_to_register:
         if op_name not in OOT_OPS:

--- a/vllm_fl/ops/fused_moe/layer.py
+++ b/vllm_fl/ops/fused_moe/layer.py
@@ -62,9 +62,16 @@ class FusedMoEFL(FusedMoE):
     - When FusedMoE() is instantiated, FusedMoEFL is created instead
     - Router operations use call_op("topk_softmax"/"grouped_topk")
     - Expert computation uses call_op("invoke_fused_moe_triton_kernel")
+
+    When VLLM_FL_PREFER_ENABLED=0, this layer acts as a thin shim that only
+    fixes the OOT backend selection (avoiding the upstream OOT→None crash) but
+    does NOT replace routers or inject FL dispatch paths. The result is native
+    CUDA execution with no FL code in the hot path.
     """
 
     def __init__(self, *args, **kwargs):
+        from vllm_fl.utils import is_oot_enabled
+
         routed_scaling_factor = kwargs.get("routed_scaling_factor", 1.0)
         shared_experts = kwargs.get("shared_experts", None)
         gate = kwargs.get("gate", None)
@@ -74,10 +81,33 @@ class FusedMoEFL(FusedMoE):
         super().__init__(*args, **kwargs)
         self._routed_scaling_factor = routed_scaling_factor
         self._apply_routed_scale_to_output = apply_routed_scale_to_output
-        # Replace quant_method with FL version that properly handles OOT backend
+        # Replace quant_method with FL version that properly handles OOT backend.
+        # This is always needed because the upstream select_unquantized_moe_backend()
+        # returns (OOT, None) for out-of-tree platforms, which would crash.
         if isinstance(self.quant_method, UnquantizedFusedMoEMethod) and not isinstance(self.quant_method, UnquantizedFusedMoEMethodFL):
             self.quant_method = UnquantizedFusedMoEMethodFL(self.moe_config)
             self.base_quant_method = self.quant_method
+
+        if not is_oot_enabled():
+            # PREFER_ENABLED=0: skip router replacement and FL dispatch paths.
+            # Only re-create the runner with the fixed quant_method so native
+            # CUDA backends are selected without any FL code in the hot path.
+            self.runner: MoERunnerInterface = MoERunner(
+                layer_name=self.layer_name,
+                moe_config=self.moe_config,
+                router=self.router,
+                gate=gate,
+                shared_experts=shared_experts,
+                quant_method=self.quant_method,
+                enable_dbo=self.vllm_config.parallel_config.enable_dbo,
+                routed_input_transform=routed_input_transform,
+                routed_output_transform=routed_output_transform,
+                routed_scaling_factor=self._routed_scaling_factor
+                if self._apply_routed_scale_to_output
+                else 1.0,
+            )
+            return
+
         # Replace router with FL version that uses call_op for flaggems dispatch.
         # NOTE: shared_experts / gate / routed transforms are passed through to
         # the runner rather than stored as attributes on this layer.  Assigning

--- a/vllm_fl/ops/fused_moe/layer.py
+++ b/vllm_fl/ops/fused_moe/layer.py
@@ -62,16 +62,9 @@ class FusedMoEFL(FusedMoE):
     - When FusedMoE() is instantiated, FusedMoEFL is created instead
     - Router operations use call_op("topk_softmax"/"grouped_topk")
     - Expert computation uses call_op("invoke_fused_moe_triton_kernel")
-
-    When VLLM_FL_PREFER_ENABLED=0, this layer acts as a thin shim that only
-    fixes the OOT backend selection (avoiding the upstream OOT→None crash) but
-    does NOT replace routers or inject FL dispatch paths. The result is native
-    CUDA execution with no FL code in the hot path.
     """
 
     def __init__(self, *args, **kwargs):
-        from vllm_fl.utils import is_oot_enabled
-
         routed_scaling_factor = kwargs.get("routed_scaling_factor", 1.0)
         shared_experts = kwargs.get("shared_experts", None)
         gate = kwargs.get("gate", None)
@@ -81,33 +74,10 @@ class FusedMoEFL(FusedMoE):
         super().__init__(*args, **kwargs)
         self._routed_scaling_factor = routed_scaling_factor
         self._apply_routed_scale_to_output = apply_routed_scale_to_output
-        # Replace quant_method with FL version that properly handles OOT backend.
-        # This is always needed because the upstream select_unquantized_moe_backend()
-        # returns (OOT, None) for out-of-tree platforms, which would crash.
+        # Replace quant_method with FL version that properly handles OOT backend
         if isinstance(self.quant_method, UnquantizedFusedMoEMethod) and not isinstance(self.quant_method, UnquantizedFusedMoEMethodFL):
             self.quant_method = UnquantizedFusedMoEMethodFL(self.moe_config)
             self.base_quant_method = self.quant_method
-
-        if not is_oot_enabled():
-            # PREFER_ENABLED=0: skip router replacement and FL dispatch paths.
-            # Only re-create the runner with the fixed quant_method so native
-            # CUDA backends are selected without any FL code in the hot path.
-            self.runner: MoERunnerInterface = MoERunner(
-                layer_name=self.layer_name,
-                moe_config=self.moe_config,
-                router=self.router,
-                gate=gate,
-                shared_experts=shared_experts,
-                quant_method=self.quant_method,
-                enable_dbo=self.vllm_config.parallel_config.enable_dbo,
-                routed_input_transform=routed_input_transform,
-                routed_output_transform=routed_output_transform,
-                routed_scaling_factor=self._routed_scaling_factor
-                if self._apply_routed_scale_to_output
-                else 1.0,
-            )
-            return
-
         # Replace router with FL version that uses call_op for flaggems dispatch.
         # NOTE: shared_experts / gate / routed transforms are passed through to
         # the runner rather than stored as attributes on this layer.  Assigning


### PR DESCRIPTION
### PR Category
Core
### PR Type
Bug Fixes
### Description
fix is_monolithic missing when setting VLLM_FL_PREFER_ENABLED=0

```
  Root cause chain:

  is_out_of_tree() _ True (PlatformFL)
      _
  select_unquantized_moe_backend() returns (OOT, None)
      _
  experts_cls = None
      _
  code calls experts_cls.is_monolithic _ AttributeError: NoneType has no attribute 'is_monolithic'

  The upstream function has this logic:

  if current_platform.is_out_of_tree():
      return UnquantizedMoeBackend.OOT, None  # _ expects OOT PluggableLayer to handle it

  When FusedMoEFL is registered, vLLM never reaches this code path (it uses FusedMoEFL's own method). But when FusedMoEFL is not registered (disabled/blacklisted), vLLM falls through to the
  built-in FusedMoE, which calls select_unquantized_moe_backend(). Since PlatformFL still reports is_out_of_tree() _ True, it returns (OOT, None) and blows up.
```
