### PR TITLE
[CICD] Add Hygon BW1000 smoke CI workflow

### DIFF
--- a/.github/configs/hygon.yml
+++ b/.github/configs/hygon.yml
@@ -12,9 +12,7 @@ runner_labels:
 
 # Container volumes (hardware-specific paths).
 container_volumes:
-  - /opt/hyhal:/opt/hyhal:ro
-  - /usr/local/hyhal:/usr/local/hyhal:ro
-  - /opt/dtk:/opt/dtk:ro
+  - /opt/hyhal:/opt/hyhal
   - /data:/data
   - /workspace:/workspace
 
@@ -29,7 +27,7 @@ container_options: >-
   --env HIP_CLANG_PATH=/opt/dtk/llvm/bin
   --env DEVICE_LIB_PATH=/opt/dtk/amdgcn/bitcode
   --env PATH=/opt/dtk/bin:/opt/dtk/hip/bin:/opt/dtk/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-  --env LD_LIBRARY_PATH=/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:/opt/dtk/hip/lib:/opt/dtk/lib:/opt/dtk/llvm/lib:/opt/dtk/dcc/lib:/opt/dtk/hsa/lib
+  --env LD_LIBRARY_PATH=/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:/opt/dtk/hip/lib:/opt/dtk/lib:/opt/dtk/llvm/lib:/opt/dtk/dcc/lib:/opt/dtk/aillvm/lib:/opt/dtk/hsa/lib
   --device=/dev/kfd
   --device=/dev/mkfd
   --device=/dev/dri

--- a/.github/configs/hygon.yml
+++ b/.github/configs/hygon.yml
@@ -21,6 +21,7 @@ container_options: >-
   --hostname vllm-plugin-fl
   --ipc=host
   --env DTK_HOME=/opt/dtk
+  --env GEMS_VENDOR=hygon
   --env ROCM_PATH=/opt/dtk
   --env HIP_PATH=/opt/dtk/hip
   --env HSA_PATH=/opt/dtk/hsa

--- a/.github/configs/hygon.yml
+++ b/.github/configs/hygon.yml
@@ -13,6 +13,7 @@ runner_labels:
 # Container volumes (hardware-specific paths).
 container_volumes:
   - /opt/hyhal:/opt/hyhal:ro
+  - /usr/local/hyhal:/usr/local/hyhal:ro
   - /data:/data
   - /workspace:/workspace
 

--- a/.github/configs/hygon.yml
+++ b/.github/configs/hygon.yml
@@ -1,0 +1,28 @@
+# Hygon Hardware Configuration
+# This file defines CI/CD settings for Hygon DCU testing.
+
+platform: hygon
+
+# Docker image for this hardware.
+ci_image: harbor.sourcefind.cn:5443/dcu/admin/base/custom:vllm0.20.0-ubuntu22.04-dtk26.04-py3.10-MiniCPM-V-4.6
+
+# Runner labels for this hardware.
+runner_labels:
+  - hg-cicd-vllm-plugin
+
+# Container volumes (hardware-specific paths).
+container_volumes:
+  - /opt/hyhal:/opt/hyhal:ro
+  - /data:/data
+  - /workspace:/workspace
+
+# Container options (hardware-specific settings).
+container_options: >-
+  --hostname vllm-plugin-fl
+  --ipc=host
+  --device=/dev/kfd
+  --device=/dev/mkfd
+  --device=/dev/dri
+  --group-add video
+  --cap-add=SYS_PTRACE
+  --security-opt seccomp=unconfined

--- a/.github/configs/hygon.yml
+++ b/.github/configs/hygon.yml
@@ -14,6 +14,7 @@ runner_labels:
 container_volumes:
   - /opt/hyhal:/opt/hyhal:ro
   - /usr/local/hyhal:/usr/local/hyhal:ro
+  - /opt/dtk:/opt/dtk:ro
   - /data:/data
   - /workspace:/workspace
 
@@ -21,6 +22,14 @@ container_volumes:
 container_options: >-
   --hostname vllm-plugin-fl
   --ipc=host
