### PR TITLE
[CICD]: Add 910C image and unified model management

### DIFF
--- a/.github/configs/ascend.yml
+++ b/.github/configs/ascend.yml
@@ -18,15 +18,11 @@
 platform: ascend
 
 # Docker image for this hardware
-ci_image: harbor.baai.ac.cn/flagscale/vllm-plugin-fl:v0.2.0-ascend-ci
+ci_image: harbor.baai.ac.cn/flagscale/vllm-plugin-fl:ascend-vllm0.20.2-a3-ci
 
 # Runner labels for this hardware
 runner_labels:
-  - self-hosted
-  - Linux
-  - ARM64
-  - ascend
-  - npu-16
+  - flagcicd-910c
 
 # Container volumes (hardware-specific paths)
 container_volumes:

--- a/.github/configs/ascend.yml
+++ b/.github/configs/ascend.yml
@@ -40,6 +40,8 @@ container_options: >-
   --hostname vllm-plugin-fl
   --ipc=host
   --privileged
+  --env ASCEND_RT_VISIBLE_DEVICES=14,15
+  --env VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
   --device /dev/davinci0
   --device /dev/davinci1
   --device /dev/davinci2

--- a/.github/configs/platforms.yml
+++ b/.github/configs/platforms.yml
@@ -23,6 +23,8 @@ platforms:
   cuda:
     enabled: true
   ascend:
+    # Ascend uses a scarce self-hosted NPU runner. Run it explicitly through
+    # the "Ascend Manual CI" workflow after host-side smoke validation.
     enabled: false
   hygon:
     enabled: true

--- a/.github/configs/platforms.yml
+++ b/.github/configs/platforms.yml
@@ -23,9 +23,9 @@ platforms:
   cuda:
     enabled: true
   ascend:
-    # Ascend uses a scarce self-hosted NPU runner. Run it explicitly through
-    # the "Ascend Manual CI" workflow after host-side smoke validation.
-    enabled: false
+    # Ascend uses a scarce self-hosted NPU runner; keep it enabled when
+    # validating Ascend changes in PR CI.
+    enabled: true
   hygon:
     enabled: true
   metax:

--- a/.github/scripts/ascend/check.sh
+++ b/.github/scripts/ascend/check.sh
@@ -2,6 +2,40 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 # Check Huawei Ascend NPU availability.
 set -euo pipefail
+
 echo "=== Checking Ascend NPU availability ==="
-# TODO: Replace with actual Ascend device check command.
-npu-smi info || echo "WARNING: npu-smi not found. Ascend device check skipped."
+
+if ! command -v npu-smi >/dev/null 2>&1; then
+  echo "::error::npu-smi is required but was not found in PATH."
+  exit 1
+fi
+
+if [[ -z "${ASCEND_RT_VISIBLE_DEVICES:-}" ]]; then
+  echo "::error::ASCEND_RT_VISIBLE_DEVICES is not set."
+  exit 1
+fi
+
+required_devices=(
+  "/dev/davinci_manager"
+  "/dev/devmm_svm"
+  "/dev/hisi_hdc"
+)
+
+IFS=',' read -r -a visible_devices <<< "${ASCEND_RT_VISIBLE_DEVICES}"
+for device_id in "${visible_devices[@]}"; do
+  device_id="${device_id//[[:space:]]/}"
+  if [[ -z "${device_id}" ]]; then
+    continue
+  fi
+  required_devices+=("/dev/davinci${device_id}")
+done
+
+for device_path in "${required_devices[@]}"; do
+  if [[ ! -e "${device_path}" ]]; then
+    echo "::error::Missing Ascend device path: ${device_path}"
+    exit 1
+  fi
+done
+
+npu-smi info
+echo "Ascend device check passed."

--- a/.github/scripts/ascend/download_models.sh
+++ b/.github/scripts/ascend/download_models.sh
@@ -21,27 +21,25 @@ export FL_MODEL_BASE_PATH="${FL_MODEL_BASE_PATH:-/data/models}"
 export HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
 
 QWEN_ROOT="${FL_MODEL_BASE_PATH}/Qwen"
