### PR TITLE
feat(quantization): add compressed-tensors W4A16 scaffolding (kernels not included)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,6 @@ If there are multiple plugins in the current environment, you can specify use vl
 
 ### Run a Task
 
-#### Compressed-tensors WNA16 models
-
-The plugin supports compressed-tensors `pack-quantized` W4A16/W8A16
-checkpoints. Its WNA16 adapter calls kernels owned by this plugin directly;
-Marlin remains an optional vLLM-native path on NVIDIA CUDA.
-
 #### Offline Batched Inference
 With vLLM and vLLM-fl installed, you can start generating texts for list of input prompts (i.e. offline batch inferencing). See the example script: [offline_inference](./examples/offline_inference.py). Or use blow python script directly.
 ```python

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ If there are multiple plugins in the current environment, you can specify use vl
 
 ### Run a Task
 
+#### Compressed-tensors WNA16 models
+
+The plugin supports compressed-tensors `pack-quantized` W4A16/W8A16
+checkpoints. Its WNA16 adapter calls kernels owned by this plugin directly;
+Marlin remains an optional vLLM-native path on NVIDIA CUDA.
+
 #### Offline Batched Inference
 With vLLM and vLLM-fl installed, you can start generating texts for list of input prompts (i.e. offline batch inferencing). See the example script: [offline_inference](./examples/offline_inference.py). Or use blow python script directly.
 ```python

--- a/tests/unit_tests/quantization/__init__.py
+++ b/tests/unit_tests/quantization/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
 """Quantization unit tests."""

--- a/tests/unit_tests/quantization/__init__.py
+++ b/tests/unit_tests/quantization/__init__.py
@@ -1,0 +1,1 @@
+"""Quantization unit tests."""

--- a/tests/unit_tests/quantization/test_compressed_tensors.py
+++ b/tests/unit_tests/quantization/test_compressed_tensors.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_fl.quantization.compressed_tensors import (
+    WNA16Scheme,
+    validate_compressed_tensors_wna16_config,
+)
+from vllm_fl.quantization.marlin import is_marlin_moe_platform
+from vllm_fl.quantization.wna16 import moe as moe_adapter
+
+
+def _config():
+    return {
+        "quant_method": "compressed-tensors",
+        "format": "pack-quantized",
+        "quantization_status": "compressed",
+        "config_groups": {
+            "w4a16_g32": {
+                "targets": ["re:^model\\..*\\.mlp\\..*$"],
+                "weights": {
+                    "num_bits": 4,
+                    "type": "int",
+                    "strategy": "group",
+                    "group_size": 32,
+                    "symmetric": True,
+                    "dynamic": False,
+                },
+            }
+        },
+        "ignore": [],
+    }
+
+
+def test_accepts_standard_w4a16_group_config():
+    schemes = validate_compressed_tensors_wna16_config(_config())
+    assert schemes == [
+        WNA16Scheme(
+            num_bits=4,
+            group_size=32,
+            symmetric=True,
+            strategy="group",
+            has_activation_quantization=False,
+        )
+    ]
+
+
+def test_rejects_algorithm_specific_or_nonstandard_format():
+    config = _config()
+    config["quant_method"] = "custom-int4"
+    with pytest.raises(ValueError, match="compressed-tensors"):
+        validate_compressed_tensors_wna16_config(config)
+
+
+def test_rejects_activation_quantization_for_wna16():
+    config = _config()
+    config["config_groups"]["w4a16_g32"]["input_activations"] = {"num_bits": 8}
+    with pytest.raises(ValueError, match="weight-only"):
+        validate_compressed_tensors_wna16_config(config)
+
+
+@pytest.mark.parametrize(
+    ("is_cuda", "expected"),
+    [(True, True), (False, False)],
+)
+def test_marlin_moe_requires_nvidia_cuda(is_cuda, expected):
+    class FakePlatform:
+        def is_cuda(self):
+            return is_cuda
+
+    assert is_marlin_moe_platform(FakePlatform()) is expected
+
+
+def test_local_moe_adapter_is_not_installed_without_kernel(monkeypatch):
+    monkeypatch.setattr(
+        moe_adapter.kernels,
+        "is_wna16_moe_available",
+        lambda: False,
+    )
+    assert moe_adapter.install_fl_wna16_moe_method() is False
+
+
+def test_local_moe_adapter_replaces_only_the_upstream_wna16_method(
+    monkeypatch,
+):
+    class UpstreamMethod:
+        pass
+
+    module = SimpleNamespace(
+        CompressedTensorsWNA16MoEMethod=UpstreamMethod,
+    )
+    monkeypatch.setattr(
+        moe_adapter.kernels,
+        "is_wna16_moe_available",
+        lambda: True,
+    )
+    monkeypatch.setattr(moe_adapter, "import_module", lambda name: module)
+    assert moe_adapter.install_fl_wna16_moe_method() is True
+    assert issubclass(
+        module.CompressedTensorsWNA16MoEMethod,
+        UpstreamMethod,
+    )
+    assert module.CompressedTensorsWNA16MoEMethod._vllm_fl_local_wna16_moe

--- a/tests/unit_tests/quantization/test_compressed_tensors.py
+++ b/tests/unit_tests/quantization/test_compressed_tensors.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
 from types import SimpleNamespace
 
 import pytest

--- a/tests/unit_tests/quantization/test_compressed_tensors.py
+++ b/tests/unit_tests/quantization/test_compressed_tensors.py
@@ -4,8 +4,12 @@ from types import SimpleNamespace
 
 import pytest
 
+from vllm_fl.quantization import compressed_tensors
 from vllm_fl.quantization.compressed_tensors import (
+    CompatibilityReport,
     WNA16Scheme,
+    inspect_vllm_compressed_tensors_api,
+    register_compressed_tensors_oot,
     validate_compressed_tensors_wna16_config,
 )
 from vllm_fl.quantization.marlin import is_marlin_moe_platform
@@ -103,3 +107,92 @@ def test_local_moe_adapter_replaces_only_the_upstream_wna16_method(
         UpstreamMethod,
     )
     assert module.CompressedTensorsWNA16MoEMethod._vllm_fl_local_wna16_moe
