### PR TITLE
[CICD] Add Hygon CI image workflow

### DIFF
--- a/.github/configs/hygon.yml
+++ b/.github/configs/hygon.yml
@@ -18,7 +18,7 @@
 platform: hygon
 
 # Docker image for this hardware.
-ci_image: harbor.sourcefind.cn:5443/dcu/admin/base/custom:vllm0.20.0-ubuntu22.04-dtk26.04-py3.10-MiniCPM-V-4.6
+ci_image: harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl:vllm-plugin-fl-hygon-vllm0.20.2-dtk26.04-py3.10-ci
 
 # Runner labels for this hardware.
 runner_labels:
@@ -27,6 +27,7 @@ runner_labels:
 # Container volumes (hardware-specific paths).
 container_volumes:
   - /opt/hyhal:/opt/hyhal
+  - /usr/local/hyhal:/usr/local/hyhal
   - /data:/data
   - /workspace:/workspace
 
@@ -42,7 +43,7 @@ container_options: >-
   --env HIP_CLANG_PATH=/opt/dtk/llvm/bin
   --env DEVICE_LIB_PATH=/opt/dtk/amdgcn/bitcode
   --env PATH=/opt/dtk/bin:/opt/dtk/hip/bin:/opt/dtk/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-  --env LD_LIBRARY_PATH=/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:/opt/dtk/hip/lib:/opt/dtk/lib:/opt/dtk/llvm/lib:/opt/dtk/dcc/lib:/opt/dtk/aillvm/lib:/opt/dtk/hsa/lib
+  --env LD_LIBRARY_PATH=/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:/usr/local/hyhal/lib:/opt/dtk/hip/lib:/opt/dtk/lib:/opt/dtk/llvm/lib:/opt/dtk/dcc/lib:/opt/dtk/aillvm/lib:/opt/dtk/hsa/lib
   --device=/dev/kfd
   --device=/dev/mkfd
   --device=/dev/dri

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -5,97 +5,104 @@ set -euo pipefail
 
 git config --global --add safe.directory "$(pwd)"
 
-export GEMS_VENDOR="${GEMS_VENDOR:-hygon}"
-export DTK_HOME="${DTK_HOME:-/opt/dtk}"
-export ROCM_PATH="${ROCM_PATH:-${DTK_HOME}}"
-export HIP_PATH="${HIP_PATH:-${DTK_HOME}/hip}"
-export HSA_PATH="${HSA_PATH:-${DTK_HOME}/hsa}"
-export HIP_CLANG_PATH="${HIP_CLANG_PATH:-${DTK_HOME}/llvm/bin}"
-export DEVICE_LIB_PATH="${DEVICE_LIB_PATH:-${DTK_HOME}/amdgcn/bitcode}"
+: "${GEMS_VENDOR:?GEMS_VENDOR is not set}"
+: "${VLLM_PLUGINS:?VLLM_PLUGINS is not set}"
+: "${DTK_HOME:?DTK_HOME is not set}"
+: "${ROCM_PATH:?ROCM_PATH is not set}"
+: "${HIP_PATH:?HIP_PATH is not set}"
+: "${HSA_PATH:?HSA_PATH is not set}"
+: "${HIP_CLANG_PATH:?HIP_CLANG_PATH is not set}"
+: "${DEVICE_LIB_PATH:?DEVICE_LIB_PATH is not set}"
+: "${LD_LIBRARY_PATH:?LD_LIBRARY_PATH is not set}"
 
-DTK_PATH="${DTK_HOME}/bin:${HIP_PATH}/bin:${HIP_CLANG_PATH}"
-DTK_LIBRARY_PATH="/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:${HIP_PATH}/lib:${DTK_HOME}/lib:${DTK_HOME}/llvm/lib:${DTK_HOME}/dcc/lib:${DTK_HOME}/aillvm/lib:${HSA_PATH}/lib"
-export PATH="${DTK_PATH}:${PATH}"
-export LD_LIBRARY_PATH="${DTK_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+USE_IMAGE_PLUGIN="${HYGON_USE_IMAGE_PLUGIN:-1}"
 