+  --env DTK_HOME=/opt/dtk
+  --env ROCM_PATH=/opt/dtk
+  --env HIP_PATH=/opt/dtk/hip
+  --env HSA_PATH=/opt/dtk/hsa
+  --env HIP_CLANG_PATH=/opt/dtk/llvm/bin
+  --env DEVICE_LIB_PATH=/opt/dtk/amdgcn/bitcode
+  --env PATH=/opt/dtk/bin:/opt/dtk/hip/bin:/opt/dtk/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  --env LD_LIBRARY_PATH=/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:/opt/dtk/hip/lib:/opt/dtk/lib:/opt/dtk/llvm/lib:/opt/dtk/dcc/lib:/opt/dtk/hsa/lib
   --device=/dev/kfd
   --device=/dev/mkfd
   --device=/dev/dri

--- a/.github/configs/platforms.yml
+++ b/.github/configs/platforms.yml
@@ -10,3 +10,5 @@ platforms:
     enabled: true
   ascend:
     enabled: false
+  hygon:
+    enabled: true

--- a/.github/configs/platforms.yml
+++ b/.github/configs/platforms.yml
@@ -7,7 +7,7 @@
 
 platforms:
   cuda:
-    enabled: false
+    enabled: true
   ascend:
     enabled: false
   hygon:

--- a/.github/configs/platforms.yml
+++ b/.github/configs/platforms.yml
@@ -7,7 +7,7 @@
 
 platforms:
   cuda:
-    enabled: true
+    enabled: false
   ascend:
     enabled: false
   hygon:

--- a/.github/scripts/hygon/check.sh
+++ b/.github/scripts/hygon/check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (c) 2025 BAAI. All rights reserved.
+# Check Hygon DCU availability.
+set -euo pipefail
+
+echo "=== Checking Hygon DCU availability ==="
+
+command -v hy-smi
+hy-smi
+hy-smi --showmeminfo vram || true
+
+test -e /dev/kfd
+test -e /dev/mkfd
+test -d /dev/dri
+test -d /opt/hyhal

--- a/.github/scripts/hygon/check.sh
+++ b/.github/scripts/hygon/check.sh
@@ -6,9 +6,20 @@ set -euo pipefail
 echo "Current time: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "=== Checking Hygon DCU availability ==="
 
-command -v hy-smi
-hy-smi
-hy-smi --showmeminfo vram || true
+HY_SMI_BIN=""
+if command -v hy-smi >/dev/null 2>&1; then
+  HY_SMI_BIN="$(command -v hy-smi)"
+elif [[ -x /opt/hyhal/bin/hy-smi ]]; then
+  HY_SMI_BIN="/opt/hyhal/bin/hy-smi"
+fi
+
+if [[ -n "${HY_SMI_BIN}" ]]; then
+  echo "Using hy-smi: ${HY_SMI_BIN}"
+  "${HY_SMI_BIN}"
+  "${HY_SMI_BIN}" --showmeminfo vram || true
+else
+  echo "::warning::hy-smi not found in PATH or /opt/hyhal/bin; skipping SMI output."
+fi
 
 test -e /dev/kfd
 test -e /dev/mkfd

--- a/.github/scripts/hygon/check.sh
+++ b/.github/scripts/hygon/check.sh
@@ -3,6 +3,7 @@
 # Check Hygon DCU availability.
 set -euo pipefail
 
+echo "Current time: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "=== Checking Hygon DCU availability ==="
 
 command -v hy-smi

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -5,9 +5,26 @@ set -euo pipefail
 
 git config --global --add safe.directory "$(pwd)"
 
