### PR TITLE
ci: add two-tier approval gate before GPU tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,17 @@
 # CI Workflow for VLLM Plugin FL
 # This workflow defines the CI process for the VLLM Plugin FL project.
 # It includes linting and platform-specific testing stages.
+#
+# Security model (two-tier):
+#   Tier 1 — lint: runs immediately on every PR, no approval required.
+#   Tier 2 — build + GPU tests: gated behind the "protected" environment.
+#             A repo maintainer must approve before any code runs on
+#             self-hosted GPU runners.  Schedule and workflow_dispatch
+#             bypass the gate because they only run trusted base-branch code.
+#
+# Setup required (one-time, per repo):
+#   Settings → Environments → New environment → name: "protected"
+#   Add Required reviewers (org members who can approve PRs for testing).
 name: CI
 
 on:
@@ -25,21 +36,36 @@ concurrency:
 jobs:
   # ============================================================
   # Job 1: Lint (ruff check, ruff format, typos)
-  # Runs on every push/PR. Fast, no special requirements.
+  # Tier 1 — runs immediately on every PR, no approval required.
   # ============================================================
   lint:
     uses: ./.github/workflows/_lint.yml
 
   # ============================================================
-  # Job 2: Build & install check
+  # Job 2: Approval gate
+  # Tier 2 — waits for a maintainer to approve via the "protected"
+  # environment before any code runs on self-hosted GPU runners.
+  # On schedule / workflow_dispatch the environment has no reviewers
+  # configured for those event types, so it passes through automatically.
+  # ============================================================
+  gate:
+    needs: lint
+    runs-on: ubuntu-latest
+    environment: protected
+    steps:
+      - name: Approved
+        run: echo "Gate passed — proceeding to build and GPU tests."
+
+  # ============================================================
+  # Job 3: Build & install check
   # Verify the package can be built and installed cleanly.
   # ============================================================
   build:
-    needs: lint
+    needs: gate
     uses: ./.github/workflows/_build_wheel.yml
 
   # ============================================================
-  # Job 3: Discover which platforms to test
+  # Job 4: Discover which platforms to test
   # ============================================================
   discover:
     needs: build
@@ -78,7 +104,7 @@ jobs:
         run: python3 .github/scripts/detect_platforms.py
 
   # ============================================================
-  # Job 4a: CUDA platform testing
+  # Job 5a: CUDA platform testing
   # ============================================================
   test-cuda:
     needs: discover
@@ -89,7 +115,7 @@ jobs:
     secrets: inherit
 
   # ============================================================
-  # Job 4b: Ascend platform testing
+  # Job 5b: Ascend platform testing
   # ============================================================
   test-ascend:
     needs: discover


### PR DESCRIPTION
## Background

Currently any external contributor can open a PR and immediately trigger GPU test jobs on our self-hosted runners — no human review is required. All GPU jobs run inside containers configured with `--privileged`, which gives the container near-unrestricted access to the host kernel. The combination means a malicious PR can execute arbitrary code on the host machine and potentially pivot to other workloads running on the same node.

This is not a theoretical risk. The attack path is straightforward:

```
Open PR → CI triggers automatically → malicious code runs in --privileged container
→ mount host filesystem or read /proc/1/environ → host shell or secrets
```

## What this PR does

Introduces a minimal two-tier CI model by inserting a single `gate` job between `lint` and `build`:

- **Tier 1 — lint**: runs immediately on every PR, no approval needed. Fast, stateless, runs on `ubuntu-latest` with no elevated privileges.
- **Tier 2 — build + GPU tests**: gated behind the `protected` GitHub Environment. The `gate` job pauses and waits for a maintainer to click **Approve** in the Actions UI before any code reaches a self-hosted GPU runner.

`schedule` and `workflow_dispatch` events are unaffected — they run trusted base-branch code and pass through the gate automatically.

## Change summary

- One new `gate` job referencing `environment: protected`
- `build` job `needs` changed from `lint` → `gate`
- All downstream jobs unchanged
- Job numbering in comments updated (no logic change)

## One-time setup required

After merging, a repo admin needs to create the environment in GitHub:

> **Settings → Environments → New environment → name: `protected`**
> Add Required reviewers (org members who should approve PRs before GPU tests run).

Without this step the gate job will pass through immediately and the protection has no effect.