+
+
+def test_compatibility_probe_accepts_refactored_scheme_classes(monkeypatch):
+    """Class integration points remain valid when method ownership changes."""
+
+    class UpstreamClass:
+        pass
+
+    def fake_import(module_name):
+        if module_name.endswith("compressed_tensors_wNa16"):
+            raise ImportError("historical module name is unavailable")
+        return SimpleNamespace(
+            CompressedTensorsWNA16=UpstreamClass,
+            CompressedTensorsWNA16MoEMethod=UpstreamClass,
+        )
+
+    monkeypatch.setattr(compressed_tensors, "import_module", fake_import)
+    report = inspect_vllm_compressed_tensors_api()
+
+    assert report.linear_wna16 is True
+    assert report.moe_wna16 is True
+    assert report.details == ()
+
+
+def test_moe_registration_does_not_require_linear_scheme(monkeypatch):
+    report = CompatibilityReport(
+        vllm_version="test",
+        linear_wna16=False,
+        moe_wna16=True,
+    )
+    calls = []
+
+    monkeypatch.setattr(
+        compressed_tensors,
+        "inspect_vllm_compressed_tensors_api",
+        lambda: report,
+    )
+    monkeypatch.setattr(
+        "vllm_fl.quantization.wna16.kernels.is_wna16_moe_available",
+        lambda: True,
+    )
+    monkeypatch.setattr("vllm_fl.utils.is_oot_enabled", lambda: True)
+    monkeypatch.setattr(
+        "vllm_fl.quantization.wna16.moe.install_fl_wna16_moe_method",
+        lambda: calls.append("install") or True,
+    )
+    monkeypatch.setattr(
+        "vllm_fl.quantization.marlin.configure_wna16_moe_backend",
+        lambda: calls.append("configure") or "plugin-local",
+    )
+
+    assert register_compressed_tensors_oot() is report
+    assert calls == ["install", "configure"]
+
+
+def test_moe_install_failure_leaves_upstream_selection_unchanged(monkeypatch):
+    report = CompatibilityReport(
+        vllm_version="test",
+        linear_wna16=True,
+        moe_wna16=True,
+    )
+    calls = []
+
+    monkeypatch.setattr(
+        compressed_tensors,
+        "inspect_vllm_compressed_tensors_api",
+        lambda: report,
+    )
+    monkeypatch.setattr(
+        "vllm_fl.quantization.wna16.kernels.is_wna16_moe_available",
+        lambda: True,
+    )
+    monkeypatch.setattr("vllm_fl.utils.is_oot_enabled", lambda: True)
+
+    def fail_install():
+        calls.append("install")
+        raise ImportError("changed upstream API")
+
+    monkeypatch.setattr(
+        "vllm_fl.quantization.wna16.moe.install_fl_wna16_moe_method",
+        fail_install,
+    )
+    monkeypatch.setattr(
+        "vllm_fl.quantization.marlin.configure_wna16_moe_backend",
+        lambda: calls.append("configure") or "plugin-local",
+    )
+
+    assert register_compressed_tensors_oot() is report
+    assert calls == ["install"]

--- a/tests/unit_tests/quantization/test_wna16_kernels.py
+++ b/tests/unit_tests/quantization/test_wna16_kernels.py
@@ -1,0 +1,64 @@
+import pytest
+import torch
+
+from vllm_fl.quantization.wna16.kernels import gemm, moe
+
+
+def test_gemm_is_unavailable_without_plugin_operator(monkeypatch):
+    monkeypatch.setattr(gemm, "_resolve_wna16_gemm", lambda: None)
+    assert gemm.is_wna16_gemm_available() is False
+    with pytest.raises(RuntimeError, match="not built"):
+        gemm.wna16_gemm(
+            torch.empty(1, 8),
+            torch.empty(1, 1, dtype=torch.int32),
+            torch.empty(1, 1),
+            8,
+        )
+
+
+def test_gemm_calls_fixed_plugin_operator(monkeypatch):
+    calls = []
+
+    def kernel(*args):
+        calls.append(args)
+        return torch.ones(2, 3)
+
+    monkeypatch.setattr(gemm, "_resolve_wna16_gemm", lambda: kernel)
+    result = gemm.wna16_gemm(
+        torch.empty(2, 8),
+        torch.empty(3, 1, dtype=torch.int32),
+        torch.empty(3, 1),
+        8,
+    )
+    assert gemm.is_wna16_gemm_available() is True
+    assert result.shape == (2, 3)
+    assert len(calls) == 1
+
+
+def test_moe_calls_fixed_plugin_operator(monkeypatch):
+    calls = []
+
+    def kernel(*args):
+        calls.append(args)
+        return torch.ones(1)
+
+    monkeypatch.setattr(moe, "_resolve_wna16_moe", lambda: kernel)
+    assert moe.is_wna16_moe_available() is True
+    result = moe.wna16_moe(
+        torch.empty(1, 8),
+        torch.empty(2, 4, 1, dtype=torch.int32),
+        torch.empty(2, 4, 1, dtype=torch.int32),
+        torch.empty(2, 4, 1),
+        torch.empty(2, 4, 1),
+        torch.empty(1, 2),
+        torch.empty(1, 2, dtype=torch.int32),
+        4,
+        8,
+        "silu",
+        False,
+        2,
+        None,
+        True,
+    )
+    assert result.shape == (1,)
+    assert len(calls) == 1

--- a/tests/unit_tests/quantization/test_wna16_kernels.py
+++ b/tests/unit_tests/quantization/test_wna16_kernels.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
 import pytest
 import torch
 

--- a/tests/unit_tests/quantization/test_wna16_reference.py
+++ b/tests/unit_tests/quantization/test_wna16_reference.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
 import pytest
 import torch
 

--- a/tests/unit_tests/quantization/test_wna16_reference.py
+++ b/tests/unit_tests/quantization/test_wna16_reference.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from vllm_fl.quantization.wna16.reference import (
+    unpack_uint4b8,
+    wna16_gemm_reference,
+)
+
+
+def _pack_uint4b8(values: torch.Tensor) -> torch.Tensor:
+    codes = (values.to(torch.int32) + 8).reshape(values.shape[0], -1, 8)
+    shifts = torch.arange(0, 32, 4, dtype=torch.int32)
+    return torch.sum(codes << shifts, dim=-1).to(torch.int32)
+
+
+def test_wna16_reference_matches_dequantized_matmul():
+    values = torch.tensor(
+        [
+            [-8, -7, -1, 0, 1, 4, 6, 7],
+            [7, 6, 4, 1, 0, -1, -7, -8],
+        ],
+        dtype=torch.int8,
+    )
+    packed = _pack_uint4b8(values)
+    scales = torch.tensor([[0.5, 2.0], [1.5, 0.25]])
+    x = torch.arange(16, dtype=torch.float32).reshape(2, 8) / 8
+    bias = torch.tensor([0.25, -0.5])
+
+    expected_weight = values.float() * scales.repeat_interleave(4, dim=1)
+    expected = x @ expected_weight.t() + bias
+    actual = wna16_gemm_reference(x, packed, scales, 4, bias)
+
+    assert torch.equal(unpack_uint4b8(packed), values)
+    assert torch.allclose(actual, expected)
+
+
+def test_wna16_reference_rejects_incompatible_scales():
+    x = torch.ones((1, 8))
+    packed = torch.zeros((2, 1), dtype=torch.int32)
+    with pytest.raises(ValueError, match="weight_scale"):
+        wna16_gemm_reference(x, packed, torch.ones((2, 1)), 4)