+HYGON_SEARCH_ROOTS=()
+for root in \
+  /opt/hyhal \
+  /usr/local/hyhal \
+  /opt/dtk \
+  /usr/local/dtk \
+  /usr/local/lib \
+  /usr/local/lib64 \
+  /usr/lib \
+  /usr/lib64 \
+  /lib \
+  /lib64; do
+  [[ -e "${root}" ]] && HYGON_SEARCH_ROOTS+=("${root}")
+done
+
+echo "Searching Hygon runtime libraries in: ${HYGON_SEARCH_ROOTS[*]}"
+
 mapfile -t HYGON_LIB_DIRS < <(
   {
-    find -L /opt/hyhal /usr/local/hyhal -name "libgalaxyhip.so*" \
+    find -L "${HYGON_SEARCH_ROOTS[@]}" -name "libgalaxyhip.so*" \
       -exec dirname {} \; 2>/dev/null || true
     for dir in \
       /opt/hyhal/lib \
@@ -39,6 +56,9 @@ if [[ "${#HYGON_LIB_DIRS[@]}" -gt 0 ]]; then
 else
   echo "::warning::No Hygon library directories found under /opt/hyhal."
 fi
+
+find -L "${HYGON_SEARCH_ROOTS[@]}" -name "libgalaxyhip.so*" -print 2>/dev/null || true
+ldconfig -p 2>/dev/null | grep -F "libgalaxyhip" || true
 
 TEST_DEPS=(
   pytest

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -8,7 +8,9 @@ git config --global --add safe.directory "$(pwd)"
 if command -v uv >/dev/null 2>&1; then
   uv pip install --system --upgrade pip
   uv pip install --system --no-build-isolation -e ".[test]"
+  uv pip install --system pytest-cov pytest-json-report
 else
   python -m pip install --upgrade pip
   python -m pip install --no-build-isolation -e ".[test]"
+  python -m pip install pytest-cov pytest-json-report
 fi

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -7,8 +7,19 @@ git config --global --add safe.directory "$(pwd)"
 
 mapfile -t HYGON_LIB_DIRS < <(
   {
-    find /opt/hyhal -type f -name "libgalaxyhip.so*" -printf "%h\n" 2>/dev/null || true
-    for dir in /opt/hyhal/lib /opt/hyhal/lib64 /opt/hyhal/hip/lib; do
+    find -L /opt/hyhal /usr/local/hyhal -name "libgalaxyhip.so*" \
+      -exec dirname {} \; 2>/dev/null || true
+    for dir in \
+      /opt/hyhal/lib \
+      /opt/hyhal/lib64 \
+      /opt/hyhal/hip/lib \
+      /opt/hyhal/hip/lib64 \
+      /opt/hyhal/lib/x86_64-linux-gnu \
+      /usr/local/hyhal/lib \
+      /usr/local/hyhal/lib64 \
+      /usr/local/hyhal/hip/lib \
+      /usr/local/hyhal/hip/lib64 \
+      /usr/local/hyhal/lib/x86_64-linux-gnu; do
       [[ -d "${dir}" ]] && echo "${dir}"
     done
   } | awk '!seen[$0]++'
@@ -19,6 +30,10 @@ if [[ "${#HYGON_LIB_DIRS[@]}" -gt 0 ]]; then
   export LD_LIBRARY_PATH="${HYGON_LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
   if [[ -n "${GITHUB_ENV:-}" ]]; then
     echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
+  fi
+  if command -v ldconfig >/dev/null 2>&1 && [[ -w /etc/ld.so.conf.d ]]; then
+    printf "%s\n" "${HYGON_LIB_DIRS[@]}" > /etc/ld.so.conf.d/hygon.conf
+    ldconfig
   fi
   echo "Configured Hygon LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 else
@@ -46,3 +61,9 @@ else
   python -m pip install --no-build-isolation -e . --no-deps
   python -m pip install "${TEST_DEPS[@]}"
 fi
+
+python - <<'PY'
+import torch
+
+print(f"Torch import ok: {torch.__version__}")
+PY

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -5,12 +5,24 @@ set -euo pipefail
 
 git config --global --add safe.directory "$(pwd)"
 
+TEST_DEPS=(
+  pytest
+  pytest-cov
+  pytest-timeout
+  pytest-json-report
+  numpy
+  requests
+  openai
+  decorator
+  pyyaml
+)
+
 if command -v uv >/dev/null 2>&1; then
   uv pip install --system --upgrade pip
-  uv pip install --system --no-build-isolation -e ".[test]"
-  uv pip install --system pytest-cov pytest-json-report
+  uv pip install --system --no-build-isolation -e . --no-deps
+  uv pip install --system "${TEST_DEPS[@]}"
 else
   python -m pip install --upgrade pip
-  python -m pip install --no-build-isolation -e ".[test]"
-  python -m pip install pytest-cov pytest-json-report
+  python -m pip install --no-build-isolation -e . --no-deps
+  python -m pip install "${TEST_DEPS[@]}"
 fi

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -5,6 +5,26 @@ set -euo pipefail
 
 git config --global --add safe.directory "$(pwd)"
 
+mapfile -t HYGON_LIB_DIRS < <(
+  {
+    find /opt/hyhal -type f -name "libgalaxyhip.so*" -printf "%h\n" 2>/dev/null || true
+    for dir in /opt/hyhal/lib /opt/hyhal/lib64 /opt/hyhal/hip/lib; do
+      [[ -d "${dir}" ]] && echo "${dir}"
+    done
+  } | awk '!seen[$0]++'
+)
+
+if [[ "${#HYGON_LIB_DIRS[@]}" -gt 0 ]]; then
+  HYGON_LD_LIBRARY_PATH="$(IFS=:; echo "${HYGON_LIB_DIRS[*]}")"
+  export LD_LIBRARY_PATH="${HYGON_LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
+  fi
+  echo "Configured Hygon LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+else
+  echo "::warning::No Hygon library directories found under /opt/hyhal."
+fi
+
 TEST_DEPS=(
   pytest
   pytest-cov

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright (c) 2025 BAAI. All rights reserved.
+# Setup script for Hygon DCU CI environment.
+set -euo pipefail
+
+git config --global --add safe.directory "$(pwd)"
+
+if command -v uv >/dev/null 2>&1; then
+  uv pip install --system --upgrade pip
+  uv pip install --system --no-build-isolation -e ".[test]"
+else
+  python -m pip install --upgrade pip
+  python -m pip install --no-build-isolation -e ".[test]"
+fi

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -5,60 +5,36 @@ set -euo pipefail
 
 git config --global --add safe.directory "$(pwd)"
 
-HYGON_SEARCH_ROOTS=()
-for root in \
-  /opt/hyhal \
-  /usr/local/hyhal \
-  /opt/dtk \
-  /usr/local/dtk \
-  /usr/local/lib \
-  /usr/local/lib64 \
-  /usr/lib \
-  /usr/lib64 \
-  /lib \
-  /lib64; do
-  [[ -e "${root}" ]] && HYGON_SEARCH_ROOTS+=("${root}")
-done
+export DTK_HOME="${DTK_HOME:-/opt/dtk}"
+export ROCM_PATH="${ROCM_PATH:-${DTK_HOME}}"
+export HIP_PATH="${HIP_PATH:-${DTK_HOME}/hip}"
+export HSA_PATH="${HSA_PATH:-${DTK_HOME}/hsa}"
+export HIP_CLANG_PATH="${HIP_CLANG_PATH:-${DTK_HOME}/llvm/bin}"
+export DEVICE_LIB_PATH="${DEVICE_LIB_PATH:-${DTK_HOME}/amdgcn/bitcode}"
 
-echo "Searching Hygon runtime libraries in: ${HYGON_SEARCH_ROOTS[*]}"
+DTK_PATH="${DTK_HOME}/bin:${HIP_PATH}/bin:${HIP_CLANG_PATH}"
+DTK_LIBRARY_PATH="/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:${HIP_PATH}/lib:${DTK_HOME}/lib:${DTK_HOME}/llvm/lib:${DTK_HOME}/dcc/lib:${HSA_PATH}/lib"
+export PATH="${DTK_PATH}:${PATH}"
+export LD_LIBRARY_PATH="${DTK_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
-mapfile -t HYGON_LIB_DIRS < <(
-  {
-    find -L "${HYGON_SEARCH_ROOTS[@]}" -name "libgalaxyhip.so*" \
-      -exec dirname {} \; 2>/dev/null || true
-    for dir in \
-      /opt/hyhal/lib \
-      /opt/hyhal/lib64 \
-      /opt/hyhal/hip/lib \
-      /opt/hyhal/hip/lib64 \
-      /opt/hyhal/lib/x86_64-linux-gnu \
-      /usr/local/hyhal/lib \
-      /usr/local/hyhal/lib64 \
-      /usr/local/hyhal/hip/lib \
-      /usr/local/hyhal/hip/lib64 \
-      /usr/local/hyhal/lib/x86_64-linux-gnu; do
-      [[ -d "${dir}" ]] && echo "${dir}"
-    done
-  } | awk '!seen[$0]++'
-)
-
-if [[ "${#HYGON_LIB_DIRS[@]}" -gt 0 ]]; then
-  HYGON_LD_LIBRARY_PATH="$(IFS=:; echo "${HYGON_LIB_DIRS[*]}")"
-  export LD_LIBRARY_PATH="${HYGON_LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-  if [[ -n "${GITHUB_ENV:-}" ]]; then
-    echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
-  fi
-  if command -v ldconfig >/dev/null 2>&1 && [[ -w /etc/ld.so.conf.d ]]; then
-    printf "%s\n" "${HYGON_LIB_DIRS[@]}" > /etc/ld.so.conf.d/hygon.conf
-    ldconfig
-  fi
-  echo "Configured Hygon LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
-else
-  echo "::warning::No Hygon library directories found under /opt/hyhal."
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  for name in \
+    DTK_HOME \
+    ROCM_PATH \
+    HIP_PATH \
+    HSA_PATH \
+    HIP_CLANG_PATH \
+    DEVICE_LIB_PATH \
+    PATH \
+    LD_LIBRARY_PATH; do
+    echo "${name}=${!name}" >> "${GITHUB_ENV}"
+  done
 fi
 
-find -L "${HYGON_SEARCH_ROOTS[@]}" -name "libgalaxyhip.so*" -print 2>/dev/null || true
-ldconfig -p 2>/dev/null | grep -F "libgalaxyhip" || true
+echo "DTK_HOME=${DTK_HOME}"
+echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+test -e "${HIP_PATH}/lib/libgalaxyhip.so.5"
+test -e "${DTK_HOME}/llvm/lib/libomp.so"
 
 TEST_DEPS=(
   pytest

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 git config --global --add safe.directory "$(pwd)"
 
+export GEMS_VENDOR="${GEMS_VENDOR:-hygon}"
 export DTK_HOME="${DTK_HOME:-/opt/dtk}"
 export ROCM_PATH="${ROCM_PATH:-${DTK_HOME}}"
 export HIP_PATH="${HIP_PATH:-${DTK_HOME}/hip}"
@@ -19,6 +20,7 @@ export LD_LIBRARY_PATH="${DTK_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH
 
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   for name in \
+    GEMS_VENDOR \
     DTK_HOME \
     ROCM_PATH \
     HIP_PATH \
@@ -41,12 +43,20 @@ TEST_DEPS=(
   pytest-cov
   pytest-timeout
   pytest-json-report
+  scikit-build-core==0.11
+  pybind11
+  ninja
+  cmake
   numpy
   requests
   openai
   decorator
   pyyaml
+  sqlalchemy
 )
+
+FLAGGEMS_REF="8d23621eb1381ae96b315a9287ce3cc555433824"
+FLAGGEMS_SOURCE="${FLAGGEMS_PATH:-/workspace/FlagGems}"
 
 if command -v uv >/dev/null 2>&1; then
   uv pip install --system --upgrade pip
@@ -58,9 +68,35 @@ else
   python -m pip install "${TEST_DEPS[@]}"
 fi
 
+test -d "${FLAGGEMS_SOURCE}/src/flag_gems"
+git config --global --add safe.directory "${FLAGGEMS_SOURCE}"
+
+FLAGGEMS_HEAD="$(git -C "${FLAGGEMS_SOURCE}" rev-parse HEAD)"
+if [[ "${FLAGGEMS_HEAD}" != "${FLAGGEMS_REF}" ]]; then
+  echo "Unexpected FlagGems commit: ${FLAGGEMS_HEAD}; expected ${FLAGGEMS_REF}."
+  exit 1
+fi
+
+if ! grep -q 'kwargs.pop("num_ldmatrixes", None)' \
+  "${FLAGGEMS_SOURCE}/src/flag_gems/runtime/configloader.py"; then
+  echo "FlagGems num_ldmatrixes compatibility patch is missing."
+  exit 1
+fi
+
+FLAGGEMS_DIR="$(mktemp -d)/FlagGems"
+cp -a "${FLAGGEMS_SOURCE}" "${FLAGGEMS_DIR}"
+
+if command -v uv >/dev/null 2>&1; then
+  uv pip install --system --no-build-isolation -e "${FLAGGEMS_DIR}" --no-deps
+else
+  python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}" --no-deps
+fi
+
 python - <<'PY'
+import flag_gems
 import torch
 
+print(f"FlagGems import ok: {getattr(flag_gems, '__version__', 'unknown')}")
 print(f"Torch import ok: {torch.__version__}")
 print(f"Accelerator available: {torch.cuda.is_available()}")
 print(f"Accelerator count: {torch.cuda.device_count()}")

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -13,7 +13,7 @@ export HIP_CLANG_PATH="${HIP_CLANG_PATH:-${DTK_HOME}/llvm/bin}"
 export DEVICE_LIB_PATH="${DEVICE_LIB_PATH:-${DTK_HOME}/amdgcn/bitcode}"
 
 DTK_PATH="${DTK_HOME}/bin:${HIP_PATH}/bin:${HIP_CLANG_PATH}"
-DTK_LIBRARY_PATH="/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:${HIP_PATH}/lib:${DTK_HOME}/lib:${DTK_HOME}/llvm/lib:${DTK_HOME}/dcc/lib:${HSA_PATH}/lib"
+DTK_LIBRARY_PATH="/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:${HIP_PATH}/lib:${DTK_HOME}/lib:${DTK_HOME}/llvm/lib:${DTK_HOME}/dcc/lib:${DTK_HOME}/aillvm/lib:${HSA_PATH}/lib"
 export PATH="${DTK_PATH}:${PATH}"
 export LD_LIBRARY_PATH="${DTK_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
@@ -62,4 +62,6 @@ python - <<'PY'
 import torch
 
 print(f"Torch import ok: {torch.__version__}")
+print(f"Accelerator available: {torch.cuda.is_available()}")
+print(f"Accelerator count: {torch.cuda.device_count()}")
 PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,14 @@ jobs:
     with:
       platform: ascend
     secrets: inherit
+
+  # ============================================================
+  # Job 4c: Hygon platform testing
+  # ============================================================
+  test-hygon:
+    needs: discover
+    if: contains(fromJson(needs.discover.outputs.platforms), 'hygon')
+    uses: ./.github/workflows/_platform_test.yml
+    with:
+      platform: hygon
+    secrets: inherit

--- a/tests/e2e_tests/serving/test_serving_smoke.py
+++ b/tests/e2e_tests/serving/test_serving_smoke.py
@@ -63,6 +63,7 @@ def server():
         tp_size=_CFG.engine.get("tensor_parallel_size", 1),
         api_key=serve.api_key,
         served_model_name=serve.served_model_name,
+        max_retries=serve.startup_retries,
         extra_args=extra_args,
     ) as srv:
         yield srv

--- a/tests/models/qwen3_6/27b_tp2_eager.yaml
+++ b/tests/models/qwen3_6/27b_tp2_eager.yaml
@@ -1,0 +1,29 @@
+# Qwen3.6-27B Hygon smoke configuration (TP=2, eager).
+
+llm:
+  model: "/workspace/Qwen3.6-27B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 8192
+  gpu_memory_utilization: 0.95
+  enforce_eager: true
+  trust_remote_code: false
+  disable_custom_all_reduce: true
+
+generate:
+  prompts:
+    - "Introduce yourself,please"
+  sampling:
+    max_tokens: 100
+    temperature: 0.0
+
+serve:
+  served_model_name: "qwen"
+  endpoints: ["chat"]
+  stream: false
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "Introduce yourself,please"
+  sampling:
+    temperature: 0.0

--- a/tests/models/qwen3_6/35b_a3b_tp2_eager.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_eager.yaml
@@ -19,6 +19,7 @@ generate:
 
 serve:
   served_model_name: "qwen"
+  startup_retries: 120
   endpoints: ["chat"]
   stream: false
   max_tokens: 256

--- a/tests/models/qwen3_6/35b_a3b_tp2_eager.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_eager.yaml
@@ -1,0 +1,29 @@
+# Qwen3.6-35B-A3B Hygon smoke configuration (TP=2, eager).
+
+llm:
+  model: "/workspace/Qwen3.6-35B-A3B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 8192
+  gpu_memory_utilization: 0.95
+  enforce_eager: true
+  trust_remote_code: false
+  disable_custom_all_reduce: true
+
+generate:
+  prompts:
+    - "Introduce yourself,please"
+  sampling:
+    max_tokens: 100
+    temperature: 0.0
+
+serve:
+  served_model_name: "qwen"
+  endpoints: ["chat"]
+  stream: false
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "Introduce yourself,please"
+  sampling:
+    temperature: 0.0

--- a/tests/platforms/hygon.yaml
+++ b/tests/platforms/hygon.yaml
@@ -25,9 +25,9 @@ bw1000:
   tests:
     e2e:
       inference:
-        qwen3_6: ["35b_a3b_tp2_eager", "27b_tp2_eager"]
+        qwen3_6: ["27b_tp2_eager"]
       serving:
-        qwen3_6: ["35b_a3b_tp2_eager", "27b_tp2_eager"]
+        qwen3_6: ["27b_tp2_eager"]
     functional:
       include:
         - TestAllReduceCorrectness

--- a/tests/platforms/hygon.yaml
+++ b/tests/platforms/hygon.yaml
@@ -1,0 +1,46 @@
+platform: hygon
+vendor: hygon
+
+device_types:
+  bw1000:
+    memory_gb: 64
+    tags: [bf16, fp16, fp32]
+
+tolerance:
+  inference:
+    default:
+      rtol: 1e-5
+      atol: 1e-8
+    bfloat16:
+      rtol: 1e-3
+      atol: 1e-3
+
+env_defaults:
+  GEMS_VENDOR: "hygon"
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+  VLLM_FL_FLAGOS_BLACKLIST: "pow_scalar,pow_tensor_scalar,pow_tensor_tensor,pow_tensor_scalar_,pow_tensor_tensor_,cat"
+
+bw1000:
+  name: "bw1000"
+  tests:
+    e2e:
+      inference:
+        qwen3_6: ["35b_a3b_tp2_eager", "27b_tp2_eager"]
+      serving:
+        qwen3_6: ["35b_a3b_tp2_eager", "27b_tp2_eager"]
+    functional:
+      include:
+        - TestAllReduceCorrectness
+        - TestReduceScatterCorrectness
+        - TestAllGatherCorrectness
+        - TestSendRecvCorrectness
+        - TestCommunicatorDisabled
+        - TestDistributedUtils
+      exclude: []
+    unit:
+      include:
+        - test_public_git_exports_shape
+      exclude: []
+    benchmark:
+      enabled: true
+      smoke: ["serve"]

--- a/tests/platforms/hygon.yaml
+++ b/tests/platforms/hygon.yaml
@@ -29,17 +29,10 @@ bw1000:
       serving:
         qwen3_6: ["27b_tp2_eager"]
     functional:
-      include:
-        - TestAllReduceCorrectness
-        - TestReduceScatterCorrectness
-        - TestAllGatherCorrectness
-        - TestSendRecvCorrectness
-        - TestCommunicatorDisabled
-        - TestDistributedUtils
+      include: "*"
       exclude: []
     unit:
-      include:
-        - test_public_git_exports_shape
+      include: "*"
       exclude: []
     benchmark:
       enabled: true

--- a/tests/platforms/hygon.yaml
+++ b/tests/platforms/hygon.yaml
@@ -27,7 +27,7 @@ bw1000:
       inference:
         qwen3_6: ["27b_tp2_eager"]
       serving:
-        qwen3_6: ["27b_tp2_eager"]
+        qwen3_6: ["35b_a3b_tp2_eager"]
     functional:
       include: "*"
       exclude: []

--- a/tests/unit_tests/flaggems/test_gems_whitelist.py
+++ b/tests/unit_tests/flaggems/test_gems_whitelist.py
@@ -16,7 +16,7 @@ from vllm_fl.utils import get_flag_gems_whitelist_blacklist, use_flaggems_op
 # On some platforms (e.g. Ascend), get_flagos_blacklist() returns a non-empty
 # default blacklist which would interfere with env-var-only assertions.
 _no_platform_blacklist = patch(
-    "vllm_fl.dispatch.config.get_flagos_blacklist", return_value=None
+    "vllm_fl.dispatch.config.get_flagos_blacklist", new=lambda: None
 )
 
 

--- a/tests/utils/model_config.py
+++ b/tests/utils/model_config.py
@@ -111,6 +111,9 @@ class ServeConfig:
         max_tokens: Max tokens for serving requests.
         served_model_name: Alias passed via ``--served-model-name``.
             Empty string means use the model path directly.
+        startup_retries: Number of health-check attempts allowed while the
+            vLLM server starts. Each attempt is followed by the server helper's
+            polling interval.
         stream: Whether to test streaming responses (chat endpoint).
         sampling: Sampling parameters (temperature, top_p, etc.) injected
             into the request payload.
@@ -126,6 +129,7 @@ class ServeConfig:
     chat_messages: list[dict[str, Any]] = field(default_factory=list)
     max_tokens: int = 50
     served_model_name: str = ""
+    startup_retries: int = 60
     stream: bool = False
     sampling: dict[str, Any] = field(default_factory=dict)
     extra_body: dict[str, Any] = field(default_factory=dict)
@@ -145,6 +149,7 @@ class ServeConfig:
             chat_messages=raw.get("chat_messages", []),
             max_tokens=raw.get("max_tokens", 50),
             served_model_name=raw.get("served_model_name", ""),
+            startup_retries=int(raw.get("startup_retries", 60)),
             stream=raw.get("stream", False),
             sampling=raw.get("sampling", {}),
             extra_body=raw.get("extra_body", {}),


### PR DESCRIPTION
## Summary

This PR adds the first-stage Hygon/BW1000 CI smoke workflow.

Main changes:
- Add Hygon platform configuration.
- Add Hygon runner, Docker image, device mount, and container options.
- Add Hygon environment check and setup scripts.
- Add Hygon platform test matrix.
- Enable the first-stage smoke loop:
  - unit
  - functional
  - Qwen3.6-27B TP=2 eager inference
  - Qwen3.6-27B TP=2 eager serving
  - benchmark serve smoke

## Validation

Environment validation has been completed on Hygon BW1000.

Validated items:
- Hygon Docker image startup: passed
- Hygon device check: passed
- unit tests: passed
- functional tests: passed
- Qwen3.6-27B TP=2 eager inference: passed
- Qwen3.6-27B TP=2 eager serving: passed
- benchmark serve smoke: passed

## Notes

This PR keeps the first-stage CI scope minimal and only enables validated smoke cases by default. Larger model cases such as Qwen3.6-35B-A3B can be added to the default matrix after the model is provisioned and verified on the runner.