### PR TITLE
[CICD] Add MetaX graph serving smoke cases

### DIFF
--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -61,12 +61,7 @@ def resolve_task_dir(task_key: str) -> str:
 def resolve_e2e_timeout(config: dict, device: str, task_dir: str) -> int:
     """Return timeout for an E2E task, allowing platform YAML overrides."""
     default = DEFAULT_TIMEOUT.get(task_dir, 60)
-    timeouts = (
-        config.get(device, {})
-        .get("tests", {})
-        .get("timeouts", {})
-        .get("e2e", {})
-    )
+    timeouts = config.get(device, {}).get("tests", {}).get("timeouts", {}).get("e2e", {})
     value = timeouts.get(task_dir, default)
     return int(value)
 

--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -58,6 +58,19 @@ def resolve_task_dir(task_key: str) -> str:
     return TASK_DIR_MAP.get(task_key, task_key)
 
 
+def resolve_e2e_timeout(config: dict, device: str, task_dir: str) -> int:
+    """Return timeout for an E2E task, allowing platform YAML overrides."""
+    default = DEFAULT_TIMEOUT.get(task_dir, 60)
+    timeouts = (
+        config.get(device, {})
+        .get("tests", {})
+        .get("timeouts", {})
+        .get("e2e", {})
+    )
+    value = timeouts.get(task_dir, default)
+    return int(value)
+
+
 def get_device_sections(config: dict) -> list[str]:
     """Return device section names present in the config.
 
@@ -108,7 +121,7 @@ def build_e2e_matrix(
     # Build one matrix entry per (task, device) group
     entries = []
     for (task_dir, device), case_list in groups.items():
-        timeout = DEFAULT_TIMEOUT.get(task_dir, 60)
+        timeout = resolve_e2e_timeout(config, device, task_dir)
         entries.append(
             {
                 "task": task_dir,

--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -61,7 +61,9 @@ def resolve_task_dir(task_key: str) -> str:
 def resolve_e2e_timeout(config: dict, device: str, task_dir: str) -> int:
     """Return timeout for an E2E task, allowing platform YAML overrides."""
     default = DEFAULT_TIMEOUT.get(task_dir, 60)
-    timeouts = config.get(device, {}).get("tests", {}).get("timeouts", {}).get("e2e", {})
+    timeouts = (
+        config.get(device, {}).get("tests", {}).get("timeouts", {}).get("e2e", {})
+    )
     value = timeouts.get(task_dir, default)
     return int(value)
 

--- a/tests/models/qwen3_6/27b_tp2_graph_metax.yaml
+++ b/tests/models/qwen3_6/27b_tp2_graph_metax.yaml
@@ -1,0 +1,43 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen3.6-27B MetaX smoke configuration (TP=2, graph).
+
+llm:
+  model: "/data/models/Qwen/Qwen3.6-27B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 8192
+  gpu_memory_utilization: 0.95
+  enforce_eager: false
+  trust_remote_code: false
+  disable_custom_all_reduce: true
+
+generate:
+  prompts:
+    - "Introduce yourself,please"
+  sampling:
+    max_tokens: 100
+    temperature: 0.0
+
+serve:
+  served_model_name: "qwen"
+  endpoints: ["chat"]
+  stream: false
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "Introduce yourself,please"
+  sampling:
+    temperature: 0.0

--- a/tests/models/qwen3_6/27b_tp2_graph_metax.yaml
+++ b/tests/models/qwen3_6/27b_tp2_graph_metax.yaml
@@ -19,7 +19,7 @@ llm:
   tensor_parallel_size: 2
   pipeline_parallel_size: 1
   max_model_len: 8192
-  gpu_memory_utilization: 0.95
+  gpu_memory_utilization: 0.90
   enforce_eager: false
   trust_remote_code: false
   disable_custom_all_reduce: true
@@ -33,6 +33,7 @@ generate:
 
 serve:
   served_model_name: "qwen"
+  startup_retries: 300
   endpoints: ["chat"]
   stream: false
   max_tokens: 256

--- a/tests/models/qwen3_6/35b_a3b_tp2_graph_metax.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_graph_metax.yaml
@@ -33,7 +33,7 @@ generate:
 
 serve:
   served_model_name: "qwen"
-  startup_retries: 120
+  startup_retries: 300
   endpoints: ["chat"]
   stream: false
   max_tokens: 256

--- a/tests/models/qwen3_6/35b_a3b_tp2_graph_metax.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_graph_metax.yaml
@@ -1,0 +1,44 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen3.6-35B-A3B MetaX smoke configuration (TP=2, graph).
+
+llm:
+  model: "/data/models/Qwen/Qwen3.6-35B-A3B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 8192
+  gpu_memory_utilization: 0.90
+  enforce_eager: false
+  trust_remote_code: false
+  disable_custom_all_reduce: true
+
+generate:
+  prompts:
+    - "Introduce yourself,please"
+  sampling:
+    max_tokens: 100
+    temperature: 0.0
+
+serve:
+  served_model_name: "qwen"
+  startup_retries: 120
+  endpoints: ["chat"]
+  stream: false
+  max_tokens: 256
+  chat_messages:
+    - role: "user"
+      content: "Introduce yourself,please"
+  sampling:
+    temperature: 0.0

--- a/tests/platforms/metax.yaml
+++ b/tests/platforms/metax.yaml
@@ -42,7 +42,11 @@ c550:
       inference:
         qwen3_6: ["27b_tp2_eager_metax"]
       serving:
-        qwen3_6: ["35b_a3b_tp2_eager_metax"]
+        qwen3_6:
+          - "27b_tp2_eager_metax"
+          - "27b_tp2_graph_metax"
+          - "35b_a3b_tp2_eager_metax"
+          - "35b_a3b_tp2_graph_metax"
     functional:
       include: "*"
       exclude: []

--- a/tests/platforms/metax.yaml
+++ b/tests/platforms/metax.yaml
@@ -44,9 +44,12 @@ c550:
       serving:
         qwen3_6:
           - "27b_tp2_eager_metax"
-          - "27b_tp2_graph_metax"
           - "35b_a3b_tp2_eager_metax"
+          - "27b_tp2_graph_metax"
           - "35b_a3b_tp2_graph_metax"
+    timeouts:
+      e2e:
+        serving: 180
     functional:
       include: "*"
       exclude: []


### PR DESCRIPTION
## Summary

- Add MetaX graph-mode serving smoke cases for Qwen3.6-27B and Qwen3.6-35B-A3B.
- Keep existing MetaX eager serving cases and run eager/graph serving cases together in CI.
- Do not add graph cases for benchmark.

## Changes

- Add `27b_tp2_graph_metax` serving case.
- Add `35b_a3b_tp2_graph_metax` serving case.
- Update MetaX platform config to include both eager and graph serving cases.

## Validation

- `python3 tests/run.py --platform metax --scope e2e --dry-run`

Result: passed, 5 cases discovered.