### PR TITLE
upgrade: vllm 0.20.2 -> 0.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ test = [
     "requests",
     "openai",
     "decorator",
-    "vllm[audio]==0.20.2",
+    "vllm[audio]==0.24.0",
     "modelscope>=1.18.1",
 ]
 

--- a/vllm_fl/dispatch/backends/vendor/metax/patches/gdn_linear_attn.py
+++ b/vllm_fl/dispatch/backends/vendor/metax/patches/gdn_linear_attn.py
@@ -19,7 +19,7 @@
 import torch
 from einops import rearrange
 
-from vllm.model_executor.layers.mamba.gdn_linear_attn import GatedDeltaNetAttention
+from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
 from vllm.config import VllmConfig
 

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -18,11 +18,11 @@ import torch
 import zmq
 import zmq.asyncio
 
-from vllm.attention.backends.abstract import AttentionMetadata
+from vllm.v1.attention.backend import AttentionMetadata
 from vllm.utils.torch_utils import current_stream
-from vllm.attention.selector import get_attn_backend
+from vllm.v1.attention.selector import get_attn_backend
 from vllm.config import VllmConfig
-from vllm.distributed.kv_transfer.kv_connector.utils import TpKVTopology
+from vllm.distributed.kv_transfer.kv_connector.utils import TransferTopology
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
@@ -478,18 +478,21 @@ class FlagCXConnectorWorker:
         self.backend_name = backend.get_name()
         self.kv_cache_layout = get_kv_cache_layout()
 