-if [[ -n "${GITHUB_ENV:-}" ]]; then
-  for name in \
-    GEMS_VENDOR \
-    DTK_HOME \
-    ROCM_PATH \
-    HIP_PATH \
-    HSA_PATH \
-    HIP_CLANG_PATH \
-    DEVICE_LIB_PATH \
-    PATH \
-    LD_LIBRARY_PATH; do
-    echo "${name}=${!name}" >> "${GITHUB_ENV}"
-  done
+if [[ "${USE_IMAGE_PLUGIN}" == "1" ]]; then
+    IMAGE_PLUGIN_ROOT="${VLLM_FL_IMAGE_PLUGIN_ROOT:-/opt/vllm-src/vllm-plugin-FL}"
+    test -d "${IMAGE_PLUGIN_ROOT}/vllm_fl"
+
+    # The Hygon CI image already contains the validated plugin commit. Keep the
+    # checkout available for tests and configs, but load vllm_fl from the image.
+    HYGON_SITE_DIR="${RUNNER_TEMP:-/tmp}/hygon-python-site"
+    mkdir -p "${HYGON_SITE_DIR}"
+    cat > "${HYGON_SITE_DIR}/sitecustomize.py" <<'PY'
+import importlib.abc
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+
+class _ImageVllmFLFinder(importlib.abc.MetaPathFinder):
+    def __init__(self, root):
+        self.package_dir = Path(root) / "vllm_fl"
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname != "vllm_fl":
+            return None
+        init_file = self.package_dir / "__init__.py"
+        if not init_file.exists():
+            return None
+        return importlib.util.spec_from_file_location(
+            fullname,
+            init_file,
+            submodule_search_locations=[str(self.package_dir)],
+        )
+
+
+_root = os.environ.get("VLLM_FL_IMAGE_PLUGIN_ROOT")
+if _root:
+    sys.meta_path.insert(0, _ImageVllmFLFinder(_root))
+PY
+
+    export VLLM_FL_IMAGE_PLUGIN_ROOT="${IMAGE_PLUGIN_ROOT}"
+    export PYTHONPATH="${HYGON_SITE_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+
+    if [[ -n "${GITHUB_ENV:-}" ]]; then
+        {
+            echo "VLLM_FL_IMAGE_PLUGIN_ROOT=${VLLM_FL_IMAGE_PLUGIN_ROOT}"
+            echo "PYTHONPATH=${PYTHONPATH}"
+        } >> "${GITHUB_ENV}"
+    fi
+else
+    unset VLLM_FL_IMAGE_PLUGIN_ROOT
 fi
+
+export HYGON_USE_IMAGE_PLUGIN="${USE_IMAGE_PLUGIN}"
 
 echo "DTK_HOME=${DTK_HOME}"
 echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
+echo "HYGON_USE_IMAGE_PLUGIN=${HYGON_USE_IMAGE_PLUGIN}"
+if [[ "${USE_IMAGE_PLUGIN}" == "1" ]]; then
+    echo "VLLM_FL_IMAGE_PLUGIN_ROOT=${VLLM_FL_IMAGE_PLUGIN_ROOT}"
+    echo "PYTHONPATH=${PYTHONPATH}"
+fi
 test -e "${HIP_PATH}/lib/libgalaxyhip.so.5"
 test -e "${DTK_HOME}/llvm/lib/libomp.so"
 
-TEST_DEPS=(
-  pytest
-  pytest-cov
-  pytest-timeout
-  pytest-json-report
-  scikit-build-core==0.11
-  pybind11
-  ninja
-  cmake
-  numpy
-  requests
-  openai
-  decorator
-  pyyaml
-  sqlalchemy
-)
-
-FLAGGEMS_REF="8d23621eb1381ae96b315a9287ce3cc555433824"
-FLAGGEMS_SOURCE="${FLAGGEMS_PATH:-/workspace/FlagGems}"
-
-if command -v uv >/dev/null 2>&1; then
-  uv pip install --system --upgrade pip
-  uv pip install --system --no-build-isolation -e . --no-deps
-  uv pip install --system "${TEST_DEPS[@]}"
-else
-  python -m pip install --upgrade pip
-  python -m pip install --no-build-isolation -e . --no-deps
-  python -m pip install "${TEST_DEPS[@]}"
-fi
-
-test -d "${FLAGGEMS_SOURCE}/src/flag_gems"
-git config --global --add safe.directory "${FLAGGEMS_SOURCE}"
-
-FLAGGEMS_HEAD="$(git -C "${FLAGGEMS_SOURCE}" rev-parse HEAD)"
-if [[ "${FLAGGEMS_HEAD}" != "${FLAGGEMS_REF}" ]]; then
-  echo "Unexpected FlagGems commit: ${FLAGGEMS_HEAD}; expected ${FLAGGEMS_REF}."
-  exit 1
-fi
-
-if ! grep -q 'kwargs.pop("num_ldmatrixes", None)' \
-  "${FLAGGEMS_SOURCE}/src/flag_gems/runtime/configloader.py"; then
-  echo "FlagGems num_ldmatrixes compatibility patch is missing."
-  exit 1
-fi
-
-FLAGGEMS_DIR="$(mktemp -d)/FlagGems"
-cp -a "${FLAGGEMS_SOURCE}" "${FLAGGEMS_DIR}"
-
-if command -v uv >/dev/null 2>&1; then
-  uv pip install --system --no-build-isolation -e "${FLAGGEMS_DIR}" --no-deps
-else
-  python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}" --no-deps
-fi
-
 python - <<'PY'
