### PR TITLE
ci: skip CI for fork, draft, and work-in-progress PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     - cron: '0 18 * * *'  # daily at 2:00 AM CST (UTC+8)
   pull_request:
     branches: [main, devops]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -28,6 +29,15 @@ jobs:
   # Runs on every push/PR. Fast, no special requirements.
   # ============================================================
   lint:
+    # Skip: fork-internal PRs, draft PRs, PRs with WIP/wip in title
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        github.repository == 'flagos-ai/vllm-plugin-FL' &&
+        !github.event.pull_request.draft &&
+        !contains(github.event.pull_request.title, 'WIP') &&
+        !contains(github.event.pull_request.title, 'wip')
+      )
     uses: ./.github/workflows/_lint.yml
 
   # ============================================================

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -3,6 +3,7 @@ name: Code Scan
 on:
   pull_request:
     branches: [main, devops]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -28,6 +29,12 @@ jobs:
   # ============================================================
   codeql:
     name: CodeQL Analysis
+    # Skip: fork-internal PRs, draft PRs, PRs with WIP/wip in title
+    if: |
+      github.repository == 'flagos-ai/vllm-plugin-FL' &&
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.title, 'WIP') &&
+      !contains(github.event.pull_request.title, 'wip')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (attempt 1)
@@ -61,8 +68,14 @@ jobs:
   # ============================================================
   dependency-review:
     name: Dependency Review
+    # Skip: fork-internal PRs, draft PRs, PRs with WIP/wip in title
+    if: |
+      github.event_name == 'pull_request' &&
+      github.repository == 'flagos-ai/vllm-plugin-FL' &&
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.title, 'WIP') &&
+      !contains(github.event.pull_request.title, 'wip')
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout (attempt 1)
         id: checkout1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,7 @@ name: "Pull Request Labeler"
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -10,6 +10,12 @@ permissions:
 
 jobs:
   label:
+    # Skip: fork-internal PRs, draft PRs, PRs with WIP/wip in title
+    if: |
+      github.repository == 'flagos-ai/vllm-plugin-FL' &&
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.title, 'WIP') &&
+      !contains(github.event.pull_request.title, 'wip')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/notify-feishu.yml
+++ b/.github/workflows/notify-feishu.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   notify:
     name: "Notify (overall)"
+    # Don't notify when CI was skipped (draft/WIP/fork-internal PRs)
+    if: github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true


### PR DESCRIPTION
## Summary

Add workflow guards to prevent unnecessary CI runs and reduce noise:

- **Fork-internal PRs**: CI no longer triggers when running inside a fork repository (fork→upstream PRs still trigger normally)
- **Draft PRs**: CI skips draft PRs entirely
- **WIP PRs**: CI skips PRs with `WIP` or `wip` in the title
- **ready_for_review**: CI re-triggers automatically when a draft PR is marked as ready
- **Feishu notification**: Skip notification when CI conclusion is `skipped`

## Changed files

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add `ready_for_review` type; guard on `lint` job (gates entire pipeline) |
| `.github/workflows/code-scan.yml` | Add `ready_for_review` type; guards on `codeql` and `dependency-review` jobs |
| `.github/workflows/labeler.yml` | Add `ready_for_review` type; guard on `label` job |
| `.github/workflows/notify-feishu.yml` | Skip notification when `workflow_run.conclusion == 'skipped'` |

## How it works

The guard condition uses `github.repository == 'flagos-ai/vllm-plugin-FL'` to distinguish fork-internal runs from upstream runs:
- **Fork-internal PR** (e.g. fork's feature → fork's main): workflow runs in the fork repo → condition is false → CI skipped
- **Fork→upstream PR**: workflow runs in upstream repo → condition is true → CI runs normally
- **Upstream-internal PR**: same as above → CI runs normally

For `ci.yml`, the guard is placed only on the `lint` job. Since all downstream jobs (`build`, `discover`, `test-*`) chain via `needs: lint`, skipping `lint` skips the entire pipeline.

Reusable workflows (`_lint.yml`, `_build_wheel.yml`, etc.) don't need changes since they are invoked via `workflow_call` and inherit the caller's filtering.

For example: 
<img width="1359" height="173" alt="screenshot-20260701-180959" src="https://github.com/user-attachments/assets/37456a4b-83e6-486e-989f-32a72148fc12" />
such prs in draft status will not trigger ci, as long as those with "wip" in the title
<img width="1389" height="710" alt="image" src="https://github.com/user-attachments/assets/ab503167-1b74-4b8b-9d8c-0b2d4bcfb651" />
after click ready for review, workflow will detect status and trigger ci