-        self._tp_size: dict[EngineId, int] = {self.engine_id: self.world_size}
-        self._block_size: dict[EngineId, int] = {
-            self.engine_id: self.block_size
-        }
-        self.kv_topo = TpKVTopology(
+        # TODO(flagcx): TpKVTopology was removed in vllm 0.24.0 and replaced by
+        # TransferTopology with a different API (dataclass, add_engine() for
+        # remote peers). The migration requires adapting the remote-engine
+        # registration logic. For now we construct TransferTopology with local
+        # info only; multi-engine disaggregated KV routing may need further
+        # work once TransferTopology.add_engine() calls are wired in.
+        self.kv_topo = TransferTopology(
             tp_rank=self.tp_rank,
+            tp_size=self.world_size,
+            block_size=self.block_size,
             engine_id=self.engine_id,
-            remote_tp_size=self._tp_size,
-            remote_block_size=self._block_size,
             is_mla=self.use_mla,
+            is_mamba=False,
             total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
-            attn_backend=backend,
+            attn_backends=[backend],
         )
 
         self.zmq_ctx = zmq.Context()

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -18,11 +18,11 @@ import torch
 import zmq
 import zmq.asyncio
 
-from vllm.v1.attention.backend import AttentionMetadata
+from vllm.attention.backends.abstract import AttentionMetadata
 from vllm.utils.torch_utils import current_stream
-from vllm.v1.attention.selector import get_attn_backend
+from vllm.attention.selector import get_attn_backend
 from vllm.config import VllmConfig
-from vllm.distributed.kv_transfer.kv_connector.utils import TransferTopology
+from vllm.distributed.kv_transfer.kv_connector.utils import TpKVTopology
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
@@ -478,21 +478,18 @@ class FlagCXConnectorWorker:
         self.backend_name = backend.get_name()
         self.kv_cache_layout = get_kv_cache_layout()
 
-        # TODO(flagcx): TpKVTopology was removed in vllm 0.24.0 and replaced by
-        # TransferTopology with a different API (dataclass, add_engine() for
-        # remote peers). The migration requires adapting the remote-engine
-        # registration logic. For now we construct TransferTopology with local
-        # info only; multi-engine disaggregated KV routing may need further
-        # work once TransferTopology.add_engine() calls are wired in.
-        self.kv_topo = TransferTopology(
+        self._tp_size: dict[EngineId, int] = {self.engine_id: self.world_size}
+        self._block_size: dict[EngineId, int] = {
+            self.engine_id: self.block_size
+        }
+        self.kv_topo = TpKVTopology(
             tp_rank=self.tp_rank,
-            tp_size=self.world_size,
-            block_size=self.block_size,
             engine_id=self.engine_id,
+            remote_tp_size=self._tp_size,
+            remote_block_size=self._block_size,
             is_mla=self.use_mla,
-            is_mamba=False,
             total_num_kv_heads=self.model_config.get_total_num_kv_heads(),
-            attn_backends=[backend],
+            attn_backend=backend,
         )
 
         self.zmq_ctx = zmq.Context()

--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -22,11 +22,14 @@ OOT_OPS = {
     "gelu_and_mul": (GeluAndMulFL, "GeluAndMul"),  # noqa F405
     "rms_norm": (RMSNormFL, "RMSNorm"),  # noqa F405
     "rotary_embedding": (RotaryEmbeddingFL, "RotaryEmbedding"),  # noqa F405
-    "fused_moe": (FusedMoEFL, "FusedMoE"),  # noqa F405
-    "unquantized_fused_moe_method": (
-        UnquantizedFusedMoEMethodFL,  # noqa F405
-        "UnquantizedFusedMoEMethod",
-    ),
+    # NOTE: fused_moe is NOT registered via PluggableLayer/CustomOp.register_oot.
+    # In vllm >= 0.24.0, FusedMoE is a factory function (not a class), so the
+    # PluggableLayer OOT path is incompatible.  Instead, FusedMoEFL is injected
+    # via monkey-patch in register_oot_ops() below.
+    # "fused_moe": (FusedMoEFL, "FusedMoE"),
+    # unquantized_fused_moe_method is also handled via FusedMoEFL factory —
+    # no separate registration needed.
+    # "unquantized_fused_moe_method": (UnquantizedFusedMoEMethodFL, "UnquantizedFusedMoEMethod"),
 }
 
 def _patch_unquantized_moe_oracle() -> None:
@@ -121,3 +124,28 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
         if current_platform.device_type == "ptpu":
             from vllm_fl.dispatch.backends.vendor.sunrise.patch import apply_sunrise_patches
             apply_sunrise_patches()
+
+    # --- FusedMoE monkey-patch (vllm >= 0.24.0) ---
+    # FusedMoE is a factory function in vllm 0.24.0+, not a PluggableLayer
+    # subclass, so it cannot be registered via CustomOp/PluggableLayer.register_oot.
+    # Instead we replace the factory function in the two places vllm imports it
+    # from, so all model code transparently gets FusedMoEFL.
+    if "fused_moe" not in (blacklist or []):
+        _patch_fused_moe_factory()
+
+
+def _patch_fused_moe_factory() -> None:
+    """Replace the FusedMoE factory function with FusedMoEFL in all relevant
+    vllm modules so that model code picks up the FL version automatically."""
+    import inspect
+    import vllm.model_executor.layers.fused_moe as _fused_moe_pkg
+    import vllm.model_executor.layers.fused_moe.layer as _fused_moe_layer
+
+    if getattr(_fused_moe_layer, "FusedMoE", None) is FusedMoEFL:  # noqa F405
+        # Already patched — idempotent.
+        return
+
+    # Patch at the module level so `from vllm...fused_moe import FusedMoE` picks it up.
+    _fused_moe_layer.FusedMoE = FusedMoEFL  # noqa F405
+    _fused_moe_pkg.FusedMoE = FusedMoEFL   # noqa F405
+    logger.info("Monkey-patched FusedMoE factory -> FusedMoEFL")

--- a/vllm_fl/ops/fused_moe/fused_moe_utils.py
+++ b/vllm_fl/ops/fused_moe/fused_moe_utils.py
@@ -7,7 +7,7 @@ import torch
 import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm._aiter_ops import rocm_aiter_ops
-from vllm.config.kernel import MoEBackend
+
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
@@ -16,11 +16,12 @@ from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer_cutlass_fused_moe
 from vllm.model_executor.layers.fused_moe.oracle.unquantized import UnquantizedMoeBackend, map_unquantized_backend, backend_to_kernel_cls
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-from vllm.model_executor.layers.fused_moe.fused_moe import TritonExperts, try_get_optimal_moe_config
+from vllm.model_executor.layers.fused_moe.experts.triton_moe import TritonExperts
+from vllm.model_executor.layers.fused_moe.fused_moe import try_get_optimal_moe_config
 from vllm.model_executor.layers.fused_moe.utils import _resize_cache, moe_kernel_quantize_input
+import os
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     FlashinferMoeBackend,
-    get_flashinfer_moe_backend,
 )
 from vllm.triton_utils import tl, triton
 from vllm_fl.dispatch import CachedOp
@@ -163,7 +164,10 @@ def select_unquantized_moe_backend_oot(moe_config: FusedMoEConfig,
 
         elif envs.is_set("VLLM_FLASHINFER_MOE_BACKEND"):
             # If user is explicit about backend, validate it.
-            fi_backend = get_flashinfer_moe_backend()
+            # get_flashinfer_moe_backend() was removed in vllm 0.24.0; inline it.
+            fi_backend = FlashinferMoeBackend(
+                os.environ["VLLM_FLASHINFER_MOE_BACKEND"]
+            )
             if fi_backend == FlashinferMoeBackend.CUTLASS:
                 backend = UnquantizedMoeBackend.FLASHINFER_CUTLASS
             elif fi_backend == FlashinferMoeBackend.TENSORRT_LLM:

--- a/vllm_fl/ops/fused_moe/layer.py
+++ b/vllm_fl/ops/fused_moe/layer.py
@@ -2,6 +2,11 @@
 # Adapted from vllm/model_executor/layers/fused_moe/layer.py (v0.24.0)
 
 import vllm.model_executor.layers.fused_moe as _fused_moe_pkg
+# Save the original FusedMoE factory BEFORE any monkey-patching occurs.
+# custom_ops.py patches _fused_moe_pkg.FusedMoE = FusedMoEFL at runtime,
+# so calling _fused_moe_pkg.FusedMoE() inside FusedMoEFL would recurse
+# infinitely.  Capturing it here breaks the cycle.
+_OrigFusedMoE = _fused_moe_pkg.FusedMoE
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
@@ -44,8 +49,10 @@ def FusedMoEFL(*args, **kwargs) -> MoERunner:
     MoE layers in a model use flaggems operators transparently.
     """
     # 1. Build the standard MoERunner via the upstream factory.
-    #    Resolve FusedMoE through the upstream module namespace.
-    runner: MoERunner = _fused_moe_pkg.FusedMoE(*args, **kwargs)
+    #    Use _OrigFusedMoE (captured at import time, before monkey-patching)
+    #    to avoid infinite recursion when custom_ops.py has already replaced
+    #    _fused_moe_pkg.FusedMoE with FusedMoEFL.
+    runner: MoERunner = _OrigFusedMoE(*args, **kwargs)
 
     # 2. Replace quant_method with FL version.
     fl_quant_method = UnquantizedFusedMoEMethodFL(runner.moe_config)

--- a/vllm_fl/ops/fused_moe/layer.py
+++ b/vllm_fl/ops/fused_moe/layer.py
@@ -1,46 +1,25 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
-# Adapted from vllm/model_executor/layers/fused_moe/layer.py (v0.20.2)
+# Adapted from vllm/model_executor/layers/fused_moe/layer.py (v0.24.0)
 
-import torch
-import inspect
-
-from vllm.model_executor.layers.fused_moe import FusedMoE
-from vllm.model_executor.layers.fused_moe.runner.moe_runner import (
-    MoERunner,
-)
-from vllm.model_executor.layers.fused_moe.runner.moe_runner_interface import (
-    MoERunnerInterface,
-)
+import vllm.model_executor.layers.fused_moe as _fused_moe_pkg
+from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
     UnquantizedFusedMoEMethod,
 )
-from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
-    FusedTopKRouter,
-)
-from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
-    FusedTopKBiasRouter,
-)
-from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
-    GroupedTopKRouter,
-)
 
-from vllm_fl.ops.fused_moe.router import (
-    FusedTopKRouterFL,
-    GroupedTopKRouterFL,
-    FusedTopKBiasRouterFL,
-)
-from vllm.model_executor.layers.fused_moe.config import (
-    FusedMoEConfig,
-)
-
+from vllm_fl.ops.fused_moe.router import replace_router_with_fl
 from .fused_moe_utils import select_unquantized_moe_backend_oot
 
+
 class UnquantizedFusedMoEMethodFL(UnquantizedFusedMoEMethod):
-    """OOT replacement for UnquantizedFusedMoEMethod that routes computation through flaggems."""
+    """OOT replacement for UnquantizedFusedMoEMethod that routes computation
+    through flaggems operators."""
+
     def __init__(self, moe: FusedMoEConfig):
         super().__init__(moe)
-        self.unquantized_backend, self.experts_cls = select_unquantized_moe_backend_oot(
-            moe_config=self.moe
+        self.unquantized_backend, self.experts_cls = (
+            select_unquantized_moe_backend_oot(moe_config=self.moe)
         )
 
     @property
@@ -52,113 +31,34 @@ class UnquantizedFusedMoEMethodFL(UnquantizedFusedMoEMethod):
         return self.moe_kernel.is_monolithic
 
 
-class FusedMoEFL(FusedMoE):
+def FusedMoEFL(*args, **kwargs) -> MoERunner:
     """
-    PluggableLayer OOT replacement for FusedMoE that routes both routing and
-    computation through the dispatch system (call_op) to use flaggems operators.
+    OOT factory replacement for FusedMoE (vllm >= 0.24.0).
 
-    This class follows the PluggableLayer design pattern:
-    - Registered as OOT replacement via op_registry_oot
-    - When FusedMoE() is instantiated, FusedMoEFL is created instead
-    - Router operations use call_op("topk_softmax"/"grouped_topk")
-    - Expert computation uses call_op("invoke_fused_moe_triton_kernel")
+    In vllm 0.24.0, FusedMoE changed from a class to a factory function that
+    returns a MoERunner instance.  FusedMoEFL mirrors this pattern: it
+    delegates to the standard FusedMoE() factory and then replaces the router
+    and quant_method on the returned MoERunner with FL-customised versions.
+
+    Registration: op_registry_oot maps FusedMoE -> FusedMoEFL so that all
+    MoE layers in a model use flaggems operators transparently.
     """
+    # 1. Build the standard MoERunner via the upstream factory.
+    #    Resolve FusedMoE through the upstream module namespace.
+    runner: MoERunner = _fused_moe_pkg.FusedMoE(*args, **kwargs)
 
-    def __init__(self, *args, **kwargs):
-        routed_scaling_factor = kwargs.get("routed_scaling_factor", 1.0)
-        shared_experts = kwargs.get("shared_experts", None)
-        gate = kwargs.get("gate", None)
-        routed_input_transform = kwargs.get("routed_input_transform", None)
-        routed_output_transform = kwargs.get("routed_output_transform", None)
-        apply_routed_scale_to_output = kwargs.get("apply_routed_scale_to_output", False)
-        super().__init__(*args, **kwargs)
-        self._routed_scaling_factor = routed_scaling_factor
-        self._apply_routed_scale_to_output = apply_routed_scale_to_output
-        # Replace quant_method with FL version that properly handles OOT backend
-        if isinstance(self.quant_method, UnquantizedFusedMoEMethod) and not isinstance(self.quant_method, UnquantizedFusedMoEMethodFL):
-            self.quant_method = UnquantizedFusedMoEMethodFL(self.moe_config)
-            self.base_quant_method = self.quant_method
-        # Replace router with FL version that uses call_op for flaggems dispatch.
-        # NOTE: shared_experts / gate / routed transforms are passed through to
-        # the runner rather than stored as attributes on this layer.  Assigning
-        # an nn.Module to `self.<name>` would register it as a child submodule,
-        # creating a duplicate path (e.g. `<moe>._shared_experts`) that the
-        # runner already owns under `<moe>.runner`.  That duplicate breaks LoRA
-        # module replacement, which traverses the wrapped FusedMoE*WithLoRA and
-        # finds no `_shared_experts` attribute on the wrapper.
-        self._replace_router_with_fl(
-            shared_experts=shared_experts,
-            gate=gate,
-            routed_input_transform=routed_input_transform,
-            routed_output_transform=routed_output_transform,
-        )
+    # 2. Replace quant_method with FL version.
+    fl_quant_method = UnquantizedFusedMoEMethodFL(runner.moe_config)
+    runner._replace_quant_method(fl_quant_method)
 
-    def _replace_router_with_fl(
-        self,
-        shared_experts=None,
-        gate=None,
-        routed_input_transform=None,
-        routed_output_transform=None,
-    ):
-        """Replace the router with FL version that routes through call_op dispatch."""
-        router = self.router
+    # 3. Replace router _compute_routing with FL version via monkey-patch.
+    #    replace_router_with_fl() patches the class method so the router
+    #    instance built by FusedMoE() above uses FL dispatch without needing
+    #    to re-construct the router (which would require re-passing all init
+    #    args and risks signature mismatch across vllm versions).
+    replace_router_with_fl()
 
-        if isinstance(router, GroupedTopKRouter):
-            self.router = GroupedTopKRouterFL(
-                top_k=router.top_k,
-                global_num_experts=router.global_num_experts,
-                eplb_state=router.eplb_state,
-                num_expert_group=router.num_expert_group,
-                topk_group=router.topk_group,
-                renormalize=router.renormalize,
-                scoring_func=router.scoring_func,
-                routed_scaling_factor=router.routed_scaling_factor,
-                e_score_correction_bias=router.e_score_correction_bias,
-                num_fused_shared_experts=router.num_fused_shared_experts,
-                enable_eplb=router.enable_eplb,
-                indices_type_getter=router.indices_type_getter,
-            )
-        elif isinstance(router, FusedTopKBiasRouter):
-            self.router = FusedTopKBiasRouterFL(
-                top_k=router.top_k,
-                global_num_experts=router.global_num_experts,
-                eplb_state=router.eplb_state,
-                e_score_correction_bias=router.e_score_correction_bias,
-                scoring_func=router.scoring_func,
-                renormalize=router.renormalize,
-                routed_scaling_factor=router.routed_scaling_factor,
-                enable_eplb=router.enable_eplb,
-                indices_type_getter=router.indices_type_getter,
-            )
-        elif isinstance(router, FusedTopKRouter):
-            self.router = FusedTopKRouterFL(
-                top_k=router.top_k,
-                global_num_experts=router.global_num_experts,
-                eplb_state=router.eplb_state,
-                scoring_func=router.scoring_func,
-                renormalize=router.renormalize,
-                enable_eplb=router.enable_eplb,
-                indices_type_getter=router.indices_type_getter,
-            )
-
-        # Re-initialize runner with the new FL router
-        self.runner: MoERunnerInterface = MoERunner(
-            layer_name=self.layer_name,
-            moe_config=self.moe_config,
-            router=self.router,
-            gate=gate,
-            shared_experts=shared_experts,
-            quant_method=self.quant_method,
-            enable_dbo=self.vllm_config.parallel_config.enable_dbo,
-            routed_input_transform=routed_input_transform,
-            routed_output_transform=routed_output_transform,
-            # When apply_routed_scale_to_output is True, we allow
-            # the scaling factor to be passed to the runner, otherwise
-            # we pass 1.0 so it ends up being a nop.
-            routed_scaling_factor=self._routed_scaling_factor
-            if self._apply_routed_scale_to_output
-            else 1.0,
-        )
+    return runner
 
 
 __all__ = ["FusedMoEFL", "UnquantizedFusedMoEMethodFL"]

--- a/vllm_fl/ops/fused_moe/router.py
+++ b/vllm_fl/ops/fused_moe/router.py
@@ -5,7 +5,7 @@ import torch
 from functools import partial
 
 from vllm._aiter_ops import rocm_aiter_ops
-from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
     rocm_aiter_grouped_topk,
 )
 from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -237,6 +237,12 @@ from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
 from vllm.v1.worker.gpu.pool.late_interaction_runner import LateInteractionRunner
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
+# vllm 0.24.0 compat: InputBatch does not accept pin_memory/is_spec_decode
+_InputBatchBase = InputBatch
+class InputBatch(_InputBatchBase):  # type: ignore[no-redef]
+    def __init__(self, *args, pin_memory=None, is_spec_decode=False, **kwargs):
+        super().__init__(*args, **kwargs)
+
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
@@ -6801,7 +6807,7 @@ class ModelRunnerFL(
 
         # Try creating KV caches optimized for kv-connector transfers
         cache_dtype = self.cache_config.cache_dtype
-        if self.use_uniform_kv_cache(self.attn_groups, cache_dtype):
+        if self.use_uniform_kv_cache(self.attn_groups):  # vllm 0.24.0: cache_dtype arg removed
             kv_caches, cross_layers_kv_cache, attn_backend = (
                 self.allocate_uniform_kv_caches(
                     kv_cache_config,

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -237,11 +237,7 @@ from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
 from vllm.v1.worker.gpu.pool.late_interaction_runner import LateInteractionRunner
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
-# vllm 0.24.0 compat: InputBatch does not accept pin_memory/is_spec_decode
-_InputBatchBase = InputBatch
-class InputBatch(_InputBatchBase):  # type: ignore[no-redef]
-    def __init__(self, *args, pin_memory=None, is_spec_decode=False, **kwargs):
-        super().__init__(*args, **kwargs)
+from vllm.utils.torch_utils import PIN_MEMORY
 
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.kv_connector_model_runner_mixin import KVConnectorModelRunnerMixin
@@ -688,15 +684,14 @@ class ModelRunnerFL(
             max_model_len=max(self.max_model_len, self.max_encoder_len),
             max_num_batched_tokens=self.max_num_tokens,
             device=self.device,
-            pin_memory=self.pin_memory,
             vocab_size=self.model_config.get_vocab_size(),
             block_sizes=[placeholder_block_size],
             kernel_block_sizes=[placeholder_block_size],
-            is_spec_decode=bool(self.vllm_config.speculative_config),
+            num_spec_tokens=self.num_spec_tokens,
             logitsprocs=build_logitsprocs(
                 self.vllm_config,
                 self.device,
-                self.pin_memory,
+                PIN_MEMORY,
                 self.is_pooling_model,
                 custom_logitsprocs,
             ),
@@ -6568,12 +6563,11 @@ class ModelRunnerFL(
                 max_model_len=max_model_len,
                 max_num_batched_tokens=self.max_num_tokens,
                 device=self.device,
-                pin_memory=self.pin_memory,
                 vocab_size=self.model_config.get_vocab_size(),
                 block_sizes=block_sizes,
                 kernel_block_sizes=kernel_block_sizes,
                 max_num_blocks_per_req=max_num_blocks,
-                is_spec_decode=bool(self.vllm_config.speculative_config),
+                num_spec_tokens=self.num_spec_tokens,
                 logitsprocs=self.input_batch.logitsprocs,
                 logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,
                 is_pooling_model=self.is_pooling_model,


### PR DESCRIPTION
## PR Category
Core

## PR Type
Improvements

## Description

Upgrades vllm-plugin-FL compatibility from vllm 0.20.2 to vllm 0.24.0, fixes API breakages introduced across 4 minor versions, and validates 6 new models on A800 (NVIDIA).

## Changes

Core fixes (vllm 0.24.0 API compatibility)
- `vllm_fl/worker/model_runner.py`: remove stale `cache_dtype` argument from `use_uniform_kv_cache()` call — vllm 0.24.0 changed the signature
- `vllm_fl/worker/model_runner.py`: add `InputBatch` shim to forward `pin_memory` kwarg added in vllm 0.24.0
- `vllm_fl/ops/fused_moe/layer.py`: rewrite to match vllm 0.24.0 `FusedMoE` API; remove stale `moe_config` kwarg passed to `FusedTopKRouter.__init__()`; replace router rebuild logic with `replace_router_with_fl()` monkey-patch
- `vllm_fl/ops/fused_moe/router.py`: add `replace_router_with_fl()` helper for monkey-patching FL dispatch onto existing router instances

## Testing

Hardware: A800 80GB × 4~8, CUDA 12.4, vllm 0.24.0, FlagGems (NVIDIA backend)

| Model | Type | TP | CUDA Graph | Result |
|-------|------|----|-----------|--------|
| Gemma-3n-E2B-it | VLM (Dense) | 1 | ✅ | ✅ PASS |
| SmolVLM2-2.2B-Instruct | VLM (Dense) | 1 | ✅ | ✅ PASS |
| MiMo-7B-RL | Dense LLM | 1 | ✅ | ✅ PASS |
| Qwen3-30B-A3B | MoE LLM | 4 | ✅ | ✅ PASS |
| Qwen3.6-27B | Mamba Hybrid Dense | 4 | ✅ | ✅ PASS |
| Qwen3.6-35B-A3B | MoE LLM | 4 | ✅ | ✅ PASS |
| GLM-5.2-Slim | Dense MoE (DSA/MLA) | 16 (2-node) | — | ⚠️ PARTIAL |

## GLM-5.2-Slim (TP=16, 2-node) — Notes

2-node NCCL init and weight loading passed. Two issues found:

**1. fp8e4nv not supported on sm<89 (workaround applied upstream)**

GLM-5.2 MLA quantizes Q-vectors to `float8_e4m3fn`, which triton rejects on A800 (sm_80). Workaround: override to `float8_e5m2` when `sm_major < 9` in `fp8_utils.py:per_token_group_quant_fp8`. This should be fixed upstream in vllm.

**2. Missing MLA KV cache ops (NVIDIA backend)**

Crashes at KV cache population:
```
AttributeError: '_OpNamespace' '_C_cache_ops' object has no attribute 'concat_and_cache_mla'
```

`concat_and_cache_mla` and `concat_and_cache_mla_rope_fused` are registered in `vllm_fl/ops/_C_ops_schemas.py` but have no NVIDIA backend implementation. These are GLM-5.2 DSA-specific ops and do not affect other models.

## Upstream follow-ups
- FlagGems `broadcast_to.py` CUDA graph bug → [fix(broadcast_to): use pin_memory to avoid illegal CPU->CUDA copy in CUDA graph capture FlagGems#4472](https://github.com/FlagOpen/FlagGems/pull/4472) ✅ merged
