### PR TITLE
fix flagcx torch backend bug and flaggems w8a8 mm not support on txda…

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -117,8 +117,10 @@ def register():
 def register_quant_linear():
     from vllm.platforms import current_platform
     # vllm.model_executor.kernels.linear triggers cutlass_scaled_mm_supports_fp8
-    # at module level, which requires torch.ops._C — not available on MUSA.
+    # at module level, which requires torch.ops._C — not available on MUSA and Tsingmicro.
     if current_platform.device_type == "musa":
+        return
+    elif current_platform.device_type == "txda":
         return
     from vllm_fl.quantization.quant_linear import add_oot_quant_kernel
     add_oot_quant_kernel()

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -56,7 +56,7 @@ def _resolve_flagcx_backend() -> bool:
     try:
         if flagcx_path not in sys.path:
             sys.path.insert(0, flagcx_path)
-        import plugin.torch.flagcx  # triggers _C.so load and backend registration
+        import flagcx  # triggers _C.so load and backend registration
         return torch.distributed.is_backend_available("flagcx")
     except Exception:
         logger.warning(


### PR DESCRIPTION
… flaggems.

<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->
Vendor 
### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->
 Bug Fixes
### Description
<!-- Describe what this PR does and why. -->
fix flagcx torch backend bug and flaggems w8a8 mm not support on txda flaggems.
### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->

### Changes
<!-- List the key changes made in this PR. -->
- vllm_fl/__init__.py
- vllm_fl/platform.py


### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->
-
yes
### Checklist
- [x] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
