### PR TITLE
fix(metax): avoid vllm._C dependency in activation ops for empty builds

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/metax/impl/activation.py
+++ b/vllm_fl/dispatch/backends/vendor/metax/impl/activation.py
@@ -15,17 +15,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
 import torch
-from vllm.model_executor.layers.activation import (
-    SiluAndMul,
-    GeluAndMul,
-)
+import torch.nn.functional as F
 
 
 def silu_and_mul_maca(obj, x: torch.Tensor) -> torch.Tensor:
     """
-    SiLU activation followed by element-wise multiplication using CUDA.
-
-    Uses vLLM's optimized CUDA kernel when available.
+    SiLU activation followed by element-wise multiplication.
 
     Args:
         obj: The calling obj (for interface consistency)
@@ -34,15 +29,13 @@ def silu_and_mul_maca(obj, x: torch.Tensor) -> torch.Tensor:
     Returns:
         Output tensor of shape [..., d]
     """
-    act_fn = SiluAndMul()
-    return act_fn.forward_cuda(x)
+    d = x.shape[-1] // 2
+    return F.silu(x[..., :d]) * x[..., d:]
 
 
 def gelu_and_mul_maca(obj, x: torch.Tensor) -> torch.Tensor:
     """
-    GELU activation followed by element-wise multiplication using CUDA.
-
-    Uses vLLM's optimized CUDA kernel when available.
+    GELU activation followed by element-wise multiplication.
 
     Args:
         obj: The calling obj (for interface consistency)
@@ -51,5 +44,5 @@ def gelu_and_mul_maca(obj, x: torch.Tensor) -> torch.Tensor:
     Returns:
         Output tensor of shape [..., d]
     """
-    act_fn = GeluAndMul()
-    return act_fn.forward_cuda(x)
+    d = x.shape[-1] // 2
+    return F.gelu(x[..., :d], approximate="none") * x[..., d:]


### PR DESCRIPTION
## Problem

When vllm is built with VLLM_TARGET_DEVICE=empty, vllm._C is not compiled and torch.ops._C.silu_and_mul / torch.ops._C.gelu_and_mul do not exist. The MetaX activation functions instantiate SiluAndMul() / GeluAndMul(), whose __init__ accesses torch.ops._C.* — causing AttributeError at model load time.

## Root cause

silu_and_mul_maca and gelu_and_mul_maca delegate to vllm's compiled CUDA kernel classes (SiluAndMul, GeluAndMul). These depend on vllm._C.abi3.so which is absent in empty builds.

## Fix

Replace with pure PyTorch: F.silu / F.gelu — functionally identical and works on both empty and full vllm builds.

## Credit

Originally authored by ftgreat <ldwang@baai.ac.cn> in commit 1357ddf (2026-07-21) on the MetaX CI node. This PR upstreams that fix.

## Testing

Verified on MetaX C550 (MACA 3.7.2.0, torch 2.8.0+metax): vllm 0.20.2 empty + vllm-plugin-FL, Qwen3-4B, eager mode, flash attention, inference succeeds without _C stubs.