--- a/vllm_fl/quantization/__init__.py
+++ b/vllm_fl/quantization/__init__.py
@@ -11,3 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Quantization compatibility and out-of-tree kernel registration."""
+
+from .compressed_tensors import (
+    CompatibilityReport,
+    WNA16Scheme,
+    inspect_vllm_compressed_tensors_api,
+    validate_compressed_tensors_wna16_config,
+)
+
+__all__ = [
+    "CompatibilityReport",
+    "WNA16Scheme",
+    "inspect_vllm_compressed_tensors_api",
+    "validate_compressed_tensors_wna16_config",
+]

--- a/vllm_fl/quantization/compressed_tensors.py
+++ b/vllm_fl/quantization/compressed_tensors.py
@@ -1,4 +1,16 @@
 # Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Compatibility glue for standard compressed-tensors WNA16 checkpoints.
 
 The checkpoint contract remains owned by compressed-tensors. This module only
@@ -142,8 +154,19 @@ def inspect_vllm_compressed_tensors_api() -> CompatibilityReport:
 
 
 def register_compressed_tensors_oot() -> CompatibilityReport:
-    """Configure upstream WNA16 runtime selection for the FL platform."""
+    """Configure upstream WNA16 runtime selection for the FL platform.
+
+    No-op unless the plugin-local WNA16 MoE operator is actually built.
+    This keeps the upstream vLLM path (Marlin on CUDA, generic elsewhere)
+    fully untouched until the FL kernel is available.
+    """
     report = inspect_vllm_compressed_tensors_api()
+
+    from vllm_fl.quantization.wna16.kernels import is_wna16_moe_available
+
+    if not is_wna16_moe_available():
+        return report
+
     if not report.supported:
         logger.warning(
             "compressed-tensors WNA16 compatibility is incomplete for vLLM %s: %s",

--- a/vllm_fl/quantization/compressed_tensors.py
+++ b/vllm_fl/quantization/compressed_tensors.py
@@ -1,0 +1,175 @@
+# Copyright 2026 FlagOS Contributors
+"""Compatibility glue for standard compressed-tensors WNA16 checkpoints.
+
+The checkpoint contract remains owned by compressed-tensors. This module only
+adapts vLLM's runtime implementation to the FL out-of-tree platform.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class WNA16Scheme:
+    num_bits: int
+    group_size: int | None
+    symmetric: bool
+    strategy: str
+    has_activation_quantization: bool
+
+    @classmethod
+    def from_group(cls, group: dict[str, Any]) -> WNA16Scheme:
+        weights = group.get("weights") or {}
+        return cls(
+            num_bits=int(weights.get("num_bits", 0)),
+            group_size=weights.get("group_size"),
+            symmetric=bool(weights.get("symmetric", False)),
+            strategy=str(weights.get("strategy", "")),
+            has_activation_quantization=group.get("input_activations") is not None,
+        )
+
+    def validate(self) -> None:
+        if self.num_bits not in {4, 8}:
+            raise ValueError(
+                f"WNA16 supports 4-bit or 8-bit weights, got {self.num_bits}"
+            )
+        if self.strategy not in {"group", "channel"}:
+            raise ValueError(
+                f"WNA16 requires group or channel strategy, got {self.strategy!r}"
+            )
+        if self.strategy == "group" and (
+            not isinstance(self.group_size, int) or self.group_size <= 0
+        ):
+            raise ValueError("Group-wise WNA16 requires a positive group_size")
+        if not self.symmetric:
+            raise ValueError("FL WNA16 currently requires symmetric weights")
+        if self.has_activation_quantization:
+            raise ValueError("WNA16 is weight-only; input_activations must be omitted")
+
+
+def validate_compressed_tensors_wna16_config(
+    config: dict[str, Any],
+) -> list[WNA16Scheme]:
+    """Validate the standard subset consumed by the FL WNA16 runtime."""
+    if config.get("quant_method") != "compressed-tensors":
+        raise ValueError("quant_method must be 'compressed-tensors'")
+    if config.get("format") != "pack-quantized":
+        raise ValueError("WNA16 requires compressed-tensors format 'pack-quantized'")
+    groups = config.get("config_groups")
+    if not isinstance(groups, dict) or not groups:
+        raise ValueError("compressed-tensors config_groups must be a non-empty mapping")
+    schemes: list[WNA16Scheme] = []
+    for name, group in groups.items():
+        if not isinstance(group, dict) or not group.get("targets"):
+            raise ValueError(f"config group {name!r} must declare targets")
+        scheme = WNA16Scheme.from_group(group)
+        scheme.validate()
+        schemes.append(scheme)
+    return schemes
+
+
+@dataclass(frozen=True)
+class CompatibilityReport:
+    vllm_version: str
+    linear_wna16: bool
+    moe_wna16: bool
+    details: tuple[str, ...] = ()
+
+    @property
+    def supported(self) -> bool:
+        return self.linear_wna16 and self.moe_wna16
+
+
+def inspect_vllm_compressed_tensors_api() -> CompatibilityReport:
+    """Probe the narrow upstream API surface used by this plugin."""
+    try:
+        vllm_version = version("vllm")
+    except PackageNotFoundError:
+        vllm_version = "unknown"
+
+    details: list[str] = []
+    linear_wna16 = False
+    moe_wna16 = False
+    try:
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (  # noqa: E501
+            CompressedTensorsWNA16,
+        )
+
+        linear_wna16 = all(
+            hasattr(CompressedTensorsWNA16, name)
+            for name in (
+                "create_weights",
+                "process_weights_after_loading",
+                "apply_weights",
+            )
+        )
+        if not linear_wna16:
+            details.append("CompressedTensorsWNA16 API is incomplete")
+    except (ImportError, AttributeError, OSError, RuntimeError) as exc:
+        details.append(f"linear WNA16 unavailable: {exc}")
+
+    try:
+        from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_wna16 import (  # noqa: E501
+            CompressedTensorsWNA16MoEMethod,
+        )
+
+        moe_wna16 = all(
+            hasattr(CompressedTensorsWNA16MoEMethod, name)
+            for name in (
+                "create_weights",
+                "process_weights_after_loading",
+                "get_fused_moe_quant_config",
+            )
+        )
+        if not moe_wna16:
+            details.append("CompressedTensorsWNA16MoEMethod API is incomplete")
+    except (ImportError, AttributeError, OSError, RuntimeError) as exc:
+        details.append(f"MoE WNA16 unavailable: {exc}")
+
+    return CompatibilityReport(
+        vllm_version=vllm_version,
+        linear_wna16=linear_wna16,
+        moe_wna16=moe_wna16,
+        details=tuple(details),
+    )
+
+
+def register_compressed_tensors_oot() -> CompatibilityReport:
+    """Configure upstream WNA16 runtime selection for the FL platform."""
+    report = inspect_vllm_compressed_tensors_api()
+    if not report.supported:
+        logger.warning(
+            "compressed-tensors WNA16 compatibility is incomplete for vLLM %s: %s",
+            report.vllm_version,
+            "; ".join(report.details),
+        )
+        return report
+
+    from vllm_fl.utils import is_oot_enabled
+
+    if is_oot_enabled():
+        try:
+            from vllm_fl.quantization.marlin import configure_wna16_moe_backend
+            from vllm_fl.quantization.wna16.moe import (
+                install_fl_wna16_moe_method,
+            )
+
+            install_fl_wna16_moe_method()
+            backend = configure_wna16_moe_backend()
+            logger.info(
+                "compressed-tensors WNA16 MoE backend for FL: %s",
+                backend,
+            )
+        except (ImportError, AttributeError, OSError, RuntimeError) as exc:
+            logger.warning(
+                "Could not configure FL compressed-tensors WNA16 MoE: %s",
+                exc,
+            )
+    return report

--- a/vllm_fl/quantization/compressed_tensors.py
+++ b/vllm_fl/quantization/compressed_tensors.py
@@ -20,12 +20,25 @@ adapts vLLM's runtime implementation to the FL out-of-tree platform.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+_LINEAR_WNA16_MODULES = (
+    "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+    "compressed_tensors_wNa16",
+    # Keep working if upstream normalizes the historical mixed-case filename.
+    "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+    "compressed_tensors_wna16",
+)
+_MOE_WNA16_MODULES = (
+    "vllm.model_executor.layers.quantization.compressed_tensors."
+    "compressed_tensors_moe.compressed_tensors_moe_wna16",
+)
 
 
 @dataclass(frozen=True)
@@ -99,6 +112,32 @@ class CompatibilityReport:
         return self.linear_wna16 and self.moe_wna16
 
 