-MODEL_IDS=(
-    "Qwen/Qwen3-0.6B"
+HF_MODEL_ID="Qwen/Qwen3-0.6B"
+MODELSCOPE_MODEL_IDS=(
     "Qwen/Qwen3.6-27B"
     "Qwen/Qwen3.6-35B-A3B"
 )
 
 mkdir -p "${QWEN_ROOT}"
 
-for MODEL_ID in "${MODEL_IDS[@]}"; do
-    MODEL_DIR="${QWEN_ROOT}/${MODEL_ID#Qwen/}"
-    if [[ -f "${MODEL_DIR}/config.json" ]]; then
-        echo "Model already available: ${MODEL_DIR}"
-        continue
-    fi
-
-    export MODEL_ID MODEL_DIR
+MODEL_DIR="${QWEN_ROOT}/${HF_MODEL_ID#Qwen/}"
+if [[ -f "${MODEL_DIR}/config.json" ]]; then
+    echo "Model already available: ${MODEL_DIR}"
+else
+    export MODEL_ID="${HF_MODEL_ID}" MODEL_DIR
     echo "Downloading ${MODEL_ID} from ${HF_ENDPOINT} to ${MODEL_DIR}"
     python - <<'PY'
 import os
 
 from huggingface_hub import snapshot_download
+
 
 snapshot_download(
     repo_id=os.environ["MODEL_ID"],
@@ -49,7 +47,23 @@ snapshot_download(
     endpoint=os.environ["HF_ENDPOINT"],
 )
 PY
+    test -f "${MODEL_DIR}/config.json"
+    echo "Model ready: ${MODEL_DIR}"
+fi
 
+if ! command -v modelscope >/dev/null 2>&1; then
+    pip install modelscope --break-system-packages
+fi
+
+for MODEL_ID in "${MODELSCOPE_MODEL_IDS[@]}"; do
+    MODEL_DIR="${QWEN_ROOT}/${MODEL_ID#Qwen/}"
+    if [[ -f "${MODEL_DIR}/config.json" ]]; then
+        echo "Model already available: ${MODEL_DIR}"
+        continue
+    fi
+
+    echo "Downloading ${MODEL_ID} from ModelScope to ${MODEL_DIR}"
+    modelscope download --model "${MODEL_ID}" --local_dir "${MODEL_DIR}"
     test -f "${MODEL_DIR}/config.json"
     echo "Model ready: ${MODEL_DIR}"
 done

--- a/.github/scripts/ascend/download_models.sh
+++ b/.github/scripts/ascend/download_models.sh
@@ -21,19 +21,24 @@ export FL_MODEL_BASE_PATH="${FL_MODEL_BASE_PATH:-/data/models}"
 export HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
 
 QWEN_ROOT="${FL_MODEL_BASE_PATH}/Qwen"
-MODEL_ID="Qwen/Qwen3-0.6B"
-MODEL_DIR="${QWEN_ROOT}/Qwen3-0.6B"
+MODEL_IDS=(
+    "Qwen/Qwen3-0.6B"
+    "Qwen/Qwen3.6-27B"
+    "Qwen/Qwen3.6-35B-A3B"
+)
 
 mkdir -p "${QWEN_ROOT}"
 
-if [[ -f "${MODEL_DIR}/config.json" ]]; then
-    echo "Model already available: ${MODEL_DIR}"
-    exit 0
-fi
+for MODEL_ID in "${MODEL_IDS[@]}"; do
+    MODEL_DIR="${QWEN_ROOT}/${MODEL_ID#Qwen/}"
+    if [[ -f "${MODEL_DIR}/config.json" ]]; then
+        echo "Model already available: ${MODEL_DIR}"
+        continue
+    fi
 
-export MODEL_ID MODEL_DIR
-echo "Downloading ${MODEL_ID} from ${HF_ENDPOINT} to ${MODEL_DIR}"
-python - <<'PY'
+    export MODEL_ID MODEL_DIR
+    echo "Downloading ${MODEL_ID} from ${HF_ENDPOINT} to ${MODEL_DIR}"
+    python - <<'PY'
 import os
 
 from huggingface_hub import snapshot_download
@@ -45,5 +50,6 @@ snapshot_download(
 )
 PY
 
-test -f "${MODEL_DIR}/config.json"
-echo "Model ready: ${MODEL_DIR}"
+    test -f "${MODEL_DIR}/config.json"
+    echo "Model ready: ${MODEL_DIR}"
+done

--- a/.github/scripts/ascend/download_models.sh
+++ b/.github/scripts/ascend/download_models.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Provision models on the host-mounted /data volume. Images must not contain
+# model weights; every platform test refers to the same host path convention.
+set -euo pipefail
+
+export FL_MODEL_BASE_PATH="${FL_MODEL_BASE_PATH:-/data/models}"
+export HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
+
+QWEN_ROOT="${FL_MODEL_BASE_PATH}/Qwen"
+MODEL_ID="Qwen/Qwen3-0.6B"
+MODEL_DIR="${QWEN_ROOT}/Qwen3-0.6B"
+
+mkdir -p "${QWEN_ROOT}"
+
+if [[ -f "${MODEL_DIR}/config.json" ]]; then
+    echo "Model already available: ${MODEL_DIR}"
+    exit 0
+fi
+
+export MODEL_ID MODEL_DIR
+echo "Downloading ${MODEL_ID} from ${HF_ENDPOINT} to ${MODEL_DIR}"
+python - <<'PY'
+import os
+
+from huggingface_hub import snapshot_download
+
+snapshot_download(
+    repo_id=os.environ["MODEL_ID"],
+    local_dir=os.environ["MODEL_DIR"],
+    endpoint=os.environ["HF_ENDPOINT"],
+)
+PY
+
+test -f "${MODEL_DIR}/config.json"
+echo "Model ready: ${MODEL_DIR}"

--- a/.github/scripts/ascend/setup.sh
+++ b/.github/scripts/ascend/setup.sh
@@ -6,4 +6,19 @@ set -euo pipefail
 git config --global --add safe.directory "$(pwd)"
 
 pip install --upgrade pip "setuptools>=77.0.3"
-pip install --no-build-isolation -e ".[test]"
+pip install \
+    --constraint requirements/ascend.txt \
+    --no-build-isolation \
+    --no-deps \
+    -e .
+
+python - <<'PY'
+import numpy
+
+expected = "1.26.4"
+if numpy.__version__ != expected:
+    raise RuntimeError(
+        f"Unexpected NumPy version: {numpy.__version__}; expected {expected}"
+    )
+print(f"NumPy version: {numpy.__version__}")
+PY

--- a/.github/workflows/_e2e_test.yml
+++ b/.github/workflows/_e2e_test.yml
@@ -93,6 +93,13 @@ jobs:
       - name: Check device availability
         run: bash .github/scripts/${{ inputs.platform }}/check.sh
 
+      - name: Prepare host models
+        run: |
+          model_script=".github/scripts/${{ inputs.platform }}/download_models.sh"
+          if [ -f "${model_script}" ]; then
+            bash "${model_script}"
+          fi
+
       - name: Install project
         run: bash .github/scripts/${{ inputs.platform }}/setup.sh
 

--- a/.github/workflows/ascend-manual.yml
+++ b/.github/workflows/ascend-manual.yml
@@ -1,0 +1,37 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ascend runners are scarce shared resources. Validate the image and selected
+# cases directly on the host first, then dispatch this workflow when a recorded
+# full CI result is needed.
+name: Ascend Manual CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: ascend-manual-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test-ascend:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'run-ascend-ci'
+    uses: ./.github/workflows/_platform_test.yml
+    with:
+      platform: ascend
+    secrets: inherit

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -52,7 +52,7 @@ All arguments are passed directly to `vllm bench throughput`.
 Example:
 ```bash
 python benchmarks/benchmark_throughput_autotune.py \
-  --model /models/Qwen3-Next-80B-A3B-Instruct \
+  --model /data/models/Qwen/Qwen3-Next-80B-A3B-Instruct \
   --tensor-parallel-size 4 \
   --dataset-name random \
   --input-len 6144 \

--- a/benchmarks/benchmark_throughput_autotune.py
+++ b/benchmarks/benchmark_throughput_autotune.py
@@ -768,7 +768,7 @@ def main() -> None:
             "No throughput arguments provided. "
             "Pass them after the script args, e.g.: "
             'python benchmark_gems_autotune.py --ops "silu_and_mul" -- '
-            "--model /models/Qwen3-Next-80B-A3B-Instruct --tensor-parallel-size 4 ..."
+            "--model /data/models/Qwen/Qwen3-Next-80B-A3B-Instruct --tensor-parallel-size 4 ..."
         )
 
     if args.background and not os.environ.get("FLAGGEMS_AUTOTUNE_BACKGROUND"):

--- a/benchmarks/benchmark_throughput_serve.py
+++ b/benchmarks/benchmark_throughput_serve.py
@@ -17,7 +17,7 @@
 
 # Usage:
 #  1. Start the server as follows (adjust model path and args as needed):
-# vllm serve /models/Qwen3.6-27B --tensor-parallel-size 2 --max-model-len 262144 --no-enable-log-requests --no-enable-prefix-caching
+# vllm serve /data/models/Qwen/Qwen3.6-27B --tensor-parallel-size 2 --max-model-len 262144 --no-enable-log-requests --no-enable-prefix-caching
 
 #  2. Run this benchmark script (default: 4 test cases):
 # python benchmarks/benchmark_throughput_serve.py
@@ -35,7 +35,7 @@ import time
 from datetime import datetime
 from statistics import mean
 
-MODEL = "/models/Qwen3.6-27B"
+MODEL = "/data/models/Qwen/Qwen3.6-27B"
 
 # total runs for each case
 RUNS = 4

--- a/benchmarks/flagos_eval/run_benchmark.sh
+++ b/benchmarks/flagos_eval/run_benchmark.sh
@@ -17,7 +17,7 @@
 set -e
 
 # Arguments
-MODEL_PATH=${1:?"Please provide model path, e.g.: ./run_benchmark.sh /workspace/Qwen3-4B/"}
+MODEL_PATH=${1:?"Please provide model path, e.g.: ./run_benchmark.sh /data/models/Qwen/Qwen3-4B/"}
 
 # Output directory
 OUTPUT_DIR=bench_results

--- a/benchmarks/flagos_eval/run_eval.sh
+++ b/benchmarks/flagos_eval/run_eval.sh
@@ -17,8 +17,8 @@
 set -e
 
 # Arguments
-MODEL_PATH=${1:?"Please provide model path, e.g.: ./run_eval.sh /workspace/Qwen3-4B/ hf_xxx"}
-HF_TOKEN=${2:?"Please provide HF_TOKEN, e.g.: ./run_eval.sh /workspace/Qwen3-4B/ hf_xxx"}
+MODEL_PATH=${1:?"Please provide model path, e.g.: ./run_eval.sh /data/models/Qwen/Qwen3-4B/ hf_xxx"}
+HF_TOKEN=${2:?"Please provide HF_TOKEN, e.g.: ./run_eval.sh /data/models/Qwen/Qwen3-4B/ hf_xxx"}
 
 # Environment variables
 export HF_ENDPOINT=https://hf-mirror.com            # China mirror (can be removed for overseas)

--- a/benchmarks/flagos_eval/run_mixed_benchmark.sh
+++ b/benchmarks/flagos_eval/run_mixed_benchmark.sh
@@ -30,12 +30,12 @@ set -e
 #   seed: Random seed for shuffle (default: 42)
 #
 # Example:
-#   ./run_mixed_benchmark.sh /workspace/Qwen3-4B/
-#   ./run_mixed_benchmark.sh /workspace/Qwen3-4B/ 123
+#   ./run_mixed_benchmark.sh /data/models/Qwen/Qwen3-4B/
+#   ./run_mixed_benchmark.sh /data/models/Qwen/Qwen3-4B/ 123
 # ============================================================================
 
 # Arguments
-MODEL_PATH=${1:?"Please provide model path, e.g.: ./run_mixed_benchmark.sh /workspace/Qwen3-4B/"}
+MODEL_PATH=${1:?"Please provide model path, e.g.: ./run_mixed_benchmark.sh /data/models/Qwen/Qwen3-4B/"}
 SEED=${2:-42}
 
 # Output directory

--- a/docker/ascend/Dockerfile
+++ b/docker/ascend/Dockerfile
@@ -12,143 +12,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG VLLM_VERSION=0.19.0
-ARG CANN_VERSION=8.5.1
-ARG CANN_CHIP=a3
-ARG UBUNTU_VERSION=22.04
-ARG PYTHON_VERSION=3.11
+# Keep the chip image aligned with the environment validated on Ascend 910C.
+ARG ASCEND_BASE_IMAGE=quay.io/ascend/vllm-ascend:v0.20.2rc1-a3
 
 # ---------- base stage ----------
-FROM quay.io/ascend/cann:${CANN_VERSION}-${CANN_CHIP}-ubuntu${UBUNTU_VERSION}-py${PYTHON_VERSION} AS base
+FROM ${ASCEND_BASE_IMAGE} AS base
 
-ARG MOONCAKE_TAG=v0.3.8.post1
-ARG SOC_VERSION=ascend910_9391
-ENV DEBIAN_FRONTEND=noninteractive
-ENV SOC_VERSION=${SOC_VERSION} \
-    TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
+ARG FLAGGEMS_VERSION=3e6528cf04f5f964a7b0fa6628de6f0410dbfd02
 
-RUN pip install --upgrade pip setuptools
+ENV DEBIAN_FRONTEND=noninteractive \
+    VLLM_PLUGINS=fl \
+    VLLM_FL_PLATFORM=ascend \
+    HF_ENDPOINT=https://hf-mirror.com \
+    FL_MODEL_BASE_PATH=/data/models
 
-# Add BiShengIR compiler to PATH
-ENV PATH="${ASCEND_TOOLKIT_HOME}/tools/bishengir/bin:${PATH}"
-
-# Install system deps (clang-15 for triton-ascend, jemalloc for memory alloc)
-RUN apt-get update -y && \
-    apt-get install -y git \
-        vim \
-        wget \
-        net-tools \
-        gcc \
-        g++ \
+RUN python -m pip install --upgrade pip "setuptools>=77.0.3" \
+    && python -m pip install --no-cache-dir \
+        scikit-build-core==0.11 \
+        pybind11 \
+        ninja \
         cmake \
-        numactl \
-        libnuma-dev \
-        libjemalloc2 \
-        clang-15 \
-    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 \
-    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
-    rm -rf /var/cache/apt/* /var/lib/apt/lists/*
-
-# Build & install Mooncake (distributed KV cache)
-COPY ./scripts/mooncake_installer.sh /tmp/mooncake_installer.sh
-RUN git clone --depth 1 --branch ${MOONCAKE_TAG} https://github.com/kvcache-ai/Mooncake /tmp/Mooncake \
-    && mv /tmp/mooncake_installer.sh /tmp/Mooncake/ \
-    && cd /tmp/Mooncake \
-    && bash mooncake_installer.sh -y \
-    && ARCH=$(uname -m) \
-    && source /usr/local/Ascend/ascend-toolkit/set_env.sh \
-    && export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/devlib:/usr/local/Ascend/ascend-toolkit/latest/${ARCH}-linux/lib64:$LD_LIBRARY_PATH \
-    && mkdir -p build \
-    && cd build \
-    && cmake .. -DUSE_ASCEND_DIRECT=ON \
-    && make -j$(nproc) && make install \
-    && rm -rf /tmp/Mooncake
-
-# Install triton-ascend, ray, protobuf
-RUN pip install triton-ascend==3.2.0 \
-        'ray>=2.47.1,<=2.48.0' \
-        'protobuf>3.20.0' && \
-    pip cache purge
-
-# jemalloc preload + devlib LD_LIBRARY_PATH
-RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:${LD_PRELOAD}" >> ~/.bashrc && \
-    echo "export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib" >> ~/.bashrc
+    && git clone https://github.com/flagos-ai/FlagGems.git /workspace/FlagGems \
+    && git -C /workspace/FlagGems checkout "${FLAGGEMS_VERSION}" \
+    && python -m pip install --no-build-isolation /workspace/FlagGems \
+    && python -m pip cache purge
 
 WORKDIR /workspace
 
 # ---------- dev stage ----------
 FROM base AS dev
 
-ARG VLLM_VERSION=0.19.0
-
-RUN pip install \
+RUN python -m pip install --no-cache-dir \
         pytest \
         pytest-cov \
         pytest-json-report \
         ruff \
-        pre-commit \
-        ninja \
-        cmake
-
-# Install vLLM (uninstall triton pulled by vllm on x86 — conflicts on Ascend)
-RUN VLLM_TARGET_DEVICE="empty" pip install "vllm[audio]==${VLLM_VERSION}" \
-        --extra-index-url https://download.pytorch.org/whl/cpu/ && \
-    pip uninstall -y triton && \
-    pip cache purge
+        pre-commit
 
 # ---------- ci stage ----------
-FROM base AS ci
+FROM dev AS ci
 
-ARG VLLM_VERSION=0.19.0
-
-# Install dev/test tools
-RUN pip install \
-        pytest \
-        pytest-cov \
+RUN python -m pip install --no-cache-dir \
         pytest-timeout \
-        pytest-json-report \
         pytest-metadata \
-        numpy \
+        numpy==1.26.4 \
         requests \
+        openai \
         decorator \
+        pyyaml \
         "modelscope>=1.18.1" \
-        ruff \
-        pre-commit \
-        ninja \
-        cmake
-
-# Install vLLM (uninstall triton pulled by vllm on x86 — conflicts on Ascend)
-RUN VLLM_TARGET_DEVICE="empty" pip install "vllm[audio]==${VLLM_VERSION}" \
-        --extra-index-url https://download.pytorch.org/whl/cpu/ && \
-    pip uninstall -y triton && \
-    pip cache purge
-
-# Install FlagGems (NPU backend)
-ARG FLAGGEMS_VERSION=v5.0.0
-RUN pip install -U scikit-build-core==0.11 pybind11 \
-    && git clone --branch ${FLAGGEMS_VERSION} --depth 1 https://github.com/flagos-ai/FlagGems /workspace/FlagGems \
-    && pip install --no-build-isolation \
-        --config-settings=cmake.define.FLAGGEMS_BACKEND=NPU \
-        /workspace/FlagGems
-
-# Install FlagTree
-RUN pip install flagtree==0.4.0+ascend3.2 \
-        --index-url=https://resource.flagos.net/repository/flagos-pypi-hosted/simple \
-        --trusted-host=resource.flagos.net
-
-# Set environment variables for vLLM and Triton
-ENV VLLM_PLUGINS=fl
-ENV TRITON_ALL_BLOCKS_PARALLEL=1
+        "huggingface_hub>=0.34"
 
 # ---------- release stage ----------
 FROM base AS release
-
-ARG INDEX_URL
-ARG EXTRA_INDEX_URL
-ARG VLLM_VERSION=0.19.0
-
-# Install vLLM
-# Todo
 
 WORKDIR /workspace

--- a/docker/ascend/README.md
+++ b/docker/ascend/README.md
@@ -1,0 +1,38 @@
+# Ascend CI image
+
+The Ascend 910C CI image is built from the environment validated in
+`ascend+empty vllm0.20.2+vllm-plugin-fl.docx`:
+
+```text
+quay.io/ascend/vllm-ascend:v0.20.2rc1-a3
+```
+
+Build the image from the repository root:
+
+```bash
+docker/build.sh \
+  --platform ascend \
+  --target ci \
+  --image-name harbor.baai.ac.cn/flagscale/vllm-plugin-fl
+```
+
+Push `ascend-vllm0.20.2-a3-ci` before enabling the image in CI.
+
+Models are stored on the host and mounted into the container through `/data`.
+The common convention is:
+
+```text
+/data/models/
+└── Qwen/
+    └── Qwen3-0.6B/
+```
+
+The E2E workflow runs `.github/scripts/ascend/download_models.sh`
+idempotently. It downloads `Qwen/Qwen3-0.6B` through
+`https://hf-mirror.com` only when the model is absent.
+
+To avoid occupying a scarce NPU runner during development, validate changes
+on the host with the same image, setup script, and `tests/run.py` command
+first. When host validation passes, dispatch the `Ascend Manual CI` workflow
+to produce the recorded unit, functional, E2E, and benchmark results. Ascend
+is intentionally excluded from the automatic PR platform registry.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -36,6 +36,9 @@ METAX_PYTHON_VERSION="${METAX_PYTHON_VERSION:-3.12}"
 METAX_PYTHON_TAG="${METAX_PYTHON_TAG:-py312}"
 METAX_MACA_VERSION="${METAX_MACA_VERSION:-3.7.0.107}"
 METAX_VLLM_VERSION="${METAX_VLLM_VERSION:-0.20.2}"
+ASCEND_VLLM_VERSION="${ASCEND_VLLM_VERSION:-0.20.2}"
+ASCEND_BASE_IMAGE="${ASCEND_BASE_IMAGE:-quay.io/ascend/vllm-ascend:v0.20.2rc1-a3}"
+ASCEND_FLAGGEMS_VERSION="${ASCEND_FLAGGEMS_VERSION:-3e6528cf04f5f964a7b0fa6628de6f0410dbfd02}"
 HYGON_BASE_IMAGE="${HYGON_BASE_IMAGE:-harbor.sourcefind.cn:5443/dcu/admin/base/custom:vllm0.20.0-ubuntu22.04-dtk26.04-py3.10-MiniCPM-V-4.6}"
 HYGON_VLLM_VERSION="${HYGON_VLLM_VERSION:-0.20.2}"
 HYGON_DTK_VERSION="${HYGON_DTK_VERSION:-26.04}"
@@ -162,6 +165,9 @@ VERSIONS (override via environment variables):
   Ascend:
     CANN_VERSION         CANN version (default: ${CANN_VERSION})
     CANN_CHIP            CANN chip: 910b, a3 (default: ${CANN_CHIP})
+    ASCEND_VLLM_VERSION  vLLM version in the validated image (default: ${ASCEND_VLLM_VERSION})
+    ASCEND_BASE_IMAGE    Validated Ascend vLLM base image (default: ${ASCEND_BASE_IMAGE})
+    ASCEND_FLAGGEMS_VERSION FlagGems git ref for Ascend (default: ${ASCEND_FLAGGEMS_VERSION})
   MetaX:
     METAX_BASE_IMAGE     Base image (default: ${METAX_BASE_IMAGE})
     METAX_MACA_VERSION   MACA version used in generated image tag (default: ${METAX_MACA_VERSION})
@@ -182,11 +188,12 @@ EXAMPLES:
     # Build CUDA dev image
     ./build.sh --target dev
 
-    # Build Ascend CI image for 910b
+    # Build the validated Ascend CI image
     ./build.sh --platform ascend --target ci
 
-    # Build Ascend CI image for A3
-    CANN_CHIP=a3 ./build.sh --platform ascend --target ci --build-arg SOC_VERSION=ascend910_9391
+    # Override the Ascend base image when validating a new stack
+    ASCEND_BASE_IMAGE=quay.io/ascend/vllm-ascend:v0.20.2rc1-a3 \
+        ./build.sh --platform ascend --target ci
 
     # Build Hygon CI image
     ./build.sh --platform hygon --target ci
@@ -257,12 +264,11 @@ fi
 BUILD_CONTEXT="${SCRIPT_DIR}/${PLATFORM}"
 
 # Platform-specific build args and auto-tag
-BUILD_ARGS=(
-    --build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}"
-)
+BUILD_ARGS=()
 
 if [[ "${PLATFORM}" == "cuda" ]]; then
     BUILD_ARGS+=(
+        --build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}"
         --build-arg "CUDA_VERSION=${CUDA_VERSION}"
         --build-arg "PYTHON_VERSION=${PYTHON_VERSION}"
         --build-arg "VLLM_VERSION=${VLLM_VERSION}"
@@ -274,19 +280,19 @@ if [[ "${PLATFORM}" == "cuda" ]]; then
         IMAGE_TAG="cuda${CUDA_VERSION}-ubuntu${UBUNTU_VERSION}-py${PYTHON_VERSION}-${TARGET}"
     fi
 elif [[ "${PLATFORM}" == "ascend" ]]; then
+    VLLM_VERSION="${ASCEND_VLLM_VERSION}"
     BUILD_ARGS+=(
-        --build-arg "CANN_VERSION=${CANN_VERSION}"
-        --build-arg "CANN_CHIP=${CANN_CHIP}"
-        --build-arg "PYTHON_VERSION=${PYTHON_VERSION}"
-        --build-arg "VLLM_VERSION=${VLLM_VERSION}"
+        --build-arg "ASCEND_BASE_IMAGE=${ASCEND_BASE_IMAGE}"
+        --build-arg "FLAGGEMS_VERSION=${ASCEND_FLAGGEMS_VERSION}"
     )
     if [[ -z "${IMAGE_TAG}" ]]; then
-        IMAGE_TAG="cann${CANN_VERSION}-${CANN_CHIP}-ubuntu${UBUNTU_VERSION}-py${PYTHON_VERSION}-${TARGET}"
+        IMAGE_TAG="ascend-vllm${VLLM_VERSION}-a3-${TARGET}"
     fi
 elif [[ "${PLATFORM}" == "hygon" ]]; then
     PYTHON_VERSION="${HYGON_PYTHON_VERSION}"
     VLLM_VERSION="${HYGON_VLLM_VERSION}"
     BUILD_ARGS+=(
+        --build-arg "UBUNTU_VERSION=${UBUNTU_VERSION}"
         --build-arg "HYGON_BASE_IMAGE=${HYGON_BASE_IMAGE}"
         --build-arg "PYTHON_VERSION=${HYGON_PYTHON_VERSION}"
         --build-arg "VLLM_VERSION=${HYGON_VLLM_VERSION}"
@@ -323,8 +329,8 @@ msg "  Target:         ${TARGET}"
 if [[ "${PLATFORM}" == "cuda" ]]; then
     msg "  CUDA:           ${CUDA_VERSION}"
 elif [[ "${PLATFORM}" == "ascend" ]]; then
-    msg "  CANN:           ${CANN_VERSION}"
-    msg "  Chip:           ${CANN_CHIP}"
+    msg "  Base image:     ${ASCEND_BASE_IMAGE}"
+    msg "  FlagGems:       ${ASCEND_FLAGGEMS_VERSION}"
 elif [[ "${PLATFORM}" == "hygon" ]]; then
     msg "  DTK:            ${HYGON_DTK_VERSION}"
     msg "  Hygon Python:   ${HYGON_PYTHON_VERSION}"
@@ -337,8 +343,10 @@ elif [[ "${PLATFORM}" == "metax" ]]; then
     msg "  MetaX Python:   ${METAX_PYTHON_VERSION}"
     msg "  Base image:     ${METAX_BASE_IMAGE}"
 fi
-msg "  Ubuntu:         ${UBUNTU_VERSION}"
-msg "  Python:         ${PYTHON_VERSION}"
+if [[ "${PLATFORM}" != "ascend" ]]; then
+    msg "  Ubuntu:         ${UBUNTU_VERSION}"
+    msg "  Python:         ${PYTHON_VERSION}"
+fi
 msg "  vLLM:           ${VLLM_VERSION}"
 msg ""
 

--- a/examples/glm_5_offline_inference.py
+++ b/examples/glm_5_offline_inference.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     sampling_params = SamplingParams(max_tokens=10, temperature=0.0)
     # Create an LLM.
     llm = LLM(
-        model="/models/GLM-5-FP8",
+        model="/data/models/GLM-5-FP8",
         tensor_parallel_size=8,
         pipeline_parallel_size=1,
         enforce_eager=False,

--- a/examples/minimax_m27_offline_inference.py
+++ b/examples/minimax_m27_offline_inference.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     sampling_params = SamplingParams(max_tokens=10, temperature=0.0)
     # Create an LLM.
     llm = LLM(
-        model="/models/MiniMax-M2.7",
+        model="/data/models/MiniMax-M2.7",
         tensor_parallel_size=8,
         pipeline_parallel_size=1,
         enforce_eager=False,

--- a/examples/qwen3_5_offline_inference.py
+++ b/examples/qwen3_5_offline_inference.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     sampling_params = SamplingParams(max_tokens=10, temperature=0.0)
     # Create an LLM.
     llm = LLM(
-        model="/models/Qwen3.5-397B-A17B",
+        model="/data/models/Qwen/Qwen3.5-397B-A17B",
         tensor_parallel_size=8,
         pipeline_parallel_size=2,
         enforce_eager=False,

--- a/requirements/ascend.txt
+++ b/requirements/ascend.txt
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Keep the validated Ascend runtime compatible with FlagGems and
+# triton-ascend. The generic test extra otherwise resolves NumPy 2.x.
+numpy==1.26.4

--- a/tests/e2e_tests/serving/test_serving_smoke.py
+++ b/tests/e2e_tests/serving/test_serving_smoke.py
@@ -56,7 +56,7 @@ def server():
     serve = _CFG.serve
 
     # Build extra_args from engine config + serve-specific overrides
-    extra_args = _CFG.serve_args(**serve.extra_engine)
+    extra_args = [*_CFG.serve_args(**serve.extra_engine), *serve.extra_args]
 
     with VllmServer(
         model=_CFG.model,

--- a/tests/models/qwen3/06b_tp2.yaml
+++ b/tests/models/qwen3/06b_tp2.yaml
@@ -30,3 +30,14 @@ generate:
   parametrize:
     enforce_eager: [true, false]
     dtype: ["bfloat16"]
+
+serve:
+  served_model_name: "qwen"
+  endpoints: ["chat"]
+  stream: false
+  max_tokens: 64
+  chat_messages:
+    - role: "user"
+      content: "Introduce large language models briefly."
+  sampling:
+    temperature: 0.0

--- a/tests/models/qwen3_6/27b_tp2_eager_ascend.yaml
+++ b/tests/models/qwen3_6/27b_tp2_eager_ascend.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen3.6-27B Ascend 910C validation from the platform verification guide.
+
+llm:
+  model: "/data/models/Qwen/Qwen3.6-27B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 4096
+  gpu_memory_utilization: 0.8
+  enforce_eager: true
+  trust_remote_code: true
+  enable_chunked_prefill: false
+  async_scheduling: false
+  enable_prefix_caching: false
+
+generate:
+  prompts:
+    - "Introduce large language models briefly."
+  sampling:
+    max_tokens: 100
+    temperature: 0.0
+
+serve:
+  served_model_name: "qwen"
+  startup_retries: 180
+  endpoints: ["chat"]
+  stream: true
+  max_tokens: 1024
+  chat_messages:
+    - role: "user"
+      content: "Introduce large language models briefly."
+  sampling:
+    temperature: 0.0

--- a/tests/models/qwen3_6/27b_tp2_eager_ascend.yaml
+++ b/tests/models/qwen3_6/27b_tp2_eager_ascend.yaml
@@ -36,6 +36,10 @@ generate:
 serve:
   served_model_name: "qwen"
   startup_retries: 180
+  extra_args:
+    - "--no-enable-chunked-prefill"
+    - "--no-async-scheduling"
+    - "--no-enable-prefix-caching"
   endpoints: ["chat"]
   stream: true
   max_tokens: 1024

--- a/tests/models/qwen3_6/35b_a3b_tp2_eager_ascend.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_eager_ascend.yaml
@@ -36,6 +36,10 @@ generate:
 serve:
   served_model_name: "qwen"
   startup_retries: 180
+  extra_args:
+    - "--no-enable-chunked-prefill"
+    - "--no-async-scheduling"
+    - "--no-enable-prefix-caching"
   endpoints: ["chat"]
   stream: true
   max_tokens: 1024

--- a/tests/models/qwen3_6/35b_a3b_tp2_eager_ascend.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_eager_ascend.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen3.6-35B-A3B Ascend 910C validation from the platform verification guide.
+
+llm:
+  model: "/data/models/Qwen/Qwen3.6-35B-A3B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 4096
+  gpu_memory_utilization: 0.8
+  enforce_eager: true
+  trust_remote_code: true
+  enable_chunked_prefill: false
+  async_scheduling: false
+  enable_prefix_caching: false
+
+generate:
+  prompts:
+    - "Introduce large language models briefly."
+  sampling:
+    max_tokens: 100
+    temperature: 0.0
+
+serve:
+  served_model_name: "qwen"
+  startup_retries: 180
+  endpoints: ["chat"]
+  stream: true
+  max_tokens: 1024
+  chat_messages:
+    - role: "user"
+      content: "Introduce large language models briefly."
+  sampling:
+    temperature: 0.0

--- a/tests/models/qwen3_6/35b_a3b_tp2_eager_hygon.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_eager_hygon.yaml
@@ -18,8 +18,8 @@ llm:
   model: "/data/models/Qwen/Qwen3.6-35B-A3B"
   tensor_parallel_size: 2
   pipeline_parallel_size: 1
-  max_model_len: 262144
-  gpu_memory_utilization: 0.90
+  max_model_len: 8192
+  gpu_memory_utilization: 0.95
   enforce_eager: true
   trust_remote_code: false
   disable_custom_all_reduce: true
@@ -33,11 +33,6 @@ generate:
 
 serve:
   served_model_name: "qwen"
-  extra_engine:
-    enforce_eager: false
-    disable_custom_all_reduce: false
-    enable_log_requests: false
-    enable_prefix_caching: false
   startup_retries: 120
   endpoints: ["chat"]
   stream: false

--- a/tests/platforms/ascend.yaml
+++ b/tests/platforms/ascend.yaml
@@ -62,7 +62,8 @@ env_defaults: {}
   tests:
     e2e:
       # Add or remove test cases per model
-      inference: {}
+      inference:
+        qwen3: ["06b_tp2"]
       serving:
         qwen3: ["06b_tp2"]
     functional:

--- a/tests/platforms/ascend.yaml
+++ b/tests/platforms/ascend.yaml
@@ -63,9 +63,9 @@ env_defaults: {}
     e2e:
       # Add or remove test cases per model
       inference:
-        qwen3: ["06b_tp2"]
+        qwen3_6: ["27b_tp2_eager_ascend", "35b_a3b_tp2_eager_ascend"]
       serving:
-        qwen3: ["06b_tp2"]
+        qwen3_6: ["27b_tp2_eager_ascend", "35b_a3b_tp2_eager_ascend"]
     functional:
       # Include patterns: "*" for all, or list specific paths
       include: "*"

--- a/tests/platforms/ascend.yaml
+++ b/tests/platforms/ascend.yaml
@@ -76,3 +76,6 @@ env_defaults: {}
       include: "*"
       # Exclude patterns: empty list or list paths to exclude
       exclude: []
+    benchmark:
+      enabled: true
+      smoke: ["serve"]

--- a/tests/platforms/ascend.yaml
+++ b/tests/platforms/ascend.yaml
@@ -33,7 +33,7 @@ platform: ascend
 vendor: huawei
 
 device_types:
-  910b:
+  910c:
     memory_gb: 64
     tags: [ascend, bf16]
 
@@ -57,14 +57,14 @@ unsupported_features: []
 env_defaults: {}
 
 # ---- Device-specific test configurations ------------------------------------
-910b:
-  name: "910b"
+910c:
+  name: "910c"
   tests:
     e2e:
       # Add or remove test cases per model
       inference: {}
       serving:
-        qwen3: ["4b_tp2"]
+        qwen3: ["06b_tp2"]
     functional:
       # Include patterns: "*" for all, or list specific paths
       include: "*"

--- a/tests/unit_tests/dispatch/test_ascend_patch.py
+++ b/tests/unit_tests/dispatch/test_ascend_patch.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm_fl.dispatch.backends.vendor.ascend.patch import (
+    patch_accelerator_empty_cache,
+)
+
+
+def test_patch_accelerator_empty_cache(monkeypatch):
+    replacement = lambda: None
+    monkeypatch.setattr(
+        torch, "npu", SimpleNamespace(empty_cache=replacement), raising=False
+    )
+    monkeypatch.setattr(torch.accelerator, "empty_cache", lambda: None)
+
+    patch_accelerator_empty_cache()
+
+    assert torch.accelerator.empty_cache is replacement

--- a/tests/unit_tests/dispatch/test_ascend_rotary.py
+++ b/tests/unit_tests/dispatch/test_ascend_rotary.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Tests for the Ascend rotary embedding implementation."""
+
+import torch
+
+from vllm_fl.dispatch.backends.reference.impl.rotary import rotary_embedding_torch
+from vllm_fl.dispatch.backends.vendor.ascend.impl.rotary import rotary_embedding_ascend
+
+
+def test_ascend_rotary_falls_back_for_float32():
+    num_tokens = 4
+    num_heads = 2
+    head_size = 8
+
+    query = torch.randn(num_tokens, num_heads, head_size)
+    key = torch.randn_like(query)
+    positions = torch.arange(num_tokens)
+    frequencies = torch.randn(16, head_size // 2)
+    cos = frequencies.cos()
+    sin = frequencies.sin()
+
+    actual_query, actual_key = rotary_embedding_ascend(
+        None, query, key, cos, sin, positions, inplace=False
+    )
+    expected_query, expected_key = rotary_embedding_torch(
+        None, query, key, cos, sin, positions, inplace=False
+    )
+
+    torch.testing.assert_close(actual_query, expected_query)
+    torch.testing.assert_close(actual_key, expected_key)

--- a/tests/unit_tests/dispatch/test_ascend_rotary.py
+++ b/tests/unit_tests/dispatch/test_ascend_rotary.py
@@ -2,13 +2,19 @@
 
 """Tests for the Ascend rotary embedding implementation."""
 
+import pytest
 import torch
 
 from vllm_fl.dispatch.backends.reference.impl.rotary import rotary_embedding_torch
-from vllm_fl.dispatch.backends.vendor.ascend.impl.rotary import rotary_embedding_ascend
+
+pytest.importorskip("torch_npu")
 
 
 def test_ascend_rotary_falls_back_for_float32():
+    from vllm_fl.dispatch.backends.vendor.ascend.impl.rotary import (
+        rotary_embedding_ascend,
+    )
+
     num_tokens = 4
     num_heads = 2
     head_size = 8

--- a/tests/utils/model_config.py
+++ b/tests/utils/model_config.py
@@ -104,6 +104,7 @@ class ServeConfig:
     Fields:
         api_key: Optional API key for authenticated endpoints.
         extra_engine: Engine param overrides for serving (e.g. dtype).
+        extra_args: Raw command-line arguments appended to ``vllm serve``.
         endpoints: List of endpoints to test (``"completion"``, ``"chat"``,
                    ``"embedding"``).
         completion_prompt: Prompt string for ``/v1/completions`` endpoint.
@@ -124,6 +125,7 @@ class ServeConfig:
 
     api_key: str = ""
     extra_engine: dict[str, Any] = field(default_factory=dict)
+    extra_args: list[str] = field(default_factory=list)
     endpoints: list[str] = field(default_factory=list)
     completion_prompt: str = "Hello"
     chat_messages: list[dict[str, Any]] = field(default_factory=list)
@@ -144,6 +146,7 @@ class ServeConfig:
         return cls(
             api_key=raw.get("api_key", ""),
             extra_engine=raw.get("extra_engine", {}),
+            extra_args=raw.get("extra_args", []),
             endpoints=raw.get("endpoints", []),
             completion_prompt=raw.get("completion_prompt", "Hello"),
             chat_messages=raw.get("chat_messages", []),

--- a/vllm_fl/dispatch/backends/vendor/ascend/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/__init__.py
@@ -5,8 +5,9 @@ Ascend (Huawei) backend for vllm-plugin-FL dispatch.
 """
 
 from .ascend import AscendBackend
-from .patch import patch_mamba_config
+from .patch import patch_accelerator_empty_cache, patch_mamba_config
 
+patch_accelerator_empty_cache()
 patch_mamba_config()
 
 __all__ = ["AscendBackend"]

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/rotary.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/rotary.py
@@ -36,6 +36,26 @@ def rotary_embedding_ascend(
     Returns:
         Tuple of (embedded_query, embedded_key)
     """
+    # The ATB rotary kernel used by torch-npu does not support FP32 inputs.
+    # Launch failures are reported asynchronously and otherwise surface in a
+    # later, unrelated operator. Keep the optimized path for model dtypes and
+    # use the reference implementation for unsupported dtypes.
+    if query.dtype not in (torch.float16, torch.bfloat16):
+        from vllm_fl.dispatch.backends.reference.impl.rotary import (
+            rotary_embedding_torch,
+        )
+
+        return rotary_embedding_torch(
+            obj,
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            rotary_interleaved=rotary_interleaved,
+            inplace=inplace,
+        )
+
     import torch_npu
 
     # query/key shape: [num_tokens, num_heads, rotary_dim]

--- a/vllm_fl/dispatch/backends/vendor/ascend/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/patch.py
@@ -9,6 +9,23 @@ import vllm
 logger = logging.getLogger(__name__)
 _patches_applied = False
 
+
+def patch_accelerator_empty_cache():
+    """Redirect generic accelerator cache cleanup to torch-npu.
+
+    ``torch.accelerator.empty_cache`` uses an incompatible allocator on NPU.
+    Patch it during Ascend backend import so cleanup also works in the engine
+    parent process, not only in worker processes.
+    """
+    npu = getattr(torch, "npu", None)
+    accelerator = getattr(torch, "accelerator", None)
+    if npu is None or accelerator is None or not hasattr(npu, "empty_cache"):
+        return
+
+    accelerator.empty_cache = npu.empty_cache
+    logger.info("Patched torch.accelerator.empty_cache for Ascend NPU")
+
+
 def apply_ascend_patches():
     """Apply all Ascend-specific patches."""
     global _patches_applied


### PR DESCRIPTION
## Summary

- Add an Ascend 910C Docker image based on quay.io/ascend/vllm-ascend:v0.20.2rc1-a3
- Standardize host model paths under /data/models/
- Store Qwen models under /data/models/Qwen/
- Download Qwen3-0.6B through https://hf-mirror.com
- Add Ascend 910C serving and chat E2E tests
- Use manually triggered Ascend CI to avoid unnecessarily occupying scarce NPU runners

## Manual validation

Validated on bm-jn-zs-bj2-910C-64G-10-115:

- Branch: dev-hr-ascend
- Commit: ecd3eb6fe3a00e106ebc154a55f88a0efebdb7ca
- Image: harbor.baai.ac.cn/flagscale/vllm-plugin-fl:ascend-vllm0.20.2-a3-ci
- Image digest: sha256:5062ac23b8b8247e5b4faa5d2c61b7b8e82e46a9ae7c55fe15c5cdbe3533f4b7
- Model: /data/models/Qwen/Qwen3-0.6B
- NumPy: 1.26.4
- Pytest: 2 passed
- Result: Overall: PASSED