### PR TITLE
fix bug for hygon import DeviceDetector

### DIFF
--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -8,7 +8,7 @@ import flag_gems
 try:
     # FlagGems<=5.0.2: DeviceDetector lives in device.
     from flag_gems.runtime.backend.device import DeviceDetector
-except (ImportError,FileNotFoundError):
+except (ImportError, FileNotFoundError):
     # FlagGems>5.0.2: DeviceDetector lives in device_finder.
     from flag_gems.runtime.backend.device_finder import DeviceDetector
 from flag_gems.runtime import backend

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -8,7 +8,7 @@ import flag_gems
 try:
     # FlagGems<=5.0.2: DeviceDetector lives in device.
     from flag_gems.runtime.backend.device import DeviceDetector
-except ImportError:
+except (ImportError,FileNotFoundError):
     # FlagGems>5.0.2: DeviceDetector lives in device_finder.
     from flag_gems.runtime.backend.device_finder import DeviceDetector
 from flag_gems.runtime import backend


### PR DESCRIPTION
### PR Type
Bug Fixes

### Description
Fix `DeviceDetector` import issue on Hygon devices.

`flag_gems.runtime.backend.device` may raise `FileNotFoundError` during import,
so this PR catches both `ImportError` and `FileNotFoundError`, then falls back
to `flag_gems.runtime.backend.device_finder`.

### Testing
Hygon device check passed.