+def _class_is_available(
+    module_names: tuple[str, ...], class_name: str
+) -> tuple[
+    bool,
+    str | None,
+]:
+    """Find an upstream class without pinning its method implementation.
+
+    The adapters intentionally rely on vLLM's public scheme classes rather
+    than a frozen list of methods. Methods may move to a base class or be
+    refactored between vLLM releases while the integration point remains
+    compatible.
+    """
+    failures: list[str] = []
+    for module_name in module_names:
+        try:
+            candidate = getattr(import_module(module_name), class_name)
+        except (ImportError, AttributeError, OSError, RuntimeError) as exc:
+            failures.append(f"{module_name}: {exc}")
+            continue
+        if isinstance(candidate, type):
+            return True, None
+        failures.append(f"{module_name}: {class_name} is not a class")
+    return False, "; ".join(failures)
+
+
 def inspect_vllm_compressed_tensors_api() -> CompatibilityReport:
     """Probe the narrow upstream API surface used by this plugin."""
     try:
@@ -107,43 +146,19 @@ def inspect_vllm_compressed_tensors_api() -> CompatibilityReport:
         vllm_version = "unknown"
 
     details: list[str] = []
-    linear_wna16 = False
-    moe_wna16 = False
-    try:
-        from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_wNa16 import (  # noqa: E501
-            CompressedTensorsWNA16,
-        )
+    linear_wna16, linear_error = _class_is_available(
+        _LINEAR_WNA16_MODULES,
+        "CompressedTensorsWNA16",
+    )
+    if linear_error:
+        details.append(f"linear WNA16 unavailable: {linear_error}")
 
-        linear_wna16 = all(
-            hasattr(CompressedTensorsWNA16, name)
-            for name in (
-                "create_weights",
-                "process_weights_after_loading",
-                "apply_weights",
-            )
-        )
-        if not linear_wna16:
-            details.append("CompressedTensorsWNA16 API is incomplete")
-    except (ImportError, AttributeError, OSError, RuntimeError) as exc:
-        details.append(f"linear WNA16 unavailable: {exc}")
-
-    try:
-        from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_wna16 import (  # noqa: E501
-            CompressedTensorsWNA16MoEMethod,
-        )
-
-        moe_wna16 = all(
-            hasattr(CompressedTensorsWNA16MoEMethod, name)
-            for name in (
-                "create_weights",
-                "process_weights_after_loading",
-                "get_fused_moe_quant_config",
-            )
-        )
-        if not moe_wna16:
-            details.append("CompressedTensorsWNA16MoEMethod API is incomplete")
-    except (ImportError, AttributeError, OSError, RuntimeError) as exc:
-        details.append(f"MoE WNA16 unavailable: {exc}")
+    moe_wna16, moe_error = _class_is_available(
+        _MOE_WNA16_MODULES,
+        "CompressedTensorsWNA16MoEMethod",
+    )
+    if moe_error:
+        details.append(f"MoE WNA16 unavailable: {moe_error}")
 
     return CompatibilityReport(
         vllm_version=vllm_version,
@@ -167,9 +182,12 @@ def register_compressed_tensors_oot() -> CompatibilityReport:
     if not is_wna16_moe_available():
         return report
 
-    if not report.supported:
+    # Linear registration is independent and handled by
+    # register_fl_wna16_linear_kernel. Do not disable the MoE adapter merely
+    # because a vLLM release moved or removed its linear WNA16 scheme.
+    if not report.moe_wna16:
         logger.warning(
-            "compressed-tensors WNA16 compatibility is incomplete for vLLM %s: %s",
+            "compressed-tensors WNA16 MoE is unavailable for vLLM %s: %s",
             report.vllm_version,
             "; ".join(report.details),
         )
@@ -184,7 +202,12 @@ def register_compressed_tensors_oot() -> CompatibilityReport:
                 install_fl_wna16_moe_method,
             )
 
-            install_fl_wna16_moe_method()
+            if not install_fl_wna16_moe_method():
+                logger.warning(
+                    "FL WNA16 MoE operator disappeared during registration; "
+                    "leaving vLLM's upstream backend selection unchanged"
+                )
+                return report
             backend = configure_wna16_moe_backend()
             logger.info(
                 "compressed-tensors WNA16 MoE backend for FL: %s",
@@ -192,7 +215,8 @@ def register_compressed_tensors_oot() -> CompatibilityReport:
             )
         except (ImportError, AttributeError, OSError, RuntimeError) as exc:
             logger.warning(
-                "Could not configure FL compressed-tensors WNA16 MoE: %s",
+                "Could not configure FL compressed-tensors WNA16 MoE; "
+                "vLLM's upstream backend selection remains unchanged: %s",
                 exc,
             )
     return report

--- a/vllm_fl/quantization/marlin.py
+++ b/vllm_fl/quantization/marlin.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Keep vLLM's native Marlin WNA16 MoE path NVIDIA-only."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_MARLIN_GUARD_MARKER = "_vllm_fl_marlin_platform_guard"
+
+
+def is_marlin_moe_platform(platform: Any) -> bool:
+    """Return whether vLLM's PTX Marlin MoE backend is valid."""
+    return bool(platform.is_cuda())
+
+
+def _install_platform_guard() -> None:
+    """Prevent vLLM 0.20.2 from choosing Marlin on non-NVIDIA OOT devices."""
+    from vllm.platforms import current_platform
+
+    moe_module = import_module(
+        "vllm.model_executor.layers.quantization.compressed_tensors."
+        "compressed_tensors_moe.compressed_tensors_moe"
+    )
+    current_check = moe_module.check_moe_marlin_supports_layer
+    if getattr(current_check, _MARLIN_GUARD_MARKER, False):
+        return
+
+    def guarded_check(layer, group_size):
+        from vllm_fl.quantization.wna16.kernels import (
+            is_wna16_moe_available,
+        )
+
+        return (
+            not is_wna16_moe_available()
+            and is_marlin_moe_platform(current_platform)
+            and current_check(layer, group_size)
+        )
+
+    setattr(guarded_check, _MARLIN_GUARD_MARKER, True)
+    moe_module.check_moe_marlin_supports_layer = guarded_check
+
+
+def configure_wna16_moe_backend() -> str:
+    """Guard upstream selection and otherwise leave vLLM's backend untouched."""
+    from vllm.platforms import current_platform
+
+    from vllm_fl.quantization.wna16.kernels import (
+        is_wna16_moe_available,
+    )
+
+    _install_platform_guard()
+    if is_wna16_moe_available():
+        return "plugin-local"
+    if not is_marlin_moe_platform(current_platform):
+        return "generic"
+    return "marlin"
+
+
+__all__ = [
+    "configure_wna16_moe_backend",
+    "is_marlin_moe_platform",
+]

--- a/vllm_fl/quantization/marlin.py
+++ b/vllm_fl/quantization/marlin.py
@@ -27,7 +27,14 @@ def is_marlin_moe_platform(platform: Any) -> bool:
 
 
 def _install_platform_guard() -> None:
-    """Prevent vLLM 0.20.2 from choosing Marlin on non-NVIDIA OOT devices."""
+    """Prevent vLLM 0.20.2 from choosing Marlin on non-NVIDIA OOT devices.
+
+    Upstream's shape check excludes ROCm but otherwise assumes CUDA. FL uses
+    ``PlatformEnum.OOT`` for several vendors, so a compatible shape alone can
+    incorrectly select the PTX-only Marlin implementation. When the local
+    operator exists, returning false also routes selection through the WNA16
+    method replaced by ``install_fl_wna16_moe_method``.
+    """
     from vllm.platforms import current_platform
 
     moe_module = import_module(

--- a/vllm_fl/quantization/marlin.py
+++ b/vllm_fl/quantization/marlin.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2026 BAAI. All rights reserved.
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Keep vLLM's native Marlin WNA16 MoE path NVIDIA-only."""
 
 from __future__ import annotations

--- a/vllm_fl/quantization/quant_linear.py
+++ b/vllm_fl/quantization/quant_linear.py
@@ -1,21 +1,16 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 
+import os
 from vllm.platforms import PlatformEnum, current_platform
+from vllm_fl.utils import use_flaggems_op
 
 from .fp8 import FlagGemsFp8BlockScaledMMLinearKernel
-from vllm_fl.utils import use_flaggems_op
+
 
 FLAGGEMS_FP8_BLOCK_GEMM_OP = "flaggems_fp8_block_gemm"
 
 
-def _merge_candidates(registry, candidates) -> None:
-    destination = registry.setdefault(PlatformEnum.OOT, [])
-    for kernel in candidates:
-        if kernel not in destination:
-            destination.append(kernel)
-
-
-def _resolve_source_platform() -> PlatformEnum | None:
+def _resolve_source_platform() -> PlatformEnum:
     """
     Determine which upstream platform's kernel list to clone for OOT.
 
@@ -23,18 +18,16 @@ def _resolve_source_platform() -> PlatformEnum | None:
     - nvidia, metax, musa, etc. (cuda_alike) -> CUDA kernels
     - rocm-alike OOT                         -> ROCM kernels
     - cpu-alike OOT                          -> CPU kernels
-    - unknown                                -> no cloned kernels
+    - fallback                               -> CUDA kernels
     """
+    if current_platform.is_cuda_alike():
+        return PlatformEnum.CUDA
     if current_platform.is_rocm():
         return PlatformEnum.ROCM
     if current_platform.is_cpu():
         return PlatformEnum.CPU
-    if current_platform.is_cuda_alike():
-        return PlatformEnum.CUDA
-    # Copying CUDA kernels to an unrelated platform can pass registration and
-    # fail much later during model loading. Unknown platforms must provide
-    # explicit FL kernels instead.
-    return None
+    # Fallback: try CUDA as the most common case
+    return PlatformEnum.CUDA
 
 
 def add_oot_quant_kernel() -> None:
@@ -46,26 +39,32 @@ def add_oot_quant_kernel() -> None:
     is_supported() / can_implement() will filter at runtime.
     """
     from vllm.model_executor.kernels.linear import (
-        _POSSIBLE_FP8_BLOCK_KERNELS,
-        _POSSIBLE_FP8_KERNELS,
         _POSSIBLE_INT8_KERNELS,
+        _POSSIBLE_FP8_KERNELS,
         _POSSIBLE_KERNELS,
+        _POSSIBLE_FP8_BLOCK_KERNELS,
     )
-
     source = _resolve_source_platform()
-    source_kernels = _POSSIBLE_KERNELS.get(source, []) if source else []
-    source_int8 = _POSSIBLE_INT8_KERNELS.get(source, []) if source else []
-    source_fp8 = _POSSIBLE_FP8_KERNELS.get(source, []) if source else []
-    source_fp8_block = _POSSIBLE_FP8_BLOCK_KERNELS.get(source, []) if source else []
 
-    _merge_candidates(_POSSIBLE_KERNELS, source_kernels)
-    _merge_candidates(_POSSIBLE_INT8_KERNELS, source_int8)
-    _merge_candidates(_POSSIBLE_FP8_KERNELS, source_fp8)
-    _merge_candidates(_POSSIBLE_FP8_BLOCK_KERNELS, source_fp8_block)
+    if PlatformEnum.OOT not in _POSSIBLE_KERNELS:
+        _POSSIBLE_KERNELS[PlatformEnum.OOT] = list(
+            _POSSIBLE_KERNELS.get(source, [])
+        )
 
-    from .wna16.linear import register_fl_wna16_linear_kernel
+    if PlatformEnum.OOT not in _POSSIBLE_INT8_KERNELS:
+        _POSSIBLE_INT8_KERNELS[PlatformEnum.OOT] = list(
+            _POSSIBLE_INT8_KERNELS.get(source, [])
+        )
 
-    register_fl_wna16_linear_kernel(_POSSIBLE_KERNELS)
+    if PlatformEnum.OOT not in _POSSIBLE_FP8_KERNELS:
+        _POSSIBLE_FP8_KERNELS[PlatformEnum.OOT] = list(
+            _POSSIBLE_FP8_KERNELS.get(source, [])
+        )
+
+    if PlatformEnum.OOT not in _POSSIBLE_FP8_BLOCK_KERNELS:
+        _POSSIBLE_FP8_BLOCK_KERNELS[PlatformEnum.OOT] = list(
+            _POSSIBLE_FP8_BLOCK_KERNELS.get(source, [])
+        )
 
     if (
         current_platform.supports_fp8()
@@ -77,6 +76,10 @@ def add_oot_quant_kernel() -> None:
             0, FlagGemsFp8BlockScaledMMLinearKernel
         )
 
+    # WNA16 hooks below are self-gated on kernel availability and are a
+    # no-op until the plugin's csrc-side operators are built.
+    from .wna16.linear import register_fl_wna16_linear_kernel
     from .compressed_tensors import register_compressed_tensors_oot
 
+    register_fl_wna16_linear_kernel(_POSSIBLE_KERNELS)
     register_compressed_tensors_oot()

--- a/vllm_fl/quantization/quant_linear.py
+++ b/vllm_fl/quantization/quant_linear.py
@@ -1,16 +1,21 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 
-import os
 from vllm.platforms import PlatformEnum, current_platform
-from vllm_fl.utils import use_flaggems_op
 
 from .fp8 import FlagGemsFp8BlockScaledMMLinearKernel
-
+from vllm_fl.utils import use_flaggems_op
 
 FLAGGEMS_FP8_BLOCK_GEMM_OP = "flaggems_fp8_block_gemm"
 
 
-def _resolve_source_platform() -> PlatformEnum:
+def _merge_candidates(registry, candidates) -> None:
+    destination = registry.setdefault(PlatformEnum.OOT, [])
+    for kernel in candidates:
+        if kernel not in destination:
+            destination.append(kernel)
+
+
+def _resolve_source_platform() -> PlatformEnum | None:
     """
     Determine which upstream platform's kernel list to clone for OOT.
 
@@ -18,16 +23,18 @@ def _resolve_source_platform() -> PlatformEnum:
     - nvidia, metax, musa, etc. (cuda_alike) -> CUDA kernels
     - rocm-alike OOT                         -> ROCM kernels
     - cpu-alike OOT                          -> CPU kernels
-    - fallback                               -> CUDA kernels
+    - unknown                                -> no cloned kernels
     """
-    if current_platform.is_cuda_alike():
-        return PlatformEnum.CUDA
     if current_platform.is_rocm():
         return PlatformEnum.ROCM
     if current_platform.is_cpu():
         return PlatformEnum.CPU
-    # Fallback: try CUDA as the most common case
-    return PlatformEnum.CUDA
+    if current_platform.is_cuda_alike():
+        return PlatformEnum.CUDA
+    # Copying CUDA kernels to an unrelated platform can pass registration and
+    # fail much later during model loading. Unknown platforms must provide
+    # explicit FL kernels instead.
+    return None
 
 
 def add_oot_quant_kernel() -> None:
@@ -39,32 +46,26 @@ def add_oot_quant_kernel() -> None:
     is_supported() / can_implement() will filter at runtime.
     """
     from vllm.model_executor.kernels.linear import (
-        _POSSIBLE_INT8_KERNELS,
-        _POSSIBLE_FP8_KERNELS,
-        _POSSIBLE_KERNELS,
         _POSSIBLE_FP8_BLOCK_KERNELS,
+        _POSSIBLE_FP8_KERNELS,
+        _POSSIBLE_INT8_KERNELS,
+        _POSSIBLE_KERNELS,
     )
+
     source = _resolve_source_platform()
+    source_kernels = _POSSIBLE_KERNELS.get(source, []) if source else []
+    source_int8 = _POSSIBLE_INT8_KERNELS.get(source, []) if source else []
+    source_fp8 = _POSSIBLE_FP8_KERNELS.get(source, []) if source else []
+    source_fp8_block = _POSSIBLE_FP8_BLOCK_KERNELS.get(source, []) if source else []
 
-    if PlatformEnum.OOT not in _POSSIBLE_KERNELS:
-        _POSSIBLE_KERNELS[PlatformEnum.OOT] = list(
-            _POSSIBLE_KERNELS.get(source, [])
-        )
+    _merge_candidates(_POSSIBLE_KERNELS, source_kernels)
+    _merge_candidates(_POSSIBLE_INT8_KERNELS, source_int8)
+    _merge_candidates(_POSSIBLE_FP8_KERNELS, source_fp8)
+    _merge_candidates(_POSSIBLE_FP8_BLOCK_KERNELS, source_fp8_block)
 
-    if PlatformEnum.OOT not in _POSSIBLE_INT8_KERNELS:
-        _POSSIBLE_INT8_KERNELS[PlatformEnum.OOT] = list(
-            _POSSIBLE_INT8_KERNELS.get(source, [])
-        )
+    from .wna16.linear import register_fl_wna16_linear_kernel
 
-    if PlatformEnum.OOT not in _POSSIBLE_FP8_KERNELS:
-        _POSSIBLE_FP8_KERNELS[PlatformEnum.OOT] = list(
-            _POSSIBLE_FP8_KERNELS.get(source, [])
-        )
-
-    if PlatformEnum.OOT not in _POSSIBLE_FP8_BLOCK_KERNELS:
-        _POSSIBLE_FP8_BLOCK_KERNELS[PlatformEnum.OOT] = list(
-            _POSSIBLE_FP8_BLOCK_KERNELS.get(source, [])
-        )
+    register_fl_wna16_linear_kernel(_POSSIBLE_KERNELS)
 
     if (
         current_platform.supports_fp8()
@@ -75,3 +76,7 @@ def add_oot_quant_kernel() -> None:
         _POSSIBLE_FP8_BLOCK_KERNELS[PlatformEnum.OOT].insert(
             0, FlagGemsFp8BlockScaledMMLinearKernel
         )
+
+    from .compressed_tensors import register_compressed_tensors_oot
+
+    register_compressed_tensors_oot()

--- a/vllm_fl/quantization/wna16/__init__.py
+++ b/vllm_fl/quantization/wna16/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Plugin-local kernels for standard compressed-tensors WNA16 weights."""
+
+from .kernels import (
+    is_wna16_gemm_available,
+    is_wna16_moe_available,
+    wna16_gemm,
+    wna16_moe,
+)
+
+__all__ = [
+    "is_wna16_gemm_available",
+    "is_wna16_moe_available",
+    "wna16_gemm",
+    "wna16_moe",
+]

--- a/vllm_fl/quantization/wna16/__init__.py
+++ b/vllm_fl/quantization/wna16/__init__.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2026 BAAI. All rights reserved.
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Plugin-local kernels for standard compressed-tensors WNA16 weights."""
 
 from .kernels import (

--- a/vllm_fl/quantization/wna16/kernels/__init__.py
+++ b/vllm_fl/quantization/wna16/kernels/__init__.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2026 BAAI. All rights reserved.
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Fixed kernel entry points used by the WNA16 quantization adapters.
 
 Implementations live in this package and are called directly. They are not

--- a/vllm_fl/quantization/wna16/kernels/__init__.py
+++ b/vllm_fl/quantization/wna16/kernels/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Fixed kernel entry points used by the WNA16 quantization adapters.
+
+Implementations live in this package and are called directly. They are not
+registered with vllm-fl's general operator dispatch.
+"""
+
+from .gemm import is_wna16_gemm_available, wna16_gemm
+from .moe import is_wna16_moe_available, wna16_moe
+
+__all__ = [
+    "is_wna16_gemm_available",
+    "is_wna16_moe_available",
+    "wna16_gemm",
+    "wna16_moe",
+]

--- a/vllm_fl/quantization/wna16/kernels/gemm.py
+++ b/vllm_fl/quantization/wna16/kernels/gemm.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Direct binding for the plugin-owned fused WNA16 GEMM."""
+
+from __future__ import annotations
+
+import torch
+
+
+def _resolve_wna16_gemm():
+    """Resolve the fixed torch operator exported by this plugin's extension."""
+    try:
+        return torch.ops.vllm_fl.wna16_gemm.default
+    except AttributeError:
+        return None
+
+
+def is_wna16_gemm_available() -> bool:
+    return _resolve_wna16_gemm() is not None
+
+
+def wna16_gemm(
+    x: torch.Tensor,
+    weight_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run fused dequantization GEMM without an intermediate FP tensor."""
+    kernel = _resolve_wna16_gemm()
+    if kernel is None:
+        raise RuntimeError(
+            "vllm_fl::wna16_gemm is not built; implement it under "
+            "vllm_fl/quantization/wna16/kernels"
+        )
+    return kernel(x, weight_packed, weight_scale, group_size, bias)
+
+
+__all__ = ["is_wna16_gemm_available", "wna16_gemm"]

--- a/vllm_fl/quantization/wna16/kernels/gemm.py
+++ b/vllm_fl/quantization/wna16/kernels/gemm.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2026 BAAI. All rights reserved.
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Direct binding for the plugin-owned fused WNA16 GEMM."""
 
 from __future__ import annotations

--- a/vllm_fl/quantization/wna16/kernels/moe.py
+++ b/vllm_fl/quantization/wna16/kernels/moe.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2026 BAAI. All rights reserved.
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Direct binding reserved for the plugin-owned fused WNA16 MoE kernel."""
 
 from __future__ import annotations

--- a/vllm_fl/quantization/wna16/kernels/moe.py
+++ b/vllm_fl/quantization/wna16/kernels/moe.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Direct binding reserved for the plugin-owned fused WNA16 MoE kernel."""
+
+from __future__ import annotations
+
+import torch
+
+
+def _resolve_wna16_moe():
+    """Resolve the fixed torch operator exported by this plugin's extension."""
+    try:
+        return torch.ops.vllm_fl.wna16_moe.default
+    except AttributeError:
+        return None
+
+
+def is_wna16_moe_available() -> bool:
+    return _resolve_wna16_moe() is not None
+
+
+def wna16_moe(
+    x: torch.Tensor,
+    w13_weight_packed: torch.Tensor,
+    w2_weight_packed: torch.Tensor,
+    w13_weight_scale: torch.Tensor,
+    w2_weight_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_bits: int,
+    group_size: int,
+    activation: str,
+    apply_router_weight_on_input: bool,
+    global_num_experts: int,
+    expert_map: torch.Tensor | None,
+    inplace: bool,
+) -> torch.Tensor:
+    """Run the plugin-owned fused WNA16 MoE operator."""
+    kernel = _resolve_wna16_moe()
+    if kernel is None:
+        raise RuntimeError(
+            "vllm_fl::wna16_moe is not built; implement it under "
+            "vllm_fl/quantization/wna16/kernels"
+        )
+    return kernel(
+        x,
+        w13_weight_packed,
+        w2_weight_packed,
+        w13_weight_scale,
+        w2_weight_scale,
+        topk_weights,
+        topk_ids,
+        num_bits,
+        group_size,
+        activation,
+        apply_router_weight_on_input,
+        global_num_experts,
+        expert_map,
+        inplace,
+    )
+
+
+__all__ = ["is_wna16_moe_available", "wna16_moe"]

--- a/vllm_fl/quantization/wna16/linear.py
+++ b/vllm_fl/quantization/wna16/linear.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""vLLM MPLinearKernel adapter for the plugin-local WNA16 GEMM."""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.model_executor.kernels.linear import (
+    MPLinearKernel,
+    MPLinearLayerConfig,
+)
+from vllm.scalar_type import scalar_types
+
+from . import kernels
+
+
+class FLWNA16LinearKernel(MPLinearKernel):
+    """Consume standard uint4b8 weights through the fixed local kernel."""
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return -1
+
+    @classmethod
+    def can_implement(
+        cls,
+        config: MPLinearLayerConfig,
+    ) -> tuple[bool, str | None]:
+        if config.weight_type != scalar_types.uint4b8:
+            return False, "FL WNA16 currently requires symmetric uint4b8"
+        if config.zero_points:
+            return False, "FL WNA16 does not use explicit zero points"
+        if config.has_g_idx:
+            return False, "FL WNA16 does not support activation ordering"
+        if config.act_type not in {torch.bfloat16, torch.float16}:
+            return False, "FL WNA16 requires BF16 or FP16 activations"
+        if config.group_size <= 0:
+            return False, "FL WNA16 requires group-wise quantization"
+        input_size, output_size = config.partition_weight_shape
+        if input_size % config.group_size:
+            return False, "input size must be divisible by group_size"
+        if input_size % 8:
+            return False, "input size must be divisible by the INT4 pack factor"
+        if output_size <= 0:
+            return False, "output size must be positive"
+        if not kernels.is_wna16_gemm_available():
+            return False, "the plugin-local wna16_gemm kernel is not built"
+        return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        weight, scale, _, _ = self._get_weight_params(layer)
+        if weight.dtype != torch.int32 or weight.ndim != 2:
+            raise ValueError("FL WNA16 expects weight_packed as 2D int32")
+        if not weight.is_contiguous():
+            weight.data = weight.data.contiguous()
+        if not scale.is_contiguous():
+            scale.data = scale.data.contiguous()
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        weight, scale, _, _ = self._get_weight_params(layer)
+        original_shape = x.shape
+        x_2d = x.reshape(-1, original_shape[-1])
+        output = kernels.wna16_gemm(
+            x_2d,
+            weight,
+            scale,
+            self.config.group_size,
+            bias,
+        )
+        return output.reshape(*original_shape[:-1], output.shape[-1])
+
+
+def register_fl_wna16_linear_kernel(registry: dict) -> bool:
+    """Prepend the FL kernel only when its fixed local operator is built."""
+    if not kernels.is_wna16_gemm_available():
+        return False
+    from vllm.platforms import PlatformEnum
+
+    candidates = registry.setdefault(PlatformEnum.OOT, [])
+    if FLWNA16LinearKernel not in candidates:
+        candidates.insert(0, FLWNA16LinearKernel)
+    return True
+
+
+__all__ = ["FLWNA16LinearKernel", "register_fl_wna16_linear_kernel"]

--- a/vllm_fl/quantization/wna16/linear.py
+++ b/vllm_fl/quantization/wna16/linear.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2026 BAAI. All rights reserved.
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """vLLM MPLinearKernel adapter for the plugin-local WNA16 GEMM."""
 
 from __future__ import annotations

--- a/vllm_fl/quantization/wna16/linear.py
+++ b/vllm_fl/quantization/wna16/linear.py
@@ -27,7 +27,12 @@ from . import kernels
 
 
 class FLWNA16LinearKernel(MPLinearKernel):
-    """Consume standard uint4b8 weights through the fixed local kernel."""
+    """Consume standard uint4b8 weights through the fixed local operator.
+
+    vLLM's MPLinear registry selects this adapter only when
+    ``vllm_fl::wna16_gemm`` is registered. The execution path does not fall
+    through to CUDA, FlagGems, or the test-only reference implementation.
+    """
 
     @classmethod
     def get_min_capability(cls) -> int:

--- a/vllm_fl/quantization/wna16/moe.py
+++ b/vllm_fl/quantization/wna16/moe.py
@@ -21,11 +21,10 @@ import torch
 
 from . import kernels
 
-
 _ADAPTER_MARKER = "_vllm_fl_local_wna16_moe"
-_UPSTREAM_MODULE = (
+_UPSTREAM_MODULES = (
     "vllm.model_executor.layers.quantization.compressed_tensors."
-    "compressed_tensors_moe.compressed_tensors_moe_wna16"
+    "compressed_tensors_moe.compressed_tensors_moe_wna16",
 )
 
 
@@ -55,9 +54,7 @@ def _build_local_moe_method(base_method):
                 num_bits=self.num_bits,
                 group_size=self.group_size,
                 activation=layer.activation,
-                apply_router_weight_on_input=(
-                    layer.apply_router_weight_on_input
-                ),
+                apply_router_weight_on_input=(layer.apply_router_weight_on_input),
                 global_num_experts=layer.global_num_experts,
                 expert_map=layer.expert_map,
                 inplace=not self.moe.disable_inplace,
@@ -67,12 +64,24 @@ def _build_local_moe_method(base_method):
 
 
 def install_fl_wna16_moe_method() -> bool:
-    """Use the local MoE adapter when the fixed plugin operator is built."""
+    """Install the local MoE method when the fixed plugin operator is built.
+
+    vLLM 0.20.2 selects WNA16 MoE through a scheme class rather than a kernel
+    registry, so replacing that class is the installation point.
+    """
     if not kernels.is_wna16_moe_available():
         return False
 
-    module = import_module(_UPSTREAM_MODULE)
-    current = module.CompressedTensorsWNA16MoEMethod
+    module = None
+    for module_name in _UPSTREAM_MODULES:
+        try:
+            module = import_module(module_name)
+            current = module.CompressedTensorsWNA16MoEMethod
+            break
+        except (ImportError, AttributeError):
+            continue
+    if module is None:
+        raise ImportError("Could not find vLLM's WNA16 MoE method")
     if getattr(current, _ADAPTER_MARKER, False):
         return True
     module.CompressedTensorsWNA16MoEMethod = _build_local_moe_method(current)

--- a/vllm_fl/quantization/wna16/moe.py
+++ b/vllm_fl/quantization/wna16/moe.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""vLLM compressed-tensors adapter for the plugin-local WNA16 MoE."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+import torch
+
+from . import kernels
+
+
+_ADAPTER_MARKER = "_vllm_fl_local_wna16_moe"
+_UPSTREAM_MODULE = (
+    "vllm.model_executor.layers.quantization.compressed_tensors."
+    "compressed_tensors_moe.compressed_tensors_moe_wna16"
+)
+
+
+def _build_local_moe_method(base_method):
+    class FLCompressedTensorsWNA16MoEMethod(base_method):
+        """Keep vLLM weight loading but call the fixed plugin operator."""
+
+        _vllm_fl_local_wna16_moe = True
+
+        def apply(
+            self,
+            layer,
+            x: torch.Tensor,
+            topk_weights: torch.Tensor,
+            topk_ids: torch.Tensor,
+            shared_experts_input: torch.Tensor | None,
+        ) -> torch.Tensor:
+            del shared_experts_input
+            return kernels.wna16_moe(
+                x=x,
+                w13_weight_packed=layer.w13_weight_packed,
+                w2_weight_packed=layer.w2_weight_packed,
+                w13_weight_scale=layer.w13_weight_scale,
+                w2_weight_scale=layer.w2_weight_scale,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                num_bits=self.num_bits,
+                group_size=self.group_size,
+                activation=layer.activation,
+                apply_router_weight_on_input=(
+                    layer.apply_router_weight_on_input
+                ),
+                global_num_experts=layer.global_num_experts,
+                expert_map=layer.expert_map,
+                inplace=not self.moe.disable_inplace,
+            )
+
+    return FLCompressedTensorsWNA16MoEMethod
+
+
+def install_fl_wna16_moe_method() -> bool:
+    """Use the local MoE adapter when the fixed plugin operator is built."""
+    if not kernels.is_wna16_moe_available():
+        return False
+
+    module = import_module(_UPSTREAM_MODULE)
+    current = module.CompressedTensorsWNA16MoEMethod
+    if getattr(current, _ADAPTER_MARKER, False):
+        return True
+    module.CompressedTensorsWNA16MoEMethod = _build_local_moe_method(current)
+    return True
+
+
+__all__ = ["install_fl_wna16_moe_method"]

--- a/vllm_fl/quantization/wna16/moe.py
+++ b/vllm_fl/quantization/wna16/moe.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2026 BAAI. All rights reserved.
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """vLLM compressed-tensors adapter for the plugin-local WNA16 MoE."""
 
 from __future__ import annotations

--- a/vllm_fl/quantization/wna16/reference.py
+++ b/vllm_fl/quantization/wna16/reference.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Torch WNA16 reference used for correctness tests, not kernel selection."""
+
+from __future__ import annotations
+
+import torch
+
+
+def unpack_uint4b8(
+    weight_packed: torch.Tensor,
+    *,
+    in_features: int | None = None,
+) -> torch.Tensor:
+    """Unpack compressed-tensors uint4b8 int32 words to signed int8."""
+    if weight_packed.ndim != 2 or weight_packed.dtype != torch.int32:
+        raise ValueError("weight_packed must be a 2D int32 tensor")
+    shifts = torch.arange(
+        0,
+        32,
+        4,
+        dtype=torch.int32,
+        device=weight_packed.device,
+    )
+    codes = torch.bitwise_and(
+        torch.bitwise_right_shift(weight_packed.unsqueeze(-1), shifts),
+        0xF,
+    ).reshape(weight_packed.shape[0], -1)
+    if in_features is not None:
+        if in_features < 0 or in_features > codes.shape[1]:
+            raise ValueError("in_features is incompatible with weight_packed")
+        codes = codes[:, :in_features]
+    return (codes.to(torch.int16) - 8).to(torch.int8)
+
+
+def wna16_gemm_reference(
+    x: torch.Tensor,
+    weight_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Materialize dequantized weights for small numerical tests only."""
+    if x.ndim < 2:
+        raise ValueError("x must have at least two dimensions")
+    if group_size <= 0 or x.shape[-1] % group_size:
+        raise ValueError("group_size must divide the input feature dimension")
+    expected_scale_shape = (
+        weight_packed.shape[0],
+        x.shape[-1] // group_size,
+    )
+    if tuple(weight_scale.shape) != expected_scale_shape:
+        raise ValueError(
+            f"weight_scale must have shape {expected_scale_shape}, "
+            f"got {tuple(weight_scale.shape)}"
+        )
+
+    values = unpack_uint4b8(
+        weight_packed,
+        in_features=x.shape[-1],
+    )
+    scales = weight_scale.repeat_interleave(group_size, dim=1)
+    weight = values.to(scales.dtype) * scales
+    output = torch.matmul(x, weight.transpose(0, 1))
+    if bias is not None:
+        output = output + bias
+    return output
+
+
+__all__ = ["unpack_uint4b8", "wna16_gemm_reference"]

--- a/vllm_fl/quantization/wna16/reference.py
+++ b/vllm_fl/quantization/wna16/reference.py
@@ -11,7 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Torch WNA16 reference used for correctness tests, not kernel selection."""
+"""Torch WNA16 reference used only by unit tests.
+
+This module is deliberately absent from the MPLinear and MoE registration
+paths. It materializes the dequantized weight and must not be selected for
+model inference.
+"""
 
 from __future__ import annotations
 

--- a/vllm_fl/quantization/wna16/reference.py
+++ b/vllm_fl/quantization/wna16/reference.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2026 BAAI. All rights reserved.
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Torch WNA16 reference used for correctness tests, not kernel selection."""
 
 from __future__ import annotations


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
Core

### PR Type
New Features

### Description
Introduces the plugin-side scaffolding for standard `compressed-tensors`
`pack-quantized` WNA16 (W4A16 / W8A16) checkpoints on the FL out-of-tree
platform.

This PR intentionally does **not** ship the CUDA/HIP kernel implementations
themselves — it only adds:

- A checkpoint-config validator for the standard compressed-tensors subset
  the FL runtime consumes.
- vLLM-side adapters (`MPLinearKernel` for linear, subclass swap for the
  compressed-tensors WNA16 MoE method) that dispatch to a plugin-local
  `torch.ops.vllm_fl.wna16_{gemm,moe}` operator.
- A Marlin-selection guard that keeps upstream's native Marlin MoE backend
  NVIDIA-only when running under `PlatformEnum.OOT`.
- A pure-Torch WNA16 reference implementation used exclusively for
  correctness tests, not for kernel selection.

All hooks are **self-gated on `torch.ops.vllm_fl.wna16_*` being registered**.
Until the C++/CUDA side of the operators lands, `add_oot_quant_kernel()`
behaves identically to `main` — the wna16 registrations early-return and no
vLLM module attributes are patched. This keeps upstream and vendor paths
completely undisturbed while the kernel work is in progress.

### Related Issues
N/A

### Changes
- Add `vllm_fl/quantization/compressed_tensors.py`:
  `validate_compressed_tensors_wna16_config`,
  `inspect_vllm_compressed_tensors_api`,
  `register_compressed_tensors_oot`.
- Add `vllm_fl/quantization/wna16/` subpackage:
  - `linear.py` — `FLWNA16LinearKernel` (`MPLinearKernel` adapter) +
    `register_fl_wna16_linear_kernel`.
  - `moe.py` — `install_fl_wna16_moe_method` (dynamic subclass swap of
    `CompressedTensorsWNA16MoEMethod`).
  - `kernels/{gemm,moe}.py` — direct bindings for the fixed plugin
    operators (`torch.ops.vllm_fl.wna16_{gemm,moe}`) with availability
    probes.
  - `reference.py` — Torch-only reference used for tests only.
- Add `vllm_fl/quantization/marlin.py`: platform guard that scopes vLLM's
  native Marlin MoE selection to CUDA under `PlatformEnum.OOT`.
- Wire two self-gated hook calls at the end of
  `quant_linear.add_oot_quant_kernel()`; no other behavior change to the
  existing OOT kernel registration path.
- Add unit tests under `tests/unit_tests/quantization/` covering config
  validation, the MoE adapter installation, the kernel operator dispatch,
  and the reference implementation.


### Testing

### Checklist

