### PR TITLE
fix(metax): fall back to Triton cache ops when vllm C extensions are missing

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/metax/patches/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/metax/patches/__init__.py
@@ -29,3 +29,27 @@ from . import gdn_linear_attn  # noqa: F401 — register MacaGatedDeltaNetAttent
 # TODO: remove when MetaX Triton support is available.
 import vllm.utils.import_utils as iu
 iu.has_triton_kernels = lambda: False
+
+# --------------------------------------------------
+# When vllm is built with VLLM_TARGET_DEVICE=empty, the C extension modules
+# are not compiled.  torch.ops._C_cache_ops.* are not registered, so the
+# MetaX flash attention backend's reshape_and_cache_flash call path fails.
+#
+# vllm ships a pure-Triton implementation (triton_reshape_and_cache_flash)
+# for platforms lacking the compiled extension.  Route _custom_ops through
+# the Triton fallback when the C ops are missing.
+#
+# Safe for standard vllm wheels: the patch only fires when _C_cache_ops is
+# absent, and every op in the dispatch chain is covered by the Triton kernel.
+import torch
+
+if not hasattr(torch.ops, "_C_cache_ops"):
+    import vllm._custom_ops as _custom_ops
+    from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+        triton_reshape_and_cache_flash,
+        triton_reshape_and_cache_flash_per_token_head_quant,
+    )
+    _custom_ops.reshape_and_cache_flash = triton_reshape_and_cache_flash
+    _custom_ops.reshape_and_cache_flash_per_token_head_quant = (
+        triton_reshape_and_cache_flash_per_token_head_quant
+    )


### PR DESCRIPTION
## Problem

When vllm is built with `VLLM_TARGET_DEVICE=empty`, `torch.ops._C_cache_ops` is not registered. The MetaX flash attention backend calls `vllm._custom_ops.reshape_and_cache_flash` which delegates to that C extension — causing `AttributeError` at runtime:

```
AttributeError: '_OpNamespace' '_C_cache_ops' object has no attribute 'reshape_and_cache_flash'
```

## Root cause

vllm's `_custom_ops.py` hardcodes `torch.ops._C_cache_ops.reshape_and_cache_flash(...)` — a compiled CUDA C extension that doesn't exist in empty builds.

## Fix

vllm already ships a pure-Triton implementation (`triton_reshape_and_cache_flash`) in `vllm.v1.attention.ops.triton_reshape_and_cache_flash` for platforms missing the compiled extension. This patch monkey-patches `_custom_ops` to route through the Triton fallback when `_C_cache_ops` is absent.

The patch only fires when `hasattr(torch.ops, '_C_cache_ops')` is `False` — standard vllm wheels with compiled C extensions are completely unaffected.

## Pattern

Follows the same pattern as the existing Triton kernel disablement in `patches/__init__.py` line 30-31.

## Testing

Verified on MetaX C550 (MACA 3.7.2.0, torch 2.8.0+metax):
- vllm 0.20.2 built with `VLLM_TARGET_DEVICE=empty` 
- vllm-plugin-FL main branch
- Qwen3-4B eager mode, flash attention — `vllm serve` starts and inference succeeds

```
prompt_tokens=9, completion_tokens=32 ✅
```