+import os
+from pathlib import Path
+
 import flag_gems
 import torch
+import vllm
+import vllm_fl
 
+if os.environ.get("HYGON_USE_IMAGE_PLUGIN", "1") == "1":
+    image_plugin_root = Path(os.environ["VLLM_FL_IMAGE_PLUGIN_ROOT"]).resolve()
+    expected_package = image_plugin_root / "vllm_fl"
+    plugin_file = Path(vllm_fl.__file__).resolve()
+    if (
+        plugin_file != expected_package / "__init__.py"
+        and expected_package not in plugin_file.parents
+    ):
+        raise RuntimeError(
+            f"Unexpected vllm_fl path: {plugin_file}; expected under {expected_package}"
+        )
+
+print(f"vLLM import ok: {vllm.__version__}")
+print(f"vLLM-FL import ok: {vllm_fl.__file__}")
 print(f"FlagGems import ok: {getattr(flag_gems, '__version__', 'unknown')}")
 print(f"Torch import ok: {torch.__version__}")
 print(f"Accelerator available: {torch.cuda.is_available()}")

--- a/.github/workflows/_benchmark_test.yml
+++ b/.github/workflows/_benchmark_test.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: benchmark-${{ inputs.platform }}
           path: |

--- a/.github/workflows/_build_wheel.yml
+++ b/.github/workflows/_build_wheel.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Upload wheel
         if: inputs.upload-artifact
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: wheel
           path: dist/*.whl

--- a/.github/workflows/_e2e_test.yml
+++ b/.github/workflows/_e2e_test.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: e2e-${{ inputs.platform }}-${{ inputs.device }}-${{ inputs.task }}
           path: |

--- a/.github/workflows/_functional_test.yml
+++ b/.github/workflows/_functional_test.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: functional-${{ inputs.platform }}
           path: |

--- a/.github/workflows/_unit_test.yml
+++ b/.github/workflows/_unit_test.yml
@@ -78,6 +78,8 @@ jobs:
         run: bash .github/scripts/${{ inputs.platform }}/check.sh
 
       - name: Install project
+        env:
+          HYGON_USE_IMAGE_PLUGIN: "0"
         run: bash .github/scripts/${{ inputs.platform }}/setup.sh
 
       - name: Run unit tests
@@ -89,6 +91,7 @@ jobs:
       - name: Upload coverage report
         if: inputs.upload_coverage && always()
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: coverage-${{ inputs.platform }}
           path: |

--- a/.typos.toml
+++ b/.typos.toml
@@ -32,8 +32,10 @@ npu = "npu"
 NPU = "NPU"
 hccl = "hccl"
 HCCL = "HCCL"
+hsa = "hsa"
 cann = "cann"
 CANN = "CANN"
+HSA = "HSA"
 
 [files]
 extend-exclude = [

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ import torch
 from vllm.config.compilation import CompilationConfig
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     prompts = [
         "Hello, my name is",
     ]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -31,6 +31,14 @@ UBUNTU_VERSION="${UBUNTU_VERSION:-22.04}"
 VLLM_VERSION="${VLLM_VERSION:-0.19.0}"
 CANN_VERSION="${CANN_VERSION:-8.5.1}"
 CANN_CHIP="${CANN_CHIP:-910b}"
+HYGON_BASE_IMAGE="${HYGON_BASE_IMAGE:-harbor.sourcefind.cn:5443/dcu/admin/base/custom:vllm0.20.0-ubuntu22.04-dtk26.04-py3.10-MiniCPM-V-4.6}"
+HYGON_VLLM_VERSION="${HYGON_VLLM_VERSION:-0.20.2}"
+HYGON_DTK_VERSION="${HYGON_DTK_VERSION:-26.04}"
+HYGON_PYTHON_VERSION="${HYGON_PYTHON_VERSION:-3.10}"
+HYGON_RUNTIME_LIB_DIR="${HYGON_RUNTIME_LIB_DIR:-/opt/hyhal/lib}"
+HYGON_RUNTIME_ROOTS="${HYGON_RUNTIME_ROOTS:-/opt/dtk:/opt/hyhal:/usr/local/hyhal}"
+FLAGGEMS_VERSION="${FLAGGEMS_VERSION:-62d70b9e858ec407572153ee8cdf65cc24a637d5}"
+VLLM_PLUGIN_FL_VERSION="${VLLM_PLUGIN_FL_VERSION:-ffa2ee3eb3831f3873dd0966d12fc8e0b4e6e3d4}"
 
 # ---- Build options ----
 PLATFORM="${PLATFORM:-cuda}"
@@ -55,6 +63,73 @@ msg() {
     printf ">>> %s\n" "$1"
 }
 
+cleanup_hygon_runtime_overlay() {
+    if [[ -n "${HYGON_RUNTIME_OVERLAY:-}" ]]; then
+        rm -rf "${HYGON_RUNTIME_OVERLAY}"
+    fi
+}
+
+stage_hygon_runtime_files() {
+    local src rel
+    for src in "$@"; do
+        [[ -e "${src}" ]] || continue
+        rel="${src#/}"
+        mkdir -p "${HYGON_RUNTIME_OVERLAY}/$(dirname "${rel}")"
+        cp -aL "${src}" "${HYGON_RUNTIME_OVERLAY}/${rel}"
+    done
+}
+
+prepare_hygon_runtime_overlay() {
+    HYGON_RUNTIME_OVERLAY="${SCRIPT_DIR}/hygon/.hygon-runtime"
+    rm -rf "${HYGON_RUNTIME_OVERLAY}"
+    mkdir -p "${HYGON_RUNTIME_OVERLAY}/opt/hyhal/lib"
+
+    mapfile -t HYGON_RUNTIME_LIBS < <(
+        find "${HYGON_RUNTIME_LIB_DIR}" -maxdepth 1 -name 'librocm_smi64.so*' -print 2>/dev/null | sort
+    )
+    if [[ "${#HYGON_RUNTIME_LIBS[@]}" -eq 0 ]]; then
+        err "Hygon runtime libraries not found: ${HYGON_RUNTIME_LIB_DIR}/librocm_smi64.so*"
+    fi
+
+    stage_hygon_runtime_files "${HYGON_RUNTIME_LIBS[@]}"
+
+    local runtime_roots=()
+    local existing_runtime_roots=()
+    local root
+    IFS=: read -r -a runtime_roots <<< "${HYGON_RUNTIME_ROOTS}"
+    for root in "${runtime_roots[@]}"; do
+        if [[ -d "${root}" ]]; then
+            existing_runtime_roots+=("${root}")
+        fi
+    done
+    if [[ "${#existing_runtime_roots[@]}" -eq 0 ]]; then
+        err "Hygon runtime roots not found: ${HYGON_RUNTIME_ROOTS}"
+    fi
+
+    mapfile -t HYGON_HSA_RUNTIME_FILES < <(
+        find "${existing_runtime_roots[@]}" \( -type f -o -type l \) \
+            \( -name 'libhsa-runtime64.so*' \
+            -o -name 'hsa-runtime64*cmake' \
+            -o -path '*/hsa-runtime64/*.cmake' \) \
+            -print 2>/dev/null | sort -u
+    )
+    if [[ "${#HYGON_HSA_RUNTIME_FILES[@]}" -eq 0 ]]; then
+        err "Hygon HSA runtime files not found under: ${HYGON_RUNTIME_ROOTS}"
+    fi
+    stage_hygon_runtime_files "${HYGON_HSA_RUNTIME_FILES[@]}"
+
+    mapfile -t HYGON_ROCM_SMI_CMAKE_FILES < <(
+        find "${existing_runtime_roots[@]}" \( -type f -o -type l \) \
+            \( -name 'rocm_smi*cmake' -o -path '*/rocm_smi/*.cmake' \) \
+            -print 2>/dev/null | sort -u
+    )
+    if [[ "${#HYGON_ROCM_SMI_CMAKE_FILES[@]}" -gt 0 ]]; then
+        stage_hygon_runtime_files "${HYGON_ROCM_SMI_CMAKE_FILES[@]}"
+    fi
+
+    trap cleanup_hygon_runtime_overlay EXIT
+}
+
 usage() {
     cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
@@ -62,7 +137,7 @@ Usage: $(basename "$0") [OPTIONS]
 Build the vllm-plugin-FL Docker image.
 
 OPTIONS:
-    --platform PLATFORM    Platform to build: cuda, ascend (default: ${PLATFORM})
+    --platform PLATFORM    Platform to build: cuda, ascend, hygon (default: ${PLATFORM})
     --target TARGET        Build target: dev, ci, release (default: ${TARGET})
     --image-name NAME      Image name (default: ${IMAGE_NAME})
     --image-tag TAG        Image tag (default: auto-generated)
@@ -82,6 +157,15 @@ VERSIONS (override via environment variables):
   Ascend:
     CANN_VERSION         CANN version (default: ${CANN_VERSION})
     CANN_CHIP            CANN chip: 910b, a3 (default: ${CANN_CHIP})
+  Hygon:
+    HYGON_BASE_IMAGE     Base image (default: ${HYGON_BASE_IMAGE})
+    HYGON_VLLM_VERSION   vLLM version installed in empty mode (default: ${HYGON_VLLM_VERSION})
+    HYGON_DTK_VERSION    DTK version used in generated image tag (default: ${HYGON_DTK_VERSION})
+    HYGON_PYTHON_VERSION Python version in Hygon base image tag (default: ${HYGON_PYTHON_VERSION})
+    HYGON_RUNTIME_LIB_DIR Hygon runtime library source dir (default: ${HYGON_RUNTIME_LIB_DIR})
+    HYGON_RUNTIME_ROOTS  Colon-separated roots for Hygon runtime overlay files (default: ${HYGON_RUNTIME_ROOTS})
+    FLAGGEMS_VERSION     FlagGems git ref (default: ${FLAGGEMS_VERSION})
+    VLLM_PLUGIN_FL_VERSION vllm-plugin-FL git ref (default: ${VLLM_PLUGIN_FL_VERSION})
 
 EXAMPLES:
     # Build CUDA dev image
@@ -92,6 +176,9 @@ EXAMPLES:
 
     # Build Ascend CI image for A3
     CANN_CHIP=a3 ./build.sh --platform ascend --target ci --build-arg SOC_VERSION=ascend910_9391
+
+    # Build Hygon CI image
+    ./build.sh --platform hygon --target ci
 
     # Build with custom PyPI mirror
     ./build.sh --target dev --index-url https://pypi.tuna.tsinghua.edu.cn/simple
@@ -158,13 +245,13 @@ BUILD_CONTEXT="${SCRIPT_DIR}/${PLATFORM}"
 # Platform-specific build args and auto-tag
 BUILD_ARGS=(
     --build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}"
-    --build-arg "PYTHON_VERSION=${PYTHON_VERSION}"
-    --build-arg "VLLM_VERSION=${VLLM_VERSION}"
 )
 
 if [[ "${PLATFORM}" == "cuda" ]]; then
     BUILD_ARGS+=(
         --build-arg "CUDA_VERSION=${CUDA_VERSION}"
+        --build-arg "PYTHON_VERSION=${PYTHON_VERSION}"
+        --build-arg "VLLM_VERSION=${VLLM_VERSION}"
         --build-arg "UV_VERSION=${UV_VERSION}"
         --build-arg "INDEX_URL=${INDEX_URL}"
         --build-arg "EXTRA_INDEX_URL=${EXTRA_INDEX_URL}"
@@ -176,12 +263,29 @@ elif [[ "${PLATFORM}" == "ascend" ]]; then
     BUILD_ARGS+=(
         --build-arg "CANN_VERSION=${CANN_VERSION}"
         --build-arg "CANN_CHIP=${CANN_CHIP}"
+        --build-arg "PYTHON_VERSION=${PYTHON_VERSION}"
+        --build-arg "VLLM_VERSION=${VLLM_VERSION}"
     )
     if [[ -z "${IMAGE_TAG}" ]]; then
         IMAGE_TAG="cann${CANN_VERSION}-${CANN_CHIP}-ubuntu${UBUNTU_VERSION}-py${PYTHON_VERSION}-${TARGET}"
     fi
+elif [[ "${PLATFORM}" == "hygon" ]]; then
+    PYTHON_VERSION="${HYGON_PYTHON_VERSION}"
+    VLLM_VERSION="${HYGON_VLLM_VERSION}"
+    BUILD_ARGS+=(
+        --build-arg "HYGON_BASE_IMAGE=${HYGON_BASE_IMAGE}"
+        --build-arg "PYTHON_VERSION=${HYGON_PYTHON_VERSION}"
+        --build-arg "VLLM_VERSION=${HYGON_VLLM_VERSION}"
+        --build-arg "INDEX_URL=${INDEX_URL}"
+        --build-arg "EXTRA_INDEX_URL=${EXTRA_INDEX_URL}"
+        --build-arg "FLAGGEMS_VERSION=${FLAGGEMS_VERSION}"
+        --build-arg "VLLM_PLUGIN_FL_VERSION=${VLLM_PLUGIN_FL_VERSION}"
+    )
+    if [[ -z "${IMAGE_TAG}" ]]; then
+        IMAGE_TAG="hygon-vllm${VLLM_VERSION}-dtk${HYGON_DTK_VERSION}-py${HYGON_PYTHON_VERSION}-${TARGET}"
+    fi
 else
-    err "Unknown platform '${PLATFORM}'. Must be 'cuda' or 'ascend'."
+    err "Unknown platform '${PLATFORM}'. Must be 'cuda', 'ascend', or 'hygon'."
 fi
 
 FULL_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
@@ -194,11 +298,22 @@ if [[ "${PLATFORM}" == "cuda" ]]; then
 elif [[ "${PLATFORM}" == "ascend" ]]; then
     msg "  CANN:           ${CANN_VERSION}"
     msg "  Chip:           ${CANN_CHIP}"
+elif [[ "${PLATFORM}" == "hygon" ]]; then
+    msg "  DTK:            ${HYGON_DTK_VERSION}"
+    msg "  Hygon Python:   ${HYGON_PYTHON_VERSION}"
+    msg "  Base image:     ${HYGON_BASE_IMAGE}"
+    msg "  Runtime libs:   ${HYGON_RUNTIME_LIB_DIR}"
+    msg "  FlagGems:       ${FLAGGEMS_VERSION}"
+    msg "  Plugin:         ${VLLM_PLUGIN_FL_VERSION}"
 fi
 msg "  Ubuntu:         ${UBUNTU_VERSION}"
 msg "  Python:         ${PYTHON_VERSION}"
 msg "  vLLM:           ${VLLM_VERSION}"
 msg ""
+
+if [[ "${PLATFORM}" == "hygon" ]]; then
+    prepare_hygon_runtime_overlay
+fi
 
 docker build \
     -f "${DOCKERFILE}" \

--- a/docker/hygon/Dockerfile
+++ b/docker/hygon/Dockerfile
@@ -1,0 +1,139 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG HYGON_BASE_IMAGE=harbor.sourcefind.cn:5443/dcu/admin/base/custom:vllm0.20.0-ubuntu22.04-dtk26.04-py3.10-MiniCPM-V-4.6
+
+# ---------- base stage ----------
+FROM ${HYGON_BASE_IMAGE} AS base
+
+ARG VLLM_VERSION=0.20.2
+ARG PYTHON_VERSION=3.10
+ARG UBUNTU_VERSION=22.04
+ARG INDEX_URL
+ARG EXTRA_INDEX_URL
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DTK_HOME=/opt/dtk \
+    ROCM_PATH=/opt/dtk \
+    HIP_PATH=/opt/dtk/hip \
+    HSA_PATH=/opt/dtk/hsa \
+    HIP_CLANG_PATH=/opt/dtk/llvm/bin \
+    DEVICE_LIB_PATH=/opt/dtk/amdgcn/bitcode \
+    GEMS_VENDOR=hygon \
+    VLLM_PLUGINS=fl
+ENV PATH="/root/.local/bin:/opt/dtk/bin:/opt/dtk/hip/bin:/opt/dtk/llvm/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/hyhal/lib/criu:/opt/hyhal/lib/rocprofiler:/opt/hyhal/lib:/usr/local/hyhal/lib:/opt/dtk/hip/lib:/opt/dtk/lib:/opt/dtk/llvm/lib:/opt/dtk/dcc/lib:/opt/dtk/aillvm/lib:/opt/dtk/hsa/lib:${LD_LIBRARY_PATH}"
+ENV CMAKE_PREFIX_PATH="/opt/dtk:/opt/dtk/hip:/opt/dtk/hsa:/opt/hyhal:/usr/local/hyhal:${CMAKE_PREFIX_PATH}"
+
+# Add the minimal Hygon runtime libraries staged by docker/build.sh.
+COPY .hygon-runtime/ /
+
+# Prepare Python build tooling for editable source installs.
+RUN python -m pip install --upgrade \
+        ${INDEX_URL:+--index-url ${INDEX_URL}} \
+        ${EXTRA_INDEX_URL:+--extra-index-url ${EXTRA_INDEX_URL}} \
+        pip "setuptools<81" wheel setuptools-scm
+
+# Replace the base image's vLLM with official vLLM built in empty mode.
+RUN python -m pip uninstall -y vllm || true \
+    && python -m pip cache remove vllm || true \
+    && SITE_PACKAGES="$(python -c 'import site; print(site.getsitepackages()[0])')" \
+    && find "${SITE_PACKAGES}" -maxdepth 1 \
+        \( -name "vllm" -o -name "vllm-*.dist-info" -o -name "vllm-*.egg-info" \) \
+        -exec rm -rf {} + 2>/dev/null || true \
+    && rm -rf /opt/vllm-src/vllm \
+    && mkdir -p /opt/vllm-src \
+    && git clone https://github.com/vllm-project/vllm.git /opt/vllm-src/vllm \
+    && cd /opt/vllm-src/vllm \
+    && git checkout "v${VLLM_VERSION}" \
+    && VLLM_TARGET_DEVICE=empty python -m pip install -v --no-build-isolation -e . --no-deps
+
+WORKDIR /workspace
+
+# ---------- ci stage ----------
+FROM base AS ci
+
+ARG INDEX_URL
+ARG EXTRA_INDEX_URL
+ARG FLAGGEMS_VERSION=62d70b9e858ec407572153ee8cdf65cc24a637d5
+ARG VLLM_PLUGIN_FL_VERSION=ffa2ee3eb3831f3873dd0966d12fc8e0b4e6e3d4
+
+# Install dev/test tools in the image instead of every CI job.
+RUN python -m pip install \
+        ${INDEX_URL:+--index-url ${INDEX_URL}} \
+        ${EXTRA_INDEX_URL:+--extra-index-url ${EXTRA_INDEX_URL}} \
+        pytest \
+        pytest-cov \
+        pytest-timeout \
+        pytest-json-report \
+        numpy \
+        requests \
+        openai \
+        decorator \
+        pyyaml \
+        sqlalchemy \
+        setuptools-scm \
+        scikit-build-core==0.11 \
+        pybind11 \
+        ninja \
+        cmake
+
+# Install FlagGems from the pinned source commit.
+RUN rm -rf /opt/vllm-src/FlagGems \
+    && mkdir -p /opt/vllm-src \
+    && git clone https://github.com/flagos-ai/FlagGems /opt/vllm-src/FlagGems \
+    && cd /opt/vllm-src/FlagGems \
+    && git checkout "${FLAGGEMS_VERSION}" \
+    && python -m pip install \
+        ${INDEX_URL:+--index-url ${INDEX_URL}} \
+        ${EXTRA_INDEX_URL:+--extra-index-url ${EXTRA_INDEX_URL}} \
+        --no-build-isolation -e .
+
+# Install vllm-plugin-FL from the pinned source commit.
+RUN rm -rf /opt/vllm-src/vllm-plugin-FL \
+    && mkdir -p /opt/vllm-src \
+    && git clone https://github.com/flagos-ai/vllm-plugin-FL /opt/vllm-src/vllm-plugin-FL \
+    && cd /opt/vllm-src/vllm-plugin-FL \
+    && git checkout "${VLLM_PLUGIN_FL_VERSION}" \
+    && CMAKE_ARGS="-DCMAKE_PREFIX_PATH=/opt/dtk;/opt/dtk/hip;/opt/dtk/hsa;/opt/hyhal;/usr/local/hyhal ${CMAKE_ARGS:-}" \
+        VLLM_VENDOR=cuda python -m pip install \
+        ${INDEX_URL:+--index-url ${INDEX_URL}} \
+        ${EXTRA_INDEX_URL:+--extra-index-url ${EXTRA_INDEX_URL}} \
+        --no-build-isolation -e .
+
+WORKDIR /workspace
+
+# ---------- dev stage ----------
+FROM base AS dev
+
+ARG INDEX_URL
+ARG EXTRA_INDEX_URL
+
+RUN python -m pip install \
+        ${INDEX_URL:+--index-url ${INDEX_URL}} \
+        ${EXTRA_INDEX_URL:+--extra-index-url ${EXTRA_INDEX_URL}} \
+        pytest \
+        pytest-cov \
+        pytest-json-report \
+        ruff \
+        pre-commit \
+        ninja \
+        cmake
+
+WORKDIR /workspace
+
+# ---------- release stage ----------
+FROM base AS release
+
+WORKDIR /workspace

--- a/tests/README.md
+++ b/tests/README.md
@@ -303,6 +303,7 @@ Unit tests should be fast, isolated, and not require GPU or model weights. Use t
 import pytest
 import torch
 
+
 class TestMyOp:
     def test_basic(self, device):
         """The `device` fixture returns cuda:0 or npu:0 automatically."""
@@ -321,6 +322,7 @@ import pytest
 import torch
 
 pytestmark = pytest.mark.gpu
+
 
 def test_my_kernel(device):
     x = torch.randn(16, 256, device=device)

--- a/tests/e2e_tests/serving/test_bge_m3.py
+++ b/tests/e2e_tests/serving/test_bge_m3.py
@@ -32,10 +32,14 @@ MODEL_NAME = "BAAI/bge-m3"
 
 SENTENCES_1 = ["What is BGE M3?", "Defination of BM25"]
 SENTENCES_2 = [
-    "BGE M3 is an embedding model supporting dense retrieval, "
-    "lexical matching and multi-vector interaction.",
-    "BM25 is a bag-of-words retrieval function that ranks a set "
-    "of documents based on the query terms appearing in each document",
+    (
+        "BGE M3 is an embedding model supporting dense retrieval, "
+        "lexical matching and multi-vector interaction."
+    ),
+    (
+        "BM25 is a bag-of-words retrieval function that ranks a set "
+        "of documents based on the query terms appearing in each document"
+    ),
 ]
 
 SIMILARITY_REFERENCE = [[0.6265, 0.3477], [0.3499, 0.678]]

--- a/tests/models/qwen3_6/27b_tp2_eager_hygon.yaml
+++ b/tests/models/qwen3_6/27b_tp2_eager_hygon.yaml
@@ -1,0 +1,49 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen3.6-27B Hygon smoke configuration (TP=2, eager).
+
+llm:
+  model: "/workspace/Qwen3.6-27B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 262144
+  gpu_memory_utilization: 0.90
+  enforce_eager: true
+  trust_remote_code: false
+  disable_custom_all_reduce: true
+
+generate:
+  prompts:
+    - "介绍一下北京"
+  sampling:
+    max_tokens: 100
+    temperature: 0.0
+
+serve:
+  served_model_name: "qwen"
+  extra_engine:
+    enforce_eager: false
+    disable_custom_all_reduce: false
+    enable_log_requests: false
+    enable_prefix_caching: false
+  startup_retries: 120
+  endpoints: ["chat"]
+  stream: false
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "介绍一下北京"
+  sampling:
+    temperature: 0.7

--- a/tests/models/qwen3_6/35b_a3b_tp2_eager_hygon.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_eager_hygon.yaml
@@ -1,0 +1,49 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen3.6-35B-A3B Hygon smoke configuration (TP=2, eager).
+
+llm:
+  model: "/workspace/Qwen3.6-35B-A3B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 262144
+  gpu_memory_utilization: 0.90
+  enforce_eager: true
+  trust_remote_code: false
+  disable_custom_all_reduce: true
+
+generate:
+  prompts:
+    - "介绍一下北京"
+  sampling:
+    max_tokens: 100
+    temperature: 0.0
+
+serve:
+  served_model_name: "qwen"
+  extra_engine:
+    enforce_eager: false
+    disable_custom_all_reduce: false
+    enable_log_requests: false
+    enable_prefix_caching: false
+  startup_retries: 120
+  endpoints: ["chat"]
+  stream: false
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "介绍一下北京"
+  sampling:
+    temperature: 0.7

--- a/tests/platforms/hygon.yaml
+++ b/tests/platforms/hygon.yaml
@@ -39,9 +39,9 @@ bw1000:
   tests:
     e2e:
       inference:
-        qwen3_6: ["27b_tp2_eager"]
+        qwen3_6: ["27b_tp2_eager_hygon"]
       serving:
-        qwen3_6: ["35b_a3b_tp2_eager"]
+        qwen3_6: ["35b_a3b_tp2_eager_hygon"]
     functional:
       include: "*"
       exclude: []


### PR DESCRIPTION
## Summary

- Add dedicated Hygon CI Dockerfile based on the validated BW1000 base image.
- Preinstall official vLLM 0.20.2 in empty mode, pinned FlagGems, and pinned vllm-plugin-FL.
- Switch Hygon CI to the prebuilt CI image.
- Add Hygon-specific Qwen3.6 E2E cases aligned with validation requirements.
- Make artifact upload steps non-blocking to avoid self-hosted runner network flakes failing CI.

## Validation

- test-hygon / setup passed
- test-hygon / unit passed
- test-hygon / functional passed
- test-hygon / E2E inference passed
- test-hygon / E2E serving passed
- test-hygon / benchmark smoke passed