### PR TITLE
[Sunrise] Add cuda-graph, int8 support on Sunrise

### DIFF
--- a/.github/configs/cuda.yml
+++ b/.github/configs/cuda.yml
@@ -29,6 +29,11 @@ runner_labels:
   - gpu-8
   - cuda130
 
+# Device-specific runner labels override the platform defaults for E2E jobs.
+device_runner_labels:
+  h20:
+    - vllm-plugin-ci-h20
+
 # Runner labels for this hardware (Platform hosted)
 # runner_labels:
 #   - ci-vllm-plugin-fl

--- a/.github/scripts/load_config.py
+++ b/.github/scripts/load_config.py
@@ -45,6 +45,7 @@ def load_platform_config(platform: str) -> dict:
 
     # Ensure the platform key is present
     config.setdefault("platform", platform)
+    config.setdefault("device_runner_labels", {})
     return config
 
 

--- a/.github/workflows/_platform_test.yml
+++ b/.github/workflows/_platform_test.yml
@@ -140,7 +140,7 @@ jobs:
       device: ${{ matrix.test.device }}
       cases: ${{ matrix.test.cases }}
       ci_image: ${{ matrix.test.image || fromJson(needs.setup.outputs.config).ci_image }}
-      runner_labels: ${{ toJson(fromJson(needs.setup.outputs.config).runner_labels) }}
+      runner_labels: ${{ toJson(fromJson(needs.setup.outputs.config).device_runner_labels[matrix.test.device] || fromJson(needs.setup.outputs.config).runner_labels) }}
       container_volumes: ${{ toJson(fromJson(needs.setup.outputs.config).container_volumes) }}
       container_options: ${{ fromJson(needs.setup.outputs.config).container_options }}
       timeout: ${{ matrix.test.timeout || 60 }}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
     ```sh
     git clone https://github.com/flagos-ai/FlagCX.git
     cd FlagCX
-    git checkout -b v0.9.0
+    git checkout -b v0.13.0
     git submodule update --init --recursive
     ```
 

--- a/examples/disaggregated_serving_xpyd/router.py
+++ b/examples/disaggregated_serving_xpyd/router.py
@@ -124,7 +124,11 @@ app = FastAPI(lifespan=lifespan)
 
 async def send_to_prefill(prefill_client, endpoint, req_data, request_id):
     data = req_data.copy()
-    data["kv_transfer_params"] = {"do_remote_decode": True, "do_remote_prefill": False}
+    data["kv_transfer_params"] = {
+        "do_remote_decode": True,
+        "do_remote_prefill": False,
+        "transfer_id": f"fgx-{request_id}",
+    }
     data["stream"] = False
     data["max_tokens"] = 1
     if "max_completion_tokens" in data:
@@ -153,6 +157,7 @@ async def stream_from_decode(
         "do_remote_decode": False,
         "remote_host": prefill_client["remote_host"],
         "remote_port": prefill_client["side_channel_port"],
+        "transfer_id": f"fgx-{request_id}",
     }
     headers = {"X-Request-Id": request_id}
     api_key = os.environ.get("OPENAI_API_KEY", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ test = [
     "numpy",
     "requests",
     "openai",
+    "pillow",
     "decorator",
     "vllm[audio]==0.20.2",
     "modelscope>=1.18.1",

--- a/tests/README.md
+++ b/tests/README.md
@@ -239,6 +239,7 @@ generate:
 | `serve.endpoints` | list | No | Endpoints to test: `completion`, `chat` |
 | `serve.completion_prompt` | str | No | Prompt for `/v1/completions` |
 | `serve.chat_messages` | list | No | Messages for `/v1/chat/completions` |
+| `serve.chat_cases` | list | No | Named chat requests run against one server; `expected` validates required response substrings and `generated_image: true` creates the local image fixture |
 | `serve.max_tokens` | int | No | Max tokens for serving requests (default: 50) |
 | `serve.api_key` | str | No | API key for authenticated endpoints |
 | `serve.extra_engine` | dict | No | Engine param overrides for serving only |

--- a/tests/e2e_tests/serving/test_serving_smoke.py
+++ b/tests/e2e_tests/serving/test_serving_smoke.py
@@ -15,7 +15,9 @@ Supports both non-streaming (raw requests) and streaming (OpenAI SDK) modes,
 controlled by the ``serve.stream`` flag in the model YAML.
 """
 
+import base64
 import os
+from io import BytesIO
 
 import pytest
 import requests
@@ -138,12 +140,67 @@ def _run_chat(base_url: str, headers: dict) -> None:
     Otherwise, uses a plain requests POST.
     """
     serve = _CFG.serve
-    messages = serve.chat_messages or [{"role": "user", "content": "Hello"}]
+    chat_cases = serve.chat_cases or [
+        {
+            "name": "default",
+            "messages": serve.chat_messages or [{"role": "user", "content": "Hello"}],
+        }
+    ]
 
-    if serve.stream:
-        _run_chat_streaming(base_url, serve, messages)
-    else:
-        _run_chat_non_streaming(base_url, headers, serve, messages)
+    for chat_case in chat_cases:
+        case_name = chat_case.get("name", "unnamed")
+        if chat_case.get("generated_image"):
+            messages = _generated_image_messages(
+                chat_case.get("prompt", "Describe this image.")
+            )
+        else:
+            messages = chat_case.get("messages", [])
+
+        assert messages, f"Chat case '{case_name}' has no messages"
+        print(f"\nRunning chat case: {case_name}")
+        if serve.stream:
+            response_text = _run_chat_streaming(base_url, serve, messages)
+        else:
+            response_text = _run_chat_non_streaming(base_url, headers, serve, messages)
+
+        expected = chat_case.get("expected")
+        if expected:
+            expected_values = expected if isinstance(expected, list) else [expected]
+            normalized_response = response_text.casefold()
+            missing = [
+                value
+                for value in expected_values
+                if value.casefold() not in normalized_response
+            ]
+            is_correct = not missing
+            print(f"Answer validation: {'CORRECT' if is_correct else 'INCORRECT'}")
+            assert is_correct, f"Chat case '{case_name}' is missing expected: {missing}"
+
+
+def _generated_image_messages(prompt: str) -> list[dict]:
+    """Create the local image payload used by the Qwen multimodal smoke case."""
+    from PIL import Image, ImageDraw
+
+    image = Image.new("RGB", (300, 200), color="white")
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((50, 50, 250, 150), fill="blue")
+    draw.text((90, 80), "Hello VLM", fill="yellow")
+
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG")
+    encoded = base64.b64encode(buffer.getvalue()).decode("utf-8")
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{encoded}"},
+                },
+                {"type": "text", "text": prompt},
+            ],
+        }
+    ]
 
 
 def _run_chat_non_streaming(
@@ -151,7 +208,7 @@ def _run_chat_non_streaming(
     headers: dict,
     serve,
     messages: list[dict],
-) -> None:
+) -> str:
     """Non-streaming chat completions via raw requests."""
     payload: dict = {
         "model": _REQUEST_MODEL,
@@ -177,13 +234,14 @@ def _run_chat_non_streaming(
     content = data["choices"][0]["message"]["content"]
     assert len(content.strip()) > 0, "Assistant message is empty"
     print(f"\nResponse: {content}")
+    return content
 
 
 def _run_chat_streaming(
     base_url: str,
     serve,
     messages: list[dict],
-) -> None:
+) -> str:
     """Streaming chat completions via OpenAI SDK."""
     import httpx
     from openai import OpenAI
@@ -214,6 +272,7 @@ def _run_chat_streaming(
 
     assert len(text.strip()) > 0, "Streaming response is empty"
     print(f"\nStreaming response: {text}")
+    return text
 
 
 def _run_embedding(base_url: str, headers: dict) -> None:

--- a/tests/models/qwen3_6/27b_tp2_262k.yaml
+++ b/tests/models/qwen3_6/27b_tp2_262k.yaml
@@ -1,0 +1,43 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen3.6-27B 262K serving configuration (TP=2).
+
+llm:
+  model: "/data/models/Qwen/Qwen3.6-27B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 262144
+  trust_remote_code: false
+
+serve:
+  served_model_name: "qwen"
+  startup_retries: 120
+  endpoints: ["chat"]
+  stream: true
+  max_tokens: 1024
+  sampling:
+    temperature: 0.0
+  chat_cases:
+    - name: text
+      messages:
+        - role: "user"
+          content: "The capital of France is"
+      expected: "Paris"
+    - name: image
+      generated_image: true
+      prompt: "Describe all visible text, colors, and shapes in English."
+      expected:
+        - "Hello VLM"
+        - "blue rectangle"

--- a/tests/models/qwen3_6/35b_a3b_tp2_262k.yaml
+++ b/tests/models/qwen3_6/35b_a3b_tp2_262k.yaml
@@ -1,0 +1,43 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qwen3.6-35B-A3B 262K serving configuration (TP=2).
+
+llm:
+  model: "/data/models/Qwen/Qwen3.6-35B-A3B"
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 1
+  max_model_len: 262144
+  trust_remote_code: false
+
+serve:
+  served_model_name: "qwen"
+  startup_retries: 120
+  endpoints: ["chat"]
+  stream: true
+  max_tokens: 1024
+  sampling:
+    temperature: 0.0
+  chat_cases:
+    - name: text
+      messages:
+        - role: "user"
+          content: "The capital of France is"
+      expected: "Paris"
+    - name: image
+      generated_image: true
+      prompt: "Describe all visible text, colors, and shapes in English."
+      expected:
+        - "Hello VLM"
+        - "blue rectangle"

--- a/tests/platforms/cuda.yaml
+++ b/tests/platforms/cuda.yaml
@@ -15,7 +15,7 @@
 # CUDA-Based Platform Configuration
 # Flexible test selection mechanism for NVIDIA GPU environments
 #
-# This platform configuration supports multiple device types (a100, a800, h100)
+# This platform configuration supports multiple device types (a100, a800, h100, h20)
 # Users can modify the following:
 # - functional: Add/remove test case names in the support lists
 #   Example: aquila: ["tp2_pp2", "tp4_pp2"] -> add or remove items
@@ -45,6 +45,10 @@ device_types:
     compute_capability: "9.0"
     memory_gb: 80
     tags: [hopper, fp8, bf16]
+  h20:
+    compute_capability: "9.0"
+    memory_gb: 140
+    tags: [hopper, fp8, bf16, china-variant]
 
 # Default numerical tolerance for result comparison (used when device doesn't override)
 tolerance:
@@ -97,3 +101,10 @@ a100:
     benchmark:
       enabled: true
       smoke: ["throughput", "latency", "serve"]
+
+h20:
+  name: "h20"
+  tests:
+    e2e:
+      serving:
+        qwen3_6: ["27b_tp2_262k", "35b_a3b_tp2_262k"]

--- a/tests/unit_tests/ops/test_c_ops_registry.py
+++ b/tests/unit_tests/ops/test_c_ops_registry.py
@@ -1,0 +1,101 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import vllm_fl
+from vllm_fl.ops import _C_ops_registry as registry
+
+
+def test_loads_legacy_and_stable_extensions_on_every_platform(monkeypatch):
+    calls = []
+    monkeypatch.setattr(registry, "_import_extension", calls.append)
+
+    assert registry.load_vllm_native_extensions()
+    assert calls == [
+        registry._LEGACY_C_EXTENSION,
+        registry._STABLE_C_EXTENSION,
+    ]
+
+
+def test_loads_stable_extension_without_legacy(monkeypatch):
+    calls = []
+
+    def import_extension(module_name):
+        calls.append(module_name)
+        if module_name == registry._LEGACY_C_EXTENSION:
+            raise ModuleNotFoundError(module_name)
+
+    monkeypatch.setattr(registry, "_import_extension", import_extension)
+
+    assert registry.load_vllm_native_extensions()
+    assert calls == [
+        registry._LEGACY_C_EXTENSION,
+        registry._STABLE_C_EXTENSION,
+    ]
+
+
+def test_loads_legacy_extension_without_stable(monkeypatch):
+    calls = []
+
+    def import_extension(module_name):
+        calls.append(module_name)
+        if module_name == registry._STABLE_C_EXTENSION:
+            raise ModuleNotFoundError(module_name)
+
+    monkeypatch.setattr(registry, "_import_extension", import_extension)
+
+    assert registry.load_vllm_native_extensions()
+    assert calls == [
+        registry._LEGACY_C_EXTENSION,
+        registry._STABLE_C_EXTENSION,
+    ]
+
+
+def test_fallback_schema_registration_skipped_when_native_extension_loaded(
+    monkeypatch,
+):
+    monkeypatch.delattr(registry.register_op_schemas, "_lib", raising=False)
+    monkeypatch.setattr(
+        registry,
+        "load_vllm_native_extensions",
+        lambda: True,
+    )
+
+    def fail_if_fallback_library_is_created(*args, **kwargs):
+        raise AssertionError("fallback schemas must not precede native CUDA ops")
+
+    monkeypatch.setattr(
+        registry.torch.library,
+        "Library",
+        fail_if_fallback_library_is_created,
+    )
+
+    registry.register_op_schemas()
+
+
+def test_plugin_initialization_loads_native_ops_before_fallback(monkeypatch):
+    monkeypatch.setattr(
+        registry,
+        "load_vllm_native_extensions",
+        lambda: True,
+    )
+
+    def fail_if_fallback_is_registered():
+        raise AssertionError("native ops must bypass fallback schema registration")
+
+    monkeypatch.setattr(
+        registry,
+        "register_op_schemas",
+        fail_if_fallback_is_registered,
+    )
+
+    vllm_fl._patch_custom_ops()

--- a/tests/unit_tests/quantization/test_compressed_tensors.py
+++ b/tests/unit_tests/quantization/test_compressed_tensors.py
@@ -4,16 +4,20 @@ from types import SimpleNamespace
 
 import pytest
 
+from vllm_fl import utils as fl_utils
 from vllm_fl.quantization import compressed_tensors
 from vllm_fl.quantization.compressed_tensors import (
     CompatibilityReport,
+    W8A8DynamicTokenScheme,
     WNA16Scheme,
     inspect_vllm_compressed_tensors_api,
     register_compressed_tensors_oot,
+    validate_compressed_tensors_w8a8_config,
     validate_compressed_tensors_wna16_config,
 )
 from vllm_fl.quantization.marlin import is_marlin_moe_platform
-from vllm_fl.quantization.wna16 import moe as moe_adapter
+from vllm_fl.quantization.w8a8 import moe as w8a8_moe_adapter, packed as packed_w8a8
+from vllm_fl.quantization.wna16 import kernels as wna16_kernels, moe as moe_adapter
 
 
 def _config():
@@ -36,6 +40,110 @@ def _config():
         },
         "ignore": [],
     }
+
+
+def _w8a8_config():
+    return {
+        "quant_method": "compressed-tensors",
+        "format": "int-quantized",
+        "quantization_status": "compressed",
+        "config_groups": {
+            "w8a8": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 8,
+                    "type": "int",
+                    "strategy": "channel",
+                    "symmetric": True,
+                    "dynamic": False,
+                },
+                "input_activations": {
+                    "num_bits": 8,
+                    "type": "int",
+                    "strategy": "token",
+                    "symmetric": True,
+                    "dynamic": True,
+                },
+            }
+        },
+        "ignore": [],
+    }
+
+
+def test_accepts_standard_dynamic_token_w8a8_config():
+    schemes = validate_compressed_tensors_w8a8_config(_w8a8_config())
+    assert schemes == [
+        W8A8DynamicTokenScheme(
+            weight_num_bits=8,
+            weight_type="int",
+            weight_strategy="channel",
+            weight_symmetric=True,
+            weight_dynamic=False,
+            weight_group_size=None,
+            input_num_bits=8,
+            input_type="int",
+            input_strategy="token",
+            input_symmetric=True,
+            input_dynamic=True,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value", "message"),
+    [
+        ("weights", "strategy", "group", "per-channel"),
+        ("weights", "group_size", 128, "must not set group_size"),
+        ("input_activations", "strategy", "tensor", "per-token"),
+        ("input_activations", "dynamic", False, "must be dynamic"),
+        ("input_activations", "symmetric", False, "symmetric"),
+    ],
+)
+def test_rejects_noncanonical_w8a8_config(section, field, value, message):
+    config = _w8a8_config()
+    config["config_groups"]["w8a8"][section][field] = value
+    with pytest.raises(ValueError, match=message):
+        validate_compressed_tensors_w8a8_config(config)
+
+
+def test_rejects_packed_format_for_canonical_w8a8():
+    config = _w8a8_config()
+    config["format"] = "pack-quantized"
+    with pytest.raises(ValueError, match="int-quantized"):
+        validate_compressed_tensors_w8a8_config(config)
+
+
+def test_w8a8_registration_does_not_depend_on_wna16_kernel(monkeypatch):
+    calls = []
+    report = CompatibilityReport(
+        vllm_version="0.20.2",
+        linear_wna16=True,
+        moe_wna16=True,
+    )
+    monkeypatch.setattr(
+        compressed_tensors,
+        "inspect_vllm_compressed_tensors_api",
+        lambda: report,
+    )
+    monkeypatch.setattr(fl_utils, "is_oot_enabled", lambda: True)
+    monkeypatch.setattr(
+        w8a8_moe_adapter,
+        "install_fl_w8a8_moe_selector",
+        lambda: calls.append("w8a8"),
+    )
+    monkeypatch.setattr(
+        packed_w8a8,
+        "install_packed_w8a8_scheme",
+        lambda: calls.append("packed-w8a8"),
+    )
+    monkeypatch.setattr(
+        wna16_kernels,
+        "is_wna16_moe_available",
+        lambda: False,
+    )
+
+    assert compressed_tensors.register_compressed_tensors_oot() is report
+    assert calls == ["packed-w8a8", "w8a8"]
 
 
 def test_accepts_standard_w4a16_group_config():
@@ -81,6 +189,11 @@ def test_local_moe_adapter_is_not_installed_without_kernel(monkeypatch):
     monkeypatch.setattr(
         moe_adapter.kernels,
         "is_wna16_moe_available",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        moe_adapter,
+        "is_flaggems_wna16_moe_available",
         lambda: False,
     )
     assert moe_adapter.install_fl_wna16_moe_method() is False

--- a/tests/unit_tests/quantization/test_packed_int8.py
+++ b/tests/unit_tests/quantization/test_packed_int8.py
@@ -1,0 +1,143 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationStrategy,
+    QuantizationType,
+)
+
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsW8A8Int8,
+)
+
+from vllm_fl.quantization.w8a8 import packed
+from vllm_fl.quantization.w8a8.int8_mode import should_use_packed_w8a8
+
+
+def _weight_args(strategy: QuantizationStrategy) -> QuantizationArgs:
+    return QuantizationArgs(
+        num_bits=8,
+        type=QuantizationType.INT,
+        strategy=strategy,
+        symmetric=True,
+        dynamic=False,
+        group_size=128 if strategy == QuantizationStrategy.GROUP else None,
+    )
+
+
+def _activation_args(
+    *,
+    strategy: QuantizationStrategy = QuantizationStrategy.TOKEN,
+    dynamic: bool = True,
+) -> QuantizationArgs:
+    return QuantizationArgs(
+        num_bits=8,
+        type=QuantizationType.INT,
+        strategy=strategy,
+        symmetric=True,
+        dynamic=dynamic,
+    )
+
+
+def test_model_config_maps_packed_channelwise_w8a8():
+    assert should_use_packed_w8a8(
+        _weight_args(QuantizationStrategy.CHANNEL),
+        _activation_args(),
+        "pack-quantized",
+    )
+
+
+def test_missing_activation_config_keeps_weight_only_scheme():
+    assert not should_use_packed_w8a8(
+        _weight_args(QuantizationStrategy.CHANNEL),
+        None,
+        "pack-quantized",
+    )
+
+
+def test_packed_w8a8_rejects_groupwise_weights():
+    with pytest.raises(ValueError, match="per-channel"):
+        should_use_packed_w8a8(
+            _weight_args(QuantizationStrategy.GROUP),
+            _activation_args(),
+            "pack-quantized",
+        )
+
+
+def test_static_tensor_activation_config_does_not_select_dynamic_w8a8():
+    assert not should_use_packed_w8a8(
+        _weight_args(QuantizationStrategy.CHANNEL),
+        _activation_args(
+            strategy=QuantizationStrategy.TENSOR,
+            dynamic=False,
+        ),
+        "pack-quantized",
+    )
+
+
+def test_packed_scheme_reuses_native_w8a8_execution(monkeypatch):
+    processed_layers = []
+
+    class FakeKernel:
+        def process_weights_after_loading(self, layer):
+            processed_layers.append(layer)
+
+        def apply_weights(self, layer, x, bias):
+            raise AssertionError("not used")
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w8a8_int8.init_int8_linear_kernel",
+        lambda *args, **kwargs: FakeKernel(),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+
+    scheme = packed.CompressedTensorsPackedW8A8Int8(layer_name="model.linear")
+    assert isinstance(scheme, CompressedTensorsW8A8Int8)
+
+    layer = torch.nn.Module()
+    scheme.create_weights(
+        layer,
+        output_partition_sizes=[4, 4],
+        input_size_per_partition=8,
+        params_dtype=torch.bfloat16,
+        weight_loader=lambda *args, **kwargs: None,
+    )
+
+    assert layer.logical_widths == [4, 4]
+    assert not hasattr(layer, "weight")
+    assert layer.weight_packed.shape == (8, 2)
+    assert layer.weight_scale.shape == (8, 1)
+    assert layer.weight_scale.dtype == torch.float32
+
+    unpacked = torch.ones((8, 8), dtype=torch.int8)
+    monkeypatch.setattr(
+        packed,
+        "unpack_uint8b128_int32",
+        lambda *args, **kwargs: unpacked,
+    )
+    scheme.process_weights_after_loading(layer)
+
+    assert not hasattr(layer, "weight_packed")
+    assert torch.equal(layer.weight, unpacked)
+    assert processed_layers == [layer]

--- a/tests/unit_tests/quantization/test_w8a8_moe.py
+++ b/tests/unit_tests/quantization/test_w8a8_moe.py
@@ -1,0 +1,179 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from types import SimpleNamespace
+
+import vllm.platforms as platforms
+
+from vllm_fl.quantization.w8a8 import moe as moe_adapter
+
+
+def test_w8a8_moe_selector_patches_oracle_and_scheme(monkeypatch):
+    def upstream_selector(*args, **kwargs):
+        return "upstream"
+
+    def upstream_builder(*args, **kwargs):
+        return "upstream-config"
+
+    oracle = SimpleNamespace(
+        select_int8_moe_backend=upstream_selector,
+    )
+    scheme = SimpleNamespace(
+        select_int8_moe_backend=upstream_selector,
+        make_int8_moe_quant_config=upstream_builder,
+    )
+    modules = {
+        moe_adapter._ORACLE_MODULE: oracle,
+        moe_adapter._SCHEME_MODULE: scheme,
+    }
+    monkeypatch.setattr(
+        moe_adapter,
+        "import_module",
+        lambda name: modules[name],
+    )
+
+    assert moe_adapter.install_fl_w8a8_moe_selector() is True
+    assert oracle.select_int8_moe_backend is scheme.select_int8_moe_backend
+    assert getattr(
+        oracle.select_int8_moe_backend,
+        moe_adapter._ADAPTER_MARKER,
+    )
+    assert getattr(
+        scheme.make_int8_moe_quant_config,
+        moe_adapter._CONFIG_BUILDER_MARKER,
+    )
+
+    config_module = SimpleNamespace(
+        int8_w8a8_moe_quant_config=lambda **kwargs: kwargs,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.layers.fused_moe.config",
+        config_module,
+    )
+    dynamic_config = scheme.make_int8_moe_quant_config(
+        w1_scale="w1",
+        w2_scale="w2",
+        a1_scale=None,
+        a2_scale=None,
+        w1_bias="b1",
+        w2_bias="b2",
+        per_act_token_quant=True,
+    )
+    assert dynamic_config == {
+        "w1_scale": "w1",
+        "w2_scale": "w2",
+        "a1_scale": None,
+        "a2_scale": None,
+        "w1_bias": "b1",
+        "w2_bias": "b2",
+        "per_act_token_quant": True,
+    }
+    assert (
+        scheme.make_int8_moe_quant_config(
+            w1_scale="w1",
+            w2_scale="w2",
+            per_act_token_quant=False,
+        )
+        == "upstream-config"
+    )
+
+
+def test_w8a8_moe_selector_uses_vllm_functional_experts(monkeypatch):
+    upstream_calls = []
+
+    def upstream_selector(*args, **kwargs):
+        upstream_calls.append((args, kwargs))
+        return "upstream"
+
+    oracle = SimpleNamespace(
+        Int8MoeBackend=SimpleNamespace(TRITON="triton"),
+        select_int8_moe_backend=upstream_selector,
+    )
+    scheme = SimpleNamespace(
+        select_int8_moe_backend=upstream_selector,
+        make_int8_moe_quant_config=lambda **kwargs: kwargs,
+    )
+    modules = {
+        moe_adapter._ORACLE_MODULE: oracle,
+        moe_adapter._SCHEME_MODULE: scheme,
+    }
+    monkeypatch.setattr(
+        moe_adapter,
+        "import_module",
+        lambda name: modules[name],
+    )
+    monkeypatch.setattr(
+        type(platforms.current_platform),
+        "is_out_of_tree",
+        lambda self: True,
+    )
+
+    import vllm_fl.utils as fl_utils
+
+    monkeypatch.setattr(fl_utils, "is_oot_enabled", lambda: True)
+
+    moe_adapter.install_fl_w8a8_moe_selector()
+    config = SimpleNamespace(
+        moe_parallel_config=SimpleNamespace(
+            use_batched_activation_format=False,
+        )
+    )
+
+    backend, experts_cls = oracle.select_int8_moe_backend(
+        config,
+        weight_key=None,
+        activation_key=None,
+    )
+
+    from vllm_fl.quantization.w8a8.moe_experts import TritonW8A8Experts
+
+    assert backend == "triton"
+    assert experts_cls is TritonW8A8Experts
+    assert upstream_calls == []
+
+
+def test_w8a8_moe_selector_install_is_idempotent(monkeypatch):
+    def installed_selector(*args, **kwargs):
+        return "installed"
+
+    setattr(installed_selector, moe_adapter._ADAPTER_MARKER, True)
+
+    def installed_builder(*args, **kwargs):
+        return "installed-config"
+
+    setattr(
+        installed_builder,
+        moe_adapter._CONFIG_BUILDER_MARKER,
+        True,
+    )
+    oracle = SimpleNamespace(
+        select_int8_moe_backend=installed_selector,
+    )
+    scheme = SimpleNamespace(
+        select_int8_moe_backend=None,
+        make_int8_moe_quant_config=installed_builder,
+    )
+    modules = {
+        moe_adapter._ORACLE_MODULE: oracle,
+        moe_adapter._SCHEME_MODULE: scheme,
+    }
+    monkeypatch.setattr(
+        moe_adapter,
+        "import_module",
+        lambda name: modules[name],
+    )
+
+    assert moe_adapter.install_fl_w8a8_moe_selector() is True
+    assert scheme.select_int8_moe_backend is installed_selector

--- a/tests/unit_tests/quantization/test_w8a8_moe_experts.py
+++ b/tests/unit_tests/quantization/test_w8a8_moe_experts.py
@@ -1,0 +1,142 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+from vllm_fl.quantization.w8a8 import moe_experts
+
+
+def _apply_arguments():
+    hidden_states = torch.ones((2, 4), dtype=torch.bfloat16)
+    return {
+        "output": torch.empty_like(hidden_states),
+        "hidden_states": hidden_states,
+        "w1": torch.ones((2, 8, 4), dtype=torch.int8),
+        "w2": torch.ones((2, 4, 4), dtype=torch.int8),
+        "topk_weights": torch.ones((2, 1), dtype=torch.float32),
+        "topk_ids": torch.zeros((2, 1), dtype=torch.int64),
+        "activation": MoEActivation.SILU,
+        "global_num_experts": 2,
+        "expert_map": None,
+        "a1q_scale": None,
+        "a2_scale": None,
+        "workspace13": torch.empty(0),
+        "workspace2": torch.empty(0),
+        "expert_tokens_meta": None,
+        "apply_router_weight_on_input": False,
+    }
+
+
+def test_functional_experts_defer_activation_quantization():
+    instance = SimpleNamespace()
+    assert (
+        moe_experts.TritonW8A8Experts.expects_unquantized_inputs.fget(instance) is True
+    )
+
+
+@pytest.mark.parametrize("supports_inplace", [True, False])
+def test_functional_experts_calls_vllm_with_float_input(
+    monkeypatch,
+    supports_inplace,
+):
+    calls = []
+
+    if supports_inplace:
+
+        def fake_fused_experts(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            inplace,
+            activation,
+            apply_router_weight_on_input,
+            global_num_experts,
+            expert_map,
+            quant_config,
+        ):
+            calls.append(
+                {
+                    "hidden_states": hidden_states,
+                    "inplace": inplace,
+                    "quant_config": quant_config,
+                }
+            )
+            return torch.full_like(hidden_states, 3)
+
+    else:
+
+        def fake_fused_experts(
+            hidden_states,
+            w1,
+            w2,
+            topk_weights,
+            topk_ids,
+            activation,
+            apply_router_weight_on_input,
+            global_num_experts,
+            expert_map,
+            quant_config,
+        ):
+            calls.append(
+                {
+                    "hidden_states": hidden_states,
+                    "quant_config": quant_config,
+                }
+            )
+            return torch.full_like(hidden_states, 3)
+
+    monkeypatch.setattr(moe_experts, "fused_experts", fake_fused_experts)
+    monkeypatch.setattr(
+        moe_experts,
+        "_FUSED_EXPERTS_HAS_INPLACE",
+        supports_inplace,
+    )
+    quant_config = SimpleNamespace(use_int8_w8a8=True)
+    instance = SimpleNamespace(quant_config=quant_config)
+    arguments = _apply_arguments()
+
+    moe_experts.TritonW8A8Experts.apply(instance, **arguments)
+
+    assert calls[0]["hidden_states"].dtype == torch.bfloat16
+    assert calls[0]["quant_config"] is quant_config
+    if supports_inplace:
+        assert calls[0]["inplace"] is False
+    assert torch.equal(
+        arguments["output"],
+        torch.full_like(arguments["output"], 3),
+    )
+
+
+def test_functional_experts_rejects_prequantized_input(monkeypatch):
+    monkeypatch.setattr(
+        moe_experts,
+        "fused_experts",
+        lambda **kwargs: pytest.fail("fused_experts must not run"),
+    )
+    instance = SimpleNamespace(
+        quant_config=SimpleNamespace(use_int8_w8a8=True),
+    )
+    arguments = _apply_arguments()
+    arguments["hidden_states"] = torch.ones((2, 4), dtype=torch.int8)
+    arguments["a1q_scale"] = torch.ones((2, 1), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="quantized before"):
+        moe_experts.TritonW8A8Experts.apply(instance, **arguments)

--- a/tests/unit_tests/quantization/test_w8a8_reference.py
+++ b/tests/unit_tests/quantization/test_w8a8_reference.py
@@ -1,0 +1,94 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from vllm_fl.quantization.w8a8.reference import (
+    dynamic_per_token_quant_int8,
+    unpack_uint8b128_int32,
+    w8a8_linear_reference,
+)
+
+
+def test_flagos_uint8b128_unpack_roundtrip():
+    values = torch.tensor(
+        [
+            [-128, -127, -1, 0, 1, 126, 127, 42],
+            [127, 0, -128, 1, -1, 64, -64, 7],
+        ],
+        dtype=torch.int8,
+    )
+    codes = (values.to(torch.int16) + 128).to(torch.uint8)
+    packed = codes.contiguous().view(torch.int32)
+
+    assert torch.equal(unpack_uint8b128_int32(packed), values)
+
+
+def test_dynamic_per_token_quant_uses_independent_row_scales():
+    x = torch.tensor(
+        [
+            [0.0, 1.0, -2.0, 0.5],
+            [10.0, -5.0, 2.5, 0.0],
+        ],
+        dtype=torch.float32,
+    )
+    quantized, scales = dynamic_per_token_quant_int8(x)
+
+    assert quantized.dtype == torch.int8
+    assert scales.dtype == torch.float32
+    assert scales.shape == (2, 1)
+    assert torch.allclose(scales[:, 0], torch.tensor([2.0 / 127, 10.0 / 127]))
+    assert quantized[0, 2] == -127
+    assert quantized[1, 0] == 127
+    assert scales[0] != scales[1]
+
+
+def test_dynamic_per_token_quant_zero_row_is_finite():
+    quantized, scales = dynamic_per_token_quant_int8(torch.zeros(2, 8))
+    assert torch.count_nonzero(quantized) == 0
+    assert torch.isfinite(scales).all()
+    assert (scales > 0).all()
+
+
+def test_w8a8_reference_matches_explicit_qdq_matmul():
+    x = torch.tensor(
+        [[[0.0, 1.0, -2.0, 0.5], [3.0, -1.0, 0.25, 2.0]]],
+        dtype=torch.float32,
+    )
+    weight = torch.tensor(
+        [[127, -64, 12, 0], [-32, 10, 80, -127]],
+        dtype=torch.int8,
+    )
+    weight_scale = torch.tensor([[0.01], [0.025]], dtype=torch.float32)
+    bias = torch.tensor([0.5, -0.25], dtype=torch.float32)
+
+    x_q, x_scale = dynamic_per_token_quant_int8(x)
+    expected = (
+        x_q.reshape(-1, 4).float()
+        @ weight.float().t()
+        * x_scale.reshape(-1, 1)
+        * weight_scale.reshape(1, -1)
+        + bias
+    ).reshape(1, 2, 2)
+    actual = w8a8_linear_reference(x, weight, weight_scale, bias)
+    assert torch.allclose(actual, expected)
+
+
+def test_w8a8_reference_rejects_non_channel_scale():
+    with pytest.raises(ValueError, match="one value per output channel"):
+        w8a8_linear_reference(
+            torch.ones(1, 4),
+            torch.ones(2, 4, dtype=torch.int8),
+            torch.ones(1),
+        )

--- a/tests/unit_tests/quantization/test_wna16_kernels.py
+++ b/tests/unit_tests/quantization/test_wna16_kernels.py
@@ -3,7 +3,7 @@
 import pytest
 import torch
 
-from vllm_fl.quantization.wna16.kernels import gemm, moe
+from vllm_fl.quantization.wna16.kernels import gemm, moe, triton as triton_kernel
 
 
 def test_gemm_is_unavailable_without_plugin_operator(monkeypatch):
@@ -33,6 +33,34 @@ def test_gemm_calls_fixed_plugin_operator(monkeypatch):
         8,
     )
     assert gemm.is_wna16_gemm_available() is True
+    assert result.shape == (2, 3)
+    assert len(calls) == 1
+
+
+def test_w8a16_gemm_uses_triton_fallback(monkeypatch):
+    calls = []
+
+    def fallback(*args):
+        calls.append(args)
+        return torch.ones(2, 3)
+
+    monkeypatch.setattr(gemm, "_resolve_wna16_gemm", lambda: None)
+    monkeypatch.setattr(
+        triton_kernel,
+        "is_triton_w8a16_available",
+        lambda: True,
+    )
+    monkeypatch.setattr(triton_kernel, "triton_w8a16_gemm", fallback)
+
+    result = gemm.wna16_gemm(
+        torch.empty(2, 8),
+        torch.empty(3, 2, dtype=torch.int32),
+        torch.empty(3, 1),
+        8,
+        num_bits=8,
+    )
+
+    assert gemm.is_w8a16_gemm_available() is True
     assert result.shape == (2, 3)
     assert len(calls) == 1
 

--- a/tests/unit_tests/quantization/test_wna16_linear.py
+++ b/tests/unit_tests/quantization/test_wna16_linear.py
@@ -1,0 +1,103 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from vllm.model_executor.kernels.linear import MPLinearLayerConfig
+from vllm.scalar_type import scalar_types
+
+from vllm_fl.quantization.wna16 import linear
+
+
+def _config(
+    weight_type,
+    *,
+    group_size: int,
+) -> MPLinearLayerConfig:
+    return MPLinearLayerConfig(
+        full_weight_shape=(128, 64),
+        partition_weight_shape=(128, 64),
+        weight_type=weight_type,
+        act_type=torch.bfloat16,
+        group_size=group_size,
+        zero_points=False,
+        has_g_idx=False,
+    )
+
+
+@pytest.mark.parametrize("group_size", [128, -1])
+def test_w8a16_linear_accepts_group_and_channel(monkeypatch, group_size):
+    monkeypatch.setattr(
+        linear.kernels,
+        "is_w8a16_gemm_available",
+        lambda: True,
+    )
+    supported, reason = linear.FLWNA16LinearKernel.can_implement(
+        _config(scalar_types.uint8b128, group_size=group_size)
+    )
+    assert supported is True
+    assert reason is None
+
+
+def test_w8a16_linear_does_not_depend_on_w4_operator(monkeypatch):
+    monkeypatch.setattr(
+        linear.kernels,
+        "is_w8a16_gemm_available",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        linear.kernels,
+        "is_wna16_gemm_available",
+        lambda: False,
+    )
+    supported, _ = linear.FLWNA16LinearKernel.can_implement(
+        _config(scalar_types.uint8b128, group_size=128)
+    )
+    assert supported
+
+
+def test_w8a16_linear_dispatches_with_eight_bits(monkeypatch):
+    monkeypatch.setattr(
+        linear.kernels,
+        "is_w8a16_gemm_available",
+        lambda: True,
+    )
+    calls = []
+
+    def gemm(x, weight, scale, group_size, bias, *, num_bits):
+        calls.append((group_size, num_bits, bias))
+        return torch.zeros((x.shape[0], weight.shape[0]), dtype=x.dtype)
+
+    monkeypatch.setattr(linear.kernels, "wna16_gemm", gemm)
+    kernel = linear.FLWNA16LinearKernel(
+        _config(scalar_types.uint8b128, group_size=128),
+        "weight_packed",
+        "weight_scale",
+    )
+    layer = torch.nn.Module()
+    layer.weight_packed = torch.nn.Parameter(
+        torch.empty((64, 32), dtype=torch.int32),
+        requires_grad=False,
+    )
+    layer.weight_scale = torch.nn.Parameter(
+        torch.ones((64, 1)),
+        requires_grad=False,
+    )
+    output = kernel.apply_weights(
+        layer,
+        torch.ones((2, 3, 128), dtype=torch.bfloat16),
+    )
+
+    assert output.shape == (2, 3, 64)
+    assert calls == [(128, 8, None)]

--- a/tests/unit_tests/quantization/test_wna16_reference.py
+++ b/tests/unit_tests/quantization/test_wna16_reference.py
@@ -5,6 +5,8 @@ import torch
 
 from vllm_fl.quantization.wna16.reference import (
     unpack_uint4b8,
+    unpack_uint8b128,
+    w8a16_gemm_reference,
     wna16_gemm_reference,
 )
 
@@ -41,3 +43,24 @@ def test_wna16_reference_rejects_incompatible_scales():
     packed = torch.zeros((2, 1), dtype=torch.int32)
     with pytest.raises(ValueError, match="weight_scale"):
         wna16_gemm_reference(x, packed, torch.ones((2, 1)), 4)
+
+
+def test_w8a16_reference_matches_flagos_groupwise_checkpoint():
+    values = torch.tensor(
+        [
+            [-128, -64, -1, 0, 1, 32, 64, 127],
+            [127, 64, 32, 1, 0, -1, -64, -128],
+        ],
+        dtype=torch.int8,
+    )
+    codes = (values.to(torch.int16) + 128).to(torch.uint8)
+    packed = codes.contiguous().view(torch.int32)
+    scales = torch.tensor([[0.5, 2.0], [1.5, 0.25]])
+    x = torch.arange(16, dtype=torch.float32).reshape(2, 8) / 8
+
+    expected_weight = values.float() * scales.repeat_interleave(4, dim=1)
+    expected = x @ expected_weight.t()
+    actual = w8a16_gemm_reference(x, packed, scales, 4)
+
+    assert torch.equal(unpack_uint8b128(packed), values)
+    assert torch.allclose(actual, expected)

--- a/tests/utils/model_config.py
+++ b/tests/utils/model_config.py
@@ -108,6 +108,7 @@ class ServeConfig:
                    ``"embedding"``).
         completion_prompt: Prompt string for ``/v1/completions`` endpoint.
         chat_messages: Messages list for ``/v1/chat/completions`` endpoint.
+        chat_cases: Named chat cases to run against one server instance.
         max_tokens: Max tokens for serving requests.
         served_model_name: Alias passed via ``--served-model-name``.
             Empty string means use the model path directly.
@@ -127,6 +128,7 @@ class ServeConfig:
     endpoints: list[str] = field(default_factory=list)
     completion_prompt: str = "Hello"
     chat_messages: list[dict[str, Any]] = field(default_factory=list)
+    chat_cases: list[dict[str, Any]] = field(default_factory=list)
     max_tokens: int = 50
     served_model_name: str = ""
     startup_retries: int = 60
@@ -147,6 +149,7 @@ class ServeConfig:
             endpoints=raw.get("endpoints", []),
             completion_prompt=raw.get("completion_prompt", "Hello"),
             chat_messages=raw.get("chat_messages", []),
+            chat_cases=raw.get("chat_cases", []),
             max_tokens=raw.get("max_tokens", 50),
             served_model_name=raw.get("served_model_name", ""),
             startup_retries=int(raw.get("startup_retries", 60)),

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -77,19 +77,20 @@ def _patch_flash_attn_import():
 
 
 def _patch_custom_ops():
-    """Register torch.ops._C op schemas when vllm._C is unavailable."""
-    try:
-        import vllm._C  # noqa: F401
+    """Load native vLLM ops before registering missing fallback schemas."""
+    from vllm_fl.ops._C_ops_registry import (
+        load_vllm_native_extensions,
+        register_op_schemas,
+    )
+
+    if load_vllm_native_extensions():
         return
-    except (ImportError, OSError):
-        pass
 
     try:
         import vllm_fl._C  # noqa: F401
     except (ImportError, OSError) as e:
         logger.debug("Failed to import vllm_fl._C: %s", e)
 
-    from vllm_fl.ops._C_ops_registry import register_op_schemas
     register_op_schemas()
 
 

--- a/vllm_fl/compilation/graph.py
+++ b/vllm_fl/compilation/graph.py
@@ -207,10 +207,12 @@ class GraphWrapper:
                 pass
 
             graph_kwargs: dict[str, Any] = {"pool": self.graph_pool}
+            # PTPU: pass the active stream explicitly. torch.ptpu.graph()
             if current_platform.device_type == "ptpu":
                 graph_kwargs["stream"] = (
                     current_platform.torch_device_fn.current_stream()
                 )
+            # FL-specific: use platform-agnostic graph capture
             with current_platform.torch_device_fn.graph(graph, **graph_kwargs):
                 # `output` is managed by pytorch's cudagraph pool
                 output = self.runnable(*args, **kwargs)

--- a/vllm_fl/compilation/graph.py
+++ b/vllm_fl/compilation/graph.py
@@ -206,10 +206,12 @@ class GraphWrapper:
             except (ImportError, RuntimeError):
                 pass
 
-            # FL-specific: use platform-agnostic graph capture
-            with current_platform.torch_device_fn.graph(
-                graph, pool=self.graph_pool
-            ):
+            graph_kwargs: dict[str, Any] = {"pool": self.graph_pool}
+            if current_platform.device_type == "ptpu":
+                graph_kwargs["stream"] = (
+                    current_platform.torch_device_fn.current_stream()
+                )
+            with current_platform.torch_device_fn.graph(graph, **graph_kwargs):
                 # `output` is managed by pytorch's cudagraph pool
                 output = self.runnable(*args, **kwargs)
                 # Join offloader's copy stream after forward if available

--- a/vllm_fl/dispatch/backends/vendor/sunrise/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/__init__.py
@@ -1,10 +1,91 @@
 # Copyright (c) 2026 BAAI. All rights reserved.
 
-"""
-Sunrise vendor backend for vllm-plugin-FL dispatch.
+"""Sunrise vendor backend for vllm-plugin-FL dispatch."""
 
-"""
+import logging as _logging
+import os as _os
 
-from .sunrise import SunriseBackend
+_log = _logging.getLogger(__name__)
+
+# Default SSM conv state layout for upstream Triton causal_conv1d.
+if not _os.environ.get("VLLM_SSM_CONV_STATE_LAYOUT"):
+    _os.environ["VLLM_SSM_CONV_STATE_LAYOUT"] = "DS"
+    _log.info(
+        "Sunrise vendor: defaulting VLLM_SSM_CONV_STATE_LAYOUT=DS "
+        "(upstream Triton causal_conv1d)."
+    )
+
+
+_SAFE_FLASH_HEURISTIC_NAMES = frozenset(
+    {
+        "mha_block_128",
+        "mha_block_64",
+        "mha_block_32",
+        "mha_block_16",
+        "mha_varlen_decode",
+    }
+)
+
+
+def _force_safe_flash_attn_launch_config() -> bool:
+    """Pin FlagGems paged-flash heuristics to a TP-invariant safe tile.
+
+    Default heuristic bins (esp. ``mha_block_128`` with ``BLOCK_N=8`` /
+    ``mha_block_64`` with ``num_stages=3``) still produce trailing-tile NaNs
+    under some per-rank ``(h, hk)`` shapes even with ``OFF_ASYNC=1``. Forcing
+    the ``mha_block_16`` launch shape makes TP=2/TP=4 share one known-good
+    specialization. ``num_stages`` is part of Triton's cache key.
+    """
+    try:
+        from flag_gems import runtime as _gems_runtime
+        from flag_gems.runtime.backend._sunrise.heuristics_config_utils import (
+            HEURISTICS_CONFIGS,
+        )
+    except Exception as exc:  # pragma: no cover
+        _log.debug("Skipping safe flash-tile clamp: %s", exc)
+        return False
+
+    overrides = {
+        "BLOCK_M": lambda args: 16,
+        "BLOCK_N": lambda args: 16,
+        "num_warps": lambda args: 8,
+        "num_stages": lambda args: 1,
+    }
+
+    patched = False
+    for name in _SAFE_FLASH_HEURISTIC_NAMES:
+        cfg = HEURISTICS_CONFIGS.get(name)
+        if isinstance(cfg, dict):
+            cfg.update(overrides)
+            patched = True
+
+    if not getattr(_gems_runtime, "_sunrise_safe_flash_tile_wrapped", False):
+        _orig_get = _gems_runtime.get_heuristic_config
+
+        def _get_heuristic_config_safe(op_name):
+            cfg = _orig_get(op_name)
+            if op_name in _SAFE_FLASH_HEURISTIC_NAMES and isinstance(cfg, dict):
+                cfg = dict(cfg)
+                cfg.update(overrides)
+            return cfg
+
+        _gems_runtime.get_heuristic_config = _get_heuristic_config_safe
+        _gems_runtime._sunrise_safe_flash_tile_wrapped = True
+        patched = True
+
+    if patched:
+        _log.info(
+            "Sunrise vendor: forced FlagGems mha_block_* launch config to "
+            "BLOCK=16/16 warps=8 stages=1 (TP-invariant safe flash tile)."
+        )
+    return patched
+
+
+_force_safe_flash_attn_launch_config()
+
+# Import-time patches (FLA/GDN rebinds, pointwise, INT8, profiler, etc.).
+from . import patches  # noqa: F401, E402
+
+from .sunrise import SunriseBackend  # noqa: E402
 
 __all__ = ["SunriseBackend"]

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/activation.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/activation.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+Sunrise (PTPU) activation operator implementations.
+
+Routes ``silu_and_mul`` to ``torch_ptpu.sgl_kernel.silu_and_mul``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from torch_ptpu.sgl_kernel import silu_and_mul as _ptpu_silu_and_mul
+
+
+def silu_and_mul_sunrise(obj, x: torch.Tensor) -> torch.Tensor:
+    """SiLU activation followed by element-wise multiplication on PTPU.
+
+    Args:
+        obj: The calling object (unused; kept for dispatch ABI parity with the
+            FlagGems / reference implementations).
+        x: Input tensor of shape ``[..., 2 * d]``. ``[..., :d]`` is the
+            "gate" half and ``[..., d:]`` is the "up" half (gate-up
+            projection convention).
+
+    Returns:
+        Output tensor of shape ``[..., d]``.
+    """
+    return _ptpu_silu_and_mul(x)

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/attention.py
@@ -41,12 +41,10 @@ from vllm.v1.attention.backends.utils import (
 from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.platforms.interface import DeviceCapability
 from flag_gems import flash_attn_varlen_func, reshape_and_cache_flash
-# from vllm.attention.utils.fa_utils import flash_attn_varlen_func #reshape_and_cache_flash,
-# from flag_gems import reshape_and_cache_flash
 
 logger = init_logger(__name__)
 
-
+# Attention via FlagGems flash_attn_varlen_func and reshape_and_cache_flash.
 
 class AttentionFLBackend(AttentionBackend):
     accept_output_buffer: bool = True
@@ -468,6 +466,12 @@ class AttentionFLImpl(AttentionImpl):
         ### TODO(lms): support quant to int8/int4 each query input and low precision compute
         self.supports_quant_query_input = False
 
+        # ``dcp_world_size`` is consulted by ``forward`` but is never assigned in
+        # the base ``AttentionImpl``. Provide a safe default; real DCP values
+        # get set externally when DCP is enabled.
+        if not hasattr(self, "dcp_world_size"):
+            self.dcp_world_size = 1
+
     def forward(
         self,
         layer: torch.nn.Module,
@@ -550,6 +554,9 @@ class AttentionFLImpl(AttentionImpl):
             # and value[:num_actual_tokens] because the reshape_and_cache_flash
             # op uses the slot_mapping's shape to determine the number of
             # actual tokens.
+            #
+            # Always FlagGems: uses ``cache.stride(0)`` so hybrid interleaved
+            # ``(num_pages, 2, block_size, ...)`` K/V slabs are correct.
             reshape_and_cache_flash(
                 key,
                 value,
@@ -585,31 +592,33 @@ class AttentionFLImpl(AttentionImpl):
                     v_descale=layer._v_scale.expand(descale_shape),
                 )
                 return output
-            else:
-                flash_attn_varlen_func(
-                    q=query[:num_actual_tokens],
-                    k=key_cache,
-                    v=value_cache,
-                    out=output[:num_actual_tokens],
-                    cu_seqlens_q=cu_seqlens_q,
-                    max_seqlen_q=max_seqlen_q,
-                    seqused_k=seqused_k,
-                    max_seqlen_k=max_seqlen_k,
-                    softmax_scale=self.scale,
-                    causal=attn_metadata.causal,
-                    alibi_slopes=self.alibi_slopes,
-                    window_size=self.sliding_window,
-                    block_table=block_table,
-                    softcap=self.logits_soft_cap,
-                    scheduler_metadata=scheduler_metadata,
-                    fa_version=self.vllm_flash_attn_version,
-                    q_descale=layer._q_scale.expand(descale_shape),
-                    k_descale=layer._k_scale.expand(descale_shape),
-                    v_descale=layer._v_scale.expand(descale_shape),
-                    num_splits=attn_metadata.max_num_splits,
-                    s_aux=None, ### self.sinks is support in FA3
-                )
-                return output
+
+            # FlagGems unified varlen attention compute.
+
+            flash_attn_varlen_func(
+                q=query[:num_actual_tokens],
+                k=key_cache,
+                v=value_cache,
+                out=output[:num_actual_tokens],
+                cu_seqlens_q=cu_seqlens_q,
+                max_seqlen_q=max_seqlen_q,
+                seqused_k=seqused_k,
+                max_seqlen_k=max_seqlen_k,
+                softmax_scale=self.scale,
+                causal=attn_metadata.causal,
+                alibi_slopes=self.alibi_slopes,
+                window_size=self.sliding_window,
+                block_table=block_table,
+                softcap=self.logits_soft_cap,
+                scheduler_metadata=scheduler_metadata,
+                fa_version=self.vllm_flash_attn_version,
+                q_descale=layer._q_scale.expand(descale_shape),
+                k_descale=layer._k_scale.expand(descale_shape),
+                v_descale=layer._v_scale.expand(descale_shape),
+                num_splits=attn_metadata.max_num_splits,
+                s_aux=None, ### self.sinks is support in FA3
+            )
+            return output
 
         # Cascade attention (rare case).
         cascade_attention(

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/__init__.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+PTPU-native wrappers for vLLM's flash-linear-attention (FLA) ops.
+
+The wrappers here adapt the upstream ``vllm.model_executor.layers.fla.ops.*``
+signatures (which return Triton/FLA tensors) to PTPU's
+``torch_ptpu.sgl_kernel`` Gated DeltaNet kernel family. They are designed to
+be drop-in replacements; the monkey-patch in
+``vllm_fl.dispatch.backends.vendor.sunrise.patches.patch_fla_ops`` rebinds the upstream
+module attributes to these wrappers at vendor import time.
+
+See ``patches/patch_fla_ops`` for the full rationale and rebind set.
+"""
+
+from .chunk_fwd_o import chunk_fwd_o
+from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
+from .cumsum import chunk_local_cumsum
+from .fused_recurrent_packed_decode import (
+    fused_recurrent_gated_delta_rule_packed_decode,
+)
+from .fused_sigmoid_gating import fused_sigmoid_gating_delta_rule_update
+from .l2norm import l2norm_fwd
+from .solve_tril import solve_tril
+from .wy_fast import recompute_w_u_fwd
+
+__all__ = [
+    "chunk_fwd_o",
+    "chunk_local_cumsum",
+    "chunk_scaled_dot_kkt_fwd",
+    "fused_recurrent_gated_delta_rule_packed_decode",
+    "fused_sigmoid_gating_delta_rule_update",
+    "l2norm_fwd",
+    "recompute_w_u_fwd",
+    "solve_tril",
+]

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/_gdn_state_transpose.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/_gdn_state_transpose.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Triton kernels to gather/transpose/scatter GDN state between vLLM and PTPU layouts."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+_DEFAULT_BLOCK_K: int = 64
+_DEFAULT_BLOCK_V: int = 64
+
+
+@triton.jit
+def _fused_gather_transpose_kernel(
+    src_ptr,            # initial_state: (num_blocks, HV, V, K), contig bf16/fp16/fp32
+    idx_ptr,            # ssm_state_indices: (B,), int32
+    dst_ptr,            # scratch: (>=B, HV, K, V), contig (same dtype as src)
+    stride_src_n,       # initial_state.stride(0) = HV * V * K
+    stride_src_hv,      # initial_state.stride(1) = V * K
+    stride_src_v,       # initial_state.stride(2) = K
+    stride_src_k,       # initial_state.stride(3) = 1
+    stride_dst_b,       # scratch.stride(0) = HV * K * V
+    stride_dst_hv,      # scratch.stride(1) = K * V
+    stride_dst_k,       # scratch.stride(2) = V
+    stride_dst_v,       # scratch.stride(3) = 1
+    K,
+    V,
+    BLOCK_K: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+):
+    """One program handles one ``(b, hv, k_block, v_block)`` tile.
+
+    Reads ``initial_state[ssm_state_indices[b], hv, v_block, k_block]``
+    of shape ``(BLOCK_V, BLOCK_K)`` (V outer, K inner), transposes to
+    ``(BLOCK_K, BLOCK_V)``, and writes to
+    ``scratch[b, hv, k_block, v_block]``.
+    """
+    pid_b = tl.program_id(0)
+    pid_hv = tl.program_id(1)
+    pid_kv = tl.program_id(2)
+
+    # Decompose the (k_block, v_block) program id. Using row-major
+    # decomposition keeps adjacent ``pid_kv`` programs working on
+    # adjacent ``v_block`` tiles, which on PTPU favours coalesced reads
+    # of the K-innermost source layout (each ``v_block`` reads a full
+    # K row stripe).
+    num_v_blocks = tl.cdiv(V, BLOCK_V)
+    pid_k = pid_kv // num_v_blocks
+    pid_v = pid_kv % num_v_blocks
+
+    k_start = pid_k * BLOCK_K
+    v_start = pid_v * BLOCK_V
+
+    k_offs = k_start + tl.arange(0, BLOCK_K)
+    v_offs = v_start + tl.arange(0, BLOCK_V)
+    k_mask = k_offs < K
+    v_mask = v_offs < V
+
+    # Slot for this batch row. int32 source → int64 for stride
+    # arithmetic (state pools can be larger than 2^31 elements for
+    # high-throughput configs).
+    slot = tl.load(idx_ptr + pid_b).to(tl.int64)
+
+    src_offsets = (
+        slot * stride_src_n
+        + pid_hv * stride_src_hv
+        + v_offs[:, None] * stride_src_v
+        + k_offs[None, :] * stride_src_k
+    )
+    src_mask = v_mask[:, None] & k_mask[None, :]
+    src_tile = tl.load(src_ptr + src_offsets, mask=src_mask, other=0.0)
+
+    # Transpose in-register: (BLOCK_V, BLOCK_K) → (BLOCK_K, BLOCK_V).
+    # ``tl.trans`` is a metadata-only op on the in-SRAM tile; no extra
+    # memory traffic.
+    dst_tile = tl.trans(src_tile, 1, 0)
+
+    # Store dst tile in (K, V) layout.
+    dst_offsets = (
+        pid_b * stride_dst_b
+        + pid_hv * stride_dst_hv
+        + k_offs[:, None] * stride_dst_k
+        + v_offs[None, :] * stride_dst_v
+    )
+    dst_mask = k_mask[:, None] & v_mask[None, :]
+    tl.store(dst_ptr + dst_offsets, dst_tile, mask=dst_mask)
+
+
+@triton.jit
+def _fused_transpose_scatter_kernel(
+    src_ptr,            # scratch: (>=B, HV, K, V), contig (PTPU layout)
+    idx_ptr,            # ssm_state_indices: (B,), int32
+    dst_ptr,            # initial_state: (num_blocks, HV, V, K), contig (vLLM layout)
+    stride_src_b,       # scratch.stride(0)
+    stride_src_hv,      # scratch.stride(1)
+    stride_src_k,       # scratch.stride(2)
+    stride_src_v,       # scratch.stride(3)
+    stride_dst_n,       # initial_state.stride(0)
+    stride_dst_hv,      # initial_state.stride(1)
+    stride_dst_v,       # initial_state.stride(2)
+    stride_dst_k,       # initial_state.stride(3)
+    K,
+    V,
+    BLOCK_K: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+):
+    """One program handles one ``(b, hv, k_block, v_block)`` tile.
+
+    Reads ``scratch[b, hv, k_block, v_block]`` of shape
+    ``(BLOCK_K, BLOCK_V)`` (K outer, V inner), transposes to
+    ``(BLOCK_V, BLOCK_K)``, and writes to
+    ``initial_state[ssm_state_indices[b], hv, v_block, k_block]``.
+
+    Padding-row skip
+    ----------------
+    Rows where ``slot == 0`` (vLLM's ``NULL_BLOCK_ID``) skip the
+    writeback entirely. Matches FLA Triton's ``if state_idx <= 0:
+      and prevents:
+
+    1. Garbage state from cudagraph-padding rows polluting slot 0
+       (the reserved NULL slot).
+    2. Non-deterministic ``aten::index_put_``-style "last write wins"
+       races between concurrent programs all targeting slot 0 -- with
+       multiple padding rows this is a data race in Triton's
+       across-program execution model.
+
+    The unfused PyTorch ``initial_state[slot] = scratch.T(-1, -2)``
+    chain wrote whatever ``scratch`` happens to contain for padding
+    rows; in practice this was harmless because vLLM never reads slot 0,
+    but it was also undefined-order-dependent. The fused kernel makes
+    the behaviour explicit and deterministic.
+    """
+    pid_b = tl.program_id(0)
+    pid_hv = tl.program_id(1)
+    pid_kv = tl.program_id(2)
+
+    slot = tl.load(idx_ptr + pid_b).to(tl.int64)
+    # Padding-row skip: NULL_BLOCK_ID == 0 in vLLM, plus defensive guard
+    # against any future negative sentinel. Identical to FLA's
+    # ``state_idx <= 0`` check.
+    if slot <= 0:
+        return
+
+    num_v_blocks = tl.cdiv(V, BLOCK_V)
+    pid_k = pid_kv // num_v_blocks
+    pid_v = pid_kv % num_v_blocks
+
+    k_start = pid_k * BLOCK_K
+    v_start = pid_v * BLOCK_V
+
+    k_offs = k_start + tl.arange(0, BLOCK_K)
+    v_offs = v_start + tl.arange(0, BLOCK_V)
+    k_mask = k_offs < K
+    v_mask = v_offs < V
+
+    # Load src tile from scratch: (BLOCK_K, BLOCK_V).
+    src_offsets = (
+        pid_b * stride_src_b
+        + pid_hv * stride_src_hv
+        + k_offs[:, None] * stride_src_k
+        + v_offs[None, :] * stride_src_v
+    )
+    src_mask = k_mask[:, None] & v_mask[None, :]
+    src_tile = tl.load(src_ptr + src_offsets, mask=src_mask, other=0.0)
+
+    # Transpose: (BLOCK_K, BLOCK_V) → (BLOCK_V, BLOCK_K).
+    dst_tile = tl.trans(src_tile, 1, 0)
+
+    dst_offsets = (
+        slot * stride_dst_n
+        + pid_hv * stride_dst_hv
+        + v_offs[:, None] * stride_dst_v
+        + k_offs[None, :] * stride_dst_k
+    )
+    dst_mask = v_mask[:, None] & k_mask[None, :]
+    tl.store(dst_ptr + dst_offsets, dst_tile, mask=dst_mask)
+
+
+def gather_transpose_to_scratch(
+    initial_state: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    scratch: torch.Tensor,
+    block_k: int = _DEFAULT_BLOCK_K,
+    block_v: int = _DEFAULT_BLOCK_V,
+) -> None:
+    """Fused gather+transpose: copy slots out of vLLM's state pool into
+    PTPU-layout scratch in one Triton launch.
+
+    Equivalent to (but ~3 PyTorch launches less than):
+
+    .. code-block:: python
+
+        slot_idx.copy_(ssm_state_indices)             # int32 → int64
+        scratch.copy_(initial_state[slot_idx].transpose(-1, -2))
+
+    Args:
+        initial_state: vLLM state pool, shape
+            ``(num_blocks, HV, V, K)``, contiguous, any floating
+            dtype.
+        ssm_state_indices: per-sequence slot ids, shape ``(B,)``,
+            ``int32``. ``0`` is vLLM's ``NULL_BLOCK_ID`` for padding
+            rows (which read ``initial_state[0]`` -- guaranteed
+            all-zero by vLLM convention).
+        scratch: pre-allocated scratch in PTPU layout, shape
+            ``(>=B, HV, K, V)``, contiguous, same dtype as
+            ``initial_state``. Only the first ``B`` rows are written.
+        block_k, block_v: Triton compile-time tile shape. Defaults
+            ``(64, 64)`` give 4 tiles per ``(b, hv)`` for ``K = V =
+            128``.
+    """
+    B = ssm_state_indices.shape[0]
+    if B == 0:
+        return
+
+    HV, V, K = initial_state.shape[-3:]
+    assert scratch.shape[-3] == HV, (
+        f"scratch HV={scratch.shape[-3]} ≠ initial_state HV={HV}"
+    )
+    assert scratch.shape[-2] == K, (
+        f"scratch K dim ({scratch.shape[-2]}) must equal "
+        f"initial_state K ({K})"
+    )
+    assert scratch.shape[-1] == V, (
+        f"scratch V dim ({scratch.shape[-1]}) must equal "
+        f"initial_state V ({V})"
+    )
+    assert scratch.shape[0] >= B, (
+        f"scratch capacity {scratch.shape[0]} < B={B}"
+    )
+    assert initial_state.dtype == scratch.dtype, (
+        f"dtype mismatch: initial_state={initial_state.dtype}, "
+        f"scratch={scratch.dtype}"
+    )
+
+    num_kv_blocks = triton.cdiv(K, block_k) * triton.cdiv(V, block_v)
+    grid = (B, HV, num_kv_blocks)
+
+    _fused_gather_transpose_kernel[grid](
+        initial_state,
+        ssm_state_indices,
+        scratch,
+        initial_state.stride(-4),
+        initial_state.stride(-3),
+        initial_state.stride(-2),
+        initial_state.stride(-1),
+        scratch.stride(-4),
+        scratch.stride(-3),
+        scratch.stride(-2),
+        scratch.stride(-1),
+        K,
+        V,
+        BLOCK_K=block_k,
+        BLOCK_V=block_v,
+    )
+
+
+def transpose_scatter_to_pool(
+    scratch: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    initial_state: torch.Tensor,
+    block_k: int = _DEFAULT_BLOCK_K,
+    block_v: int = _DEFAULT_BLOCK_V,
+) -> None:
+    """Fused transpose+scatter: write PTPU-layout scratch back into
+    vLLM's state pool in one Triton launch.
+
+    Semantically equivalent to (but ~1 PyTorch launch less than):
+
+    .. code-block:: python
+
+        # NB: padding rows (slot_idx[b] == 0) DO NOT write back -- see
+        # below.
+        for b in range(B):
+            if ssm_state_indices[b] > 0:
+                initial_state[ssm_state_indices[b]] = (
+                    scratch[b].transpose(-1, -2)
+                )
+
+    Args:
+        scratch: PTPU-layout state, shape ``(>=B, HV, K, V)``,
+            contiguous.
+        ssm_state_indices: per-sequence slot ids, shape ``(B,)``,
+            ``int32``. Rows with ``slot <= 0`` (vLLM's NULL_BLOCK_ID
+            for padding) are **skipped** by the kernel -- matches
+            FLA Triton's ``state_idx <= 0`` skip path and avoids
+            non-deterministic races on slot 0.
+        initial_state: vLLM state pool, shape ``(num_blocks, HV, V,
+            K)``, contiguous.
+        block_k, block_v: Triton compile-time tile shape.
+    """
+    B = ssm_state_indices.shape[0]
+    if B == 0:
+        return
+
+    HV, V, K = initial_state.shape[-3:]
+    assert scratch.shape[-3] == HV
+    assert scratch.shape[-2] == K
+    assert scratch.shape[-1] == V
+    assert scratch.shape[0] >= B
+    assert initial_state.dtype == scratch.dtype
+
+    num_kv_blocks = triton.cdiv(K, block_k) * triton.cdiv(V, block_v)
+    grid = (B, HV, num_kv_blocks)
+
+    _fused_transpose_scatter_kernel[grid](
+        scratch,
+        ssm_state_indices,
+        initial_state,
+        scratch.stride(-4),
+        scratch.stride(-3),
+        scratch.stride(-2),
+        scratch.stride(-1),
+        initial_state.stride(-4),
+        initial_state.stride(-3),
+        initial_state.stride(-2),
+        initial_state.stride(-1),
+        K,
+        V,
+        BLOCK_K=block_k,
+        BLOCK_V=block_v,
+    )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/_helpers.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/_helpers.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Shared helpers for PTPU FLA wrappers."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+def ensure_chunk_indices(
+    cu_seqlens: Optional[torch.Tensor],
+    chunk_size: int,
+    chunk_indices: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    """Compute the FLA ``chunk_indices`` table when not supplied.
+
+    PTPU's per-stage kernels accept the same ``chunk_indices`` layout that
+    FLA emits via ``prepare_chunk_indices``; we only need to fall back to
+    computing it when the caller (typically FLA's own
+    ``chunk_gated_delta_rule_fwd`` orchestration) hasn't done so.
+    """
+    if chunk_indices is not None or cu_seqlens is None:
+        return chunk_indices
+    # Import lazily so this module can be loaded before the patch fires.
+    from vllm.model_executor.layers.fla.ops.index import prepare_chunk_indices
+
+    return prepare_chunk_indices(cu_seqlens, chunk_size)
+
+
+def ensure_chunk_offsets(
+    cu_seqlens: Optional[torch.Tensor],
+    chunk_size: int,
+    chunk_offsets: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    """Compute FLA's ``chunk_offsets`` table when not supplied."""
+    if chunk_offsets is not None or cu_seqlens is None:
+        return chunk_offsets
+    from vllm.model_executor.layers.fla.ops.index import prepare_chunk_offsets
+
+    return prepare_chunk_offsets(cu_seqlens, chunk_size)

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/chunk_fwd_o.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/chunk_fwd_o.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU drop-in for ``fla.ops.chunk_o.chunk_fwd_o``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from ._helpers import ensure_chunk_indices
+
+
+def chunk_fwd_o(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+    chunk_size: int = 64,
+) -> torch.Tensor:
+    """Compute the chunked attention output ``o`` on PTPU.
+
+    The PTPU sgl wrapper writes into a pre-allocated ``o`` and takes a
+    ``B_times_H`` hint for grid sizing. FLA, by contrast, allocates ``o``
+    internally and returns it; we replicate the FLA contract here.
+
+    Falls back to FLA when ``cu_seqlens`` is None (fixed-length / batched
+    layout), since PTPU's variant requires both ``cu_seqlens`` and
+    ``chunk_indices`` to be populated.
+    """
+    if cu_seqlens is None:
+        from vllm.model_executor.layers.fla.ops.chunk_o import (
+            chunk_fwd_o as _fla_chunk_fwd_o,
+        )
+
+        return _fla_chunk_fwd_o(
+            q,
+            k,
+            v,
+            h,
+            g=g,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            chunk_size=chunk_size,
+        )
+
+    chunk_indices = ensure_chunk_indices(cu_seqlens, chunk_size, chunk_indices)
+
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    o = torch.empty_like(v)
+
+    # FLA shapes: q [B, T, Hg, K], v [B, T, H, V]; B_times_H == B * H.
+    # ``q.shape[0]`` is always 1 in the varlen prefill path, but compute it
+    # generically to remain correct for any future caller.
+    B = q.shape[0]
+    H = v.shape[-2]
+    B_times_H = B * H
+
+    from torch_ptpu.sgl_kernel import chunk_fwd_o as _ptpu_chunk_fwd_o
+
+    _ptpu_chunk_fwd_o(q, k, v, h, g, o, cu_seqlens, chunk_indices, scale, B_times_H)
+    return o

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/chunk_h.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/chunk_h.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU drop-in for ``fla.ops.chunk_delta_h.chunk_gated_delta_rule_fwd_h``.
+
+This is the sixth (and previously last-remaining) GDN prefill stage. It
+computes the per-chunk hidden state ``h`` and (optionally) the recomputed
+``v_new`` and a packed ``final_state`` tensor that the orchestrator hands
+back to the SSM cache.
+
+Contract translation
+--------------------
+FLA's stage returns ``(h, v_new, final_state)``:
+
+* ``h``         : ``(B, NT, H, V, K)`` per-chunk recurrent state, dtype = ``k.dtype``
+* ``v_new``     : ``(B, T, H, V)`` (same as ``u``) – recomputed values, or ``None``
+* ``final_state``: ``(N, H, V, K)`` float32, or ``None`` when
+                  ``output_final_state=False``
+
+PTPU's ``chunk_delta_h_fwd`` writes ``h`` (and optionally ``v_new``) in
+place and treats ``initial_state`` as a *single* read-modify-write buffer
+that contains the per-sequence prior state on entry and the per-sequence
+final state on return. To preserve FLA's "fresh ``final_state`` output"
+semantics without mutating the caller's ``initial_state``, we allocate
+our own float32 buffer, seed it with the caller's initial state (or zero
+when none was supplied), pass it to PTPU as ``initial_state``, and hand
+it back as ``final_state``.
+
+State layout transpose (critical correctness note)
+--------------------------------------------------
+The PTPU SGL ``chunk_delta_h_fwd`` / ``fused_sigmoid_gating_delta_rule_update``
+kernels store the recurrent state as ``[K_row, V_col]`` — V is the
+inner contiguous dim (``offset = k*V + v``). FLA / vLLM allocate it as
+``[V_row, K_col]`` — K is the inner dim (``offset = v*K + k``). When
+``head_k_dim == head_v_dim`` (the Qwen3.5-4B case) both layouts share
+the same memory size and outer strides, so the kernel does **not**
+crash on a layout mismatch — it just produces a transposed result.
+
+To guarantee the ``final_state`` we hand back to vLLM follows the
+documented FLA contract (``[N, H, V, K]`` with ``offset = v*K + k``),
+we allocate a PTPU-native ``[N, H, K, V]`` working buffer here, copy
+the caller's initial state into it with ``transpose(-1, -2)`` first,
+let PTPU do its in-place update, then transpose the buffer back into
+the FLA-shaped ``final_state`` tensor before returning.
+
+Fallback paths
+--------------
+* ``gk is not None`` (KDA-style gating)            -> FLA Triton.
+* ``cu_seqlens is None`` (fixed-length / batched)  -> FLA Triton.
+  vLLM's varlen prefill always supplies ``cu_seqlens``; this branch only
+  guards offline test paths and warmup runs that exercise the batched
+  shape.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+
+from ._helpers import ensure_chunk_offsets
+
+
+def _fla_fallback(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: Optional[torch.Tensor],
+    gk: Optional[torch.Tensor],
+    initial_state: Optional[torch.Tensor],
+    output_final_state: bool,
+    chunk_size: int,
+    save_new_value: bool,
+    cu_seqlens: Optional[torch.Tensor],
+    chunk_indices: Optional[torch.Tensor],
+    chunk_offsets: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+    from vllm.model_executor.layers.fla.ops.chunk_delta_h import (
+        chunk_gated_delta_rule_fwd_h as _fla_chunk_gated_delta_rule_fwd_h,
+    )
+
+    return _fla_chunk_gated_delta_rule_fwd_h(
+        k=k,
+        w=w,
+        u=u,
+        g=g,
+        gk=gk,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        chunk_size=chunk_size,
+        save_new_value=save_new_value,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
+    )
+
+
+def chunk_gated_delta_rule_fwd_h(
+    k: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    gk: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    chunk_size: int = 64,
+    save_new_value: bool = True,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+    chunk_offsets: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
+    # PTPU does not surface a ``gk`` path, and ``cu_seqlens`` is mandatory
+    # for the varlen kernel — bail to FLA for anything else.
+    if gk is not None or cu_seqlens is None:
+        return _fla_fallback(
+            k, w, u, g, gk, initial_state, output_final_state,
+            chunk_size, save_new_value,
+            cu_seqlens, chunk_indices, chunk_offsets,
+        )
+
+    B, T, Hg, K = k.shape
+    H, V = u.shape[-2], u.shape[-1]
+    BT = chunk_size
+
+    chunk_offsets = ensure_chunk_offsets(cu_seqlens, BT, chunk_offsets)
+    # PTPU's ``chunk_delta_h_fwd`` is strict about its index tensor dtype
+    # (must be int32). FLA's ``prepare_chunk_offsets`` inherits the dtype
+    # of ``cu_seqlens``, which is int64 on vLLM v1's attention metadata,
+    # so we cast here. Cheap: this tensor is tiny (one int per chunk).
+    if chunk_offsets.dtype != torch.int32:
+        chunk_offsets = chunk_offsets.to(torch.int32)
+
+    # NT must match FLA's allocation: ``len(chunk_indices)`` if cu_seqlens
+    # is provided. We derive it from ``chunk_offsets[-1]`` to avoid forcing
+    # a chunk_indices materialization when the caller didn't pass one.
+    NT = int(chunk_offsets[-1].item())
+    N = cu_seqlens.numel() - 1
+
+    h = k.new_empty(B, NT, H, V, K)
+    v_new = torch.empty_like(u) if save_new_value else None
+
+    # PTPU writes the per-sequence final state back into the same buffer it
+    # reads ``initial_state`` from. To match FLA's contract ("return a
+    # fresh ``final_state`` tensor, leave the caller's ``initial_state``
+    # untouched") we own that buffer here, AND we own the layout: PTPU
+    # speaks ``[K, V]`` (V inner) while FLA / vLLM speak ``[V, K]`` (K
+    # inner). See the module docstring for the full background.
+    #
+    # Critical: PTPU's kernel only reads / writes ``initial_state`` when
+    # BOTH ``initial_state`` and ``initial_state_indices`` are non-null
+    # (see ``chunk_delta_h_fwd.cc`` ``use_initial_state``). When we want
+    # the kernel to populate ``final_state`` we MUST pass a slot-id table,
+    # otherwise the kernel runs with ``USE_INITIAL_STATE=false`` and
+    # ``INPLACE_UPDATE=false`` -> ``ptpu_state_buf`` stays at its
+    # zero-initialised contents and we silently return the wrong final
+    # state to vLLM. That zero ``final_state`` becomes the seed of the
+    # next decode step's recurrent state, breaking GDN-derived context for
+    # subsequent tokens. (Manifests dramatically on Qwen3.5-9B with very
+    # short prompts; on Qwen3.5-4B the per-chunk ``h`` carries enough
+    # local context that the regression was below the smoke-test floor.)
+    if output_final_state or initial_state is not None:
+        # Working buffer in PTPU's native [N, H, K, V] layout (V inner).
+        ptpu_state_buf: Optional[torch.Tensor] = k.new_empty(
+            N, H, K, V, dtype=torch.float32
+        )
+        if initial_state is not None:
+            # vLLM hands us [N, H, V, K]. Transpose into PTPU's [N, H, K, V]
+            # convention while seeding the buffer.
+            ptpu_state_buf.copy_(initial_state.transpose(-1, -2))
+        else:
+            ptpu_state_buf.zero_()
+        # One slot per sequence; layout matches the buffer above.
+        initial_state_indices = torch.arange(
+            N, dtype=torch.int32, device=k.device
+        )
+    else:
+        ptpu_state_buf = None
+        initial_state_indices = None
+
+    from torch_ptpu.sgl_kernel import chunk_delta_h_fwd as _ptpu_chunk_delta_h_fwd
+
+    _ptpu_chunk_delta_h_fwd(
+        k=k,
+        v=u,
+        w=w,
+        h=h,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        v_new=v_new,
+        initial_state_indices=initial_state_indices,
+        initial_state=ptpu_state_buf,
+        g=g,
+        gk=gk,
+    )
+
+    # Convert PTPU's [N, H, K, V] result back into FLA's [N, H, V, K]
+    # contract before returning.
+    if output_final_state:
+        assert ptpu_state_buf is not None
+        final_state = ptpu_state_buf.transpose(-1, -2).contiguous()
+    else:
+        final_state = None
+    return h, v_new, final_state

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/chunk_scaled_dot_kkt.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/chunk_scaled_dot_kkt.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU drop-in for ``fla.ops.chunk_scaled_dot_kkt.chunk_scaled_dot_kkt_fwd``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from ._helpers import ensure_chunk_indices
+
+
+def chunk_scaled_dot_kkt_fwd(
+    k: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+    chunk_size: int = 64,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Compute ``beta * K @ K^T`` decayed by ``g`` on PTPU.
+
+    The PTPU sgl wrapper expects all of ``(k, beta, g_cumsum, cu_seqlens,
+    chunk_indices)``; fall back to FLA when ``beta`` / ``cu_seqlens`` are
+    missing (the GDN prefill orchestrator always supplies both, so this is
+    a safety net for unusual callers).
+    """
+    if beta is None or cu_seqlens is None:
+        from vllm.model_executor.layers.fla.ops.chunk_scaled_dot_kkt import (
+            chunk_scaled_dot_kkt_fwd as _fla_chunk_scaled_dot_kkt_fwd,
+        )
+
+        return _fla_chunk_scaled_dot_kkt_fwd(
+            k,
+            g=g,
+            beta=beta,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            chunk_size=chunk_size,
+            output_dtype=output_dtype,
+        )
+
+    chunk_indices = ensure_chunk_indices(cu_seqlens, chunk_size, chunk_indices)
+
+    from torch_ptpu.sgl_kernel import (
+        chunk_scaled_dot_kkt as _ptpu_chunk_scaled_dot_kkt,
+    )
+
+    A = _ptpu_chunk_scaled_dot_kkt(k, beta, g, cu_seqlens, chunk_indices)
+    # FLA pins this to float32 downstream; PTPU should already emit float32,
+    # but cast defensively to keep the contract identical.
+    if A.dtype != output_dtype:
+        A = A.to(output_dtype)
+    return A

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/cumsum.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/cumsum.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU drop-in for ``vllm.model_executor.layers.fla.ops.cumsum.chunk_local_cumsum``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from ._helpers import ensure_chunk_indices
+
+
+def chunk_local_cumsum(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+    head_first: bool = False,
+    output_dtype: Optional[torch.dtype] = torch.float,
+    **kwargs,
+) -> torch.Tensor:
+    """Per-chunk cumulative-sum of the gating tensor on PTPU.
+
+    Mirrors the FLA signature (scalar / vector / head_first variants). PTPU's
+    ``chunk_local_cumsum`` always operates ``reverse=False`` / ``head_first=
+    False``, which is exactly what GDN prefill emits. For any non-default
+    knob we defer to FLA to keep semantics identical and avoid surprising
+    out-of-band callers.
+
+    PTPU also requires ``cu_seqlens`` (and a matching ``chunk_indices``
+    table); when ``cu_seqlens`` is ``None`` (fixed-length batch) we fall
+    back to FLA. The GDN prefill orchestrator always runs varlen, so the
+    fallback is purely a safety net.
+    """
+    if reverse or head_first or cu_seqlens is None:
+        from vllm.model_executor.layers.fla.ops.cumsum import (
+            chunk_local_cumsum as _fla_chunk_local_cumsum,
+        )
+
+        return _fla_chunk_local_cumsum(
+            g,
+            chunk_size,
+            reverse=reverse,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            head_first=head_first,
+            output_dtype=output_dtype,
+            **kwargs,
+        )
+
+    chunk_indices = ensure_chunk_indices(cu_seqlens, chunk_size, chunk_indices)
+
+    from torch_ptpu.sgl_kernel import (
+        chunk_local_cumsum as _ptpu_chunk_local_cumsum,
+    )
+
+    return _ptpu_chunk_local_cumsum(g, cu_seqlens, chunk_indices, output_dtype)

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/fused_recurrent_packed_decode.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/fused_recurrent_packed_decode.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU wrapper for FLA packed-decode GDN; transposes state layout and calls native kernel."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from ._gdn_state_transpose import (
+    gather_transpose_to_scratch,
+    transpose_scatter_to_pool,
+)
+
+
+# Pre-allocated scratch buffers for cudagraph-safe decode.
+
+_DEFAULT_HEADROOM: int = 256
+
+_PTPU_STATE_SCRATCH: "dict[tuple, torch.Tensor]" = {}
+_ARANGE_BUF: "dict[tuple, torch.Tensor]" = {}
+
+
+def _next_capacity(needed: int, current: int) -> int:
+    """Doubling-grow capacity, never below ``_DEFAULT_HEADROOM``."""
+    target = max(needed, _DEFAULT_HEADROOM)
+    if current > 0:
+        target = max(target, current * 2)
+    return target
+
+
+def _ensure_state_scratch(
+    B: int,
+    HV: int,
+    K: int,
+    V: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Lazy-init/return scratch of shape ``(>=B, HV, K, V)`` in PTPU layout.
+
+    Re-allocates (and drops the previous buffer) only when ``B`` exceeds the
+    current capacity. Once allocated, the buffer's ``data_ptr()`` is stable
+    -- captured graphs hold this pointer; replays reuse the same memory.
+    """
+    key = (device, dtype, HV, K, V)
+    buf = _PTPU_STATE_SCRATCH.get(key)
+    cur = 0 if buf is None else buf.shape[0]
+    if buf is None or cur < B:
+        new_capacity = _next_capacity(B, cur)
+        buf = torch.empty(new_capacity, HV, K, V, device=device, dtype=dtype)
+        _PTPU_STATE_SCRATCH[key] = buf
+    return buf
+
+
+def _ensure_arange_buf(
+    min_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Lazy-init/return an ``arange(>=min_size)`` buffer.
+
+    Used for both ``cu_seqlens`` (size ``B+1``) and ``local_indices``
+    (size ``B``). Both are int32 contiguous integer sequences, so a single
+    ``arange`` of ``B+1`` elements covers both via slicing.
+    """
+    key = (device, dtype)
+    buf = _ARANGE_BUF.get(key)
+    cur = 0 if buf is None else buf.numel()
+    if buf is None or cur < min_size:
+        new_capacity = _next_capacity(min_size, cur)
+        buf = torch.arange(new_capacity, device=device, dtype=dtype)
+        _ARANGE_BUF[key] = buf
+    return buf
+
+
+def fused_recurrent_gated_delta_rule_packed_decode(
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    out: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """PTPU-native re-implementation of FLA's packed-decode GDN fast path.
+
+    Parameters mirror
+    ``vllm.model_executor.layers.fla.ops.fused_recurrent_gated_delta_rule_packed_decode``
+    1:1. The function writes its result into ``out`` (in place) and into
+    ``initial_state`` (via ``ssm_state_indices`` slots), then returns the
+    same ``(out, initial_state)`` tuple the upstream wrapper would.
+    """
+    # Any shape outside what PTPU's fused_sigmoid_gating_delta_rule_update
+    # supports falls through to the saved-original FLA Triton callable.
+    if initial_state is None or ssm_state_indices is None:
+        return _fallback(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=initial_state,
+            out=out,
+            ssm_state_indices=ssm_state_indices,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+
+    if mixed_qkv.ndim != 2:
+        return _fallback(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=initial_state,
+            out=out,
+            ssm_state_indices=ssm_state_indices,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+
+    if ssm_state_indices.ndim != 1:
+        # PTPU's per-call slot indexing assumes a 1-D ``initial_state_indices``;
+        # the packed_decode contract guarantees this but be defensive.
+        return _fallback(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=initial_state,
+            out=out,
+            ssm_state_indices=ssm_state_indices,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+
+    B = mixed_qkv.shape[0]
+    if initial_state.ndim != 4:
+        return _fallback(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=initial_state,
+            out=out,
+            ssm_state_indices=ssm_state_indices,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+
+    HV, V, K = initial_state.shape[-3:]
+    qkv_dim = mixed_qkv.shape[1]
+    qk_dim_total = qkv_dim - HV * V
+    if qk_dim_total <= 0 or qk_dim_total % 2 != 0:
+        return _fallback(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=initial_state,
+            out=out,
+            ssm_state_indices=ssm_state_indices,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+    q_dim = qk_dim_total // 2
+    if q_dim % K != 0:
+        return _fallback(
+            mixed_qkv=mixed_qkv,
+            a=a,
+            b=b,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=initial_state,
+            out=out,
+            ssm_state_indices=ssm_state_indices,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        )
+    H = q_dim // K
+
+    q_flat = mixed_qkv[:, 0:H * K]
+    k_flat = mixed_qkv[:, H * K:2 * H * K]
+    v_flat = mixed_qkv[:, 2 * H * K:]
+    q = q_flat.view(1, B, H, K)
+    k = k_flat.view(1, B, H, K)
+    v = v_flat.view(1, B, HV, V)
+
+    device = mixed_qkv.device
+    state_dtype = initial_state.dtype
+
+    state_scratch_full = _ensure_state_scratch(B, HV, K, V, device, state_dtype)
+    ptpu_state_buf = state_scratch_full[:B]  # view, no allocation
+
+    arange_full = _ensure_arange_buf(B + 1, device, torch.int32)
+    cu_seqlens = arange_full[:B + 1]      # view
+    local_indices = arange_full[:B]        # view
+
+    # Gather/transpose state into PTPU layout scratch.
+    gather_transpose_to_scratch(initial_state, ssm_state_indices, ptpu_state_buf)
+
+    from torch_ptpu.sgl_kernel import (
+        fused_sigmoid_gating_delta_rule_update as _ptpu_fused_sigmoid_gating,
+    )
+
+    o = _ptpu_fused_sigmoid_gating(
+        A_log,
+        a,
+        dt_bias,
+        1.0,
+        20.0,
+        q,
+        k,
+        v,
+        b,
+        ptpu_state_buf,
+        local_indices,
+        scale=scale,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        cu_seqlens=cu_seqlens,
+        is_kda=False,
+    )
+    # Copy kernel output into caller buffer.
+    out.squeeze(1).copy_(o.squeeze(0))
+
+    # Scatter updated state back to vLLM layout.
+    transpose_scatter_to_pool(ptpu_state_buf, ssm_state_indices, initial_state)
+
+    return out, initial_state
+
+
+def _fallback(
+    *,
+    mixed_qkv: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    scale: float,
+    initial_state: Optional[torch.Tensor],
+    out: torch.Tensor,
+    ssm_state_indices: Optional[torch.Tensor],
+    use_qk_l2norm_in_kernel: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fallback to the original FLA Triton packed_decode implementation.
+
+    Uses the snapshot saved by ``patch_fla_ops.apply_patch`` so we don't
+    recurse through the module-level rebind that installed this wrapper.
+    """
+    from ...patches.patch_fla_ops import (
+        get_orig_fused_recurrent_gated_delta_rule_packed_decode,
+    )
+
+    orig = get_orig_fused_recurrent_gated_delta_rule_packed_decode()
+    if orig is None:
+        from vllm.model_executor.layers.fla.ops.fused_recurrent import (
+            fused_recurrent_gated_delta_rule_packed_decode as orig,
+        )
+
+    return orig(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=scale,
+        initial_state=initial_state,
+        out=out,
+        ssm_state_indices=ssm_state_indices,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+    )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/fused_sigmoid_gating.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/fused_sigmoid_gating.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU wrapper for fused_sigmoid_gating_delta_rule_update with state layout transpose."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+
+
+def fused_sigmoid_gating_delta_rule_update(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    inplace_final_state: bool = True,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    ssm_state_indices: Optional[torch.Tensor] = None,
+    num_accepted_tokens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    is_kda: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Single-step fused GDN decode kernel on PTPU.
+
+    PTPU's variant always writes ``final_state`` in-place into
+    ``initial_state_source``; FLA returns it as a separate tensor when
+    ``inplace_final_state=False``. The hot path in
+    ``GatedDeltaNetAttention._forward_core`` always sets
+    ``inplace_final_state=True`` with ``initial_state=ssm_state``, so the
+    PTPU contract matches directly: we return ``(o, ssm_state)``.
+
+    The ``num_accepted_tokens`` argument exists only for speculative
+    decoding and is not used by Qwen3.5 today; PTPU does not expose an
+    equivalent. We fall back to FLA whenever ``num_accepted_tokens`` is
+    set or when ``initial_state`` / ``ssm_state_indices`` are absent (the
+    paged-decode contract PTPU expects).
+    """
+    if (
+        not inplace_final_state
+        or initial_state is None
+        or ssm_state_indices is None
+        or num_accepted_tokens is not None
+    ):
+        # Use the saved un-patched FLA Triton original to avoid
+        # infinite recursion: the module-level name on
+        # ``vllm.model_executor.layers.fla.ops.fused_sigmoid_gating``
+        # has been rebound to point to *this* function by
+        # ``patch_fla_ops.apply_patch``.
+        from ...patches.patch_fla_ops import (
+            get_orig_fused_sigmoid_gating_delta_rule_update,
+        )
+
+        _fla_fused_sigmoid_gating = (
+            get_orig_fused_sigmoid_gating_delta_rule_update()
+        )
+        if _fla_fused_sigmoid_gating is None:
+            from vllm.model_executor.layers.fla.ops.fused_sigmoid_gating import (
+                fused_sigmoid_gating_delta_rule_update as _fla_fused_sigmoid_gating,  # noqa: E501
+            )
+
+        return _fla_fused_sigmoid_gating(
+            A_log=A_log,
+            a=a,
+            b=b,
+            dt_bias=dt_bias,
+            q=q,
+            k=k,
+            v=v,
+            beta=beta,
+            threshold=threshold,
+            scale=scale,
+            initial_state=initial_state,
+            inplace_final_state=inplace_final_state,
+            cu_seqlens=cu_seqlens,
+            ssm_state_indices=ssm_state_indices,
+            num_accepted_tokens=num_accepted_tokens,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            is_kda=is_kda,
+        )
+
+    from torch_ptpu.sgl_kernel import (
+        fused_sigmoid_gating_delta_rule_update as _ptpu_fused_sigmoid_gating,
+    )
+
+    # Layout transpose: vLLM's ``ssm_state`` is laid out [num_blocks, HV, V, K]
+    # but PTPU's kernel expects [slot, HV, K, V]. Build a small per-call
+    # working buffer that contains only the slots referenced by
+    # ``ssm_state_indices``, transposed into PTPU's layout. After the
+    # kernel runs we transpose the buffer back and scatter into the
+    # caller's ``initial_state`` tensor (= ``ssm_state``) so vLLM keeps
+    # its expected on-disk layout.
+    #
+    # This is also strictly cheaper than transposing the full state pool
+    # in/out per call: only B (not num_blocks) slots are touched.
+    slot_idx = ssm_state_indices.to(torch.int64)
+    state_slots_fla = initial_state.index_select(0, slot_idx)  # [B, HV, V, K]
+    ptpu_state_buf = state_slots_fla.transpose(-1, -2).contiguous()  # [B, HV, K, V]
+    # The kernel keys slots through ``ssm_state_indices`` as well, so we
+    # need to remap indices to ``arange(B)`` to address ``ptpu_state_buf``.
+    local_indices = torch.arange(
+        slot_idx.numel(), device=slot_idx.device, dtype=ssm_state_indices.dtype
+    )
+
+    o = _ptpu_fused_sigmoid_gating(
+        A_log,
+        a,
+        dt_bias,
+        beta,
+        threshold,
+        q,
+        k,
+        v,
+        b,
+        ptpu_state_buf,
+        local_indices,
+        scale=scale,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        cu_seqlens=cu_seqlens,
+        is_kda=is_kda,
+    )
+
+    # Scatter updated state slots back into the pool.
+    src_back = ptpu_state_buf.transpose(-1, -2).contiguous().to(initial_state.dtype)
+    initial_state[slot_idx] = src_back
+    return o, initial_state

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/l2norm.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/l2norm.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU drop-in for ``fla.ops.l2norm.l2norm_fwd``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+def l2norm_fwd(
+    x: torch.Tensor,
+    eps: float = 1e-6,
+    output_dtype: Optional[torch.dtype] = None,
+) -> torch.Tensor:
+    """Last-axis L2 normalization on PTPU.
+
+    Mirrors FLA's contract (returns a tensor with the same shape; only the
+    last dim is normalized). The FLA helper additionally collapses the
+    leading dims to a 2D matrix before passing to its Triton kernel — we
+    don't need that with PTPU since ``F.normalize`` (and its accelerated
+    counterpart) works on the last dim regardless of rank.
+    """
+    from torch_ptpu.sgl_kernel import ptpu_l2_normalize as _ptpu_l2_normalize
+
+    out = _ptpu_l2_normalize(x, p=2.0, dim=-1, eps=eps)
+    if output_dtype is not None and out.dtype != output_dtype:
+        out = out.to(output_dtype)
+    return out

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/solve_tril.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/solve_tril.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU drop-in for ``fla.ops.solve_tril.solve_tril``."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# When PTPU's ``solve_tril`` rejects our index tables for any reason
+# (e.g. an unexpected layout requirement we can't reverse-engineer), we
+# permanently fall back to FLA Triton in this process to avoid retrying
+# on every chunk. A single warning is emitted on first failure.
+_PTPU_SOLVE_TRIL_DISABLED = False
+
+
+def _fla_fallback(
+    A: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor],
+    chunk_indices: Optional[torch.Tensor],
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    from vllm.model_executor.layers.fla.ops.solve_tril import (
+        solve_tril as _fla_solve_tril,
+    )
+
+    return _fla_solve_tril(
+        A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        output_dtype=output_dtype,
+    )
+
+
+def solve_tril(
+    A: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+    output_dtype: torch.dtype = torch.float,
+) -> torch.Tensor:
+    """Solve ``(I + A)^-1`` for strictly lower-triangular ``A`` on PTPU.
+
+    PTPU's ``solve_tril`` (for ``BT > 16``) is a two-phase algorithm:
+
+    1. **phase 1** — solve each 16×16 sub-block independently. Driven
+       by a chunk-index table built at ``chunk_size=16``.
+    2. **merge** — recursively combine the 16×16 inverses into the
+       full ``BT×BT`` inverse. Driven by a chunk-index table built at
+       ``chunk_size=BT`` (typically 64 for GDN), which happens to be
+       the same layout FLA passes for its single-phase kernel.
+
+    The ``BT == 16`` fast path collapses into a single phase and PTPU
+    accepts ``chunk_indices_merge=None`` for that case.
+
+    Any unexpected rejection by the C++ kernel triggers a one-shot fall
+    back to FLA Triton (process-wide) so correctness is never traded
+    for performance.
+    """
+    global _PTPU_SOLVE_TRIL_DISABLED
+
+    if A.dtype != torch.float32:
+        # PTPU strictly requires float32 input; FLA pipeline always
+        # supplies float32, but defer if a caller somehow violates it.
+        return _fla_fallback(A, cu_seqlens, chunk_indices, output_dtype)
+
+    if _PTPU_SOLVE_TRIL_DISABLED:
+        return _fla_fallback(A, cu_seqlens, chunk_indices, output_dtype)
+
+    BT = A.shape[-1]
+
+    # PTPU requires explicit ``chunk_indices_*`` tables whenever
+    # ``cu_seqlens`` is provided AND ``BT > 16``. Build them from
+    # FLA's helper so the layout matches what the rest of the pipeline
+    # expects.
+    chunk_indices_phase1 = None
+    chunk_indices_merge = None
+    if cu_seqlens is not None:
+        from vllm.model_executor.layers.fla.ops.index import (
+            prepare_chunk_indices,
+        )
+
+        if BT > 16:
+            chunk_indices_phase1 = prepare_chunk_indices(cu_seqlens, 16)
+            chunk_indices_merge = (
+                chunk_indices
+                if chunk_indices is not None
+                else prepare_chunk_indices(cu_seqlens, BT)
+            )
+        else:
+            # BT == 16: single-phase path, only phase1 indices needed.
+            chunk_indices_phase1 = (
+                chunk_indices
+                if chunk_indices is not None
+                else prepare_chunk_indices(cu_seqlens, BT)
+            )
+
+    from torch_ptpu.sgl_kernel import solve_tril as _ptpu_solve_tril
+
+    try:
+        return _ptpu_solve_tril(
+            A,
+            cu_seqlens=cu_seqlens,
+            output_dtype=output_dtype,
+            chunk_indices_phase1=chunk_indices_phase1,
+            chunk_indices_merge=chunk_indices_merge,
+        )
+    except (RuntimeError, ValueError) as exc:
+        # One-shot fallback: PTPU rejected our index layout. Log once
+        # with the relevant shapes so we can iterate offline, then
+        # permanently route this op through FLA Triton.
+        _PTPU_SOLVE_TRIL_DISABLED = True
+        logger.warning(
+            "PTPU solve_tril rejected our index tables (BT=%d, "
+            "cu_seqlens=%s, phase1=%s, merge=%s): %s. Falling back to "
+            "FLA Triton for solve_tril for the rest of this process.",
+            BT,
+            None if cu_seqlens is None else tuple(cu_seqlens.shape),
+            None if chunk_indices_phase1 is None else tuple(chunk_indices_phase1.shape),
+            None if chunk_indices_merge is None else tuple(chunk_indices_merge.shape),
+            exc,
+        )
+        return _fla_fallback(A, cu_seqlens, chunk_indices, output_dtype)

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/wy_fast.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fla/wy_fast.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU drop-in for ``fla.ops.wy_fast.recompute_w_u_fwd``."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+
+from ._helpers import ensure_chunk_indices
+
+
+def recompute_w_u_fwd(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g_cumsum: torch.Tensor,
+    A: torch.Tensor,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    chunk_indices: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Recompute (w, u) given (k, v, beta, g_cumsum, A) on PTPU.
+
+    Note the parameter-order subtlety: FLA passes ``(g_cumsum, A)`` while
+    PTPU's wrapper takes ``(A, g_cumsum)`` — easy to get wrong.
+    """
+    # PTPU's recompute_w_u_fwd needs both ``A`` (chunk-tril decomposition)
+    # and the chunk index table to navigate variable-length sequences.
+    chunk_indices = ensure_chunk_indices(
+        cu_seqlens,
+        # ``A.shape[-1]`` is the chunk size FLA used (typically 64).
+        A.shape[-1],
+        chunk_indices,
+    )
+
+    from torch_ptpu.sgl_kernel import recompute_w_u_fwd as _ptpu_recompute_w_u_fwd
+
+    return _ptpu_recompute_w_u_fwd(
+        k,
+        v,
+        beta,
+        A,
+        g_cumsum,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+    )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/fused_moe.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/fused_moe.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Sunrise MoE helper fallbacks (topk_softmax, moe_sum, moe_align_block_size)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from vllm.utils.math_utils import round_up
+
+
+def topk_softmax_sunrise(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """PyTorch-native ``topk_softmax`` for PTPU.
+
+    Matches the contract of the FlagGems and CUDA implementations:
+
+    * ``gating_output``  ``[num_tokens, num_experts]`` — raw router logits.
+    * ``topk_weights``   ``[num_tokens, top_k]``      — *output*, in-place,
+      typically ``float32``.
+    * ``topk_indices``   ``[num_tokens, top_k]``      — *output*, in-place,
+      typically ``int32`` or ``int64``.
+    * ``token_expert_indices`` ``[num_tokens, top_k]`` — allocated by the
+      caller; vLLM's ``fused_topk`` helper immediately discards it (see
+      ``vllm_fl/ops/fused_moe/router.py::fused_topk``), so we deliberately
+      do **not** write to it. This matches the existing
+      ``_native_topk_with_bias`` patch in ``sunrise/patch.py``.
+    * ``renormalize``    — when ``True``, the top-k weights are rescaled
+      to sum to 1 *after* selection (standard MoE router renormalisation,
+      matching vLLM ``FusedTopKRouter``).
+
+    Numerical notes:
+
+    * Softmax runs in the gating dtype (PTPU softmax accumulates in fp32).
+    * Uses unsorted ``torch.topk`` (``sorted=False``) because vLLM's
+      downstream MoE kernels don't require sorted top-k.
+
+    Returns ``(topk_weights, topk_indices)`` (the same handles passed in)
+    so callers can use either positional or chained access.
+    """
+    if gating_output.dim() != 2:
+        raise ValueError(
+            "topk_softmax_sunrise: gating_output must be 2-D "
+            f"[num_tokens, num_experts]; got shape {tuple(gating_output.shape)}"
+        )
+
+    top_k = topk_weights.shape[-1]
+
+    scores = gating_output.softmax(dim=-1)
+
+    chosen_indices = torch.topk(scores, k=top_k, dim=-1, sorted=False).indices
+    chosen_weights = scores.gather(dim=-1, index=chosen_indices)
+    if renormalize:
+        chosen_weights = chosen_weights / chosen_weights.sum(dim=-1, keepdim=True)
+
+    topk_weights.copy_(chosen_weights.to(topk_weights.dtype))
+    topk_indices.copy_(chosen_indices.to(topk_indices.dtype))
+    return topk_weights, topk_indices
+
+
+def moe_sum_sunrise(inp: torch.Tensor, out: torch.Tensor) -> None:
+    """Reduce ``inp`` across its top-k axis into ``out``.
+
+    Contract matches vLLM's ``moe_sum`` op:
+
+    * ``inp`` shape ``[..., top_k, hidden]`` — per-token, per-expert
+      outputs already weighted by the router.
+    * ``out`` shape ``[..., hidden]``         — *output*, in-place.
+
+    Precision: for ``bf16`` / ``fp16`` inputs we **must** match FlagGems'
+    Triton kernel, which accumulates in ``float32`` and only casts on store
+    (see FlagGems ``moe_sum``). A plain bf16 ``torch.sum`` on PTPU can
+    accumulate in the output dtype and lose precision across many layers.
+    """
+    if inp.dim() < 2 or out.dim() < 1:
+        raise ValueError(
+            "moe_sum_sunrise: expected inp ndim>=2 and out ndim>=1, "
+            f"got inp.shape={tuple(inp.shape)}, out.shape={tuple(out.shape)}"
+        )
+    if inp.shape[-1] != out.shape[-1]:
+        raise ValueError(
+            "moe_sum_sunrise: hidden dim mismatch: "
+            f"inp.shape[-1]={inp.shape[-1]} vs out.shape[-1]={out.shape[-1]}"
+        )
+
+    if inp.dtype in (torch.bfloat16, torch.float16):
+        acc = torch.sum(inp, dim=-2, dtype=torch.float32)
+        out.copy_(acc.to(out.dtype))
+    else:
+        torch.sum(inp, dim=-2, out=out)
+
+
+def moe_align_block_size_sunrise(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    expert_map: Optional[torch.Tensor] = None,
+    pad_sorted_ids: bool = False,
+    ignore_invalid_experts: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """PyTorch reference ``moe_align_block_size`` for PTPU (opt-in fallback).
+
+    Default dispatch keeps FlagGems Triton first. Enable this path via
+    ``VLLM_FL_PER_OP`` / yaml reorder only when the FlagGems kernel hangs or
+    misbehaves for a given expert/token shape.
+    """
+    del ignore_invalid_experts  # reference path counts all experts in topk_ids
+
+    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
+    if pad_sorted_ids:
+        max_num_tokens_padded = round_up(max_num_tokens_padded, block_size)
+    if topk_ids.numel() < num_experts:
+        max_num_tokens_padded = min(
+            topk_ids.numel() * block_size, max_num_tokens_padded
+        )
+
+    # Match CUDA/vLLM buffer sizing (ceil) for both sorted_ids and expert_ids.
+    max_num_m_blocks = (max_num_tokens_padded + block_size - 1) // block_size
+    sorted_ids = torch.full(
+        (max_num_tokens_padded,),
+        topk_ids.numel(),
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+    expert_ids = torch.zeros(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+    num_tokens_post_pad = torch.empty((1), dtype=torch.int32, device=topk_ids.device)
+
+    flattened_token_indices = torch.arange(
+        topk_ids.numel(), device=topk_ids.device, dtype=torch.int32
+    )
+    flattened_expert_ids = topk_ids.flatten()
+    sorted_expert_ids, sort_indices = torch.sort(flattened_expert_ids, stable=True)
+    sorted_token_indices = flattened_token_indices[sort_indices]
+
+    expert_token_counts = torch.zeros(
+        num_experts, dtype=torch.int64, device=topk_ids.device
+    )
+    for expert_id in range(num_experts):
+        expert_token_counts[expert_id] = (sorted_expert_ids == expert_id).sum()
+
+    expert_padded_counts = torch.zeros(
+        num_experts, dtype=torch.int64, device=topk_ids.device
+    )
+    for expert_id in range(num_experts):
+        original_count = expert_token_counts[expert_id]
+        if expert_map is not None and expert_map[expert_id] == -1:
+            continue
+        if original_count > 0:
+            expert_padded_counts[expert_id] = (
+                (original_count + block_size - 1) // block_size
+            ) * block_size
+
+    current_pos = 0
+    current_block = 0
+    for expert_id in range(num_experts):
+        if expert_map is not None and expert_map[expert_id] == -1:
+            continue
+
+        expert_mask = sorted_expert_ids == expert_id
+        expert_tokens = sorted_token_indices[expert_mask]
+        num_expert_tokens = expert_tokens.shape[0]
+
+        if num_expert_tokens > 0:
+            sorted_ids[
+                current_pos : current_pos + num_expert_tokens
+            ] = expert_tokens
+
+            expert_blocks_needed = int(
+                expert_padded_counts[expert_id].item() // block_size
+            )
+            expert_id_new = (
+                expert_map[expert_id] if expert_map is not None else expert_id
+            )
+            expert_ids[
+                current_block : current_block + expert_blocks_needed
+            ] = expert_id_new
+
+            current_pos += int(expert_padded_counts[expert_id].item())
+            current_block += expert_blocks_needed
+
+    total_padded_tokens = int(expert_padded_counts.sum().item())
+    num_tokens_post_pad.fill_(total_padded_tokens)
+
+    return sorted_ids, expert_ids, num_tokens_post_pad
+
+
+__all__ = [
+    "topk_softmax_sunrise",
+    "moe_sum_sunrise",
+    "moe_align_block_size_sunrise",
+]

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/gemma_rms_norm.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/gemma_rms_norm.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""GemmaRMSNorm OOT shim routing rms_norm to FlagGems on PTPU."""
+
+from __future__ import annotations
+
+import logging
+import types
+from typing import Optional, Union
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def register_gemma_rms_norm_oot() -> None:
+    """Register :class:`GemmaRMSNormFL` as an OOT replacement for
+    ``GemmaRMSNorm``. Idempotent. Safe no-op outside PTPU.
+
+    Called from :func:`sunrise.patch.patch_op_cls` after the cross-
+    platform OOT layers have been registered by ``register_oot_ops``.
+    """
+    try:
+        from vllm.model_executor.custom_op import CustomOp, op_registry_oot
+        from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+        from vllm.platforms import current_platform
+
+        if getattr(current_platform, "device_type", None) != "ptpu":
+            return
+
+        if "GemmaRMSNorm" in op_registry_oot:
+            return
+
+        from vllm_fl.dispatch import call_op
+
+        class GemmaRMSNormFL(GemmaRMSNorm):
+            """Sunrise OOT replacement for :class:`GemmaRMSNorm`.
+
+            See module docstring for the rationale + numbers.
+            """
+
+            def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+                super().__init__(hidden_size, eps)
+                self._cached_offset_weight: Optional[torch.Tensor] = None
+
+            def _offset_weight(self) -> torch.Tensor:
+                # ``CustomOp.__new__`` may bypass our ``__init__`` if a
+                # sibling subclass's ``__init__`` is invoked first
+                # (depends on registration order in vLLM internals), so
+                # use ``getattr`` for the lazy init.
+                cached = getattr(self, "_cached_offset_weight", None)
+                weight_data = self.weight.data
+                if (
+                    cached is None
+                    or cached.device != weight_data.device
+                    or cached.dtype != weight_data.dtype
+                    or cached.shape != weight_data.shape
+                ):
+                    cached = (weight_data.detach() + 1.0).to(weight_data.dtype)
+                    self._cached_offset_weight = cached
+                return cached
+
+            def forward_oot(
+                self,
+                x: torch.Tensor,
+                residual: Optional[torch.Tensor] = None,
+            ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+                # Pretend the ``proxy`` object is a stock ``RMSNorm``-
+                # like layer whose ``weight`` already includes Gemma's
+                # ``+1`` offset. The sunrise ``rms_norm`` op only reads
+                # ``.weight`` and ``.variance_epsilon``.
+                proxy = types.SimpleNamespace(
+                    weight=self._offset_weight(),
+                    variance_epsilon=self.variance_epsilon,
+                )
+                return call_op("rms_norm", proxy, x, residual)
+
+        CustomOp.register_oot(
+            _decorated_op_cls=GemmaRMSNormFL, name="GemmaRMSNorm"
+        )
+        logger.info(
+            "Registered GemmaRMSNormFL as OOT replacement for "
+            "GemmaRMSNorm on Sunrise/PTPU"
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to register GemmaRMSNormFL OOT replacement on "
+            "Sunrise/PTPU: %s",
+            exc,
+        )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/int8/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/int8/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Sunrise INT8 kernel implementations for the vLLM-native W8A8 path."""
+
+from .scaled_int8_quant import dynamic_scaled_int8_quant, scaled_int8_quant
+
+__all__ = ["dynamic_scaled_int8_quant", "scaled_int8_quant"]

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/int8/scaled_int8_quant.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/int8/scaled_int8_quant.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU INT8 activation quantization for vLLM W8A8 path."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+_INT8_MIN = -128
+_INT8_MAX = 127
+# Symmetric int8 uses 127 as the scale denominator so +/-amax maps to +/-127.
+_SCALE_DENOM = 127.0
+
+
+@triton.jit
+def _dynamic_scaled_int8_quant_single_kernel(
+    y_ptr,
+    q_ptr,
+    s_ptr,
+    K,
+    y_row_stride,
+    q_row_stride,
+    eps,
+    scale_denom,
+    int8_min,
+    int8_max,
+    BLOCK: tl.constexpr,
+):
+    """Single-load path for K <= BLOCK: amax + quantize without a second HBM read."""
+    row = tl.program_id(0)
+    y_row = y_ptr + row * y_row_stride
+    q_row = q_ptr + row * q_row_stride
+
+    cols = tl.arange(0, BLOCK)
+    mask = cols < K
+    y = tl.load(y_row + cols, mask=mask, other=0.0).to(tl.float32)
+    amax = tl.max(tl.abs(y))
+    scale = tl.maximum(amax, eps) / scale_denom
+    tl.store(s_ptr + row, scale)
+
+    inv_scale = 1.0 / scale
+    x = y * inv_scale
+    r = tl.where(x >= 0, tl.floor(x + 0.5), tl.ceil(x - 0.5))
+    r = tl.minimum(tl.maximum(r, int8_min), int8_max)
+    tl.store(q_row + cols, r.to(q_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _dynamic_scaled_int8_quant_twopass_kernel(
+    y_ptr,
+    q_ptr,
+    s_ptr,
+    K,
+    y_row_stride,
+    q_row_stride,
+    eps,
+    scale_denom,
+    int8_min,
+    int8_max,
+    BLOCK: tl.constexpr,
+):
+    """Two-pass path for K > BLOCK (chunked amax, then chunked quantize)."""
+    row = tl.program_id(0)
+    y_row = y_ptr + row * y_row_stride
+    q_row = q_ptr + row * q_row_stride
+
+    amax = 0.0
+    for off in range(0, K, BLOCK):
+        cols = off + tl.arange(0, BLOCK)
+        mask = cols < K
+        y = tl.load(y_row + cols, mask=mask, other=0.0).to(tl.float32)
+        amax = tl.maximum(amax, tl.max(tl.abs(y)))
+
+    scale = tl.maximum(amax, eps) / scale_denom
+    tl.store(s_ptr + row, scale)
+
+    inv_scale = 1.0 / scale
+    for off in range(0, K, BLOCK):
+        cols = off + tl.arange(0, BLOCK)
+        mask = cols < K
+        y = tl.load(y_row + cols, mask=mask, other=0.0).to(tl.float32)
+        x = y * inv_scale
+        r = tl.where(x >= 0, tl.floor(x + 0.5), tl.ceil(x - 0.5))
+        r = tl.minimum(tl.maximum(r, int8_min), int8_max)
+        tl.store(q_row + cols, r.to(q_ptr.dtype.element_ty), mask=mask)
+
+
+def _dynamic_triton(x2d: torch.Tensor, eps: float):
+    M, K = x2d.shape
+    q = torch.empty_like(x2d, dtype=torch.int8)
+    s = torch.empty((M, 1), device=x2d.device, dtype=torch.float32)
+    BLOCK = min(triton.next_power_of_2(K), 8192)
+    num_warps = min(max(BLOCK // 256, 1), 8)
+    # Common Linear/MoE K (e.g. 2048/4096) fits in one BLOCK: use single-load
+    # kernel to avoid a second full-row HBM read per token.
+    kernel = (
+        _dynamic_scaled_int8_quant_single_kernel
+        if K <= BLOCK
+        else _dynamic_scaled_int8_quant_twopass_kernel
+    )
+    kernel[(M,)](
+        x2d,
+        q,
+        s,
+        K,
+        x2d.stride(0),
+        q.stride(0),
+        eps,
+        _SCALE_DENOM,
+        _INT8_MIN,
+        _INT8_MAX,
+        BLOCK=BLOCK,
+        num_warps=num_warps,
+    )
+    return q, s
+
+
+def _dynamic_torch(x2d: torch.Tensor, eps: float):
+    amax = x2d.abs().amax(dim=-1, keepdim=True).clamp(min=eps).to(torch.float32)
+    scale = amax / _SCALE_DENOM
+    q = (
+        (x2d.to(torch.float32) / scale)
+        .round()
+        .clamp(_INT8_MIN, _INT8_MAX)
+        .to(torch.int8)
+    )
+    return q, scale
+
+
+def _dynamic_torch_asymmetric(x2d, input, eps):
+    xmin = x2d.amin(dim=-1, keepdim=True).to(torch.float32)
+    xmax = x2d.amax(dim=-1, keepdim=True).to(torch.float32)
+    scale = ((xmax - xmin) / (_INT8_MAX - _INT8_MIN)).clamp(min=eps)
+    azp = (_INT8_MIN - (xmin / scale).round()).to(torch.int32)
+    q = (
+        (x2d.to(torch.float32) / scale).round() + azp
+    ).clamp(_INT8_MIN, _INT8_MAX).to(torch.int8)
+    return q.reshape(input.shape), scale, azp
+
+
+def _static_quant(input, scale, azp, symmetric):
+    """Static (per-tensor) INT8 quantization to match vLLM's static path."""
+    scale_f = scale.to(torch.float32)
+    x = input.to(torch.float32) / scale_f
+    if not symmetric and azp is not None:
+        x = x + azp.to(torch.float32)
+    q = x.round().clamp(_INT8_MIN, _INT8_MAX).to(torch.int8)
+    return q, scale, azp
+
+
+def dynamic_scaled_int8_quant(
+    input: torch.Tensor,
+    symmetric: bool = True,
+    eps: float = 1e-10,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Dynamic per-token INT8 quantization (Triton, torch fallback)."""
+    assert input.shape[-1] >= 1
+    x2d = input.reshape(-1, input.shape[-1]).contiguous()
+
+    if not symmetric:
+        return _dynamic_torch_asymmetric(x2d, input, eps)
+
+    backend = os.environ.get("FLAGGEMS_VLLM_INT8_QUANT_BACKEND", "triton").lower()
+    if backend == "torch":
+        q, s = _dynamic_torch(x2d, eps)
+    else:
+        try:
+            q, s = _dynamic_triton(x2d, eps)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "dynamic_scaled_int8_quant: Triton path failed (%s); "
+                "falling back to torch.",
+                e,
+            )
+            q, s = _dynamic_torch(x2d, eps)
+
+    return q.reshape(input.shape), s, None
+
+
+def scaled_int8_quant(
+    input: torch.Tensor,
+    scale: Optional[torch.Tensor] = None,
+    azp: Optional[torch.Tensor] = None,
+    symmetric: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Drop-in replacement for ``vllm._custom_ops.scaled_int8_quant``.
+
+    * ``scale is None``  -> dynamic per-token quantization (Triton).
+    * ``scale`` provided -> static per-tensor quantization (torch).
+    """
+    if scale is not None:
+        assert symmetric == (azp is None), (
+            "azp must only be provided for asymmetric quantization."
+        )
+        return _static_quant(input, scale, azp, symmetric)
+    return dynamic_scaled_int8_quant(input, symmetric=symmetric)

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/mla.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/mla.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Sunrise MLA attention backend for decode MQA and prefill MHA."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import torch
+
+from flag_gems import concat_and_cache_mla, flash_attn_varlen_func, flash_mla
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLACommonBackend,
+    MLACommonImpl,
+    MLACommonMetadata,
+)
+from vllm.utils.torch_utils import is_quantized_kv_cache
+from vllm.v1.attention.backend import AttentionLayer, AttentionType
+
+logger = init_logger(__name__)
+
+
+def torch_gather_and_maybe_dequant_cache(
+    src_cache: torch.Tensor,
+    dst: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+    token_to_seq: torch.Tensor,
+    num_tokens: int,
+    kv_cache_dtype: str,
+    scale: torch.Tensor,
+    seq_starts: torch.Tensor | None = None,
+) -> None:
+    """BF16/FP16 PyTorch fallback for ``_C_cache_ops.gather_and_maybe_dequant_cache``.
+
+    Matches vLLM ``cache_kernels.cu::gather_and_maybe_dequant_cache`` for the
+    non-FP8 path used by MLA chunked-prefill / prefix-cache context gather.
+    """
+    if kv_cache_dtype.startswith("fp8"):
+        raise NotImplementedError(
+            "Sunrise MLA: FP8 gather_and_maybe_dequant_cache not supported"
+        )
+
+    if num_tokens <= 0:
+        return
+
+    # [num_blocks, block_size, D] or [num_blocks, block_size, 1, D]
+    if src_cache.ndim == 4:
+        src = src_cache.squeeze(2)
+    else:
+        src = src_cache
+    assert src.ndim == 3, f"unexpected MLA cache shape {tuple(src_cache.shape)}"
+    block_size = src.size(1)
+    hidden = src.size(-1)
+    flat = src.reshape(-1, hidden)
+
+    token_ids = torch.arange(num_tokens, device=src.device, dtype=torch.long)
+    batch_ids = token_to_seq[:num_tokens].to(dtype=torch.long)
+    batch_start = cu_seq_lens[batch_ids].to(dtype=torch.long)
+    batch_offset = token_ids - batch_start
+    if seq_starts is not None:
+        batch_offset = batch_offset + seq_starts[batch_ids].to(dtype=torch.long)
+
+    block_table_ids = torch.div(batch_offset, block_size, rounding_mode="floor")
+    slot_ids = torch.remainder(batch_offset, block_size)
+    # block_table: [batch, max_blocks]; stride may exceed size(1)
+    block_ids = block_table[batch_ids, block_table_ids].to(dtype=torch.long)
+    flat_idx = block_ids * block_size + slot_ids
+    dst[:num_tokens].copy_(flat[flat_idx])
+
+
+def _ensure_mla_flash_attn_importable() -> None:
+    """MLACommonImpl.__init__ requires a module-level FA symbol.
+
+    On Sunrise/PTPU ``vllm_flash_attn`` is unavailable, so inject FlagGems'
+    varlen FA before ``super().__init__`` so the common FA prefill branch
+    can finish setup. Prefill still goes through our
+    ``_flash_attn_varlen_diff_headdims`` override.
+    """
+    import vllm.model_executor.layers.attention.mla_attention as mla_mod
+
+    if mla_mod.flash_attn_varlen_func is None:
+        mla_mod.flash_attn_varlen_func = flash_attn_varlen_func
+        logger.info_once(
+            "Sunrise MLA: injected FlagGems flash_attn_varlen_func into "
+            "mla_attention (vllm_flash_attn unavailable on PTPU)."
+        )
+
+
+class SunriseMLABackend(MLACommonBackend):
+    """Sunrise-owned MLA backend entry for vendor dispatch."""
+
+    @staticmethod
+    def get_name() -> str:
+        return "SUNRISE_MLA"
+
+    @staticmethod
+    def get_impl_cls() -> type["SunriseMLAImpl"]:
+        return SunriseMLAImpl
+
+
+class SunriseMLAImpl(MLACommonImpl[MLACommonMetadata]):
+    # Sunrise flash_mla does not emit LSE; DCP>1 would need a kernel upgrade.
+    can_return_lse_for_decode: bool = False
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: Optional[list[float]],
+        sliding_window: Optional[int],
+        kv_cache_dtype: str,
+        logits_soft_cap: Optional[float],
+        attn_type: str,
+        kv_sharing_target_layer_name: Optional[str],
+        # MLA Specific Arguments
+        **mla_args,
+    ) -> None:
+        _ensure_mla_flash_attn_importable()
+        super().__init__(
+            num_heads,
+            head_size,
+            scale,
+            num_kv_heads,
+            alibi_slopes,
+            sliding_window,
+            kv_cache_dtype,
+            logits_soft_cap,
+            attn_type,
+            kv_sharing_target_layer_name,
+            **mla_args,
+        )
+
+        unsupported_features = [alibi_slopes, sliding_window, logits_soft_cap]
+        if any(unsupported_features):
+            raise NotImplementedError(
+                "SunriseMLAImpl does not support one of the following: "
+                "alibi_slopes, sliding_window, logits_soft_cap"
+            )
+
+        if attn_type != AttentionType.DECODER:
+            raise NotImplementedError(
+                "Encoder self-attention and "
+                "encoder/decoder cross-attention "
+                "are not implemented for SunriseMLAImpl"
+            )
+
+        if is_quantized_kv_cache(self.kv_cache_dtype):
+            raise NotImplementedError(
+                "Sunrise MLA with FP8 KV cache not yet supported"
+            )
+
+        # Prefer FlagGems FA for prefill (diff head dims + PTPU). Parent may
+        # have set CUDA FA kwargs; our override ignores self.flash_attn_varlen_func.
+        self._pad_v = True
+
+    def _flash_attn_varlen_diff_headdims(
+        self, q, k, v, return_softmax_lse=False, softmax_scale=None, **kwargs
+    ):
+        maybe_padded_v = v
+        if self._pad_v:
+            maybe_padded_v = torch.nn.functional.pad(
+                v, [0, q.shape[-1] - v.shape[-1]], value=0
+            )
+
+        kwargs["return_softmax_lse"] = return_softmax_lse
+        attn_out = flash_attn_varlen_func(
+            q=q,
+            k=k,
+            v=maybe_padded_v,
+            softmax_scale=softmax_scale,
+            **kwargs,
+        )
+
+        lse = None
+        if isinstance(attn_out, tuple):
+            attn_out, lse = attn_out[0], attn_out[1]
+
+        if return_softmax_lse:
+            return attn_out, lse
+        return attn_out
+
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        if kv_cache.numel() == 0:
+            return
+        # PTPU builds do not ship ``torch.ops._C_cache_ops.concat_and_cache_mla``.
+        concat_and_cache_mla(
+            kv_c_normed,
+            k_pe.squeeze(1),
+            kv_cache,
+            slot_mapping.flatten(),
+            kv_cache_dtype,
+            k_scale,
+        )
+
+    def forward_mqa(
+        self,
+        q: Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: MLACommonMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Decode-path MQA over ``kv_c ‖ k_pe`` cache via Sunrise ``flash_mla``.
+
+        Expected layouts (GLM-4.7-Flash):
+        * ``q``: ``[B, H, kv_lora + rope]`` (= ``[B, H, 576]``) or
+          ``(q_nope, q_pe)`` with dims 512 / 64
+        * ``kv_c_and_k_pe_cache``: ``[num_blocks, block_size, 576]``
+        * out: ``[B, H, kv_lora_rank]`` (= ``[B, H, 512]``)
+        """
+        assert kv_c_and_k_pe_cache.numel() > 0
+        assert attn_metadata.decode is not None
+
+        if self.kv_cache_dtype.startswith("fp8"):
+            raise NotImplementedError("FP8 Sunrise MLA not yet supported")
+
+        if isinstance(q, tuple):
+            q = torch.cat(q, dim=-1)
+
+        assert isinstance(q, torch.Tensor)
+        # Common path: [B, H, D]. flash_mla wants [B, s_q, H, D].
+        if q.ndim == 3:
+            b, h, d = q.shape
+            s_q = 1
+            q4 = q.unsqueeze(1)
+        elif q.ndim == 4:
+            b, s_q, h, d = q.shape
+            q4 = q
+        else:
+            raise ValueError(f"SunriseMLAImpl.forward_mqa: unexpected q.ndim={q.ndim}")
+
+        head_dim_v = self.kv_lora_rank
+        if d <= head_dim_v:
+            raise ValueError(
+                f"MLA decode expects D=kv_lora+rope > kv_lora; got D={d}, "
+                f"kv_lora_rank={head_dim_v}"
+            )
+
+        # Cache is [num_blocks, block_size, D] (or with an extra head dim).
+        kv_cache = kv_c_and_k_pe_cache
+        if kv_cache.ndim == 4:
+            # [num_blocks, block_size, 1, D] → treat as 3D for page size.
+            page_size = kv_cache.size(1)
+        elif kv_cache.ndim == 3:
+            page_size = kv_cache.size(1)
+        else:
+            raise ValueError(
+                f"Unexpected MLA kv cache ndim={kv_cache.ndim}, "
+                f"shape={tuple(kv_cache.shape)}"
+            )
+
+        # flash_mla returns [B, s_q, H, dv]; common layer wants [B, H, dv]
+        # (s_q==1 for pure decode). Pass vLLM softmax scale when supported.
+        # Current Sunrise FlagGems ``flash_mla`` hardcodes 1/sqrt(d); optional
+        # ``sm_scale`` is accepted when newer FlagGems exposes it.
+        flash_mla_kwargs = {}
+        try:
+            import inspect
+
+            if "sm_scale" in inspect.signature(flash_mla).parameters:
+                flash_mla_kwargs["sm_scale"] = self.scale
+        except (TypeError, ValueError):
+            pass
+        o = flash_mla(
+            q4,
+            attn_metadata.decode.block_table,
+            kv_cache,
+            None,
+            page_size,
+            b,
+            s_q,
+            attn_metadata.decode.seq_lens,
+            h,
+            None,
+            d,
+            head_dim_v,
+            True,
+            **flash_mla_kwargs,
+        )
+        if s_q == 1:
+            o = o.squeeze(1)
+        else:
+            # Spec/multi-token decode: flatten query dim into batch like FA MLA.
+            o = o.reshape(b * s_q, h, head_dim_v)
+
+        return o, None

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/rms_norm_gated.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/rms_norm_gated.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""RMSNormGated OOT shim with fused FlagGems path on PTPU."""
+
+from __future__ import annotations
+
+import logging
+import types
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+
+def register_rms_norm_gated_oot() -> None:
+    """Register :class:`RMSNormGatedFL` as an OOT replacement for
+    ``RMSNormGated``. Idempotent. Safe no-op outside PTPU.
+
+    Called from :func:`sunrise.patch.patch_op_cls` after the cross-
+    platform OOT layers have been registered by ``register_oot_ops``.
+    """
+    try:
+        from vllm.model_executor.custom_op import CustomOp, op_registry_oot
+        from vllm.model_executor.layers.layernorm import RMSNormGated
+        from vllm.platforms import current_platform
+
+        if getattr(current_platform, "device_type", None) != "ptpu":
+            return
+
+        if "RMSNormGated" in op_registry_oot:
+            return
+
+        from vllm_fl.dispatch import call_op
+
+        class RMSNormGatedFL(RMSNormGated):
+            """Sunrise OOT replacement for :class:`RMSNormGated`.
+
+            See module docstring for the rationale + numbers.
+            """
+
+            def forward_oot(
+                self,
+                x: torch.Tensor,
+                z: Optional[torch.Tensor] = None,
+            ) -> torch.Tensor:
+                fast_path = (
+                    z is not None
+                    and self.norm_before_gate
+                    and self.group_size is None
+                    and self.activation in ("silu", "swish")
+                )
+                if not fast_path:
+                    # Unsupported configuration (no gate / pre-gate /
+                    # group RMS / sigmoid activation) — keep upstream
+                    # semantics unchanged.
+                    return self.forward_native(x, z)
+
+                # Pretend the ``proxy`` object is a stock RMSNorm
+                # whose ``.variance_epsilon`` matches our ``.eps``.
+                proxy = types.SimpleNamespace(
+                    weight=self.weight,
+                    variance_epsilon=self.eps,
+                )
+                out = call_op("rms_norm", proxy, x, None)
+                return out * F.silu(z)
+
+        CustomOp.register_oot(
+            _decorated_op_cls=RMSNormGatedFL, name="RMSNormGated"
+        )
+        logger.info(
+            "Registered RMSNormGatedFL as OOT replacement for "
+            "RMSNormGated on Sunrise/PTPU"
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to register RMSNormGatedFL OOT replacement on "
+            "Sunrise/PTPU: %s",
+            exc,
+        )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/rotary.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/rotary.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+Sunrise (PTPU) rotary embedding operator implementations.
+
+Routes RoPE to ``torch_ptpu.sgl_kernel.apply_rope_with_cos_sin_cache``.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from torch_ptpu.sgl_kernel import apply_rope_with_cos_sin_cache
+
+
+_CACHED_F32_CACHE_ATTR = "_vllm_fl_sunrise_cos_sin_cache_f32"
+
+
+def _get_cos_sin_cache_f32(obj, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    """Return a float32 ``[max_pos, head_dim]`` cos_sin_cache for PTPU sgl.
+
+    Prefers ``obj.cos_sin_cache`` (the RotaryEmbedding layer typically owns
+    the original cache) so we avoid recomputing it. Falls back to
+    reconstructing from the dispatched ``cos`` / ``sin`` halves when the
+    caller does not expose the cache.
+
+    The float32 view is cached as a private attribute on ``obj`` so that we
+    only pay the dtype-cast cost once per layer for the lifetime of the
+    process.
+    """
+    cached = getattr(obj, _CACHED_F32_CACHE_ATTR, None)
+    if cached is not None:
+        return cached
+
+    raw = getattr(obj, "cos_sin_cache", None)
+    if raw is None:
+        # Reconstruct from the dispatched halves; ``cos`` / ``sin`` are slices
+        # of a contiguous ``[..., 2 * rot_dim_half]`` buffer so concatenation
+        # along the last dim restores the original layout.
+        raw = torch.cat([cos, sin], dim=-1)
+
+    cache_f32 = raw.to(dtype=torch.float32)
+    try:
+        setattr(obj, _CACHED_F32_CACHE_ATTR, cache_f32)
+    except (AttributeError, TypeError):
+        # ``obj`` might be a frozen / slot-based object; that is fine, we just
+        # eat the cast cost on every call in that case.
+        pass
+    return cache_f32
+
+
+def rotary_embedding_sunrise(
+    obj,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    rotary_interleaved: bool = False,
+    inplace: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply RoPE on PTPU.
+
+    Args:
+        obj: The calling RotaryEmbedding layer (used to fetch the original
+            ``cos_sin_cache`` and to memoize the float32 version).
+        query: ``[num_tokens, num_heads, rotary_dim]`` (3D, matching the
+            shape produced by ``RotaryEmbeddingFL.forward_oot``).
+        key: ``[num_tokens, num_kv_heads, rotary_dim]`` (3D).
+        cos, sin: ``[max_seq_len, rotary_dim // 2]`` each; redundant when
+            ``obj`` exposes ``cos_sin_cache`` but kept for fallback.
+        position_ids: ``[num_tokens]`` flat tensor of absolute positions.
+        rotary_interleaved: ``False`` for neox-style (Qwen3); ``True`` for
+            GPT-J style interleaved layout.
+        inplace: Honoured implicitly -- PTPU sgl operates in-place on the
+            flat 2D view and returns the same tensors.
+
+    Returns:
+        Tuple ``(q_embed, k_embed)`` with the original 3D shapes restored.
+    """
+    num_tokens = query.shape[0]
+    rotary_dim = query.shape[-1]
+    head_size = getattr(obj, "head_size", rotary_dim)
+
+    if rotary_dim != head_size:
+        # Partial rotary: the dispatched ``query`` only contains the rotated
+        # slice ``[..., :rotary_dim]``, but PTPU's ``apply_rope_with_cos_sin_cache``
+        # expects a flat ``[tokens, num_heads * head_size]`` buffer covering
+        # the full head and rotates only the leading ``rotary_dim`` channels
+        # internally. Reconstructing the full head here would require knowing
+        # the unrotated pass-through half, which we do not have. Fall back to
+        # the FlagGems path for this less-common model topology.
+        from vllm_fl.dispatch.backends.flaggems.impl.rotary import (
+            rotary_embedding_flaggems,
+        )
+
+        return rotary_embedding_flaggems(
+            obj,
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            rotary_interleaved=rotary_interleaved,
+            inplace=inplace,
+        )
+
+    query_shape = query.shape
+    key_shape = key.shape
+
+    # PTPU sgl wants 2D [tokens, num_heads * head_size]. ``.contiguous()`` is
+    # required because the upstream wrapper produces a strided slice via
+    # ``query[..., :rotary_dim]``.
+    query_flat = query.contiguous().view(num_tokens, -1)
+    key_flat = key.contiguous().view(num_tokens, -1)
+
+    cos_sin_cache_f32 = _get_cos_sin_cache_f32(obj, cos, sin)
+
+    q_out, k_out = apply_rope_with_cos_sin_cache(
+        positions=position_ids,
+        query=query_flat,
+        key=key_flat,
+        head_size=head_size,
+        cos_sin_cache=cos_sin_cache_f32,
+        is_neox=not rotary_interleaved,
+    )
+
+    return q_out.view(query_shape), k_out.view(key_shape)

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -23,6 +23,8 @@ def apply_sunrise_patches():
     patch_distributed_runtime()
     patch_op_cls()
     patch_accelerator_empty_cache()
+    patch_memory_profiling_for_plain_allocator()
+    patch_fused_topk_bias_router()
 
 
 def patch_flagcx_stream_adapter():
@@ -208,3 +210,169 @@ def patch_accelerator_empty_cache():
         logger.info("Patched torch.accelerator.empty_cache for Sunrise/PTPU")
     except Exception as e:
         logger.warning("Failed to patch torch.accelerator.empty_cache: %s", e)
+
+
+def patch_fused_topk_bias_router():
+    """Replace CUDA-only ``vllm_topk_{sigmoid,softmax}`` with a native
+    implementation on Sunrise/PTPU.
+    """
+
+    try:
+        from vllm.platforms import current_platform
+
+        if getattr(current_platform, "device_type", None) != "ptpu":
+            return
+
+        import vllm.envs as envs
+        from vllm.model_executor.layers.fused_moe.router import (
+            fused_topk_bias_router as router_mod,
+        )
+
+        if getattr(router_mod, "_sunrise_topk_patched", False):
+            return
+
+        def _native_topk_with_bias(
+            topk_weights: torch.Tensor,
+            topk_indices: torch.Tensor,
+            token_expert_indices: torch.Tensor,
+            gating_output: torch.Tensor,
+            renormalize: bool,
+            e_score_correction_bias: torch.Tensor | None,
+            scoring_func: str,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            if scoring_func == "softmax":
+                scores = gating_output.softmax(dim=-1)
+            elif scoring_func == "sigmoid":
+                scores = gating_output.sigmoid()
+            else:
+                raise ValueError(
+                    f"Unsupported scoring function: {scoring_func}"
+                )
+
+            if e_score_correction_bias is not None:
+                scores_for_choice = scores + e_score_correction_bias.to(
+                    scores.dtype
+                ).unsqueeze(0)
+            else:
+                scores_for_choice = scores
+
+            topk = topk_weights.shape[-1]
+            use_sorted = getattr(envs, "VLLM_BATCH_INVARIANT", False)
+            chosen_indices = torch.topk(
+                scores_for_choice, k=topk, dim=-1, sorted=use_sorted
+            ).indices
+            chosen_weights = scores.gather(dim=-1, index=chosen_indices)
+            if renormalize:
+                chosen_weights = chosen_weights / chosen_weights.sum(
+                    dim=-1, keepdim=True
+                )
+
+            topk_weights.copy_(chosen_weights.to(topk_weights.dtype))
+            topk_indices.copy_(chosen_indices.to(topk_indices.dtype))
+            return topk_weights, topk_indices
+
+        def _patched_vllm_topk_sigmoid(
+            topk_weights, topk_indices, token_expert_indices,
+            gating_output, renormalize=False, e_score_correction_bias=None,
+        ):
+            return _native_topk_with_bias(
+                topk_weights, topk_indices, token_expert_indices,
+                gating_output, renormalize, e_score_correction_bias,
+                scoring_func="sigmoid",
+            )
+
+        def _patched_vllm_topk_softmax(
+            topk_weights, topk_indices, token_expert_indices,
+            gating_output, renormalize=False, e_score_correction_bias=None,
+        ):
+            return _native_topk_with_bias(
+                topk_weights, topk_indices, token_expert_indices,
+                gating_output, renormalize, e_score_correction_bias,
+                scoring_func="softmax",
+            )
+
+        router_mod.vllm_topk_sigmoid = _patched_vllm_topk_sigmoid
+        router_mod.vllm_topk_softmax = _patched_vllm_topk_softmax
+        router_mod._sunrise_topk_patched = True
+
+        logger.info(
+            "Patched fused_topk_bias_router to use native topk on PTPU"
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to patch fused_topk_bias_router for Sunrise: %s", e
+        )
+
+
+def patch_memory_profiling_for_plain_allocator():
+    """Fix KV-cache OOM caused by weights being double-counted on PTPU.
+    since ``torch_ptpu`` ships a "plain"-style device allocator that does not register
+    with PyTorch's caching allocator, ``torch.memory_reserved()`` is always ~0 on PTPU. 
+    """
+    try:
+        from vllm.platforms import current_platform
+
+        if getattr(current_platform, "device_type", None) != "ptpu":
+            return
+    except Exception as e:
+        logger.warning("Skip PTPU memory profiling patch: %s", e)
+        return
+
+    try:
+        from contextlib import contextmanager
+
+        from vllm_fl.worker import worker as worker_mod
+
+        original = worker_mod.memory_profiling_fl
+        if getattr(original, "_sunrise_mem_profile_patched", False):
+            return
+
+        gib = float(2**30)
+        _logged = {"once": False}
+
+        @contextmanager
+        def memory_profiling_fl_ptpu(baseline_snapshot, weights_memory):
+            with original(
+                baseline_snapshot, weights_memory=weights_memory
+            ) as result:
+                yield result
+
+            if (
+                result.after_profile.torch_memory == 0
+                and result.weights_memory > 0
+            ):
+                actual_used = (
+                    result.after_profile.cuda_memory
+                    - result.before_create.cuda_memory
+                )
+                corrected_non_torch = max(0, actual_used - result.weights_memory)
+                result.non_torch_increase = corrected_non_torch
+                result.non_kv_cache_memory = (
+                    corrected_non_torch
+                    + result.torch_peak_increase
+                    + result.weights_memory
+                )
+
+                if not _logged["once"]:
+                    _logged["once"] = True
+                    logger.info(
+                        "PTPU plain-allocator memory accounting fix applied: "
+                        "weights=%.2f GiB peak_act=%.2f GiB actual_used=%.2f GiB "
+                        "-> non_torch=%.2f GiB non_kv_cache=%.2f GiB",
+                        result.weights_memory / gib,
+                        result.torch_peak_increase / gib,
+                        actual_used / gib,
+                        corrected_non_torch / gib,
+                        result.non_kv_cache_memory / gib,
+                    )
+
+        memory_profiling_fl_ptpu._sunrise_mem_profile_patched = True
+        worker_mod.memory_profiling_fl = memory_profiling_fl_ptpu
+        logger.info(
+            "Patched memory_profiling_fl for PTPU plain allocator "
+            "(prevents weights double-counting in KV cache sizing)"
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to patch memory_profiling_fl for Sunrise/PTPU: %s", e
+        )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -306,8 +306,15 @@ def patch_fused_topk_bias_router():
 
 def patch_memory_profiling_for_plain_allocator():
     """Fix KV-cache OOM caused by weights being double-counted on PTPU.
-    since ``torch_ptpu`` ships a "plain"-style device allocator that does not register
-    with PyTorch's caching allocator, ``torch.memory_reserved()`` is always ~0 on PTPU. 
+
+    ``torch_ptpu`` ships a "plain"-style device allocator that does not register
+    with PyTorch's caching allocator, so ``torch.memory_reserved()`` is always
+    ~0 on PTPU. The shared :func:`memory_profiling_fl` computes
+    ``non_torch = cuda_used - torch_reserved``; with ``torch_reserved == 0``
+    this leaks the model weights into ``non_torch``. The final
+    ``non_kv_cache = weights + peak_act + non_torch`` then counts weights
+    twice, yielding a phantom OOM in ``determine_available_memory`` even when
+    the device has plenty of free memory.
     """
     try:
         from vllm.platforms import current_platform

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -44,6 +44,32 @@ def apply_sunrise_patches():
     patch_ptpu_trunc_normal_init()
     patch_minicpmo_resampler_device()
     patch_moe_force_config()
+    patch_native_moe_ops()
+    patch_native_int8_routing()
+
+
+def patch_native_moe_ops() -> None:
+    """Give vLLM's fused-MoE path implementations that exist on PTPU.
+
+    Deferred rather than import-time: the shims resolve through the FL dispatch
+    registry, which is only populated once the backends have registered. Must
+    precede ``patch_native_int8_routing``, which routes W8A8 MoE onto them.
+    """
+    from .patches import patch_moe_native_ops
+
+    patch_moe_native_ops.apply_patch()
+
+
+def patch_native_int8_routing() -> None:
+    """Re-assert the INT8 routing that ``register_oot_ops`` can overwrite.
+
+    ``register_oot_ops`` installs ``install_fl_w8a8_moe_selector`` and clones the
+    CUDA linear kernels into the OOT slot before it calls us, so sunrise has to
+    re-run the order-sensitive INT8 patches afterwards to be the last writer.
+    """
+    from .patches import patch_int8_native
+
+    patch_int8_native.install_late_patches()
 
 
 def patch_moe_force_config() -> None:

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -1,7 +1,11 @@
 # Copyright (c) 2026 BAAI. All rights reserved.
 
-import ctypes
-import importlib
+"""Sunrise deferred patches for vLLM compatibility.
+
+``apply_sunrise_patches()`` is called from ``vllm_fl.ops.custom_ops`` before
+model construction. Import-time patches live in ``patches/__init__.py``.
+"""
+
 import logging
 import os
 import sys
@@ -19,75 +23,902 @@ def apply_sunrise_patches():
         return
     _patches_applied = True
 
+    # Must run early: vLLM multi_stream_utils uses torch.cuda.stream/current_stream.
+    patch_cuda_stream_for_ptpu()
+    patch_flagcx_comm_lifecycle()
     patch_flagcx_stream_adapter()
+    patch_flagcx_collective_hot_path()
+    patch_vllm_group_coordinator_dispatch()
+    patch_op_manager_fast_path()
+    patch_oot_layer_fast_path()
+    patch_ptpu_topk_topp_sampler()
+    patch_ptpu_penalties_bincount()
     patch_distributed_runtime()
+    patch_ptpu_cudagraph()
     patch_op_cls()
     patch_accelerator_empty_cache()
     patch_memory_profiling_for_plain_allocator()
     patch_fused_topk_bias_router()
+    patch_hy_v3_shared_mlp_weights()
+    patch_mla_gather_cache_ops()
+    patch_ptpu_trunc_normal_init()
+    patch_minicpmo_resampler_device()
+
+
+def patch_minicpmo_resampler_device() -> None:
+    """Move MiniCPM-O resampler pos caches to PTPU after weight load.
+
+    ``MiniCPMOBaseModel.load_weights`` overrides ``MiniCPMV4_5.load_weights``
+    without calling ``_ensure_resampler_device()``. Resampler 2D/temporal
+    position buffers are created on CPU; vision forward then fails with
+    ``ptpu:0 vs cpu`` when adding ``pos_embed`` to activations.
+    """
+    if getattr(patch_minicpmo_resampler_device, "_done", False):
+        return
+
+    try:
+        from vllm.model_executor.models.minicpmo import MiniCPMOBaseModel
+    except ImportError:
+        return
+
+    if getattr(MiniCPMOBaseModel, "_sunrise_resampler_device_patched", False):
+        return
+
+    _orig_load_weights = MiniCPMOBaseModel.load_weights
+
+    def _load_weights(self, weights):
+        loaded = _orig_load_weights(self, weights)
+        ensure = getattr(self, "_ensure_resampler_device", None)
+        if ensure is not None:
+            ensure()
+        return loaded
+
+    MiniCPMOBaseModel.load_weights = _load_weights
+    MiniCPMOBaseModel._sunrise_resampler_device_patched = True
+    patch_minicpmo_resampler_device._done = True  # type: ignore[attr-defined]
+    logger.info(
+        "Patched MiniCPMOBaseModel.load_weights to call _ensure_resampler_device"
+    )
+
+
+def patch_cuda_stream_for_ptpu():
+    """Patch torch.cuda stream APIs for Sunrise/PTPU (non-CUDA torch).
+
+    Upstream ``vllm.utils.multi_stream_utils`` (and shared-expert overlap) call
+    ``torch.cuda.stream`` / ``current_stream`` / ``set_stream``. On PTPU those
+    hit ``AssertionError: Torch not compiled with CUDA enabled``. Mirror the
+    MUSA patch: delegate to ``current_platform.torch_device_fn`` (torch.ptpu).
+    """
+    try:
+        import contextlib
+
+        import torch.cuda as torch_cuda
+        from vllm.platforms import current_platform
+
+        if getattr(current_platform, "device_type", None) != "ptpu":
+            return
+        if getattr(torch_cuda, "_ptpu_stream_patched", False):
+            return
+
+        device_fn = current_platform.torch_device_fn
+
+        # --- aux_stream: return a PTPU Stream instead of torch.cuda.Stream() ---
+        try:
+            import vllm.utils.torch_utils as tu_mod
+
+            def _aux_stream_ptpu():
+                if tu_mod._aux_stream is None:
+                    tu_mod._aux_stream = device_fn.Stream()
+                return tu_mod._aux_stream
+
+            tu_mod.aux_stream = _aux_stream_ptpu
+            try:
+                import vllm.model_executor.layers.fused_moe.runner.shared_experts as se_mod
+
+                se_mod.aux_stream = _aux_stream_ptpu
+            except Exception:
+                pass
+            logger.info("Patched vllm.utils.torch_utils.aux_stream for PTPU")
+        except Exception as e:
+            logger.warning("Failed to patch aux_stream for PTPU: %s", e)
+
+        def _is_ptpu_stream(stream) -> bool:
+            if stream is None:
+                return False
+            try:
+                if isinstance(stream, device_fn.Stream):
+                    return True
+            except Exception:
+                pass
+            return type(stream).__module__.startswith("torch.ptpu")
+
+        # --- torch.cuda.stream() -> torch.ptpu.stream() ---
+        def _cuda_stream_ctx_ptpu(stream):
+            if stream is None:
+                return contextlib.nullcontext()
+            if _is_ptpu_stream(stream):
+                return device_fn.stream(stream)
+            # Prefer PTPU stream ctx for unknown device streams; never call
+            # the real CUDA path (raises on non-CUDA builds).
+            try:
+                return device_fn.stream(stream)
+            except Exception:
+                return contextlib.nullcontext()
+
+        torch_cuda.stream = _cuda_stream_ctx_ptpu
+
+        # --- torch.cuda.set_stream() -> torch.ptpu.set_stream() ---
+        def _set_stream_ptpu(stream):
+            if _is_ptpu_stream(stream) or stream is not None:
+                device_fn.set_stream(stream)
+                try:
+                    from vllm.utils.torch_utils import _current_stream_tls
+
+                    _current_stream_tls.value = stream
+                except Exception:
+                    pass
+
+        torch_cuda.set_stream = _set_stream_ptpu
+
+        # --- torch.cuda.current_stream() -> torch.ptpu.current_stream() ---
+        def _current_stream_ptpu(device=None):
+            return device_fn.current_stream(device)
+
+        torch_cuda.current_stream = _current_stream_ptpu
+
+        # --- torch.cuda.Event -> torch.ptpu.Event ---
+        # DeepSeek-V4 MLA wrappers and multi_stream_utils construct
+        # ``torch.cuda.Event()``; without this alias PTPU raises.
+        try:
+            torch_cuda.Event = device_fn.Event
+        except Exception as e:
+            logger.warning("Failed to patch torch.cuda.Event for PTPU: %s", e)
+
+        torch_cuda._ptpu_stream_patched = True
+        logger.info("Patched torch.cuda stream/Event APIs for PTPU")
+    except Exception as e:
+        logger.warning("Failed to patch torch.cuda stream APIs for PTPU: %s", e)
+
+
+def patch_mla_gather_cache_ops():
+    """Register torch fallbacks for MLA prefix/chunked-context KV gather.
+
+    PTPU builds lack ``torch.ops._C_cache_ops.gather_and_maybe_dequant_cache``
+    (and often ``cp_gather_cache``). Without these, Moonlight/TeleChat MLA
+    crashes on prefix-cache hits after the first request.
+
+    This fills a missing platform op; it does not override FlagGems MLA kernels.
+    """
+    if getattr(patch_mla_gather_cache_ops, "_done", False):
+        return
+
+    from vllm import _custom_ops as ops
+
+    from .impl.mla import torch_gather_and_maybe_dequant_cache
+
+    def _gather(
+        src_cache,
+        dst,
+        block_table,
+        cu_seq_lens,
+        token_to_seq,
+        num_tokens,
+        kv_cache_dtype,
+        scale,
+        seq_starts=None,
+    ):
+        return torch_gather_and_maybe_dequant_cache(
+            src_cache,
+            dst,
+            block_table,
+            cu_seq_lens,
+            token_to_seq,
+            num_tokens,
+            kv_cache_dtype,
+            scale,
+            seq_starts,
+        )
+
+    ops.gather_and_maybe_dequant_cache = _gather  # type: ignore[attr-defined]
+
+    # Best-effort: also define on torch.ops namespace if the library exists.
+    try:
+        import torch
+
+        if not hasattr(torch.ops, "_C_cache_ops"):
+            torch.library.define(
+                "_C_cache_ops::gather_and_maybe_dequant_cache",
+                "(Tensor src_cache, Tensor(a!) dst, Tensor block_table, "
+                "Tensor cu_seq_lens, Tensor token_to_seq, int num_tokens, "
+                "str kv_cache_dtype, Tensor scale, Tensor? seq_starts=None) -> ()",
+            )
+        lib = torch.library.Library("_C_cache_ops", "IMPL")
+        lib.impl("gather_and_maybe_dequant_cache", _gather, "PrivateUse1")
+        lib.impl("gather_and_maybe_dequant_cache", _gather, "CPU")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not register torch.ops gather fallback: %s", exc)
+
+    patch_mla_gather_cache_ops._done = True  # type: ignore[attr-defined]
+    logger.info(
+        "Patched gather_and_maybe_dequant_cache with Sunrise torch fallback"
+    )
+
+
+def patch_ptpu_cudagraph():
+    from .patches.patch_cudagraph import patch_ptpu_cudagraph as _patch
+
+    _patch()
+
+
+def patch_ptpu_penalties_bincount():
+    from .patches.patch_penalties import patch_ptpu_penalties_bincount as _patch
+
+    _patch()
+
+
+def patch_ptpu_trunc_normal_init() -> None:
+    """Run ``torch.nn.init.trunc_normal_`` on CPU when the tensor is on PTPU.
+
+    MiniCPM-o ``Resampler4_5`` calls ``trunc_normal_(self.query, ...)`` during
+    construction. That path uses ``aten::erfinv.out``, which PTPU does not
+    implement (``NotImplementedError: ... 'ptpu' backend``). Weight init only
+    happens at load time, so a CPU round-trip is cheap and correct.
+
+    Also rebinds ``trunc_normal_`` on already-imported vLLM MiniCPM modules
+    (they use ``from torch.nn.init import trunc_normal_``) and provides a
+    ``Tensor.erfinv_`` PTPU fallback for any other callers.
+    """
+    if getattr(patch_ptpu_trunc_normal_init, "_done", False):
+        return
+
+    import sys
+
+    import torch.nn.init as init
+
+    _orig_trunc = init.trunc_normal_
+    _orig_erfinv_ = torch.Tensor.erfinv_
+
+    def _is_ptpu_tensor(tensor: torch.Tensor) -> bool:
+        try:
+            return bool(getattr(tensor, "is_ptpu", False)) or (
+                tensor.device.type == "ptpu"
+            )
+        except Exception:
+            return False
+
+    def _erfinv_(self: torch.Tensor):
+        if not _is_ptpu_tensor(self):
+            return _orig_erfinv_(self)
+        cpu = self.detach().to("cpu")
+        _orig_erfinv_(cpu)
+        with torch.no_grad():
+            self.copy_(cpu.to(device=self.device, dtype=self.dtype))
+        return self
+
+    def _trunc_normal_(
+        tensor: torch.Tensor,
+        mean: float = 0.0,
+        std: float = 1.0,
+        a: float = -2.0,
+        b: float = 2.0,
+        generator=None,
+    ):
+        if not _is_ptpu_tensor(tensor):
+            return _orig_trunc(
+                tensor, mean=mean, std=std, a=a, b=b, generator=generator
+            )
+
+        cpu = tensor.detach().to("cpu")
+        _orig_trunc(cpu, mean=mean, std=std, a=a, b=b, generator=generator)
+        with torch.no_grad():
+            tensor.copy_(cpu.to(device=tensor.device, dtype=tensor.dtype))
+        return tensor
+
+    torch.Tensor.erfinv_ = _erfinv_  # type: ignore[method-assign, assignment]
+    init.trunc_normal_ = _trunc_normal_  # type: ignore[assignment]
+
+    # Modules that already bound the original symbol at import time.
+    for mod_name in (
+        "vllm.model_executor.models.minicpmv",
+        "vllm.model_executor.models.minicpmo",
+    ):
+        mod = sys.modules.get(mod_name)
+        if mod is not None and hasattr(mod, "trunc_normal_"):
+            mod.trunc_normal_ = _trunc_normal_
+
+    patch_ptpu_trunc_normal_init._done = True  # type: ignore[attr-defined]
+    logger.info(
+        "Patched trunc_normal_/Tensor.erfinv_ for PTPU "
+        "(CPU fallback; MiniCPM resampler init)"
+    )
+
+
+def patch_flagcx_comm_lifecycle():
+    from .patches.patch_flagcx_comm import patch_flagcx_comm_lifecycle as _patch
+
+    _patch()
 
 
 def patch_flagcx_stream_adapter():
-    """Patch FlagCX wrapper to accept PTPU streams."""
+    from .patches.patch_flagcx_stream_adapter import (
+        patch_flagcx_stream_adapter as _patch,
+    )
+
+    _patch()
+
+
+def patch_flagcx_collective_hot_path():
+    """Faster FlagCX collective wrappers for PTPU (dtype/op cache, in-place AR)."""
     try:
         from vllm.platforms import current_platform
 
         if getattr(current_platform, "device_type", None) != "ptpu":
             return
 
-        flagcx_path = os.getenv("FLAGCX_PATH")
-        if flagcx_path and os.path.isdir(flagcx_path) and flagcx_path not in sys.path:
-            sys.path.append(flagcx_path)
+        from vllm_fl.distributed.device_communicators.flagcx import (
+            PyFlagcxCommunicator,
+        )
+        from vllm_fl.distributed.communicator import CommunicatorFL
 
-        flagcx_wrapper = importlib.import_module("plugin.interservice.flagcx_wrapper")
-        FLAGCXLibrary = flagcx_wrapper.FLAGCXLibrary
-        flagcxStream_t = flagcx_wrapper.flagcxStream_t
-
-        if getattr(FLAGCXLibrary, "_sunrise_stream_patch_applied", False):
+        try:
+            from vllm_fl.distributed.device_communicators.flagcx import (
+                buffer_type,
+                flagcxDataTypeEnum,
+                flagcxRedOpTypeEnum,
+            )
+        except ImportError:
+            logger.warning(
+                "FlagCX symbols not importable; skipping collective hot-path "
+                "patch (single-card path will not be affected)."
+            )
             return
 
-        def _to_void_p(raw_stream_ptr):
-            if isinstance(raw_stream_ptr, ctypes.c_void_p):
-                return raw_stream_ptr
-            if raw_stream_ptr is None:
-                raise ValueError("Stream pointer is None.")
-            return ctypes.c_void_p(int(raw_stream_ptr))
+        if buffer_type is None or flagcxDataTypeEnum is None or flagcxRedOpTypeEnum is None:
+            logger.warning(
+                "FlagCX library not loaded (likely single-card path); "
+                "skipping collective hot-path patch."
+            )
+            return
 
-        def _extract_raw_stream_ptr(old_stream):
-            if isinstance(old_stream, (int, ctypes.c_void_p)):
-                return old_stream
+        from torch.distributed import ReduceOp
 
-            for attr in ("ptpu_stream", "cuda_stream"):
-                stream_ptr = getattr(old_stream, attr, None)
-                if stream_ptr is not None:
-                    return stream_ptr
+        # vllm.utils.current_stream is stale on PTPU; use torch.ptpu TLS.
+        _live_current_stream = current_platform.torch_device_fn.current_stream
 
-            stream_fn = getattr(old_stream, "stream", None)
-            if callable(stream_fn):
-                stream_ptr = stream_fn()
-                if stream_ptr is not None:
-                    return stream_ptr
+        if getattr(PyFlagcxCommunicator, "_sunrise_collective_hot_path_patched", False):
+            return
 
-            raise AttributeError(
-                "Unsupported stream object: expected a raw pointer or one of "
-                "`ptpu_stream`, `cuda_stream`, or callable `stream()`."
+        _dtype_enum_cache: dict = {}
+        _op_enum_cache: dict = {}
+
+        def _dtype_enum(dtype):
+            cached = _dtype_enum_cache.get(dtype)
+            if cached is None:
+                cached = flagcxDataTypeEnum.from_torch(dtype)
+                _dtype_enum_cache[dtype] = cached
+            return cached
+
+        def _op_enum(op):
+            cached = _op_enum_cache.get(op)
+            if cached is None:
+                cached = flagcxRedOpTypeEnum.from_torch(op)
+                _op_enum_cache[op] = cached
+            return cached
+
+        def _all_reduce_hot(
+            self,
+            in_tensor,
+            out_tensor=None,
+            op=ReduceOp.SUM,
+            stream=None,
+        ):
+            if self.disabled:
+                return None
+            if self.comm is None:
+                init_fn = getattr(self, "_ensure_initialized", None)
+                if init_fn is not None:
+                    init_fn()
+            if out_tensor is None:
+                out_tensor = in_tensor
+
+            cached_fn = getattr(self, "_sunrise_ar_fn", None)
+            if cached_fn is None:
+                cached_fn = self.flagcx._funcs["flagcxAllReduce"]
+                self._sunrise_ar_fn = cached_fn
+
+            flagcx_stream = (
+                self._get_default_stream_wrapper()
+                if stream is None
+                else self.flagcx.adaptor_stream_copy(stream)
             )
 
-        def _adaptor_stream_copy(self, old_stream):
-            new_stream = flagcxStream_t()
-            raw_stream_ptr = _extract_raw_stream_ptr(old_stream)
-            self.FLAGCX_CHECK(
-                self.handler.contents.devHandle.contents.streamCopy(
-                    ctypes.byref(new_stream), _to_void_p(raw_stream_ptr)
+            device_ctx = getattr(self, "_device_ctx", None)
+            if device_ctx is None:
+                device_ctx = current_platform.torch_device_fn.device(self.device)
+                self._device_ctx = device_ctx
+
+            with device_ctx:
+                rc = cached_fn(
+                    buffer_type(in_tensor.data_ptr()),
+                    buffer_type(out_tensor.data_ptr()),
+                    in_tensor.numel(),
+                    _dtype_enum(in_tensor.dtype),
+                    _op_enum(op),
+                    self.comm,
+                    flagcx_stream,
+                )
+            if rc != 0:
+                raise RuntimeError(
+                    f"FLAGCX error: {self.flagcx.flagcxGetErrorString(rc)}"
+                )
+            return out_tensor
+
+        PyFlagcxCommunicator.all_reduce = _all_reduce_hot
+
+        def _get_default_stream_wrapper(self, _live=_live_current_stream):
+            return self.flagcx.adaptor_stream_copy(_live())
+
+        def _check_rc(self, rc):
+            if rc != 0:
+                raise RuntimeError(
+                    f"FLAGCX error: {self.flagcx.flagcxGetErrorString(rc)}"
+                )
+
+        PyFlagcxCommunicator._get_default_stream_wrapper = _get_default_stream_wrapper
+        PyFlagcxCommunicator._check_rc = _check_rc
+
+        def _all_gather_hot(self, output_tensor, input_tensor, stream=None):
+            if self.disabled:
+                return
+            if self.comm is None:
+                init_fn = getattr(self, "_ensure_initialized", None)
+                if init_fn is not None:
+                    init_fn()
+            fn = getattr(self, "_sunrise_ag_fn", None)
+            if fn is None:
+                fn = self.flagcx._funcs["flagcxAllGather"]
+                self._sunrise_ag_fn = fn
+            flagcx_stream = (
+                self._get_default_stream_wrapper()
+                if stream is None
+                else self.flagcx.adaptor_stream_copy(stream)
+            )
+            self._check_rc(
+                fn(
+                    buffer_type(input_tensor.data_ptr()),
+                    buffer_type(output_tensor.data_ptr()),
+                    input_tensor.numel(),
+                    _dtype_enum(input_tensor.dtype),
+                    self.comm,
+                    flagcx_stream,
                 )
             )
-            return new_stream
 
-        FLAGCXLibrary.adaptor_stream_copy = _adaptor_stream_copy
-        FLAGCXLibrary._sunrise_stream_patch_applied = True
-        logger.info("Patched FlagCX stream adapter for Sunrise/PTPU")
+        def _reduce_scatter_hot(
+            self, output_tensor, input_tensor, op=ReduceOp.SUM, stream=None
+        ):
+            if self.disabled:
+                return
+            if self.comm is None:
+                init_fn = getattr(self, "_ensure_initialized", None)
+                if init_fn is not None:
+                    init_fn()
+            fn = getattr(self, "_sunrise_rs_fn", None)
+            if fn is None:
+                fn = self.flagcx._funcs["flagcxReduceScatter"]
+                self._sunrise_rs_fn = fn
+            flagcx_stream = (
+                self._get_default_stream_wrapper()
+                if stream is None
+                else self.flagcx.adaptor_stream_copy(stream)
+            )
+            self._check_rc(
+                fn(
+                    buffer_type(input_tensor.data_ptr()),
+                    buffer_type(output_tensor.data_ptr()),
+                    output_tensor.numel(),
+                    _dtype_enum(input_tensor.dtype),
+                    _op_enum(op),
+                    self.comm,
+                    flagcx_stream,
+                )
+            )
+
+        def _broadcast_hot(self, tensor, src, stream=None):
+            if self.disabled:
+                return
+            if self.comm is None:
+                init_fn = getattr(self, "_ensure_initialized", None)
+                if init_fn is not None:
+                    init_fn()
+            fn = getattr(self, "_sunrise_bc_fn", None)
+            if fn is None:
+                fn = self.flagcx._funcs["flagcxBroadcast"]
+                self._sunrise_bc_fn = fn
+            # Sender provides sendbuff = tensor; receivers pass NULL sendbuff.
+            tensor_ptr = tensor.data_ptr()
+            if src == self.rank:
+                sendbuff = buffer_type(tensor_ptr)
+                recvbuff = buffer_type(tensor_ptr)
+            else:
+                sendbuff = buffer_type()
+                recvbuff = buffer_type(tensor_ptr)
+            flagcx_stream = (
+                self._get_default_stream_wrapper()
+                if stream is None
+                else self.flagcx.adaptor_stream_copy(stream)
+            )
+            self._check_rc(
+                fn(
+                    sendbuff,
+                    recvbuff,
+                    tensor.numel(),
+                    _dtype_enum(tensor.dtype),
+                    src,
+                    self.comm,
+                    flagcx_stream,
+                )
+            )
+
+        def _send_hot(self, tensor, dst, stream=None):
+            if self.disabled:
+                return
+            if self.comm is None:
+                init_fn = getattr(self, "_ensure_initialized", None)
+                if init_fn is not None:
+                    init_fn()
+            fn = getattr(self, "_sunrise_send_fn", None)
+            if fn is None:
+                fn = self.flagcx._funcs["flagcxSend"]
+                self._sunrise_send_fn = fn
+            flagcx_stream = (
+                self._get_default_stream_wrapper()
+                if stream is None
+                else self.flagcx.adaptor_stream_copy(stream)
+            )
+            self._check_rc(
+                fn(
+                    buffer_type(tensor.data_ptr()),
+                    tensor.numel(),
+                    _dtype_enum(tensor.dtype),
+                    dst,
+                    self.comm,
+                    flagcx_stream,
+                )
+            )
+
+        def _recv_hot(self, tensor, src, stream=None):
+            if self.disabled:
+                return
+            if self.comm is None:
+                init_fn = getattr(self, "_ensure_initialized", None)
+                if init_fn is not None:
+                    init_fn()
+            fn = getattr(self, "_sunrise_recv_fn", None)
+            if fn is None:
+                fn = self.flagcx._funcs["flagcxRecv"]
+                self._sunrise_recv_fn = fn
+            flagcx_stream = (
+                self._get_default_stream_wrapper()
+                if stream is None
+                else self.flagcx.adaptor_stream_copy(stream)
+            )
+            self._check_rc(
+                fn(
+                    buffer_type(tensor.data_ptr()),
+                    tensor.numel(),
+                    _dtype_enum(tensor.dtype),
+                    src,
+                    self.comm,
+                    flagcx_stream,
+                )
+            )
+
+        PyFlagcxCommunicator.all_gather = _all_gather_hot
+        PyFlagcxCommunicator.reduce_scatter = _reduce_scatter_hot
+        PyFlagcxCommunicator.broadcast = _broadcast_hot
+        PyFlagcxCommunicator.send = _send_hot
+        PyFlagcxCommunicator.recv = _recv_hot
+
+        PyFlagcxCommunicator._sunrise_collective_hot_path_patched = True
+
+        if not getattr(CommunicatorFL, "_sunrise_all_reduce_inplace_patched", False):
+
+            def _ar_inplace(self, input_):
+                bound = self.__dict__.get("_sunrise_pfc_ar_bound")
+                if bound is None:
+                    pfc = self.pyflagcx_comm
+                    if pfc is None:
+                        out = input_.clone()
+                        torch.distributed.all_reduce(
+                            out, group=self.device_group
+                        )
+                        return out
+                    bound = pfc.all_reduce
+                    self._sunrise_pfc_ar_bound = bound
+                return bound(input_, out_tensor=input_)
+
+            CommunicatorFL.all_reduce = _ar_inplace
+            CommunicatorFL._sunrise_all_reduce_inplace_patched = True
+
+        logger.info("Patched FlagCX collective hot path for Sunrise/PTPU")
     except Exception as e:
-        logger.warning("Failed to patch FlagCX stream adapter for Sunrise: %s", e)
+        logger.warning(
+            "Failed to patch FlagCX collective hot path for Sunrise: %s", e
+        )
+
+
+def patch_vllm_group_coordinator_dispatch():
+    """Skip dead custom-op branches in GroupCoordinator AR/AG/RS on PTPU."""
+    try:
+        from vllm.distributed.parallel_state import GroupCoordinator
+        from vllm.platforms import current_platform
+    except Exception as e:
+        logger.warning(
+            "Failed to import GroupCoordinator (skipping dispatch patch): %s", e
+        )
+        return
+
+    if getattr(GroupCoordinator, "_sunrise_phase_b3_patched", False):
+        return
+
+    # PTPU does not use torch custom-op collectives.
+    try:
+        uses_custom_op = current_platform.use_custom_op_collectives()
+    except Exception:
+        uses_custom_op = False
+    if uses_custom_op:
+        logger.info(
+            "Skipping GroupCoordinator dispatch patch: "
+            "use_custom_op_collectives() is True"
+        )
+        return
+
+    def _fast_all_reduce(self, input_):
+        if self.world_size == 1:
+            return input_
+        dc = self.device_communicator
+        if dc is None:
+            raise ValueError("No device communicator found")
+        return dc.all_reduce(input_)
+
+    def _fast_all_gather(self, input_, dim=-1):
+        if self.world_size == 1:
+            return input_
+        assert -input_.dim() <= dim < input_.dim(), (
+            f"Invalid dim ({dim}) for input tensor with shape {input_.size()}"
+        )
+        dc = self.device_communicator
+        if dc is None:
+            raise ValueError("No device communicator found")
+        return dc.all_gather(input_, dim)
+
+    def _fast_reduce_scatter(self, input_, dim=-1):
+        if self.world_size == 1:
+            return input_
+        assert -input_.dim() <= dim < input_.dim(), (
+            f"Invalid dim ({dim}) for input tensor with shape {input_.size()}"
+        )
+        dc = self.device_communicator
+        if dc is None:
+            raise ValueError("No device communicator found")
+        return dc.reduce_scatter(input_, dim)
+
+    GroupCoordinator.all_reduce = _fast_all_reduce
+    GroupCoordinator.all_gather = _fast_all_gather
+    GroupCoordinator.reduce_scatter = _fast_reduce_scatter
+    GroupCoordinator._sunrise_phase_b3_patched = True
+
+    logger.info("Patched GroupCoordinator AR/AG/RS dispatch for Sunrise/PTPU")
+
+
+def patch_op_manager_fast_path():
+    """Cache resolved op fn on ``OpManager`` and call it directly when IO dump is off.
+
+    Invalidate on both ``OpManager.policy_epoch`` and ``get_policy_epoch()`` so
+    ``policy_context()`` / ``set_global_policy()`` (official CachedOp semantics)
+    cannot leave a stale sunrise fast-path entry.
+    """
+    if os.environ.get("VLLM_FL_SUNRISE_OPMGR_FAST", "1") != "1":
+        logger.info(
+            "OpManager fast path disabled by VLLM_FL_SUNRISE_OPMGR_FAST=0"
+        )
+        return
+
+    try:
+        from vllm_fl.dispatch.manager import OpManager
+        from vllm_fl.dispatch.io_dumper import is_dump_enabled
+        from vllm_fl.dispatch.policy import get_policy_epoch
+    except Exception as e:
+        logger.warning(
+            "Failed to import OpManager/is_dump_enabled (skipping): %s", e
+        )
+        return
+
+    if getattr(OpManager, "_sunrise_fast_path_patched", False):
+        return
+
+    _orig_call = OpManager.call
+
+    def _fast_call(self, op_name, *args, **kwargs):
+        cache = getattr(self, "_sunrise_fast_cache", None)
+        policy_epoch = get_policy_epoch()
+        if cache is not None:
+            entry = cache.get(op_name)
+            if entry is not None:
+                fn, mgr_epoch, pol_epoch = entry
+                if (
+                    mgr_epoch == self._state.policy_epoch
+                    and pol_epoch == policy_epoch
+                    and not is_dump_enabled()
+                ):
+                    return fn(*args, **kwargs)
+
+        result = _orig_call(self, op_name, *args, **kwargs)
+
+        if cache is None:
+            cache = {}
+            self._sunrise_fast_cache = cache
+        try:
+            fn = self.resolve(op_name)
+            cache[op_name] = (fn, self._state.policy_epoch, policy_epoch)
+        except Exception:
+            pass
+        return result
+
+    OpManager.call = _fast_call
+    OpManager._sunrise_fast_path_patched = True
+
+    logger.info("Patched OpManager.call hot path for Sunrise/PTPU")
+
+
+def patch_oot_layer_fast_path():
+    """Resolve op fn once in OOT ``forward_oot`` when upstream lacks CachedOp.
+
+    Official vllm-plugin-FL now routes ``RMSNormFL`` / ``SiluAndMulFL`` /
+    ``GeluAndMulFL`` through ``CachedOp`` (policy-epoch aware + fallback).
+    Replacing those ``forward_oot`` methods would drop that behavior, so this
+    patch is a no-op when CachedOp is already in use. Keep the legacy
+    resolve_op cache only for older trees that still call ``call_op`` directly.
+    """
+    if os.environ.get("VLLM_FL_SUNRISE_OOT_FAST", "1") != "1":
+        logger.info(
+            "OOT layer fast path disabled by VLLM_FL_SUNRISE_OOT_FAST=0"
+        )
+        return
+
+    try:
+        from vllm_fl.dispatch import CachedOp, resolve_op
+        from vllm_fl.ops.layernorm import RMSNormFL
+        from vllm_fl.ops.activation import SiluAndMulFL, GeluAndMulFL
+        import vllm_fl.ops.layernorm as _layernorm_mod
+        import vllm_fl.ops.activation as _activation_mod
+    except Exception as e:
+        logger.warning(
+            "Failed to import OOT layer modules (skipping): %s", e
+        )
+        return
+
+    # Upstream already ships CachedOp hot path — do not overwrite it.
+    if any(
+        isinstance(getattr(mod, name, None), CachedOp)
+        for mod, name in (
+            (_layernorm_mod, "_rms_norm"),
+            (_activation_mod, "_silu_and_mul"),
+            (_activation_mod, "_gelu_and_mul"),
+        )
+    ):
+        logger.info(
+            "Skipping sunrise OOT forward_oot patch; official CachedOp is active"
+        )
+        return
+
+    def _make_passthrough(op_name):
+        cache = [None]
+
+        def _fast_forward_oot(self, *args, **kwargs):
+            fn = cache[0]
+            if fn is None:
+                cache[0] = fn = resolve_op(op_name)
+            return fn(self, *args, **kwargs)
+
+        _fast_forward_oot.__name__ = f"_fast_forward_oot_{op_name}"
+        _fast_forward_oot.__qualname__ = f"_fast_forward_oot[{op_name}]"
+        return _fast_forward_oot
+
+    patched = []
+
+    if not getattr(RMSNormFL, "_sunrise_oot_fast_patched", False):
+        RMSNormFL.forward_oot = _make_passthrough("rms_norm")
+        RMSNormFL._sunrise_oot_fast_patched = True
+        patched.append("RMSNormFL")
+
+    if not getattr(SiluAndMulFL, "_sunrise_oot_fast_patched", False):
+        SiluAndMulFL.forward_oot = _make_passthrough("silu_and_mul")
+        SiluAndMulFL._sunrise_oot_fast_patched = True
+        patched.append("SiluAndMulFL")
+
+    if not getattr(GeluAndMulFL, "_sunrise_oot_fast_patched", False):
+        GeluAndMulFL.forward_oot = _make_passthrough("gelu_and_mul")
+        GeluAndMulFL._sunrise_oot_fast_patched = True
+        patched.append("GeluAndMulFL")
+
+    if patched:
+        logger.info(
+            "Patched OOT layer forward_oot for Sunrise/PTPU (%s)",
+            ", ".join(patched),
+        )
+
+
+def patch_ptpu_topk_topp_sampler():
+    """Use PTPU fused ``top_k_top_p_sampling_from_probs`` in ``TopKTopPSampler.forward_native``."""
+    if os.environ.get("VLLM_FL_SUNRISE_PTPU_SAMPLER", "1") != "1":
+        logger.info(
+            "PTPU sampler patch disabled by VLLM_FL_SUNRISE_PTPU_SAMPLER=0"
+        )
+        return
+
+    try:
+        from vllm.v1.sample.ops.topk_topp_sampler import (
+            TopKTopPSampler,
+            random_sample,
+        )
+        import torch_ptpu.sgl_kernel as _ptpu_sgl
+        _ptpu_topk_topp_fn = _ptpu_sgl.top_k_top_p_sampling_from_probs
+    except Exception as e:
+        logger.warning(
+            "Failed to import deps for PTPU sampler patch (skipping): %s",
+            e,
+        )
+        return
+
+    if getattr(TopKTopPSampler, "_sunrise_ptpu_sampler_patched", False):
+        return
+
+    _orig_forward_native = TopKTopPSampler.forward_native
+
+    def _ptpu_forward_native(self, logits, generators, k, p):
+        if generators:
+            return _orig_forward_native(self, logits, generators, k, p)
+
+        if self.logprobs_mode in ("processed_logits", "processed_logprobs"):
+            return _orig_forward_native(self, logits, generators, k, p)
+
+        if k is None and p is None:
+            probs = logits.softmax(dim=-1, dtype=torch.float32)
+            return random_sample(probs, generators), None
+
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        bs = probs.shape[0]
+        uniform_samples = torch.rand(
+            (32, bs), dtype=torch.float32, device=probs.device
+        )
+
+        k_arg = k if k is not None else probs.shape[-1]
+        p_arg = p if p is not None else 1.0
+
+        if isinstance(k_arg, torch.Tensor) and k_arg.dtype != torch.int32:
+            k_arg = k_arg.to(torch.int32)
+        if isinstance(p_arg, torch.Tensor) and p_arg.dtype != torch.float32:
+            p_arg = p_arg.to(torch.float32)
+
+        token_ids, _success = _ptpu_topk_topp_fn(
+            probs,
+            uniform_samples,
+            k_arg,
+            p_arg,
+            filter_apply_order="joint",
+            deterministic=True,
+            check_nan=False,
+        )
+        return token_ids, None
+
+    TopKTopPSampler.forward_native = _ptpu_forward_native
+    TopKTopPSampler._sunrise_ptpu_sampler_patched = True
+
+    logger.info(
+        "Patched TopKTopPSampler.forward_native for PTPU fused top-k/top-p sampling"
+    )
 
 
 def patch_distributed_runtime():
@@ -109,7 +940,6 @@ def patch_distributed_runtime():
         if getattr(current_platform, "device_type", None) != "ptpu":
             return
 
-        # Preserve the original Sunrise/FlagCX communicator selection logic.
         platform_cls.dist_backend = "flagcx"
         current_platform.dist_backend = "flagcx"
 
@@ -193,13 +1023,17 @@ def patch_op_cls():
     except Exception as e:
         logger.warning("Failed to patch VocabParallelEmbedding for Sunrise: %s", e)
 
+    from .impl.gemma_rms_norm import register_gemma_rms_norm_oot
+
+    register_gemma_rms_norm_oot()
+
+    from .impl.rms_norm_gated import register_rms_norm_gated_oot
+
+    register_rms_norm_gated_oot()
+
 
 def patch_accelerator_empty_cache():
-    """Redirect torch.accelerator.empty_cache() to torch.ptpu.empty_cache().
-
-    torch.accelerator.empty_cache() requires a DeviceAllocator interface that
-    PTPU does not implement. torch.ptpu.empty_cache() works correctly instead.
-    """
+    """Redirect ``torch.accelerator.empty_cache()`` to ``torch.ptpu.empty_cache()``."""
     try:
         import torch.accelerator as _accel
 
@@ -213,9 +1047,7 @@ def patch_accelerator_empty_cache():
 
 
 def patch_fused_topk_bias_router():
-    """Replace CUDA-only ``vllm_topk_{sigmoid,softmax}`` with a native
-    implementation on Sunrise/PTPU.
-    """
+    """Native top-k router on PTPU (replaces CUDA-only ``vllm_topk_{sigmoid,softmax}``)."""
 
     try:
         from vllm.platforms import current_platform
@@ -305,17 +1137,7 @@ def patch_fused_topk_bias_router():
 
 
 def patch_memory_profiling_for_plain_allocator():
-    """Fix KV-cache OOM caused by weights being double-counted on PTPU.
-
-    ``torch_ptpu`` ships a "plain"-style device allocator that does not register
-    with PyTorch's caching allocator, so ``torch.memory_reserved()`` is always
-    ~0 on PTPU. The shared :func:`memory_profiling_fl` computes
-    ``non_torch = cuda_used - torch_reserved``; with ``torch_reserved == 0``
-    this leaks the model weights into ``non_torch``. The final
-    ``non_kv_cache = weights + peak_act + non_torch`` then counts weights
-    twice, yielding a phantom OOM in ``determine_available_memory`` even when
-    the device has plenty of free memory.
-    """
+    """Correct KV-cache sizing when PTPU ``torch.memory_reserved()`` is always zero."""
     try:
         from vllm.platforms import current_platform
 
@@ -326,8 +1148,11 @@ def patch_memory_profiling_for_plain_allocator():
         return
 
     try:
+        import threading
+        import time
         from contextlib import contextmanager
 
+        from vllm.platforms import current_platform as _cp
         from vllm_fl.worker import worker as worker_mod
 
         original = worker_mod.memory_profiling_fl
@@ -337,12 +1162,64 @@ def patch_memory_profiling_for_plain_allocator():
         gib = float(2**30)
         _logged = {"once": False}
 
+        # PTPU plain allocator lacks peak stats; sample free memory during profile_run.
+        try:
+            _act_factor = float(os.environ.get("VLLM_FL_ACT_HEADROOM_FACTOR", "1.15"))
+        except ValueError:
+            _act_factor = 1.15
+        try:
+            _act_min = float(os.environ.get("VLLM_FL_ACT_HEADROOM_MIN_GIB", "1.0")) * gib
+        except ValueError:
+            _act_min = gib
+        try:
+            _sample_s = float(os.environ.get("VLLM_FL_ACT_SAMPLE_MS", "2")) / 1000.0
+        except ValueError:
+            _sample_s = 0.002
+
+        def _mem_free():
+            try:
+                free, _total = _cp.torch_device_fn.mem_get_info()
+                return int(free)
+            except Exception:
+                return None
+
         @contextmanager
         def memory_profiling_fl_ptpu(baseline_snapshot, weights_memory):
+            # Track the minimum free memory seen while the profiling forward
+            # runs -> the maximum device usage, i.e. the true activation peak.
+            state = {"min_free": None}
+            stop = threading.Event()
+
+            def _sample():
+                while not stop.is_set():
+                    free = _mem_free()
+                    if free is not None and (
+                        state["min_free"] is None or free < state["min_free"]
+                    ):
+                        state["min_free"] = free
+                    time.sleep(_sample_s)
+
             with original(
                 baseline_snapshot, weights_memory=weights_memory
             ) as result:
-                yield result
+                sampler = threading.Thread(target=_sample, daemon=True)
+                sampler.start()
+                try:
+                    yield result
+                finally:
+                    # Drain async work so a lagging peak is still observed,
+                    # then take one last sample before stopping the thread.
+                    try:
+                        _cp.torch_device_fn.synchronize()
+                    except Exception:
+                        pass
+                    free = _mem_free()
+                    if free is not None and (
+                        state["min_free"] is None or free < state["min_free"]
+                    ):
+                        state["min_free"] = free
+                    stop.set()
+                    sampler.join(timeout=1.0)
 
             if (
                 result.after_profile.torch_memory == 0
@@ -353,21 +1230,39 @@ def patch_memory_profiling_for_plain_allocator():
                     - result.before_create.cuda_memory
                 )
                 corrected_non_torch = max(0, actual_used - result.weights_memory)
+
+                # Measured transient activation peak = drop in free memory
+                # during the forward, relative to the pre-forward baseline.
+                measured_peak = 0
+                if (
+                    state["min_free"] is not None
+                    and result.before_profile.free_memory > 0
+                ):
+                    measured_peak = max(
+                        0, result.before_profile.free_memory - state["min_free"]
+                    )
+                # Fall back to any torch-reported peak if sampling failed.
+                peak_act = max(result.torch_peak_increase, measured_peak)
+                # Reserve with a safety margin: runtime steps hit shapes /
+                # autotune buffers the single profiling pass may not.
+                peak_reserve = max(int(peak_act * _act_factor), int(_act_min))
+
+                result.torch_peak_increase = peak_reserve
                 result.non_torch_increase = corrected_non_torch
                 result.non_kv_cache_memory = (
-                    corrected_non_torch
-                    + result.torch_peak_increase
-                    + result.weights_memory
+                    corrected_non_torch + peak_reserve + result.weights_memory
                 )
 
                 if not _logged["once"]:
                     _logged["once"] = True
                     logger.info(
                         "PTPU plain-allocator memory accounting fix applied: "
-                        "weights=%.2f GiB peak_act=%.2f GiB actual_used=%.2f GiB "
+                        "weights=%.2f GiB measured_peak_act=%.2f GiB "
+                        "reserved_peak_act=%.2f GiB actual_used=%.2f GiB "
                         "-> non_torch=%.2f GiB non_kv_cache=%.2f GiB",
                         result.weights_memory / gib,
-                        result.torch_peak_increase / gib,
+                        measured_peak / gib,
+                        peak_reserve / gib,
                         actual_used / gib,
                         corrected_non_torch / gib,
                         result.non_kv_cache_memory / gib,
@@ -383,3 +1278,62 @@ def patch_memory_profiling_for_plain_allocator():
         logger.warning(
             "Failed to patch memory_profiling_fl for Sunrise/PTPU: %s", e
         )
+
+
+def patch_hy_v3_shared_mlp_weights() -> None:
+    """Remap Hy-MT2 shared-expert checkpoint names when vLLM hy_v3 lacks ``shared_mlp`` prefix.
+
+    Hy-MT2 checkpoints store shared MLP weights under ``*.mlp.shared_mlp.*``.
+    Upstream vLLM ``HYV3MoEFused`` originally registered parameters as
+    ``*.mlp.gate_up_proj`` (missing the ``shared_mlp`` segment). Newer vLLM
+    builds may already use ``prefix=f"{prefix}.shared_mlp"``; in that case
+    this patch detects the correct param layout and skips remapping.
+    """
+    try:
+        from vllm.model_executor.models import hy_v3 as hy_v3_mod
+    except ImportError:
+        return
+
+    if getattr(hy_v3_mod.HYV3Model, "_sunrise_shared_mlp_weight_patch", False):
+        return
+
+    _orig_load_weights = hy_v3_mod.HYV3Model.load_weights
+
+    def _remap_shared_mlp_name(name: str) -> str:
+        if ".shared_mlp." not in name:
+            return name
+        return (
+            name.replace(".shared_mlp.gate_proj", ".gate_proj")
+            .replace(".shared_mlp.up_proj", ".up_proj")
+            .replace(".shared_mlp.down_proj", ".down_proj")
+        )
+
+    def _needs_shared_mlp_remap(self) -> bool:
+        for param_name, _ in self.named_parameters():
+            if ".mlp.shared_mlp.gate_up_proj" in param_name:
+                return False
+        for param_name, _ in self.named_parameters():
+            if ".mlp.gate_up_proj" in param_name and ".shared_mlp." not in param_name:
+                return True
+        return False
+
+    def _load_weights(self, weights):
+        if not _needs_shared_mlp_remap(self):
+            return _orig_load_weights(self, weights)
+
+        def _iter_remapped():
+            for name, tensor in weights:
+                yield _remap_shared_mlp_name(name), tensor
+
+        logger.info(
+            "HYV3Model.load_weights: remapping shared_mlp checkpoint names "
+            "(upstream hy_v3 missing .shared_mlp param prefix)"
+        )
+        return _orig_load_weights(self, _iter_remapped())
+
+    hy_v3_mod.HYV3Model.load_weights = _load_weights
+    hy_v3_mod.HYV3Model._sunrise_shared_mlp_weight_patch = True
+    logger.info(
+        "Patched HYV3Model.load_weights for Hy-MT2 shared_mlp compatibility"
+    )
+

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -43,6 +43,50 @@ def apply_sunrise_patches():
     patch_mla_gather_cache_ops()
     patch_ptpu_trunc_normal_init()
     patch_minicpmo_resampler_device()
+    patch_moe_force_config()
+
+
+def patch_moe_force_config() -> None:
+    """Pin the fused-MoE tile config, for bisecting tile-dependent bugs.
+
+    vLLM derives BLOCK_SIZE_* from the token count alone and exposes no flag to
+    fix them, but ``try_get_optimal_moe_config`` consults a module global before
+    any heuristic, which is what this sets. BLOCK_SIZE_M also reaches
+    moe_align_block_size, so the padding follows along.
+
+    Off unless VLLM_FL_MOE_FORCE_CONFIG holds a JSON object, e.g.
+    '{"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1, "num_warps": 8, "num_stages": 3}'
+    """
+    raw = os.environ.get("VLLM_FL_MOE_FORCE_CONFIG", "").strip()
+    if not raw:
+        return
+
+    import json
+
+    import vllm.model_executor.layers.fused_moe as vllm_fused_moe
+
+    config = json.loads(raw)
+    required = {
+        "BLOCK_SIZE_M",
+        "BLOCK_SIZE_N",
+        "BLOCK_SIZE_K",
+        "GROUP_SIZE_M",
+        "num_warps",
+        "num_stages",
+    }
+    missing = required - set(config)
+    if missing:
+        raise ValueError(
+            f"VLLM_FL_MOE_FORCE_CONFIG is missing {sorted(missing)}; got {config}"
+        )
+
+    vllm_fused_moe._config = config
+    logger.warning(
+        "VLLM_FL_MOE_FORCE_CONFIG is set: every fused-MoE shape will use %s. "
+        "This is a debugging lever and costs throughput.",
+        config,
+    )
 
 
 def patch_minicpmo_resampler_device() -> None:

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/__init__.py
@@ -19,6 +19,7 @@ Classification
 from . import patch_fla_ops
 from . import patch_gdn_core_attn_buf
 from . import patch_int8_native
+from . import patch_moe_config
 from . import patch_pointwise
 from . import patch_profile_decode
 from . import patch_profiler
@@ -34,6 +35,10 @@ patch_gdn_core_attn_buf.apply_patch()
 
 # compressed-tensors INT8 (W8A8) enablement on PTPU; no-op for BF16 models.
 patch_int8_native.enable_native_int8()
+
+# Fused-MoE tile config from FlagGems' sunrise backend, not vLLM's NVIDIA
+# heuristic (whose prefill tile overflows PTPU registers and hangs the w2 GEMM).
+patch_moe_config.apply_patch()
 
 # Optional per-operator decode-step profiler (env-gated).
 patch_profile_decode.install()

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/__init__.py
@@ -13,7 +13,9 @@ Classification
   optional decode profiler, torch profiler PrivateUse1 bridge.
 * **Deferred** (``patch.apply_sunrise_patches``): CUDA stream shims, FlagCX
   comm/collectives, cudagraph, sampler/penalties, distributed runtime, OOT
-  layer registration, and other worker-init hooks.
+  layer registration, the ``_moe_C`` dispatch shims, and other worker-init
+  hooks. INT8 also re-asserts its MoE routing there, because
+  ``register_oot_ops`` installs the generic FL W8A8 selector in between.
 """
 
 from . import patch_fla_ops

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/__init__.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Sunrise import-time patches.
+
+Patches in this package are applied when the sunrise vendor backend is loaded
+(``from vllm_fl.dispatch.backends.vendor import sunrise``). They must run
+before model construction and before deferred patches in ``patch.py``.
+
+Classification
+--------------
+* **Import-time** (this module): FLA/GDN kernel rebinds, FlagGems pointwise
+  fast-path, GDN core-attn buffer reuse, compressed-tensors INT8 enablement,
+  optional decode profiler, torch profiler PrivateUse1 bridge.
+* **Deferred** (``patch.apply_sunrise_patches``): CUDA stream shims, FlagCX
+  comm/collectives, cudagraph, sampler/penalties, distributed runtime, OOT
+  layer registration, and other worker-init hooks.
+"""
+
+from . import patch_fla_ops
+from . import patch_gdn_core_attn_buf
+from . import patch_int8_native
+from . import patch_pointwise
+from . import patch_profile_decode
+from . import patch_profiler
+
+# FlagGems pointwise fast-path (must run before any FlagGems op dispatch).
+patch_pointwise.apply_patch()
+
+# Route vLLM FLA/GDN kernels to PTPU sgl_kernel (Qwen3.5 linear-attention).
+patch_fla_ops.apply_patch()
+
+# Reuse GDN core_attn_out buffer (eliminates per-iter zeros_kernel).
+patch_gdn_core_attn_buf.apply_patch()
+
+# compressed-tensors INT8 (W8A8) enablement on PTPU; no-op for BF16 models.
+patch_int8_native.enable_native_int8()
+
+# Optional per-operator decode-step profiler (env-gated).
+patch_profile_decode.install()
+
+# Always-on torch.profiler PrivateUse1 bridge on PTPU.
+patch_profiler.install()

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/flagcx_stream.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/flagcx_stream.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+"""Registry and stream sync helpers for PTPU cudagraph + FlagCX."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_ptpu_cudagraph_ar_stream: Any | None = None
+
+
+def set_ptpu_cudagraph_ar_stream(stream: Any) -> None:
+    global _ptpu_cudagraph_ar_stream
+    _ptpu_cudagraph_ar_stream = stream
+
+
+def get_ptpu_cudagraph_ar_stream() -> Any | None:
+    return _ptpu_cudagraph_ar_stream
+
+
+def sync_capture_stream_before_replay() -> None:
+    """Ensure input updates on the compute stream finish before graph replay."""
+    stream = _ptpu_cudagraph_ar_stream
+    if stream is None:
+        return
+    from vllm.platforms import current_platform
+
+    if current_platform.device_type != "ptpu":
+        return
+    compute_stream = current_platform.torch_device_fn.current_stream()
+    if compute_stream is not stream:
+        stream.wait_stream(compute_stream)
+
+
+def sync_compute_stream_after_replay() -> None:
+    """Ensure post-replay work on the compute stream sees graph results."""
+    stream = _ptpu_cudagraph_ar_stream
+    if stream is None:
+        return
+    from vllm.platforms import current_platform
+
+    if current_platform.device_type != "ptpu":
+        return
+    compute_stream = current_platform.torch_device_fn.current_stream()
+    if compute_stream is not stream:
+        compute_stream.wait_stream(stream)

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_cudagraph.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_cudagraph.py
@@ -1,0 +1,727 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+"""PTPU cudagraph integration for FlagCX tensor-parallel collectives."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextlib import contextmanager, nullcontext
+
+logger = logging.getLogger(__name__)
+_patched = False
+
+
+
+# Device-wide synchronize after replay is required for TP>1 FlagCX stability.
+
+
+def patch_ptpu_cudagraph():
+    """Hook graph capture/replay and warmup for multi-rank FlagCX on PTPU."""
+    global _patched
+    if _patched:
+        return
+    try:
+        from vllm.platforms import current_platform
+
+        if current_platform.device_type != "ptpu":
+            return
+    except Exception:
+        return
+
+    _patch_graph_wrapper()
+    _patch_model_runner()
+    _patch_step_debug()
+    _patched = True
+    logger.info("Applied PTPU cudagraph patches for FlagCX")
+
+
+def patch_engine_step_debug():
+    """Engine-side per-step wall-clock instrumentation (opt-in).
+
+    Called from both ``vllm_fl:register`` (platform plugin) and
+    ``vllm_fl:register_model`` (general plugin). The latter is the only
+    one vLLM guarantees to run inside the EngineCore subprocess (see
+    ``vllm/plugins/__init__.py:14``), so when we want engine-side timing
+    we rely on that path. The function is idempotent: subsequent calls
+    are no-ops once the class is patched.
+
+    Enabled by ``VLLM_FL_SUNRISE_DEBUG_STEP=1``. Interval defaults to 100
+    cycles; override via ``VLLM_FL_SUNRISE_DEBUG_STEP_INTERVAL``.
+
+    All early-exit branches log at INFO level (with a ``[FL_INIT]``
+    marker including the process PID) so the user can confirm in the
+    serve log whether the patch landed, was skipped because the env var
+    was unset, or hit an import error.
+    """
+    pid = os.getpid()
+    env_val = os.environ.get("VLLM_FL_SUNRISE_DEBUG_STEP", "0")
+    if env_val.lower() not in ("1", "true", "yes", "on"):
+        # One-line breadcrumb so the user can grep for [FL_INIT] across
+        # the full serve log and verify which processes saw the call.
+        logger.info(
+            "[FL_INIT] patch_engine_step_debug skipped pid=%d "
+            "(VLLM_FL_SUNRISE_DEBUG_STEP=%r)",
+            pid,
+            env_val,
+        )
+        return
+
+    try:
+        from vllm.v1.engine.core import EngineCoreProc
+    except Exception as exc:
+        logger.info(
+            "[FL_INIT] patch_engine_step_debug failed pid=%d: "
+            "could not import EngineCoreProc: %s",
+            pid,
+            exc,
+        )
+        return
+
+    if getattr(EngineCoreProc, "_sunrise_engine_debug_patched", False):
+        logger.info(
+            "[FL_INIT] patch_engine_step_debug already applied pid=%d "
+            "(idempotent no-op)",
+            pid,
+        )
+        return
+
+    interval = max(
+        1,
+        int(
+            os.environ.get("VLLM_FL_SUNRISE_DEBUG_STEP_INTERVAL", "100")
+        ),
+    )
+
+    samples = {
+        "cycle_ns": [],
+        "step_fn_ns": [],
+    }
+
+    def _percentile(sorted_arr, q):
+        n = len(sorted_arr)
+        if n == 0:
+            return 0.0
+        idx = min(n - 1, max(0, int(round(q * (n - 1)))))
+        return sorted_arr[idx]
+
+    def _stats(arr):
+        if not arr:
+            return 0.0, 0.0, 0.0, 0.0
+        arr_sorted = sorted(arr)
+        n = len(arr_sorted)
+        return (
+            sum(arr_sorted) / n / 1000.0,
+            _percentile(arr_sorted, 0.5) / 1000.0,
+            _percentile(arr_sorted, 0.99) / 1000.0,
+            arr_sorted[-1] / 1000.0,
+        )
+
+    def _emit() -> None:
+        n = len(samples["cycle_ns"])
+        if n == 0:
+            return
+        cyc_m, cyc_p50, cyc_p99, cyc_max = _stats(samples["cycle_ns"])
+        stp_m, stp_p50, stp_p99, stp_max = _stats(samples["step_fn_ns"])
+        post_m = max(cyc_m - stp_m, 0.0)  # output queue put + post_step
+        logger.info(
+            "[VLLM_FL_DBG_ENGINE] cycle n=%d | "
+            "cycle=%.1fus (p50=%.1f p99=%.1f max=%.1f) | "
+            "step_fn=%.1f (p50=%.1f p99=%.1f max=%.1f) | "
+            "post(=cycle-step_fn)=%.1f",
+            n,
+            cyc_m,
+            cyc_p50,
+            cyc_p99,
+            cyc_max,
+            stp_m,
+            stp_p50,
+            stp_p99,
+            stp_max,
+            post_m,
+        )
+        for k in samples:
+            samples[k].clear()
+
+    _orig_process = EngineCoreProc._process_engine_step
+
+    def _process_engine_step_wrapped(self):
+        # Wall-clock around the entire engine cycle as the loop sees it.
+        # We also try to time ``self.step_fn()`` alone to separate
+        # scheduler / RPC work from output-queue-put + post_step. Because
+        # ``step_fn`` is captured as a bound-method attribute on the
+        # instance (set in ``EngineCore.__init__``), wrapping the class
+        # method here is sufficient to also wrap step_fn -- we just
+        # measure step_fn by calling it through the existing instance
+        # attribute, accepting that the breakdown is "best-effort" and
+        # may slightly over-attribute to step_fn if other ops sneak in
+        # between t0 and step_fn() in ``_orig_process``.
+        #
+        # Implementation note: we wrap ``_process_engine_step`` rather
+        # than rebinding ``step_fn`` because ``step_fn`` is set per
+        # instance after ``__init__`` runs, and we cannot hook into all
+        # past or future instances cleanly. Wrapping the class method
+        # is robust.
+        t0 = time.perf_counter_ns()
+        # Sub-time ``step_fn``: temporarily swap the bound method with
+        # a timing wrapper for the duration of this call only. This
+        # mutation is per-instance and reverted after the call, so the
+        # original ``self.step_fn`` is preserved.
+        orig_step_fn = self.step_fn
+        step_fn_ns_holder = [0]
+
+        def _timed_step_fn(*a, **kw):
+            t_a = time.perf_counter_ns()
+            try:
+                return orig_step_fn(*a, **kw)
+            finally:
+                step_fn_ns_holder[0] = time.perf_counter_ns() - t_a
+
+        self.step_fn = _timed_step_fn
+        try:
+            ret = _orig_process(self)
+        finally:
+            self.step_fn = orig_step_fn
+        t1 = time.perf_counter_ns()
+        samples["cycle_ns"].append(t1 - t0)
+        samples["step_fn_ns"].append(step_fn_ns_holder[0])
+        if len(samples["cycle_ns"]) >= interval:
+            _emit()
+        return ret
+
+    EngineCoreProc._process_engine_step = _process_engine_step_wrapped
+    EngineCoreProc._sunrise_engine_debug_patched = True
+
+    logger.info(
+        "[FL_INIT] patch_engine_step_debug installed pid=%d "
+        "(interval=%d steps)",
+        pid,
+        interval,
+    )
+
+
+def _ptpu_stream_ctx():
+    from vllm.platforms import current_platform
+
+    from vllm_fl.dispatch.backends.vendor.sunrise.patches.flagcx_stream import (
+        get_ptpu_cudagraph_ar_stream,
+    )
+
+    stream = get_ptpu_cudagraph_ar_stream()
+    if stream is None:
+        return nullcontext()
+    return current_platform.torch_device_fn.stream(stream)
+
+
+def _ptpu_cross_rank_sync() -> bool:
+    """Device sync + CPU barrier when TP world size > 1."""
+    from vllm.platforms import current_platform
+
+    try:
+        from vllm.distributed.parallel_state import get_tp_group
+
+        tp_group = get_tp_group()
+        if tp_group is None or tp_group.world_size <= 1:
+            return False
+        current_platform.torch_device_fn.synchronize()
+        tp_group.barrier()
+        return True
+    except Exception:
+        return False
+
+
+def _bind_flagcx_comm_to_capture_stream() -> None:
+    try:
+        from vllm.distributed.parallel_state import get_tp_group
+        from vllm.platforms import current_platform
+
+        tp_group = get_tp_group()
+        if tp_group is None or tp_group.world_size <= 1:
+            return
+        pfc = getattr(tp_group.device_communicator, "pyflagcx_comm", None)
+        if pfc is not None:
+            pfc.bind_comm_to_active_capture_stream()
+        current_platform.torch_device_fn.synchronize()
+        tp_group.barrier()
+    except Exception:
+        pass
+
+
+def _patch_graph_wrapper():
+    from vllm.config import CUDAGraphMode
+    from vllm.forward_context import get_forward_context, is_forward_context_available
+    from vllm.platforms import current_platform
+    from vllm_fl.compilation.graph import GraphWrapper
+    from vllm_fl.dispatch.backends.vendor.sunrise.patches.flagcx_stream import (
+        sync_capture_stream_before_replay,
+        sync_compute_stream_after_replay,
+    )
+
+    if getattr(GraphWrapper, "_sunrise_ptpu_cudagraph_patched", False):
+        return
+
+    _orig_call = GraphWrapper.__call__
+
+    _pid = os.getpid()
+    _env_val = os.environ.get("VLLM_FL_SUNRISE_CUDAGRAPH_DEBUG_SYNC", "0")
+    _debug_sync = _env_val.lower() in ("1", "true", "yes", "on")
+
+    if not _debug_sync:
+        # Same ``[FL_INIT]`` breadcrumb pattern as engine_step_debug /
+        # step_debug so users can grep one prefix to confirm which
+        # processes ended up in which branch. The cudagraph wrapper
+        # patch is installed in worker processes (via
+        # ``apply_sunrise_patches`` -> ``register_oot_ops``); this log
+        # lets the user verify that the env var was actually seen on
+        # each worker (and disambiguate "env unset" from "patch never
+        # ran" from "marker name typo'd").
+        logger.info(
+            "[FL_INIT] patch_graph_wrapper installed pid=%d mode=production "
+            "(VLLM_FL_SUNRISE_CUDAGRAPH_DEBUG_SYNC=%r)",
+            _pid,
+            _env_val,
+        )
+
+        def _call(self, *args, **kwargs):
+            if not is_forward_context_available():
+                return self.runnable(*args, **kwargs)
+
+            forward_context = get_forward_context()
+            graph_runtime_mode = forward_context.cudagraph_runtime_mode
+            if (
+                graph_runtime_mode == CUDAGraphMode.NONE
+                or graph_runtime_mode != self.runtime_mode
+            ):
+                return self.runnable(*args, **kwargs)
+
+            sync_capture_stream_before_replay()
+            with _ptpu_stream_ctx():
+                output = _orig_call(self, *args, **kwargs)
+                if current_platform.device_type == "ptpu":
+                    # Required for TP>1 FlagCX stability.
+                    # banner at the top of this module. The device-wide
+                    # drain is doing double duty as a FlagCX collective
+                    # state-machine pump and CANNOT be skipped (or gated
+                    # by an env var) on the replay hot path without
+                    # hanging multi-rank runs.
+                    current_platform.torch_device_fn.synchronize()
+            sync_compute_stream_after_replay()
+            return output
+
+        GraphWrapper.__call__ = _call
+    else:
+        _debug_interval = max(
+            1,
+            int(
+                os.environ.get(
+                    "VLLM_FL_SUNRISE_CUDAGRAPH_DEBUG_INTERVAL", "100"
+                )
+            ),
+        )
+
+        # Per-bucket samples in nanoseconds. Two buckets: capture (warmup
+        # path, recorded once per (mode, batch_descriptor)) and replay
+        # (steady-state, what we actually care about). Stored as plain
+        # lists so emit/clear is O(n) once per N steps.
+        _stats = {
+            "capture": {
+                "pre_ns": [],
+                "submit_ns": [],
+                "sync_ns": [],
+                "post_ns": [],
+            },
+            "replay": {
+                "pre_ns": [],
+                "submit_ns": [],
+                "sync_ns": [],
+                "post_ns": [],
+            },
+        }
+
+        def _rank_label() -> str:
+            try:
+                from vllm.distributed.parallel_state import get_tp_group
+
+                g = get_tp_group()
+                return f"tp_rank={g.rank_in_group}/{g.world_size}"
+            except Exception:
+                return "tp_rank=?"
+
+        logger.info(
+            "[FL_INIT] patch_graph_wrapper installed pid=%d "
+            "mode=debug-sync (interval=%d steps). Marker is "
+            "[VLLM_FL_DBG_SYNC]; buckets pre/submit/sync/post in us; "
+            "capture vs replay reported separately.",
+            _pid,
+            _debug_interval,
+        )
+
+        def _percentile(sorted_arr, q):
+            # 0-indexed nearest-rank percentile; arr already sorted.
+            n = len(sorted_arr)
+            if n == 0:
+                return 0.0
+            idx = min(n - 1, max(0, int(round(q * (n - 1)))))
+            return sorted_arr[idx]
+
+        def _emit(mode: str, bucket: dict) -> None:
+            n = len(bucket["sync_ns"])
+            if n == 0:
+                return
+
+            def s(name):
+                arr = sorted(bucket[name])
+                mean_us = sum(arr) / n / 1000.0
+                return (
+                    mean_us,
+                    _percentile(arr, 0.5) / 1000.0,
+                    _percentile(arr, 0.99) / 1000.0,
+                    arr[-1] / 1000.0,
+                )
+
+            pre_m, pre_p50, pre_p99, pre_max = s("pre_ns")
+            sub_m, sub_p50, sub_p99, sub_max = s("submit_ns")
+            sync_m, sync_p50, sync_p99, sync_max = s("sync_ns")
+            post_m, post_p50, post_p99, post_max = s("post_ns")
+            total_m = pre_m + sub_m + sync_m + post_m
+            sync_pct = (sync_m / total_m * 100.0) if total_m > 0 else 0.0
+
+            logger.info(
+                "[VLLM_FL_DBG_SYNC] %s mode=%s n=%d total=%.1fus | "
+                "pre=%.2f submit=%.2f sync=%.2f (%.1f%%) post=%.2f | "
+                "sync p50=%.1f p99=%.1f max=%.1f | "
+                "submit p50=%.1f p99=%.1f max=%.1f",
+                _rank_label(),
+                mode,
+                n,
+                total_m,
+                pre_m,
+                sub_m,
+                sync_m,
+                sync_pct,
+                post_m,
+                sync_p50,
+                sync_p99,
+                sync_max,
+                sub_p50,
+                sub_p99,
+                sub_max,
+            )
+
+            for k in ("pre_ns", "submit_ns", "sync_ns", "post_ns"):
+                bucket[k].clear()
+
+        def _call(self, *args, **kwargs):
+            if not is_forward_context_available():
+                return self.runnable(*args, **kwargs)
+
+            forward_context = get_forward_context()
+            graph_runtime_mode = forward_context.cudagraph_runtime_mode
+            if (
+                graph_runtime_mode == CUDAGraphMode.NONE
+                or graph_runtime_mode != self.runtime_mode
+            ):
+                return self.runnable(*args, **kwargs)
+
+            # Capture vs replay detection: a missing entry (first time
+            # we see this batch_descriptor) or an entry whose ``graph``
+            # is still ``None`` means ``_orig_call`` is about to RECORD
+            # the cudagraph; any later call with the same descriptor
+            # will short-circuit to ``entry.graph.replay()``. Mirrors
+            # ``vllm_fl/compilation/graph.py:167-169``.
+            bd = forward_context.batch_descriptor
+            entry = (
+                self.concrete_graph_entries.get(bd)
+                if bd is not None
+                else None
+            )
+            mode = (
+                "CAPTURE"
+                if (entry is None or entry.graph is None)
+                else "REPLAY"
+            )
+            bucket = _stats["capture" if mode == "CAPTURE" else "replay"]
+
+            t0 = time.perf_counter_ns()
+            sync_capture_stream_before_replay()
+            t1 = time.perf_counter_ns()
+            with _ptpu_stream_ctx():
+                output = _orig_call(self, *args, **kwargs)
+                t2 = time.perf_counter_ns()
+                if current_platform.device_type == "ptpu":
+                    current_platform.torch_device_fn.synchronize()
+                t3 = time.perf_counter_ns()
+            sync_compute_stream_after_replay()
+            t4 = time.perf_counter_ns()
+
+            bucket["pre_ns"].append(t1 - t0)
+            bucket["submit_ns"].append(t2 - t1)
+            bucket["sync_ns"].append(t3 - t2)
+            bucket["post_ns"].append(t4 - t3)
+            if len(bucket["sync_ns"]) >= _debug_interval:
+                _emit(mode, bucket)
+            return output
+
+        GraphWrapper.__call__ = _call
+
+    GraphWrapper._sunrise_ptpu_cudagraph_patched = True
+
+
+def _patch_model_runner():
+    import vllm_fl.worker.model_runner as model_runner_mod
+    from vllm.config import CUDAGraphMode
+    from vllm.platforms import current_platform
+    from vllm_fl.worker.model_runner import ModelRunnerFL
+
+    if getattr(ModelRunnerFL, "_sunrise_cudagraph_hooks_patched", False):
+        return
+
+    _bind_on_graph_capture = {"enabled": False}
+
+    if current_platform.dist_backend == "flagcx":
+        _orig_graph_capture = model_runner_mod.graph_capture
+
+        @contextmanager
+        def _graph_capture(device):
+            with _orig_graph_capture(device) as ctx:
+                from vllm_fl.dispatch.backends.vendor.sunrise.patches.flagcx_stream import (
+                    set_ptpu_cudagraph_ar_stream,
+                )
+
+                set_ptpu_cudagraph_ar_stream(ctx.stream)
+                if _bind_on_graph_capture["enabled"]:
+                    _bind_flagcx_comm_to_capture_stream()
+                yield ctx
+
+        model_runner_mod.graph_capture = _graph_capture
+
+    _orig_capture_model = ModelRunnerFL.capture_model
+
+    def capture_model(self, *args, **kwargs):
+        _bind_on_graph_capture["enabled"] = True
+        try:
+            return _orig_capture_model(self, *args, **kwargs)
+        finally:
+            _bind_on_graph_capture["enabled"] = False
+
+    ModelRunnerFL.capture_model = capture_model
+
+    def _warmup_and_capture(
+        self,
+        desc,
+        cudagraph_runtime_mode,
+        profile_seq_lens=None,
+        allow_microbatching=False,
+        num_warmups=None,
+    ):
+        if num_warmups is None:
+            num_warmups = self.compilation_config.cudagraph_num_of_warmups
+        force_attention = cudagraph_runtime_mode == CUDAGraphMode.FULL
+
+        for _ in range(num_warmups):
+            _ptpu_cross_rank_sync()
+            self._dummy_run(
+                desc.num_tokens,
+                cudagraph_runtime_mode=CUDAGraphMode.NONE,
+                force_attention=force_attention,
+                uniform_decode=desc.uniform,
+                allow_microbatching=allow_microbatching,
+                skip_eplb=True,
+                remove_lora=False,
+                num_active_loras=desc.num_active_loras,
+                profile_seq_lens=profile_seq_lens,
+            )
+        _ptpu_cross_rank_sync()
+        self._dummy_run(
+            desc.num_tokens,
+            cudagraph_runtime_mode=cudagraph_runtime_mode,
+            uniform_decode=desc.uniform,
+            allow_microbatching=allow_microbatching,
+            skip_eplb=True,
+            remove_lora=False,
+            num_active_loras=desc.num_active_loras,
+            is_graph_capturing=True,
+            profile_seq_lens=profile_seq_lens,
+        )
+
+    ModelRunnerFL._warmup_and_capture = _warmup_and_capture
+    ModelRunnerFL._sunrise_cudagraph_hooks_patched = True
+
+
+def _patch_step_debug():
+    """Per-step end-to-end wall-clock breakdown around ``execute_model``.
+
+    Opt-in via ``VLLM_FL_SUNRISE_DEBUG_STEP=1``. Measures execute_model,
+    sample_tokens, and the gap between consecutive steps so the user can
+    see how much wall time lives OUTSIDE the cudagraph wrapper (where
+    ``VLLM_FL_SUNRISE_CUDAGRAPH_DEBUG_SYNC`` measures the GPU forward).
+    """
+    if not os.environ.get(
+        "VLLM_FL_SUNRISE_DEBUG_STEP", "0"
+    ).lower() in ("1", "true", "yes", "on"):
+        return
+
+    from vllm_fl.worker.model_runner import ModelRunnerFL
+
+    if getattr(ModelRunnerFL, "_sunrise_step_debug_patched", False):
+        return
+
+    interval = max(
+        1,
+        int(
+            os.environ.get("VLLM_FL_SUNRISE_DEBUG_STEP_INTERVAL", "100")
+        ),
+    )
+
+    samples = {
+        "execute_model_ns": [],
+        "sample_tokens_ns": [],
+        "inter_step_gap_ns": [],
+    }
+    last_st_return_ns = [None]
+
+    def _rank_label() -> str:
+        try:
+            from vllm.distributed.parallel_state import get_tp_group
+
+            g = get_tp_group()
+            return f"tp_rank={g.rank_in_group}/{g.world_size}"
+        except Exception:
+            return "tp_rank=?"
+
+    def _percentile(sorted_arr, q):
+        n = len(sorted_arr)
+        if n == 0:
+            return 0.0
+        idx = min(n - 1, max(0, int(round(q * (n - 1)))))
+        return sorted_arr[idx]
+
+    def _stats(arr):
+        if not arr:
+            return 0.0, 0.0, 0.0, 0.0
+        arr_sorted = sorted(arr)
+        n = len(arr_sorted)
+        mean_us = sum(arr_sorted) / n / 1000.0
+        return (
+            mean_us,
+            _percentile(arr_sorted, 0.5) / 1000.0,
+            _percentile(arr_sorted, 0.99) / 1000.0,
+            arr_sorted[-1] / 1000.0,
+        )
+
+    def _emit() -> None:
+        n = len(samples["execute_model_ns"])
+        if n == 0:
+            return
+        em_m, em_p50, em_p99, em_max = _stats(samples["execute_model_ns"])
+        st_m, st_p50, st_p99, st_max = _stats(samples["sample_tokens_ns"])
+        gap_m, gap_p50, gap_p99, gap_max = _stats(
+            samples["inter_step_gap_ns"]
+        )
+        total = em_m + st_m + gap_m
+        # Avoid divide-by-zero in the unlikely case of empty samples.
+        em_pct = (em_m / total * 100.0) if total > 0 else 0.0
+        st_pct = (st_m / total * 100.0) if total > 0 else 0.0
+        gap_pct = (gap_m / total * 100.0) if total > 0 else 0.0
+
+        logger.info(
+            "[VLLM_FL_DBG_STEP] %s n=%d total/step=%.1fus | "
+            "execute_model=%.1f (%.1f%%, p50=%.1f p99=%.1f max=%.1f) | "
+            "sample_tokens=%.1f (%.1f%%, p50=%.1f p99=%.1f max=%.1f) | "
+            "inter_step_gap=%.1f (%.1f%%, p50=%.1f p99=%.1f max=%.1f)",
+            _rank_label(),
+            n,
+            total,
+            em_m,
+            em_pct,
+            em_p50,
+            em_p99,
+            em_max,
+            st_m,
+            st_pct,
+            st_p50,
+            st_p99,
+            st_max,
+            gap_m,
+            gap_pct,
+            gap_p50,
+            gap_p99,
+            gap_max,
+        )
+        for k in samples:
+            samples[k].clear()
+
+    _orig_execute_model = ModelRunnerFL.execute_model
+    _orig_sample_tokens = ModelRunnerFL.sample_tokens
+
+    # One-shot config dump at first ``execute_model`` call. Logs the
+    # scheduler-side pipelining config so the user can confirm whether
+    # engine-worker overlap is actually active. ``async_scheduling``
+    # auto-enables to True unless: pooling model / unsupported spec
+    # decode / executor lacks ``supports_async_scheduling`` (see
+    # ``vllm/config/vllm.py:770-843``). If False under our TP>1 + PTPU
+    # + decode-only setup, the engine serializes worker steps and ~step
+    # of engine CPU work compounds per token -- which lines up with the
+    # observed gap between worker total and benchmark TPOT.
+    _state_logged = [False]
+
+    def _log_config_once(self_runner) -> None:
+        if _state_logged[0]:
+            return
+        _state_logged[0] = True
+        try:
+            from vllm.distributed.parallel_state import get_tp_group
+
+            if get_tp_group().rank_in_group != 0:
+                return  # only rank 0 logs
+        except Exception:
+            pass
+        try:
+            logger.info(
+                "[VLLM_FL_DBG_STEP] scheduler_config.async_scheduling=%s "
+                "model_runner.use_async_scheduling=%s "
+                "pp_size=%s tp_size=%s",
+                getattr(
+                    self_runner.scheduler_config, "async_scheduling", "<unset>"
+                ),
+                getattr(self_runner, "use_async_scheduling", "<unset>"),
+                self_runner.parallel_config.pipeline_parallel_size,
+                self_runner.parallel_config.tensor_parallel_size,
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning(
+                "[VLLM_FL_DBG_STEP] could not log async_scheduling state: %s",
+                exc,
+            )
+
+    def execute_model_wrapped(self, *args, **kwargs):
+        _log_config_once(self)
+        t0 = time.perf_counter_ns()
+        if last_st_return_ns[0] is not None:
+            samples["inter_step_gap_ns"].append(t0 - last_st_return_ns[0])
+        ret = _orig_execute_model(self, *args, **kwargs)
+        t1 = time.perf_counter_ns()
+        samples["execute_model_ns"].append(t1 - t0)
+        return ret
+
+    def sample_tokens_wrapped(self, *args, **kwargs):
+        t0 = time.perf_counter_ns()
+        ret = _orig_sample_tokens(self, *args, **kwargs)
+        t1 = time.perf_counter_ns()
+        samples["sample_tokens_ns"].append(t1 - t0)
+        last_st_return_ns[0] = t1
+        # Emit when execute_model has accumulated ``interval`` samples;
+        # gap may be one short (first step has no predecessor).
+        if len(samples["execute_model_ns"]) >= interval:
+            _emit()
+        return ret
+
+    ModelRunnerFL.execute_model = execute_model_wrapped
+    ModelRunnerFL.sample_tokens = sample_tokens_wrapped
+    ModelRunnerFL._sunrise_step_debug_patched = True
+
+    logger.info(
+        "[VLLM_FL_DBG_STEP] per-step end-to-end instrumentation enabled "
+        "(interval=%d steps).",
+        interval,
+    )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_fla_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_fla_ops.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Redirect FLA GDN kernels to PTPU sgl_kernel implementations."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_PATCH_APPLIED = False
+_ORIG_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE = None
+_ORIG_FUSED_RECURRENT_GATED_DELTA_RULE_PACKED_DECODE = None
+
+
+def get_orig_fused_sigmoid_gating_delta_rule_update():
+    """Return the un-patched FLA Triton ``fused_sigmoid_gating_delta_rule_update``."""
+    return _ORIG_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE
+
+
+def get_orig_fused_recurrent_gated_delta_rule_packed_decode():
+    """Return the un-patched FLA Triton ``...packed_decode``."""
+    return _ORIG_FUSED_RECURRENT_GATED_DELTA_RULE_PACKED_DECODE
+
+
+def apply_patch() -> bool:
+    """Idempotently install the PTPU FLA dispatch patch (all stages → sgl)."""
+    global _PATCH_APPLIED
+    if _PATCH_APPLIED:
+        return False
+
+    try:
+        import torch_ptpu.sgl_kernel as _ptpu_sgl  # noqa: F401
+    except Exception as exc:  # pragma: no cover - non-PTPU env
+        logger.debug(
+            "Skipping PTPU FLA patch (torch_ptpu.sgl_kernel not importable): %s",
+            exc,
+        )
+        return False
+
+    try:
+        from vllm.model_executor.layers.fla.ops import (
+            chunk as _fla_chunk,
+            chunk_delta_h as _fla_chunk_delta_h,
+            chunk_o as _fla_chunk_o,
+            chunk_scaled_dot_kkt as _fla_chunk_scaled_dot_kkt,
+            cumsum as _fla_cumsum,
+            fused_recurrent as _fla_fused_recurrent,
+            fused_sigmoid_gating as _fla_fused_sigmoid_gating,
+            l2norm as _fla_l2norm,
+            solve_tril as _fla_solve_tril,
+            wy_fast as _fla_wy_fast,
+        )
+        from vllm.model_executor.layers.fla import ops as _fla_ops_pkg
+    except Exception as exc:  # pragma: no cover - vLLM without GDN support
+        logger.debug(
+            "Skipping PTPU FLA patch (vLLM FLA modules not importable): %s",
+            exc,
+        )
+        return False
+
+    global _ORIG_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE
+    _ORIG_FUSED_SIGMOID_GATING_DELTA_RULE_UPDATE = (
+        _fla_fused_sigmoid_gating.fused_sigmoid_gating_delta_rule_update
+    )
+    global _ORIG_FUSED_RECURRENT_GATED_DELTA_RULE_PACKED_DECODE
+    _ORIG_FUSED_RECURRENT_GATED_DELTA_RULE_PACKED_DECODE = (
+        _fla_fused_recurrent.fused_recurrent_gated_delta_rule_packed_decode
+    )
+
+    from ..impl.fla.chunk_fwd_o import chunk_fwd_o as _ptpu_chunk_fwd_o
+    from ..impl.fla.chunk_h import (
+        chunk_gated_delta_rule_fwd_h as _ptpu_chunk_gated_delta_rule_fwd_h,
+    )
+    from ..impl.fla.chunk_scaled_dot_kkt import (
+        chunk_scaled_dot_kkt_fwd as _ptpu_chunk_scaled_dot_kkt_fwd,
+    )
+    from ..impl.fla.cumsum import chunk_local_cumsum as _ptpu_chunk_local_cumsum
+    from ..impl.fla.fused_recurrent_packed_decode import (
+        fused_recurrent_gated_delta_rule_packed_decode as _ptpu_packed_decode,
+    )
+    from ..impl.fla.fused_sigmoid_gating import (
+        fused_sigmoid_gating_delta_rule_update as _ptpu_fused_sigmoid_gating,
+    )
+    from ..impl.fla.l2norm import l2norm_fwd as _ptpu_l2norm_fwd
+    from ..impl.fla.solve_tril import solve_tril as _ptpu_solve_tril
+    from ..impl.fla.wy_fast import recompute_w_u_fwd as _ptpu_recompute_w_u_fwd
+
+    # Prefill stages
+    _fla_cumsum.chunk_local_cumsum = _ptpu_chunk_local_cumsum
+    _fla_chunk_scaled_dot_kkt.chunk_scaled_dot_kkt_fwd = (
+        _ptpu_chunk_scaled_dot_kkt_fwd
+    )
+    _fla_solve_tril.solve_tril = _ptpu_solve_tril
+    _fla_wy_fast.recompute_w_u_fwd = _ptpu_recompute_w_u_fwd
+    _fla_chunk_delta_h.chunk_gated_delta_rule_fwd_h = (
+        _ptpu_chunk_gated_delta_rule_fwd_h
+    )
+    _fla_chunk_o.chunk_fwd_o = _ptpu_chunk_fwd_o
+
+    _fla_chunk.chunk_local_cumsum = _ptpu_chunk_local_cumsum
+    _fla_chunk.chunk_scaled_dot_kkt_fwd = _ptpu_chunk_scaled_dot_kkt_fwd
+    _fla_chunk.solve_tril = _ptpu_solve_tril
+    _fla_chunk.recompute_w_u_fwd = _ptpu_recompute_w_u_fwd
+    _fla_chunk.chunk_gated_delta_rule_fwd_h = _ptpu_chunk_gated_delta_rule_fwd_h
+    _fla_chunk.chunk_fwd_o = _ptpu_chunk_fwd_o
+    _fla_chunk.l2norm_fwd = _ptpu_l2norm_fwd
+
+    # Decode / aux
+    _fla_l2norm.l2norm_fwd = _ptpu_l2norm_fwd
+    _fla_fused_sigmoid_gating.fused_sigmoid_gating_delta_rule_update = (
+        _ptpu_fused_sigmoid_gating
+    )
+    _fla_ops_pkg.fused_sigmoid_gating_delta_rule_update = (
+        _ptpu_fused_sigmoid_gating
+    )
+    _fla_fused_recurrent.fused_recurrent_gated_delta_rule_packed_decode = (
+        _ptpu_packed_decode
+    )
+    _fla_ops_pkg.fused_recurrent_gated_delta_rule_packed_decode = (
+        _ptpu_packed_decode
+    )
+
+    try:
+        from vllm.model_executor.layers.mamba import (
+            gdn_linear_attn as _gdn_lib,
+        )
+    except Exception as exc:  # pragma: no cover - vLLM without GDN
+        logger.debug(
+            "PTPU FLA patch: gdn_linear_attn not importable, skipping "
+            "module-level rebind: %s",
+            exc,
+        )
+    else:
+        _gdn_lib.fused_sigmoid_gating_delta_rule_update = (
+            _ptpu_fused_sigmoid_gating
+        )
+        _gdn_lib.l2norm_fwd = _ptpu_l2norm_fwd
+        _gdn_lib.fused_recurrent_gated_delta_rule_packed_decode = (
+            _ptpu_packed_decode
+        )
+
+    _PATCH_APPLIED = True
+    logger.info(
+        "Applied PTPU FLA patch: all 6 GDN prefill stages + spec/mixed "
+        "decode + l2norm + packed_decode route to torch_ptpu.sgl_kernel."
+    )
+    return True
+
+
+__all__ = [
+    "apply_patch",
+    "get_orig_fused_recurrent_gated_delta_rule_packed_decode",
+    "get_orig_fused_sigmoid_gating_delta_rule_update",
+]

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_flagcx_comm.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_flagcx_comm.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Lazy FlagCX comm init and capture-stream bind on PTPU."""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import os
+from typing import Optional, Union
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from vllm.distributed.utils import StatelessProcessGroup
+
+try:
+    import torch.ptpu as torch_ptpu
+except ImportError:
+    torch_ptpu = None  # type: ignore[assignment,misc]
+
+logger = logging.getLogger(__name__)
+
+
+def patch_flagcx_comm_lifecycle() -> None:
+    """Defer ``flagcxCommInitRank`` to first collective; bind comm on capture stream."""
+    try:
+        from vllm.platforms import current_platform
+
+        if current_platform.device_type != "ptpu":
+            return
+    except Exception:
+        return
+
+    # Import flagcx first so FLAGCX_PATH is on sys.path for plugin imports.
+    from vllm_fl.distributed.device_communicators.flagcx import (
+        FLAGCXLibrary,
+        PyFlagcxCommunicator,
+        flagcxUniqueId,
+    )
+
+    if flagcxUniqueId is None or FLAGCXLibrary is None:
+        logger.warning("FlagCX not available; skipping comm lifecycle patch")
+        return
+
+    if getattr(PyFlagcxCommunicator, "_sunrise_comm_lifecycle_patched", False):
+        return
+
+    assert torch_ptpu is not None, "torch.ptpu required for PTPU comm lifecycle patch"
+
+    def _ptpu_init(
+        self,
+        group: Union[ProcessGroup, StatelessProcessGroup],
+        device: Union[str, torch.device],
+        library_path: Optional[str] = None,
+    ) -> None:
+        if not isinstance(group, StatelessProcessGroup):
+            assert dist.is_initialized()
+            assert dist.get_backend(group) != dist.Backend.NCCL, (
+                "PyNcclCommunicator should be attached to a non-NCCL group."
+            )
+            self.rank = dist.get_rank(group)
+            self.world_size = dist.get_world_size(group)
+        else:
+            self.rank = group.rank
+            self.world_size = group.world_size
+
+        self.group = group
+
+        if self.world_size == 1:
+            self.available = False
+            self.disabled = True
+            return
+
+        try:
+            if library_path is None:
+                flagcx_path = os.getenv("FLAGCX_PATH")
+                library_path = os.path.join(flagcx_path, "build/lib/libflagcx.so")
+                self.flagcx = FLAGCXLibrary(library_path)
+            else:
+                self.flagcx = FLAGCXLibrary(library_path)
+        except Exception:
+            self.available = False
+            self.disabled = True
+            return
+
+        self.available = True
+        self.disabled = False
+
+        if self.rank == 0:
+            self.unique_id = self.flagcx.flagcxGetUniqueId()
+        else:
+            self.unique_id = flagcxUniqueId()
+
+        if not isinstance(group, StatelessProcessGroup):
+            tensor = torch.ByteTensor(list(self.unique_id.internal))
+            ranks = dist.get_process_group_ranks(group)
+            dist.broadcast(tensor, src=ranks[0], group=group)
+            byte_list = tensor.tolist()
+            for i, byte in enumerate(byte_list):
+                self.unique_id.internal[i] = byte
+        else:
+            self.unique_id = group.broadcast_obj(self.unique_id, src=0)
+
+        if isinstance(device, str):
+            device = torch.device(device)
+        assert isinstance(device, torch.device)
+        self.device = device
+        self._device_ctx = torch_ptpu.device(self.device)
+        self.comm = None
+
+    def _ensure_initialized(self) -> None:
+        if self.comm is not None:
+            return
+        if not getattr(self, "available", False) or self.disabled:
+            return
+
+        with self._device_ctx:
+            self.comm = self.flagcx.flagcxCommInitRank(
+                self.world_size, self.unique_id, self.rank
+            )
+
+    def bind_comm_to_active_capture_stream(self) -> None:
+        if self.disabled:
+            return
+        self._ensure_initialized()
+        if self.comm is None:
+            return
+        from vllm.platforms import current_platform
+
+        stream = torch_ptpu.current_stream(self.device)
+        data = torch.zeros(1, device=self.device)
+        self.all_reduce(data, stream=stream)
+        current_platform.torch_device_fn.synchronize()
+
+    def _wrap_lazy(method):
+        def wrapper(self, *args, **kwargs):
+            if not self.disabled:
+                self._ensure_initialized()
+            return method(self, *args, **kwargs)
+
+        wrapper.__name__ = getattr(method, "__name__", "wrapper")
+        wrapper.__qualname__ = getattr(method, "__qualname__", wrapper.__name__)
+        return wrapper
+
+    _lazy_methods = (
+        "all_gatherv",
+        "reduce_scatterv",
+        "group_start",
+        "group_end",
+    )
+    _saved = {name: getattr(PyFlagcxCommunicator, name) for name in _lazy_methods}
+
+    PyFlagcxCommunicator.__init__ = _ptpu_init
+    PyFlagcxCommunicator._ensure_initialized = _ensure_initialized
+    PyFlagcxCommunicator.bind_comm_to_active_capture_stream = (
+        bind_comm_to_active_capture_stream
+    )
+    for name in _lazy_methods:
+        setattr(PyFlagcxCommunicator, name, _wrap_lazy(_saved[name]))
+
+    PyFlagcxCommunicator._sunrise_comm_lifecycle_patched = True
+    logger.info("Patched FlagCX comm lifecycle for Sunrise/PTPU")

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_flagcx_stream_adapter.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_flagcx_stream_adapter.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""FlagCX stream adapter patch for Sunrise/PTPU."""
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+import logging
+import os
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def patch_flagcx_stream_adapter() -> None:
+    """Cache ``flagcxStream_t`` per raw stream pointer; ``adaptor_stream_free`` is a no-op."""
+    try:
+        from vllm.platforms import current_platform
+
+        if getattr(current_platform, "device_type", None) != "ptpu":
+            return
+
+        flagcx_path = os.getenv("FLAGCX_PATH")
+        if flagcx_path and os.path.isdir(flagcx_path) and flagcx_path not in sys.path:
+            sys.path.append(flagcx_path)
+
+        flagcx_wrapper = importlib.import_module("plugin.interservice.flagcx_wrapper")
+        FLAGCXLibrary = flagcx_wrapper.FLAGCXLibrary
+        flagcxStream_t = flagcx_wrapper.flagcxStream_t
+
+        if getattr(FLAGCXLibrary, "_sunrise_stream_patch_applied", False):
+            return
+
+        def _to_void_p(raw_stream_ptr):
+            if isinstance(raw_stream_ptr, ctypes.c_void_p):
+                return raw_stream_ptr
+            if raw_stream_ptr is None:
+                raise ValueError("Stream pointer is None.")
+            return ctypes.c_void_p(int(raw_stream_ptr))
+
+        def _extract_raw_stream_ptr(old_stream):
+            if isinstance(old_stream, (int, ctypes.c_void_p)):
+                return old_stream
+
+            for attr in ("ptpu_stream", "cuda_stream"):
+                stream_ptr = getattr(old_stream, attr, None)
+                if stream_ptr is not None:
+                    return stream_ptr
+
+            stream_fn = getattr(old_stream, "stream", None)
+            if callable(stream_fn):
+                stream_ptr = stream_fn()
+                if stream_ptr is not None:
+                    return stream_ptr
+
+            raise AttributeError(
+                "Unsupported stream object: expected a raw pointer or one of "
+                "`ptpu_stream`, `cuda_stream`, or callable `stream()`."
+            )
+
+        def _raw_key(raw_stream_ptr):
+            if isinstance(raw_stream_ptr, ctypes.c_void_p):
+                return int(raw_stream_ptr.value or 0)
+            return int(raw_stream_ptr)
+
+        def _adaptor_stream_copy(self, old_stream):
+            raw_stream_ptr = _extract_raw_stream_ptr(old_stream)
+            key = _raw_key(raw_stream_ptr)
+            cache = self.__dict__.setdefault("_sunrise_flagcx_stream_cache", {})
+            cached = cache.get(key)
+            if cached is not None:
+                return cached
+
+            new_stream = flagcxStream_t()
+            self.FLAGCX_CHECK(
+                self.devHandle.contents.streamCopy(
+                    ctypes.byref(new_stream), _to_void_p(raw_stream_ptr)
+                )
+            )
+            cache[key] = new_stream
+            return new_stream
+
+        def _adaptor_stream_free(self, stream):
+            return
+
+        FLAGCXLibrary.adaptor_stream_copy = _adaptor_stream_copy
+        FLAGCXLibrary.adaptor_stream_free = _adaptor_stream_free
+        FLAGCXLibrary._sunrise_stream_patch_applied = True
+        logger.info("Patched FlagCX stream adapter for Sunrise/PTPU")
+    except Exception as e:
+        logger.warning("Failed to patch FlagCX stream adapter for Sunrise: %s", e)

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_gdn_core_attn_buf.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_gdn_core_attn_buf.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Reuse GDN core_attn_out buffer to avoid per-iter torch.zeros under cudagraph."""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import os
+from typing import Any, Optional, Tuple
+
+import torch
+
+_log = logging.getLogger(__name__)
+
+_PATCH_APPLIED = False
+
+# Cached buffer sizes for cudagraph capture vs eager prefill.
+_CAPTURE_SIZES: "Optional[frozenset]" = None
+
+
+def _capture_sizes() -> "frozenset":
+    """Cudagraph capture batch sizes for this worker (empty if none/eager)."""
+    global _CAPTURE_SIZES
+    if _CAPTURE_SIZES is not None:
+        return _CAPTURE_SIZES
+    sizes: set = set()
+    env = os.environ.get("VLLM_FL_GDN_CORE_ATTN_PERSIST_SIZES")
+    if env:
+        try:
+            sizes = {int(x) for x in env.replace(",", " ").split()}
+        except ValueError:
+            sizes = set()
+    else:
+        try:
+            from vllm.config import get_current_vllm_config
+
+            cc = get_current_vllm_config().compilation_config
+            cs = getattr(cc, "cudagraph_capture_sizes", None) or []
+            sizes = {int(s) for s in cs}
+        except Exception:
+            sizes = set()
+    _CAPTURE_SIZES = frozenset(sizes)
+    return _CAPTURE_SIZES
+
+
+def _in_cudagraph_capture() -> bool:
+    """True while a cudagraph is being captured (forward_cuda Python runs during
+    capture, but not during replay), so we know this call's buffer must persist.
+
+    Best-effort fallback for the rare case the capture-size set can't be
+    resolved; a false result only means we treat the call as eager (shared
+    buffer), which is safe unless we are genuinely mid-capture.
+    """
+    try:
+        from vllm.config import CUDAGraphMode
+        from vllm.forward_context import (
+            get_forward_context,
+            is_forward_context_available,
+        )
+
+        if not is_forward_context_available():
+            return False
+        mode = get_forward_context().cudagraph_runtime_mode
+        return mode is not None and mode != CUDAGraphMode.NONE
+    except Exception:
+        return False
+
+# When ``forward_cuda`` is active, the wrapper publishes the expected
+# ``(shape, dtype, device, cached_buffer)`` tuple here. ``_intercepted_zeros``
+# checks this slot; if the next ``torch.zeros`` call originating from
+# ``gdn_linear_attn`` matches the published signature, it returns
+# ``cached_buffer`` and clears the slot so any other ``torch.zeros``
+# inside the same forward pass goes through normally.
+_TARGET: "contextvars.ContextVar[Optional[Tuple[Tuple[int, ...], torch.dtype, torch.device, torch.Tensor]]]" = (
+    contextvars.ContextVar("_sunrise_gdn_core_attn_target", default=None)
+)
+
+
+def _is_disabled() -> bool:
+    val = os.environ.get("VLLM_FL_SUNRISE_BENCH_BASELINE_GDN_CORE_ATTN_ZEROS")
+    if val is None:
+        return False
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+class _GDNTorchProxy:
+    """Per-module proxy that forwards every attribute to ``torch`` except
+    ``zeros``, which is routed through :func:`_intercepted_zeros`.
+
+    Installed on ``vllm.model_executor.layers.mamba.gdn_linear_attn.torch``
+    so the global ``torch`` module is left untouched.
+    """
+
+    __slots__ = ("_real_torch",)
+
+    def __init__(self, real_torch: Any) -> None:
+        object.__setattr__(self, "_real_torch", real_torch)
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "zeros":
+            return _intercepted_zeros
+        return getattr(self._real_torch, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:  # pragma: no cover
+        # GDN module code never reassigns ``torch.<x>``; reject mutations
+        # so a future upstream refactor that does this fails loud.
+        raise AttributeError(
+            f"_GDNTorchProxy: refuse to set attribute {name!r}; the proxy is "
+            "read-only by design."
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"<_GDNTorchProxy real={self._real_torch!r}>"
+
+
+def _intercepted_zeros(*args: Any, **kwargs: Any) -> torch.Tensor:
+    """Replacement for ``torch.zeros`` (visible only inside
+    ``gdn_linear_attn``) that returns a cached buffer when the active
+    ``forward_cuda`` published a matching target.
+
+    Falls through to the real ``torch.zeros`` for every other call --
+    including any ``torch.zeros`` invocation in ``gdn_linear_attn`` whose
+    shape/dtype/device do not match the published target (e.g. the
+    ``ChunkGatedDeltaRule`` allocations on the prefill path).
+    """
+    target = _TARGET.get()
+    if target is not None:
+        target_shape, target_dtype, target_device, target_buf = target
+
+        if args:
+            size_arg = args[0]
+        else:
+            size_arg = kwargs.get("size")
+
+        if size_arg is not None:
+            if isinstance(size_arg, torch.Size):
+                shape_tup: Optional[Tuple[int, ...]] = tuple(size_arg)
+            elif isinstance(size_arg, (list, tuple)):
+                shape_tup = tuple(size_arg)
+            else:
+                shape_tup = None
+
+            if shape_tup is not None:
+                dtype = kwargs.get("dtype")
+                device_arg = kwargs.get("device")
+                if device_arg is None:
+                    # ``torch.zeros`` with no device kwarg uses the
+                    # default device. We deliberately only match when the
+                    # caller explicitly passes ``device=...`` so we never
+                    # capture a CPU-default call by accident.
+                    device = None
+                else:
+                    device = torch.device(device_arg)
+
+                if (
+                    shape_tup == target_shape
+                    and dtype == target_dtype
+                    and device == target_device
+                ):
+                    # Clear the slot so a second ``torch.zeros`` inside
+                    # the same forward (if any) does NOT also grab the
+                    # cached buffer.
+                    _TARGET.set(None)
+                    return target_buf
+
+    return torch.zeros(*args, **kwargs)
+
+
+def _make_forward_cuda_wrapper(orig_forward_cuda):
+    """Return a wrapped ``forward_cuda`` that publishes the target slot
+    for :func:`_intercepted_zeros` to consume.
+
+    The wrapper is per-class; ``orig_forward_cuda`` is bound at patch
+    time and captured here so we don't recurse via the rebound method.
+    """
+
+    def _patched_forward_cuda(self, hidden_states: torch.Tensor, output: torch.Tensor):
+        # Per-call kill-switch (cheap env read; cached lookups are fine
+        # because env vars are stable for the lifetime of the worker).
+        if _is_disabled():
+            return orig_forward_cuda(self, hidden_states, output)
+
+        num_tokens = hidden_states.size(0)
+        tail_shape: Tuple[int, ...] = (
+            self.num_v_heads // self.tp_size,
+            self.head_v_dim,
+        )
+        expected_shape: Tuple[int, ...] = (num_tokens, *tail_shape)
+        expected_dtype = hidden_states.dtype
+        expected_device = hidden_states.device
+
+        # Keying the cache on ``num_tokens`` (the original design) leaks
+        # unboundedly: every distinct eager prefill / mixed batch size adds a
+        # buffer that is never released, so a workload with many request
+        # lengths (e.g. an accuracy sweep) grows this dict by tens of GiB
+        # across the GDN layers. But we cannot simply share one grow-to-max
+        # buffer either: under ``FULL_DECODE_ONLY`` the decode path is captured
+        # into a cudagraph that bakes in the buffer's address, so a
+        # captured-size buffer must never be freed/reallocated.
+        #
+        # So we persist a per-size buffer ONLY for cudagraph-captured sizes
+        # (a small, fixed set); every other call -- all eager steps of
+        # arbitrary length -- shares a single grow-to-max buffer and gets a
+        # ``[:num_tokens]`` view. The cache is thus bounded regardless of how
+        # many distinct request lengths appear.
+        must_persist = (num_tokens in _capture_sizes()) or _in_cudagraph_capture()
+
+        cache = self.__dict__.setdefault("_sunrise_core_attn_out_cache", {})
+        if must_persist:
+            cache_key = (num_tokens, expected_dtype, expected_device)
+            buf = cache.get(cache_key)
+            if buf is None:
+                # Allocate via the **real** ``torch.zeros`` (NOT the intercept)
+                # so we don't accidentally publish-and-consume the slot during
+                # bootstrap.
+                buf = torch.zeros(
+                    expected_shape, dtype=expected_dtype, device=expected_device
+                )
+                cache[cache_key] = buf
+        else:
+            big_key = ("_shared", expected_dtype, expected_device)
+            base = cache.get(big_key)
+            if base is None or base.size(0) < num_tokens:
+                base = torch.zeros(
+                    (num_tokens, *tail_shape),
+                    dtype=expected_dtype,
+                    device=expected_device,
+                )
+                cache[big_key] = base
+            buf = base[:num_tokens]
+
+        token = _TARGET.set((expected_shape, expected_dtype, expected_device, buf))
+        try:
+            return orig_forward_cuda(self, hidden_states, output)
+        finally:
+            _TARGET.reset(token)
+
+    _patched_forward_cuda.__wrapped__ = orig_forward_cuda  # type: ignore[attr-defined]
+    _patched_forward_cuda.__name__ = "forward_cuda"
+    _patched_forward_cuda.__qualname__ = "GatedDeltaNetAttention.forward_cuda"
+    return _patched_forward_cuda
+
+
+def apply_patch() -> bool:
+    """Install the GDN ``core_attn_out`` zero-elision patch.
+
+    Idempotent; a silent no-op on subsequent calls. Returns ``True`` when
+    the patch was applied in this call, ``False`` if it was already
+    applied, the upstream class was missing, or the kill-switch is on.
+    """
+    global _PATCH_APPLIED
+
+    if _PATCH_APPLIED:
+        return False
+
+    if _is_disabled():
+        _log.info(
+            "Sunrise GDN core_attn_out patch skipped: "
+            "VLLM_FL_SUNRISE_BENCH_BASELINE_GDN_CORE_ATTN_ZEROS is set."
+        )
+        return False
+
+    try:
+        import vllm.model_executor.layers.mamba.gdn_linear_attn as _gdn_mod
+    except Exception as exc:  # pragma: no cover - upstream rename safety net
+        _log.warning(
+            "Sunrise GDN core_attn_out patch skipped: failed to import "
+            "vllm.model_executor.layers.mamba.gdn_linear_attn (%s). Patch "
+            "had no effect.",
+            exc,
+        )
+        return False
+
+    GatedDeltaNetAttention = getattr(_gdn_mod, "GatedDeltaNetAttention", None)
+    if GatedDeltaNetAttention is None:  # pragma: no cover
+        _log.warning(
+            "Sunrise GDN core_attn_out patch skipped: "
+            "GatedDeltaNetAttention not found in gdn_linear_attn module. "
+            "Patch had no effect."
+        )
+        return False
+
+    orig_forward_cuda = GatedDeltaNetAttention.forward_cuda
+    if getattr(orig_forward_cuda, "_sunrise_core_attn_buf_patched", False):
+        _PATCH_APPLIED = True
+        return False
+
+    # 1. Wrap forward_cuda so the contextvar is published per call.
+    wrapped = _make_forward_cuda_wrapper(orig_forward_cuda)
+    wrapped._sunrise_core_attn_buf_patched = True  # type: ignore[attr-defined]
+    GatedDeltaNetAttention.forward_cuda = wrapped
+
+    # 2. Install the per-module torch proxy. Idempotent: if a previous
+    #    apply_patch already installed a proxy, reusing it is safe.
+    current_torch = getattr(_gdn_mod, "torch", None)
+    if not isinstance(current_torch, _GDNTorchProxy):
+        if current_torch is None:  # pragma: no cover - unexpected
+            current_torch = torch
+        _gdn_mod.torch = _GDNTorchProxy(current_torch)
+
+    _PATCH_APPLIED = True
+    _log.info(
+        "Applied PTPU GDN core_attn_out zero-elision patch: "
+        "GatedDeltaNetAttention.forward_cuda reuses a per-instance zero "
+        "buffer instead of allocating + zeroing a fresh torch.zeros every "
+        "call. Disable with "
+        "VLLM_FL_SUNRISE_BENCH_BASELINE_GDN_CORE_ATTN_ZEROS=1."
+    )
+    return True

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_int8_native.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_int8_native.py
@@ -5,38 +5,56 @@
 from __future__ import annotations
 
 import logging
-import os
 
 logger = logging.getLogger(__name__)
 
 _ENABLED = False
-_OOT_KERNEL_REGISTERED = False
+_OOT_KERNEL_CLS = None
+_MOE_DECISION_LOGGED = False
 _QUANT_PATCHED = False
-_MOE_ORACLE_PATCHED = False
-_MOE_QUANT_CFG_PATCHED = False
 _MOE_ACT_QUANT_PATCHED = False
 _MM_PATCHED = False
 _FG_MM_FN = None
 _MM_SHAPE_LOGGED = False
 
 
-def _register_oot_int8_kernel() -> bool:
-    """Register a Triton INT8 ScaledMM kernel that is ``is_supported`` on OOT."""
-    global _OOT_KERNEL_REGISTERED
-    if _OOT_KERNEL_REGISTERED:
-        return True
-    try:
-        from vllm.platforms import PlatformEnum
-        from vllm.model_executor.kernels.linear import (
-            _POSSIBLE_INT8_KERNELS,
-            register_linear_kernel,
+def _log_w8a8_moe_decision(selection) -> None:
+    """Record, once, which experts class the oracle actually handed back.
+
+    W8A8 MoE reaching the wrong experts class does not raise here; it shows up
+    much later as a dtype or contract mismatch deep inside the expert GEMMs, so
+    the resolved class is worth stating plainly in the server log.
+    """
+    global _MOE_DECISION_LOGGED
+    if _MOE_DECISION_LOGGED:
+        return
+    _MOE_DECISION_LOGGED = True
+
+    experts_cls = selection[1] if isinstance(selection, tuple) else None
+    experts_name = getattr(experts_cls, "__name__", repr(experts_cls))
+    if experts_name == "TritonW8A8Experts":
+        logger.info(
+            "native-int8: W8A8 MoE resolved to experts=TritonW8A8Experts -> "
+            "vLLM functional fused_experts."
         )
-        from vllm.model_executor.kernels.linear.scaled_mm.triton import (
-            TritonInt8ScaledMMLinearKernel,
+    else:
+        logger.warning(
+            "native-int8: W8A8 MoE resolved to experts=%s, not the expected "
+            "TritonW8A8Experts. On PTPU only the functional fused_experts path "
+            "is supported for compressed-tensors W8A8.",
+            experts_name,
         )
-    except Exception as e:  # noqa: BLE001
-        logger.debug("native-int8: vLLM kernel registry unavailable (%s)", e)
-        return False
+
+
+def _build_oot_int8_kernel_cls():
+    """Create (once) the OOT-enabled subclass of vLLM's Triton INT8 kernel."""
+    global _OOT_KERNEL_CLS
+    if _OOT_KERNEL_CLS is not None:
+        return _OOT_KERNEL_CLS
+
+    from vllm.model_executor.kernels.linear.scaled_mm.triton import (
+        TritonInt8ScaledMMLinearKernel,
+    )
 
     class OOTTritonInt8ScaledMMLinearKernel(TritonInt8ScaledMMLinearKernel):
         """``TritonInt8ScaledMMLinearKernel`` allowed on the OOT platform.
@@ -53,18 +71,48 @@ def _register_oot_int8_kernel() -> bool:
         def can_implement(cls, c):
             return True, None
 
-    existing = _POSSIBLE_INT8_KERNELS.get(PlatformEnum.OOT, [])
-    if any(k.__name__ == OOTTritonInt8ScaledMMLinearKernel.__name__ for k in existing):
-        _OOT_KERNEL_REGISTERED = True
+    _OOT_KERNEL_CLS = OOTTritonInt8ScaledMMLinearKernel
+    return _OOT_KERNEL_CLS
+
+
+def _register_oot_int8_kernel() -> bool:
+    """Put the sunrise Triton INT8 ScaledMM kernel first in the OOT candidates.
+
+    ``vllm_fl.quantization.quant_linear.add_oot_quant_kernel`` clones the CUDA
+    candidate list into ``PlatformEnum.OOT``, but only when that key is absent.
+    Whether it or this function runs first depends on how the engine was
+    launched, so do not rely on either order: register when missing, and always
+    move our kernel to the front. Calling this again after the clone therefore
+    keeps the CUDA kernels as fallbacks while still preferring ours.
+    """
+    try:
+        from vllm.platforms import PlatformEnum
+        from vllm.model_executor.kernels.linear import (
+            _POSSIBLE_INT8_KERNELS,
+            register_linear_kernel,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug("native-int8: vLLM kernel registry unavailable (%s)", e)
+        return False
+
+    kernel_cls = _build_oot_int8_kernel_cls()
+
+    candidates = _POSSIBLE_INT8_KERNELS.get(PlatformEnum.OOT)
+    if candidates is None:
+        register_linear_kernel(kernel_cls, PlatformEnum.OOT, kernel_type="int8")
+        candidates = _POSSIBLE_INT8_KERNELS[PlatformEnum.OOT]
+    elif kernel_cls not in candidates:
+        candidates.insert(0, kernel_cls)
+    elif candidates[0] is not kernel_cls:
+        candidates.remove(kernel_cls)
+        candidates.insert(0, kernel_cls)
+    else:
         return True
 
-    register_linear_kernel(
-        OOTTritonInt8ScaledMMLinearKernel, PlatformEnum.OOT, kernel_type="int8"
-    )
-    _OOT_KERNEL_REGISTERED = True
     logger.info(
-        "native-int8: registered OOTTritonInt8ScaledMMLinearKernel for "
-        "PlatformEnum.OOT."
+        "native-int8: INT8 linear kernel candidates for PlatformEnum.OOT are "
+        "now %s.",
+        [k.__name__ for k in candidates],
     )
     return True
 
@@ -200,42 +248,39 @@ def _patch_triton_scaled_mm() -> bool:
 
 
 def _patch_int8_moe_oracle() -> bool:
-    """Make the int8 MoE oracle return ``TritonExpertsFL`` on OOT."""
-    global _MOE_ORACLE_PATCHED
-    if _MOE_ORACLE_PATCHED:
-        return True
+    """Publish the FL int8 MoE selector to importers that already bound a stale one.
+
+    ``install_fl_w8a8_moe_selector`` only rebinds the oracle module and the
+    compressed-tensors scheme module. Any module that did a
+    ``from ...oracle.int8 import select_int8_moe_backend`` beforehand still holds
+    the stock selector, whose support gate is CUDA/ROCm-only and would reject
+    PTPU. Re-runnable on purpose: ``register_oot_ops`` installs the FL selector
+    after the import-time patches, so sunrise has to be the last writer, and
+    ``apply_sunrise_patches`` calls this again once that has happened.
+
+    The wrapper is otherwise transparent; it exists to log which experts class
+    the oracle settles on.
+    """
     try:
         import sys
 
-        from vllm.platforms import current_platform
         import vllm.model_executor.layers.fused_moe.oracle.int8 as _int8_oracle
-        from vllm.model_executor.layers.fused_moe.oracle.int8 import Int8MoeBackend
-        from vllm_fl.ops.fused_moe.fused_moe_utils import TritonExpertsFL
-        from vllm_fl.utils import use_flaggems
     except Exception as e:  # noqa: BLE001
         logger.debug("native-int8: int8 MoE oracle unavailable (%s)", e)
         return False
 
     _orig = _int8_oracle.select_int8_moe_backend
     if getattr(_orig, "_fl_native_int8_moe", False):
-        _MOE_ORACLE_PATCHED = True
         return True
 
     def _select_int8_moe_backend_oot(config, *args, **kwargs):
-        # OOT + flaggems: force the FlagGems-routed experts class. This mirrors
-        # ``select_unquantized_moe_backend_oot`` and bypasses the CUDA/ROCm-only
-        # ``is_supported_config`` gate in the stock oracle.
-        if current_platform.is_out_of_tree() and use_flaggems():
-            return Int8MoeBackend.TRITON, TritonExpertsFL
-        return _orig(config, *args, **kwargs)
+        selection = _orig(config, *args, **kwargs)
+        _log_w8a8_moe_decision(selection)
+        return selection
 
     _select_int8_moe_backend_oot._fl_native_int8_moe = True  # type: ignore[attr-defined]
     _select_int8_moe_backend_oot._fl_original = _orig  # type: ignore[attr-defined]
 
-    # Patch the oracle module attribute (covers modules that import the symbol
-    # AFTER this runs). Then also rebind any module that already did a
-    # ``from ...oracle.int8 import select_int8_moe_backend`` (e.g. the
-    # compressed-tensors int8 MoE method), regardless of its module path.
     _int8_oracle.select_int8_moe_backend = _select_int8_moe_backend_oot
     for _mod in list(sys.modules.values()):
         if _mod is None:
@@ -243,79 +288,10 @@ def _patch_int8_moe_oracle() -> bool:
         if getattr(_mod, "select_int8_moe_backend", None) is _orig:
             _mod.select_int8_moe_backend = _select_int8_moe_backend_oot
 
-    _MOE_ORACLE_PATCHED = True
     logger.info(
-        "native-int8: patched select_int8_moe_backend -> TritonExpertsFL on OOT "
-        "(compressed-tensors INT8 W8A8 per-channel MoE routes through FlagGems)."
-    )
-    return True
-
-
-def _patch_int8_moe_quant_config() -> bool:
-    """Force dynamic per-token MoE configs onto W8A8 (not W8A16).
-
-    ``CompressedTensorsW8A8Int8MoEMethod`` sets ``w13_input_scale`` /
-    ``w2_input_scale`` to ``None`` for dynamic token quant, then calls
-    ``make_int8_moe_quant_config(..., per_act_token_quant=True)``. Upstream
-    interprets any ``None`` activation scale as W8A16 (``quant_dtype is None``),
-    so ``use_int8_w8a8`` stays False and experts run int8×bf16. Re-route that
-    case to ``int8_w8a8_moe_quant_config``.
-    """
-    global _MOE_QUANT_CFG_PATCHED
-    if _MOE_QUANT_CFG_PATCHED:
-        return True
-    try:
-        import sys
-
-        import vllm.model_executor.layers.fused_moe.oracle.int8 as _oracle
-        from vllm.model_executor.layers.fused_moe.config import (
-            int8_w8a8_moe_quant_config,
-        )
-    except Exception as e:  # noqa: BLE001
-        logger.debug("native-int8: MoE quant-config patch unavailable (%s)", e)
-        return False
-
-    _orig = _oracle.make_int8_moe_quant_config
-    if getattr(_orig, "_fl_native_int8_moe_qcfg", False):
-        _MOE_QUANT_CFG_PATCHED = True
-        return True
-
-    def _make_int8_moe_quant_config(
-        w1_scale,
-        w2_scale,
-        a1_scale=None,
-        a2_scale=None,
-        per_act_token_quant: bool = False,
-    ):
-        if per_act_token_quant and (a1_scale is None or a2_scale is None):
-            return int8_w8a8_moe_quant_config(
-                w1_scale=w1_scale,
-                w2_scale=w2_scale,
-                a1_scale=a1_scale,
-                a2_scale=a2_scale,
-                per_act_token_quant=True,
-            )
-        return _orig(
-            w1_scale,
-            w2_scale,
-            a1_scale=a1_scale,
-            a2_scale=a2_scale,
-            per_act_token_quant=per_act_token_quant,
-        )
-
-    _make_int8_moe_quant_config._fl_native_int8_moe_qcfg = True  # type: ignore[attr-defined]
-    _make_int8_moe_quant_config._fl_original = _orig  # type: ignore[attr-defined]
-    _oracle.make_int8_moe_quant_config = _make_int8_moe_quant_config
-    for _mod in list(sys.modules.values()):
-        if _mod is None:
-            continue
-        if getattr(_mod, "make_int8_moe_quant_config", None) is _orig:
-            _mod.make_int8_moe_quant_config = _make_int8_moe_quant_config
-
-    _MOE_QUANT_CFG_PATCHED = True
-    logger.info(
-        "native-int8: patched make_int8_moe_quant_config so dynamic "
-        "per-token MoE uses W8A8 (not W8A16)."
+        "native-int8: wrapped select_int8_moe_backend on OOT; the active "
+        "selector is %s.",
+        getattr(_orig, "__qualname__", _orig),
     )
     return True
 
@@ -325,7 +301,7 @@ def _patch_moe_per_token_quant_int8() -> bool:
 
     Stock kernel uses ``tl.extra.cuda.libdevice.round`` → TANG reports
     ``kernel function contain unknown call`` / ``TANG_ERROR_INVALID_IMAGE``.
-    Required once MoE runs true W8A8 (see ``_patch_int8_moe_quant_config``).
+    Required once MoE runs true W8A8 (see ``_ensure_dynamic_w8a8_quant_config``).
     """
     global _MOE_ACT_QUANT_PATCHED
     if _MOE_ACT_QUANT_PATCHED:
@@ -371,6 +347,55 @@ def _patch_moe_per_token_quant_int8() -> bool:
     return True
 
 
+def _ensure_dynamic_w8a8_quant_config() -> bool:
+    """Make sure dynamic per-token MoE builds a W8A8 (not W8A16) quant config.
+
+    ``CompressedTensorsW8A8Int8MoEMethod`` leaves ``w13_input_scale`` /
+    ``w2_input_scale`` at ``None`` for dynamic token quant, and upstream reads a
+    missing activation scale as W8A16, so ``use_int8_w8a8`` would stay False and
+    the experts would run int8xbf16. ``install_fl_w8a8_moe_selector`` fixes that
+    for every FL platform; sunrise only has to confirm it actually ran, since
+    ``register_oot_ops`` swallows the failure.
+    """
+    from importlib import import_module
+
+    try:
+        scheme_module = import_module(
+            "vllm.model_executor.layers.quantization.compressed_tensors."
+            "compressed_tensors_moe.compressed_tensors_moe_w8a8_int8"
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug("native-int8: W8A8 MoE scheme module unavailable (%s)", e)
+        return False
+
+    builder = getattr(scheme_module, "make_int8_moe_quant_config", None)
+    if not getattr(builder, "_vllm_fl_dynamic_w8a8_config", False):
+        from vllm_fl.quantization.w8a8.moe import install_fl_w8a8_moe_selector
+
+        install_fl_w8a8_moe_selector()
+        builder = scheme_module.make_int8_moe_quant_config
+        logger.info(
+            "native-int8: installed the FL dynamic W8A8 MoE quant-config "
+            "builder because register_oot_ops had not done so yet."
+        )
+
+    # The FL installer only rebinds the compressed-tensors scheme module. Other
+    # importers hold the stock builder by value (notably the online-INT8
+    # quantizer), so hand them the fixed one as well.
+    import sys
+
+    import vllm.model_executor.layers.fused_moe.oracle.int8 as _oracle
+
+    stock = _oracle.make_int8_moe_quant_config
+    if stock is not builder:
+        for module in list(sys.modules.values()):
+            if module is None:
+                continue
+            if getattr(module, "make_int8_moe_quant_config", None) is stock:
+                module.make_int8_moe_quant_config = builder
+    return True
+
+
 def enable_native_int8() -> None:
     """Enable the vLLM-native compressed-tensors INT8 path on sunrise/ptpu.
 
@@ -383,16 +408,22 @@ def enable_native_int8() -> None:
     ok_quant = _patch_scaled_int8_quant()
     ok_mm = _patch_triton_scaled_mm()
     ok_moe_act = _patch_moe_per_token_quant_int8()
-    ok_moe_qcfg = _patch_int8_moe_quant_config()
     ok_moe = _patch_int8_moe_oracle()
-    _ENABLED = (
-        ok_kernel
-        and ok_quant
-        and ok_mm
-        and ok_moe_act
-        and ok_moe_qcfg
-        and ok_moe
-    )
+    _ENABLED = ok_kernel and ok_quant and ok_mm and ok_moe_act and ok_moe
 
 
-__all__ = ["enable_native_int8"]
+def install_late_patches() -> None:
+    """Re-assert the INT8 routing that ``register_oot_ops`` overwrites.
+
+    ``apply_sunrise_patches`` runs inside ``register_oot_ops``, after it has
+    installed the generic FL W8A8 selector, and possibly after
+    ``add_oot_quant_kernel`` has cloned the CUDA linear kernels into the OOT
+    slot. Re-running the order-sensitive patches here makes sunrise the last
+    writer regardless of how the engine reached this point.
+    """
+    _ensure_dynamic_w8a8_quant_config()
+    _register_oot_int8_kernel()
+    _patch_int8_moe_oracle()
+
+
+__all__ = ["enable_native_int8", "install_late_patches"]

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_int8_native.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_int8_native.py
@@ -1,0 +1,398 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Enable vLLM native INT8 (compressed-tensors W8A8) on Sunrise/PTPU."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_ENABLED = False
+_OOT_KERNEL_REGISTERED = False
+_QUANT_PATCHED = False
+_MOE_ORACLE_PATCHED = False
+_MOE_QUANT_CFG_PATCHED = False
+_MOE_ACT_QUANT_PATCHED = False
+_MM_PATCHED = False
+_FG_MM_FN = None
+_MM_SHAPE_LOGGED = False
+
+
+def _register_oot_int8_kernel() -> bool:
+    """Register a Triton INT8 ScaledMM kernel that is ``is_supported`` on OOT."""
+    global _OOT_KERNEL_REGISTERED
+    if _OOT_KERNEL_REGISTERED:
+        return True
+    try:
+        from vllm.platforms import PlatformEnum
+        from vllm.model_executor.kernels.linear import (
+            _POSSIBLE_INT8_KERNELS,
+            register_linear_kernel,
+        )
+        from vllm.model_executor.kernels.linear.scaled_mm.triton import (
+            TritonInt8ScaledMMLinearKernel,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug("native-int8: vLLM kernel registry unavailable (%s)", e)
+        return False
+
+    class OOTTritonInt8ScaledMMLinearKernel(TritonInt8ScaledMMLinearKernel):
+        """``TritonInt8ScaledMMLinearKernel`` allowed on the OOT platform.
+
+        Compute is unchanged (pure-Triton ``triton_scaled_mm`` + the patched
+        activation quant); only platform gating is relaxed.
+        """
+
+        @classmethod
+        def is_supported(cls, compute_capability=None):
+            return True, None
+
+        @classmethod
+        def can_implement(cls, c):
+            return True, None
+
+    existing = _POSSIBLE_INT8_KERNELS.get(PlatformEnum.OOT, [])
+    if any(k.__name__ == OOTTritonInt8ScaledMMLinearKernel.__name__ for k in existing):
+        _OOT_KERNEL_REGISTERED = True
+        return True
+
+    register_linear_kernel(
+        OOTTritonInt8ScaledMMLinearKernel, PlatformEnum.OOT, kernel_type="int8"
+    )
+    _OOT_KERNEL_REGISTERED = True
+    logger.info(
+        "native-int8: registered OOTTritonInt8ScaledMMLinearKernel for "
+        "PlatformEnum.OOT."
+    )
+    return True
+
+
+def _patch_scaled_int8_quant() -> bool:
+    """Route ``vllm._custom_ops.scaled_int8_quant`` to sunrise Triton impl."""
+    global _QUANT_PATCHED
+    if _QUANT_PATCHED:
+        return True
+    try:
+        import vllm._custom_ops as _vllm_ops
+    except Exception as e:  # noqa: BLE001
+        logger.debug("native-int8: vllm._custom_ops unavailable (%s)", e)
+        return False
+
+    from ..impl.int8.scaled_int8_quant import scaled_int8_quant as _sunrise_quant
+
+    _orig = getattr(_vllm_ops, "scaled_int8_quant", None)
+
+    def _fl_scaled_int8_quant(input, scale=None, azp=None, symmetric=True):
+        return _sunrise_quant(input, scale=scale, azp=azp, symmetric=symmetric)
+
+    _fl_scaled_int8_quant._fl_original = _orig  # type: ignore[attr-defined]
+    _vllm_ops.scaled_int8_quant = _fl_scaled_int8_quant
+    _QUANT_PATCHED = True
+    logger.info(
+        "native-int8: patched vllm._custom_ops.scaled_int8_quant -> "
+        "sunrise impl/int8 scaled_int8_quant (Triton per-token)."
+    )
+    return True
+
+
+def _resolve_fg_scaled_mm():
+    """Return FlagGems' autotuned INT8 ``scaled_mm`` (cached)."""
+    global _FG_MM_FN
+    if _FG_MM_FN is not None:
+        return _FG_MM_FN
+    from flag_gems.ops.scaled_mm import scaled_mm as _fg
+    _FG_MM_FN = _fg
+    return _fg
+
+
+def _patch_triton_scaled_mm() -> bool:
+    """Route vLLM's ``triton_scaled_mm`` to FlagGems' autotuned ``scaled_mm``."""
+    global _MM_PATCHED
+    if _MM_PATCHED:
+        return True
+    try:
+        import vllm.model_executor.kernels.linear.scaled_mm.triton as _mm_mod
+    except Exception as e:  # noqa: BLE001
+        logger.debug("native-int8: vLLM triton scaled_mm module unavailable (%s)", e)
+        return False
+
+    _orig = getattr(_mm_mod, "triton_scaled_mm", None)
+    if _orig is None:
+        logger.debug("native-int8: triton_scaled_mm symbol not found; skip.")
+        return False
+    if getattr(_orig, "_fl_native_int8_mm", False):
+        _MM_PATCHED = True
+        return True
+
+    def _fl_triton_scaled_mm(
+        input, weight, scale_a, scale_b, out_dtype, bias=None, *args, **kwargs
+    ):
+        global _MM_SHAPE_LOGGED
+        fg = _resolve_fg_scaled_mm()
+
+        # Vision encoder QKV (and any batched linear) may pass [..., K].
+        # FlagGems / vLLM triton_scaled_mm only accept 2D [M, K]; CUDA
+        # cutlass_scaled_mm flattens the same way before the GEMM.
+        input_shape = input.shape
+        if input.ndim != 2:
+            input = input.reshape(-1, input_shape[-1])
+
+        # FlagGems computes input[M,K] @ mat2[K,N]; orient weight to [K,N].
+        mat2 = weight
+        transposed = False
+        if mat2.shape[0] != input.shape[1]:
+            mat2 = mat2.t()
+            transposed = True
+
+        # FlagGems right-scale accepts scalar / [N] / [1,N] (not [N,1]).
+        sb = scale_b
+        if sb is not None and sb.ndim == 2 and sb.shape[-1] == 1 and sb.numel() > 1:
+            sb = sb.reshape(-1)
+
+        if not _MM_SHAPE_LOGGED:
+            _MM_SHAPE_LOGGED = True
+            logger.info(
+                "native-int8: triton_scaled_mm->FlagGems scaled_mm active. "
+                "input=%s (2d=%s) weight=%s (transposed=%s) scale_a=%s "
+                "scale_b=%s out_dtype=%s bias=%s",
+                tuple(input_shape), tuple(input.shape),
+                tuple(weight.shape), transposed,
+                tuple(scale_a.shape), tuple(scale_b.shape) if scale_b is not None
+                else None, out_dtype, None if bias is None else tuple(bias.shape),
+            )
+
+        try:
+            out = fg(input, mat2, scale_a, sb, bias=bias, out_dtype=out_dtype)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "native-int8: FlagGems scaled_mm failed (%s); falling back to "
+                "vLLM triton_scaled_mm.", e,
+            )
+            out = _orig(input, weight, scale_a, scale_b, out_dtype, bias,
+                        *args, **kwargs)
+
+        if len(input_shape) != 2:
+            out = out.view(*input_shape[:-1], out.shape[-1])
+        return out
+
+    _fl_triton_scaled_mm._fl_native_int8_mm = True  # type: ignore[attr-defined]
+    _fl_triton_scaled_mm._fl_original = _orig  # type: ignore[attr-defined]
+
+    # Patch the defining module, then rebind any module that already did
+    # ``from ...scaled_mm.triton import triton_scaled_mm``.
+    import sys
+
+    _mm_mod.triton_scaled_mm = _fl_triton_scaled_mm
+    for _mod in list(sys.modules.values()):
+        if _mod is None:
+            continue
+        if getattr(_mod, "triton_scaled_mm", None) is _orig:
+            _mod.triton_scaled_mm = _fl_triton_scaled_mm
+
+    _MM_PATCHED = True
+    logger.info(
+        "native-int8: patched triton_scaled_mm -> FlagGems scaled_mm "
+        "(autotuned INT8 GEMM) on sunrise."
+    )
+    return True
+
+
+def _patch_int8_moe_oracle() -> bool:
+    """Make the int8 MoE oracle return ``TritonExpertsFL`` on OOT."""
+    global _MOE_ORACLE_PATCHED
+    if _MOE_ORACLE_PATCHED:
+        return True
+    try:
+        import sys
+
+        from vllm.platforms import current_platform
+        import vllm.model_executor.layers.fused_moe.oracle.int8 as _int8_oracle
+        from vllm.model_executor.layers.fused_moe.oracle.int8 import Int8MoeBackend
+        from vllm_fl.ops.fused_moe.fused_moe_utils import TritonExpertsFL
+        from vllm_fl.utils import use_flaggems
+    except Exception as e:  # noqa: BLE001
+        logger.debug("native-int8: int8 MoE oracle unavailable (%s)", e)
+        return False
+
+    _orig = _int8_oracle.select_int8_moe_backend
+    if getattr(_orig, "_fl_native_int8_moe", False):
+        _MOE_ORACLE_PATCHED = True
+        return True
+
+    def _select_int8_moe_backend_oot(config, *args, **kwargs):
+        # OOT + flaggems: force the FlagGems-routed experts class. This mirrors
+        # ``select_unquantized_moe_backend_oot`` and bypasses the CUDA/ROCm-only
+        # ``is_supported_config`` gate in the stock oracle.
+        if current_platform.is_out_of_tree() and use_flaggems():
+            return Int8MoeBackend.TRITON, TritonExpertsFL
+        return _orig(config, *args, **kwargs)
+
+    _select_int8_moe_backend_oot._fl_native_int8_moe = True  # type: ignore[attr-defined]
+    _select_int8_moe_backend_oot._fl_original = _orig  # type: ignore[attr-defined]
+
+    # Patch the oracle module attribute (covers modules that import the symbol
+    # AFTER this runs). Then also rebind any module that already did a
+    # ``from ...oracle.int8 import select_int8_moe_backend`` (e.g. the
+    # compressed-tensors int8 MoE method), regardless of its module path.
+    _int8_oracle.select_int8_moe_backend = _select_int8_moe_backend_oot
+    for _mod in list(sys.modules.values()):
+        if _mod is None:
+            continue
+        if getattr(_mod, "select_int8_moe_backend", None) is _orig:
+            _mod.select_int8_moe_backend = _select_int8_moe_backend_oot
+
+    _MOE_ORACLE_PATCHED = True
+    logger.info(
+        "native-int8: patched select_int8_moe_backend -> TritonExpertsFL on OOT "
+        "(compressed-tensors INT8 W8A8 per-channel MoE routes through FlagGems)."
+    )
+    return True
+
+
+def _patch_int8_moe_quant_config() -> bool:
+    """Force dynamic per-token MoE configs onto W8A8 (not W8A16).
+
+    ``CompressedTensorsW8A8Int8MoEMethod`` sets ``w13_input_scale`` /
+    ``w2_input_scale`` to ``None`` for dynamic token quant, then calls
+    ``make_int8_moe_quant_config(..., per_act_token_quant=True)``. Upstream
+    interprets any ``None`` activation scale as W8A16 (``quant_dtype is None``),
+    so ``use_int8_w8a8`` stays False and experts run int8×bf16. Re-route that
+    case to ``int8_w8a8_moe_quant_config``.
+    """
+    global _MOE_QUANT_CFG_PATCHED
+    if _MOE_QUANT_CFG_PATCHED:
+        return True
+    try:
+        import sys
+
+        import vllm.model_executor.layers.fused_moe.oracle.int8 as _oracle
+        from vllm.model_executor.layers.fused_moe.config import (
+            int8_w8a8_moe_quant_config,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.debug("native-int8: MoE quant-config patch unavailable (%s)", e)
+        return False
+
+    _orig = _oracle.make_int8_moe_quant_config
+    if getattr(_orig, "_fl_native_int8_moe_qcfg", False):
+        _MOE_QUANT_CFG_PATCHED = True
+        return True
+
+    def _make_int8_moe_quant_config(
+        w1_scale,
+        w2_scale,
+        a1_scale=None,
+        a2_scale=None,
+        per_act_token_quant: bool = False,
+    ):
+        if per_act_token_quant and (a1_scale is None or a2_scale is None):
+            return int8_w8a8_moe_quant_config(
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                a1_scale=a1_scale,
+                a2_scale=a2_scale,
+                per_act_token_quant=True,
+            )
+        return _orig(
+            w1_scale,
+            w2_scale,
+            a1_scale=a1_scale,
+            a2_scale=a2_scale,
+            per_act_token_quant=per_act_token_quant,
+        )
+
+    _make_int8_moe_quant_config._fl_native_int8_moe_qcfg = True  # type: ignore[attr-defined]
+    _make_int8_moe_quant_config._fl_original = _orig  # type: ignore[attr-defined]
+    _oracle.make_int8_moe_quant_config = _make_int8_moe_quant_config
+    for _mod in list(sys.modules.values()):
+        if _mod is None:
+            continue
+        if getattr(_mod, "make_int8_moe_quant_config", None) is _orig:
+            _mod.make_int8_moe_quant_config = _make_int8_moe_quant_config
+
+    _MOE_QUANT_CFG_PATCHED = True
+    logger.info(
+        "native-int8: patched make_int8_moe_quant_config so dynamic "
+        "per-token MoE uses W8A8 (not W8A16)."
+    )
+    return True
+
+
+def _patch_moe_per_token_quant_int8() -> bool:
+    """Replace vLLM's CUDA-only MoE ``per_token_quant_int8`` with sunrise impl.
+
+    Stock kernel uses ``tl.extra.cuda.libdevice.round`` → TANG reports
+    ``kernel function contain unknown call`` / ``TANG_ERROR_INVALID_IMAGE``.
+    Required once MoE runs true W8A8 (see ``_patch_int8_moe_quant_config``).
+    """
+    global _MOE_ACT_QUANT_PATCHED
+    if _MOE_ACT_QUANT_PATCHED:
+        return True
+    try:
+        import sys
+
+        import vllm.model_executor.layers.quantization.utils.int8_utils as _iu
+    except Exception as e:  # noqa: BLE001
+        logger.debug("native-int8: int8_utils unavailable (%s)", e)
+        return False
+
+    from ..impl.int8.scaled_int8_quant import scaled_int8_quant as _sunrise_quant
+
+    _orig = getattr(_iu, "per_token_quant_int8", None)
+    if _orig is None:
+        return False
+    if getattr(_orig, "_fl_native_int8_moe_act", False):
+        _MOE_ACT_QUANT_PATCHED = True
+        return True
+
+    def _fl_per_token_quant_int8(x):
+        q, s, _azp = _sunrise_quant(x, scale=None, azp=None, symmetric=True)
+        return q, s
+
+    _fl_per_token_quant_int8._fl_native_int8_moe_act = True  # type: ignore[attr-defined]
+    _fl_per_token_quant_int8._fl_original = _orig  # type: ignore[attr-defined]
+    _iu.per_token_quant_int8 = _fl_per_token_quant_int8
+
+    # Rebind modules that already did ``from ...int8_utils import per_token_quant_int8``
+    # (notably ``vllm.model_executor.layers.fused_moe.utils``).
+    for _mod in list(sys.modules.values()):
+        if _mod is None:
+            continue
+        if getattr(_mod, "per_token_quant_int8", None) is _orig:
+            _mod.per_token_quant_int8 = _fl_per_token_quant_int8
+
+    _MOE_ACT_QUANT_PATCHED = True
+    logger.info(
+        "native-int8: patched per_token_quant_int8 -> sunrise "
+        "scaled_int8_quant (MoE W8A8 activation quant on sunrise)."
+    )
+    return True
+
+
+def enable_native_int8() -> None:
+    """Enable the vLLM-native compressed-tensors INT8 path on sunrise/ptpu.
+
+    Idempotent; safe to call at import time even for non-INT8 models.
+    """
+    global _ENABLED
+    if _ENABLED:
+        return
+    ok_kernel = _register_oot_int8_kernel()
+    ok_quant = _patch_scaled_int8_quant()
+    ok_mm = _patch_triton_scaled_mm()
+    ok_moe_act = _patch_moe_per_token_quant_int8()
+    ok_moe_qcfg = _patch_int8_moe_quant_config()
+    ok_moe = _patch_int8_moe_oracle()
+    _ENABLED = (
+        ok_kernel
+        and ok_quant
+        and ok_mm
+        and ok_moe_act
+        and ok_moe_qcfg
+        and ok_moe
+    )
+
+
+__all__ = ["enable_native_int8"]

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_moe_config.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_moe_config.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Take the fused-MoE tile config from FlagGems' sunrise backend.
+
+FlagGems keeps a PTPU-tuned MoE heuristic in
+``flag_gems/runtime/backend/_sunrise/fused/fused_moe.py``
+(``_sunrise_get_default_config``), but it is installed by a context manager that
+only wraps ``flag_gems.fused_experts_impl``. The plugin never reaches that
+wrapper on PTPU: the monolithic fast path in ``vllm_fl/ops/fused_moe/
+fused_moe_utils.py`` is gated on ``current_platform.is_cuda()``, so we go through
+``TritonExpertsFL``, which picks tiles with vLLM's ``try_get_optimal_moe_config``
+and hands the result to FlagGems' kernel. FlagGems launches whatever it is given.
+
+vLLM's heuristic is tuned for NVIDIA and derives the tile from the token count
+alone. On PTPU its prefill choice (``BLOCK_SIZE_M=128``, ``BLOCK_SIZE_N=128``,
+8 warps) puts the 128x128 f32 accumulator over the register budget, which wedged
+the w2 grouped GEMM under sustained load.
+
+So rebind ``try_get_optimal_moe_config`` to a wrapper that asks FlagGems' sunrise
+backend instead. Config *ownership* moves to FlagGems, which is where the people
+tuning these kernels work; this module only routes.
+"""
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+# gemm1 (w13) and gemm2 (w2) deliberately share one config: BLOCK_SIZE_M also
+# sizes the moe_align_block_size padding that both GEMMs index into, so they
+# cannot disagree on it. Picking once matches what the callers already did.
+_GEMM_STAGE = "gemm1"
+
+
+def _sunrise_moe_config(w1_shape, w2_shape, top_k, dtype, M, block_shape=None):
+    """FlagGems-sourced replacement for vLLM's ``try_get_optimal_moe_config``."""
+    from flag_gems.fused import fused_moe as gems_moe
+    from flag_gems.runtime.backend._sunrise.fused.fused_moe import (
+        _sunrise_moe_config_patch,
+    )
+
+    # Keep VLLM_FL_MOE_FORCE_CONFIG (see patch.py) authoritative for debugging.
+    from vllm.model_executor.layers.fused_moe import get_config
+
+    override = get_config()
+    if override:
+        return override
+
+    # FlagGems' picker takes the expert count explicitly and distinguishes the
+    # two GEMM stages, neither of which vLLM's signature carries.
+    with _sunrise_moe_config_patch():
+        return gems_moe.try_get_optimal_moe_config(
+            w1_shape,
+            w2_shape,
+            top_k,
+            dtype,
+            M,
+            w1_shape[0],
+            block_shape=block_shape,
+            gemm_stage=_GEMM_STAGE,
+        )
+
+
+def apply_patch() -> bool:
+    """Rebind ``try_get_optimal_moe_config`` to the FlagGems sunrise picker."""
+    global _PATCHED
+    if _PATCHED:
+        return True
+
+    try:
+        import vllm.model_executor.layers.fused_moe.fused_moe as vllm_moe
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("moe-config: vLLM fused_moe module unavailable (%s)", exc)
+        return False
+
+    original = getattr(vllm_moe, "try_get_optimal_moe_config", None)
+    if original is None:
+        logger.debug("moe-config: try_get_optimal_moe_config not found; skip.")
+        return False
+    if getattr(original, "_fl_sunrise_moe_config", False):
+        _PATCHED = True
+        return True
+
+    def _try_get_optimal_moe_config(
+        w1_shape, w2_shape, top_k, dtype, M, block_shape=None
+    ):
+        try:
+            return _sunrise_moe_config(
+                w1_shape, w2_shape, top_k, dtype, M, block_shape=block_shape
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "moe-config: FlagGems sunrise MoE config unavailable (%s); "
+                "falling back to vLLM's NVIDIA-tuned heuristic, which has been "
+                "observed to hang the w2 GEMM on PTPU.",
+                exc,
+            )
+            return original(w1_shape, w2_shape, top_k, dtype, M, block_shape)
+
+    _try_get_optimal_moe_config._fl_sunrise_moe_config = True  # type: ignore[attr-defined]
+    _try_get_optimal_moe_config._fl_original = original  # type: ignore[attr-defined]
+
+    # Patch the defining module, then rebind the plugin modules that already did
+    # ``from ...fused_moe import try_get_optimal_moe_config`` (they hold the
+    # function by value): vllm_fl/ops/fused_moe/{fused_moe,fused_moe_utils}.py.
+    vllm_moe.try_get_optimal_moe_config = _try_get_optimal_moe_config
+    rebound = 0
+    for module in list(sys.modules.values()):
+        if module is None:
+            continue
+        if getattr(module, "try_get_optimal_moe_config", None) is original:
+            module.try_get_optimal_moe_config = _try_get_optimal_moe_config
+            rebound += 1
+
+    _PATCHED = True
+    logger.info(
+        "moe-config: fused-MoE tile config now comes from FlagGems' sunrise "
+        "backend (_sunrise_get_default_config); rebound %d importer(s).",
+        rebound,
+    )
+    return True

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_moe_native_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_moe_native_ops.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Back vLLM's native MoE helpers with FL dispatch on PTPU.
+
+vLLM's functional ``fused_experts`` reaches for two C extensions that PTPU
+wheels do not ship:
+
+* ``vllm._custom_ops`` forwards ``moe_align_block_size``, ``moe_sum`` and
+  ``topk_softmax`` straight to ``torch.ops._moe_C``, which only exists in CUDA
+  and ROCm builds. Callers get a bare
+  ``AttributeError: '_OpNamespace' '_moe_C' object has no attribute ...``.
+* ``apply_moe_activation`` calls ``torch.ops._C.silu_and_mul``. The plugin
+  registers a schema for that op so torch.compile can still pattern-match it,
+  but never an implementation, so invoking it fails at runtime.
+
+The plugin's own pipeline (``TritonExpertsFL``) never hits either gap: it
+resolves every operator through ``CachedOp`` and uses
+``vllm_fl.ops.fused_moe.activation``. Closing the gaps here is what lets vLLM's
+functional experts -- and therefore upstream's ``TritonW8A8Experts`` -- run on
+PTPU at all.
+
+The ``_moe_C`` shims are skipped when that extension is present, so they never
+shadow a real vendor kernel. The activation redirect is unconditional: this
+module is sunrise-only, and the FL implementation is the one PTPU has been
+validated against.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+_MARKER = "_fl_sunrise_moe_c_shim"
+_CACHED_OPS: dict[str, object] = {}
+
+
+def _op(name: str):
+    """Return the dispatch entry point for ``name`` (constructed once)."""
+    op = _CACHED_OPS.get(name)
+    if op is None:
+        from vllm_fl.dispatch import CachedOp
+
+        op = CachedOp(name)
+        _CACHED_OPS[name] = op
+    return op
+
+
+def _moe_c_available() -> bool:
+    """Report whether the native ``_moe_C`` MoE extension is importable."""
+    try:
+        return getattr(torch.ops._moe_C, "moe_align_block_size", None) is not None
+    except (AttributeError, RuntimeError):
+        return False
+
+
+def _moe_align_block_size(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+    sorted_token_ids: torch.Tensor,
+    experts_ids: torch.Tensor,
+    num_tokens_post_pad: torch.Tensor,
+    expert_map: torch.Tensor | None = None,
+) -> None:
+    """Out-parameter shim over the dispatch registry's return-value op.
+
+    vLLM only forwards ``expert_map`` to the kernel when it wants invalid
+    experts skipped in place; otherwise it remaps ``expert_ids`` itself after
+    the call. Mirror that by tying ``ignore_invalid_experts`` to whether a map
+    was passed down.
+    """
+    sorted_ids, expert_ids, post_pad = _op("moe_align_block_size")(
+        topk_ids,
+        block_size,
+        num_experts,
+        expert_map,
+        ignore_invalid_experts=expert_map is not None,
+    )
+
+    for produced, destination, name in (
+        (sorted_ids, sorted_token_ids, "sorted_token_ids"),
+        (expert_ids, experts_ids, "expert_ids"),
+        (post_pad, num_tokens_post_pad, "num_tokens_post_pad"),
+    ):
+        if produced.shape != destination.shape:
+            raise RuntimeError(
+                "moe_align_block_size shim: the dispatch backend returned "
+                f"{name} with shape {tuple(produced.shape)}, but vLLM "
+                f"allocated {tuple(destination.shape)}"
+            )
+        destination.copy_(produced)
+
+
+def _moe_sum(input: torch.Tensor, output: torch.Tensor) -> None:
+    _op("moe_sum")(input, output)
+
+
+def _topk_softmax(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    e_score_correction_bias: torch.Tensor | None = None,
+) -> None:
+    if e_score_correction_bias is not None:
+        raise NotImplementedError(
+            "topk_softmax shim: e_score_correction_bias has no dispatch "
+            "backend on PTPU; route this router through FusedTopKRouterFL"
+        )
+
+    weights, ids = _op("topk_softmax")(
+        topk_weights,
+        topk_ids,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+    )
+
+    # Backends are free to return fresh tensors instead of filling the caller's
+    # buffers; _custom_ops.topk_softmax is out-parameter only.
+    if weights is not topk_weights:
+        topk_weights.copy_(weights)
+    if ids is not topk_ids:
+        topk_ids.copy_(ids.to(topk_ids.dtype))
+
+
+_SHIMS = {
+    "moe_align_block_size": _moe_align_block_size,
+    "moe_sum": _moe_sum,
+    "topk_softmax": _topk_softmax,
+}
+
+
+def _rebind_importers(name: str, original, replacement) -> None:
+    """Update modules that imported ``name`` by value before we patched it."""
+    for module in list(sys.modules.values()):
+        if module is None:
+            continue
+        if getattr(module, name, None) is original:
+            setattr(module, name, replacement)
+
+
+def _patch_moe_c_ops() -> bool:
+    """Point ``vllm._custom_ops`` MoE helpers at the FL dispatch registry."""
+    if _moe_c_available():
+        logger.debug("moe-c-shim: torch.ops._moe_C is available; not patching.")
+        return True
+
+    try:
+        import vllm._custom_ops as _vllm_ops
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("moe-c-shim: vllm._custom_ops unavailable (%s)", exc)
+        return False
+
+    for name, shim in _SHIMS.items():
+        original = getattr(_vllm_ops, name, None)
+        if original is None or getattr(original, _MARKER, False):
+            continue
+
+        setattr(shim, _MARKER, True)
+        shim._fl_original = original  # type: ignore[attr-defined]
+        setattr(_vllm_ops, name, shim)
+        _rebind_importers(name, original, shim)
+
+    logger.info(
+        "moe-c-shim: torch.ops._moe_C is missing; vllm._custom_ops %s now "
+        "resolve through the FL dispatch registry.",
+        sorted(_SHIMS),
+    )
+    return True
+
+
+def _patch_moe_activation() -> bool:
+    """Give vLLM's fused-MoE activation a PTPU-capable implementation.
+
+    ``vllm_fl.ops.fused_moe.activation.apply_moe_activation`` is the same
+    function with the gated activations resolved through ``CachedOp`` instead of
+    ``torch.ops._C``; ``TritonExpertsFL`` has always used it.
+    """
+    try:
+        import vllm.model_executor.layers.fused_moe.activation as _vllm_act
+
+        from vllm_fl.ops.fused_moe.activation import (
+            apply_moe_activation as _fl_apply_moe_activation,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("moe-c-shim: MoE activation module unavailable (%s)", exc)
+        return False
+
+    original = getattr(_vllm_act, "apply_moe_activation", None)
+    if original is None or original is _fl_apply_moe_activation:
+        return True
+
+    _vllm_act.apply_moe_activation = _fl_apply_moe_activation
+    # fused_moe.py imports the symbol by value at module scope.
+    _rebind_importers("apply_moe_activation", original, _fl_apply_moe_activation)
+
+    logger.info(
+        "moe-c-shim: apply_moe_activation now resolves gated activations "
+        "through the FL dispatch registry instead of torch.ops._C."
+    )
+    return True
+
+
+def apply_patch() -> bool:
+    """Close the native-op gaps in vLLM's fused-MoE path on PTPU."""
+    global _PATCHED
+    if _PATCHED:
+        return True
+    _PATCHED = _patch_moe_c_ops() and _patch_moe_activation()
+    return _PATCHED

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_penalties.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_penalties.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PTPU fallbacks for vLLM penalty paths that use Triton atomics.
+
+Two penalty implementations exist in vLLM 0.20:
+
+1. **V1 gpu_model_runner** (used on PTPU): ``vllm.v1.sample.sampler`` ->
+   ``model_executor.layers.utils.apply_penalties`` ->
+   ``get_token_bin_counts_and_mask`` which calls ``scatter_add_``. FlagGems
+   routes ``scatter_add_`` to Triton ``atomic_add`` / ``cmpxchg``, which PTPU
+   does not support.
+
+2. **V2 gpu/model_runner** (not used yet): ``vllm.v1.worker.gpu.sample.penalties``
+   Triton ``_bincount_kernel`` with ``atomic_or`` / ``atomic_add``.
+
+Both are patched here with PyTorch references that avoid device atomics.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _get_token_bin_counts_and_mask_pytorch(
+    tokens: torch.Tensor,
+    vocab_size: int,
+    num_seqs: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """PyTorch reference for ``get_token_bin_counts_and_mask`` (no atomics)."""
+    device = tokens.device
+    bin_counts = torch.zeros(
+        (num_seqs, vocab_size), dtype=torch.long, device=device
+    )
+    mask = torch.zeros((num_seqs, vocab_size), dtype=torch.bool, device=device)
+
+    for seq_idx in range(num_seqs):
+        # Use Python-side iteration to avoid FlagGems boolean reductions
+        # (e.g. ``valid.any()``) and scatter_add_ atomics on PTPU.
+        counts: dict[int, int] = {}
+        for tok in tokens[seq_idx].tolist():
+            if tok < vocab_size:
+                counts[tok] = counts.get(tok, 0) + 1
+        for tok, cnt in counts.items():
+            bin_counts[seq_idx, tok] = cnt
+            mask[seq_idx, tok] = True
+
+    return bin_counts, mask
+
+
+def _bincount_pytorch(
+    expanded_idx_mapping: torch.Tensor,
+    all_token_ids: torch.Tensor,
+    prompt_len: torch.Tensor,
+    prefill_len: torch.Tensor,
+    prompt_bin_mask: torch.Tensor,
+    output_bin_counts: torch.Tensor,
+    max_prefill_len: int,
+) -> None:
+    """PyTorch reference for V2 ``penalties.bincount`` (no device atomics)."""
+    del max_prefill_len  # only used for Triton grid sizing
+
+    prompt_bin_mask[expanded_idx_mapping] = 0
+    output_bin_counts[expanded_idx_mapping] = 0
+
+    if expanded_idx_mapping.numel() == 0:
+        return
+
+    for req_idx in expanded_idx_mapping.unique().tolist():
+        p_len = int(prompt_len[req_idx].item())
+        pf_len = int(prefill_len[req_idx].item())
+        if p_len > 0:
+            prompt_tokens = all_token_ids[req_idx, :p_len].tolist()
+            for tok in prompt_tokens:
+                word_idx = tok // 32
+                prompt_bin_mask[req_idx, word_idx] |= 1 << (tok % 32)
+
+        if pf_len > p_len:
+            counts: dict[int, int] = {}
+            for tok in all_token_ids[req_idx, p_len:pf_len].tolist():
+                counts[tok] = counts.get(tok, 0) + 1
+            for tok, cnt in counts.items():
+                output_bin_counts[req_idx, tok] = cnt
+
+
+def patch_ptpu_penalties_bincount() -> None:
+    if os.environ.get("VLLM_FL_SUNRISE_PTPU_PENALTIES_BINCOUNT", "1") == "0":
+        logger.info(
+            "PTPU penalties patch disabled by "
+            "VLLM_FL_SUNRISE_PTPU_PENALTIES_BINCOUNT=0"
+        )
+        return
+
+    _patch_v1_penalty_bin_counts()
+    _patch_v2_penalty_bincount()
+
+
+def _patch_v1_penalty_bin_counts() -> None:
+    try:
+        from vllm.model_executor.layers import utils as layers_utils
+    except Exception as exc:
+        logger.warning(
+            "Failed to import model_executor.layers.utils "
+            "(skipping V1 penalties patch): %s",
+            exc,
+        )
+        return
+
+    if getattr(layers_utils, "_sunrise_ptpu_penalties_patched", False):
+        return
+
+    layers_utils.get_token_bin_counts_and_mask = _get_token_bin_counts_and_mask_pytorch
+    layers_utils._sunrise_ptpu_penalties_patched = True
+    logger.info(
+        "Patched model_executor.layers.utils.get_token_bin_counts_and_mask for "
+        "PTPU (PyTorch fallback; avoids FlagGems scatter_add_ cmpxchg in "
+        "repetition_penalty path)"
+    )
+
+
+def _patch_v2_penalty_bincount() -> None:
+    try:
+        from vllm.v1.worker.gpu.sample import penalties as penalties_mod
+    except Exception as exc:
+        logger.warning(
+            "Failed to import vLLM V2 penalties module "
+            "(skipping bincount patch): %s",
+            exc,
+        )
+        return
+
+    if getattr(penalties_mod, "_sunrise_ptpu_bincount_patched", False):
+        return
+
+    penalties_mod.bincount = _bincount_pytorch
+    penalties_mod._sunrise_ptpu_bincount_patched = True
+    logger.info(
+        "Patched v1.worker.gpu.sample.penalties.bincount for PTPU "
+        "(PyTorch fallback for future V2 model runner)"
+    )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_pointwise.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_pointwise.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Restore FlagGems PointwiseDynamicFunction fast path on PTPU."""
+
+from __future__ import annotations
+
+import logging
+
+_log = logging.getLogger(__name__)
+
+_PATCH_APPLIED = False
+
+
+def apply_patch() -> bool:
+    """Idempotently restore ``PointwiseDynamicFunction._call_real_impl``.
+
+    Returns ``True`` on the first successful restore, ``False`` if already
+    applied or if FlagGems / pointwise_dynamic are not importable (non-PTPU
+    or pre-5.4 FlagGems, in which case the patch is a silent no-op).
+    """
+    global _PATCH_APPLIED
+    if _PATCH_APPLIED:
+        return False
+
+    try:
+        from flag_gems.utils.pointwise_dynamic import PointwiseDynamicFunction
+    except Exception as exc:  # pragma: no cover - non-PTPU env
+        _log.debug(
+            "Skipping pointwise_dynamic restore (FlagGems not importable): %s",
+            exc,
+        )
+        return False
+
+    if getattr(PointwiseDynamicFunction, "_sunrise_complex_patch_restored", False):
+        return False
+
+    # Only restore if the sunrise patch is actually present. If we are on a
+    # pre-5.4 FlagGems (no patch installed) this attribute is False and we
+    # leave the original method alone.
+    if not getattr(PointwiseDynamicFunction, "_sunrise_complex_patched", False):
+        _log.debug(
+            "PointwiseDynamicFunction._call_real_impl is not sunrise-patched "
+            "(likely pre-5.4 FlagGems); no restore needed."
+        )
+        _PATCH_APPLIED = True
+        return False
+
+    def _call_real_impl_fast_path(
+        self, *args, _skip_tensor_check=False, **kwargs
+    ):
+        ndim, args, kwargs = self.prepare_args(
+            *args, _skip_tensor_check=_skip_tensor_check, **kwargs
+        )
+        overload = self.instantiate(ndim)
+        out = overload(*args, **kwargs)
+        return self._unwrap(out)
+
+    _call_real_impl_fast_path.__module__ = __name__
+    _call_real_impl_fast_path.__qualname__ = (
+        "PointwiseDynamicFunction._call_real_impl"
+    )
+
+    PointwiseDynamicFunction._call_real_impl = _call_real_impl_fast_path
+    PointwiseDynamicFunction._sunrise_complex_patch_restored = True
+    _PATCH_APPLIED = True
+
+    _log.info(
+        "Sunrise vendor: restored PointwiseDynamicFunction._call_real_impl "
+        "fast-path (skip the fp64-fallback check that adds ~4.3 µs / "
+        "pointwise op on Qwen3.5 bf16 hot path; saves ~2-4 ms / step on "
+        "Qwen3.5-35B-A3B). See sunrise/patches/patch_pointwise.py docstring."
+    )
+    return True

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_profile_decode.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_profile_decode.py
@@ -1,0 +1,1200 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Optional per-operator decode profiler (VLLM_FL_SUNRISE_PROFILE_DECODE=1)."""
+
+from __future__ import annotations
+
+import atexit
+import os
+import statistics
+import sys
+import time
+from collections import defaultdict
+
+import torch
+
+_PROFILE_ENABLED = os.environ.get(
+    "VLLM_FL_SUNRISE_PROFILE_DECODE", "0"
+).lower() in ("1", "true", "yes", "on")
+
+# Number of decode steps to capture after the first prefill step. The
+# first step in any sequence is prefill (not interesting for decode
+# perf); we mark prefills externally via ``mark_prefill_step()`` and
+# only count post-prefill timings.
+MAX_DECODE_STEPS = int(os.environ.get("VLLM_FL_SUNRISE_PROFILE_MAX_STEPS", "50"))
+
+
+# Per-call durations in microseconds, keyed by op name. Each list entry
+# is one CALL. Per-step rollups happen at summary time using the mark
+# from ``begin_decode_step``.
+_call_records: dict[str, list[float]] = defaultdict(list)
+_step_call_indices: list[dict[str, slice]] = []
+_step_total_us: list[float] = []
+_total_steps_seen = 0
+_decode_step_count = 0
+_in_decode_step = False
+_decode_step_start_us = 0.0
+_step_start_call_indices: dict[str, int] = {}
+
+
+def _now_us() -> float:
+    return time.perf_counter() * 1e6
+
+
+def _device_sync(device: torch.device | None) -> None:
+    if device is None:
+        return
+    if device.type == "ptpu":
+        try:
+            torch.ptpu.synchronize(device.index)
+        except Exception:
+            pass
+
+
+def _wrap_call(name: str, fn, *, infer_device_from=None):
+    """Return a timed wrapper around ``fn``.
+
+    ``infer_device_from`` is a callable ``(*args, **kwargs) -> torch.device``
+    used to pick which PTPU device to sync. If None, no sync is performed
+    (the caller is responsible for ensuring measurements are well-defined).
+    """
+
+    def _wrapped(*args, **kwargs):
+        if not _in_decode_step:
+            return fn(*args, **kwargs)
+        device = None
+        if infer_device_from is not None:
+            try:
+                device = infer_device_from(*args, **kwargs)
+            except Exception:
+                device = None
+        _device_sync(device)
+        t0 = _now_us()
+        out = fn(*args, **kwargs)
+        _device_sync(device)
+        t1 = _now_us()
+        _call_records[name].append(t1 - t0)
+        return out
+
+    return _wrapped
+
+
+def begin_decode_step(device: torch.device | None) -> None:
+    """Mark the start of a model.forward call. Call once per step."""
+    global _in_decode_step, _decode_step_start_us, _step_start_call_indices, _total_steps_seen
+    _total_steps_seen += 1
+    if _decode_step_count >= MAX_DECODE_STEPS:
+        _in_decode_step = False
+        return
+    _in_decode_step = True
+    _device_sync(device)
+    _decode_step_start_us = _now_us()
+    _step_start_call_indices = {n: len(v) for n, v in _call_records.items()}
+
+
+def end_decode_step(device: torch.device | None, was_decode_only: bool) -> None:
+    """Mark the end of a model.forward call. ``was_decode_only`` filters
+    out prefill steps; only decode-only steps are aggregated."""
+    global _in_decode_step, _decode_step_count
+    if not _in_decode_step:
+        return
+    _device_sync(device)
+    t1 = _now_us()
+    _in_decode_step = False
+    if not was_decode_only:
+        # Roll back: drop everything we recorded this step (it was prefill).
+        for n, start_idx in _step_start_call_indices.items():
+            del _call_records[n][start_idx:]
+        return
+    _step_total_us.append(t1 - _decode_step_start_us)
+    # Capture per-step slice indices for later rollup.
+    end_indices = {n: len(v) for n, v in _call_records.items()}
+    slices = {}
+    for n, start_idx in _step_start_call_indices.items():
+        slices[n] = slice(start_idx, end_indices.get(n, start_idx))
+    # Also include any new ops that fired only this step.
+    for n, end_idx in end_indices.items():
+        if n not in slices:
+            slices[n] = slice(0, end_idx)
+    _step_call_indices.append(slices)
+    _decode_step_count += 1
+    # Emit partial summaries so we get data without needing the process
+    # to shut down gracefully (vLLM is often killed via SIGTERM/SIGKILL,
+    # which doesn't trigger atexit). Print once at quarter, half, and
+    # full capture; also dump to a sidecar file.
+    if _decode_step_count == max(1, MAX_DECODE_STEPS // 4):
+        _print_summary(prefix=f"[partial @ {_decode_step_count} steps]")
+    if _decode_step_count == max(1, MAX_DECODE_STEPS // 2):
+        _print_summary(prefix=f"[partial @ {_decode_step_count} steps]")
+    if _decode_step_count == MAX_DECODE_STEPS:
+        _print_summary(prefix=f"[final @ {_decode_step_count} steps]")
+
+
+def _format_summary() -> str:
+    lines = []
+    lines.append("=" * 78)
+    lines.append(
+        f"Sunrise decode-step profile (decode-only steps captured: "
+        f"{_decode_step_count} / {MAX_DECODE_STEPS}, total forwards: {_total_steps_seen})"
+    )
+    if _decode_step_count == 0:
+        lines.append("(no decode-only steps captured — profiler did not see any)")
+        lines.append("=" * 78)
+        return "\n".join(lines)
+
+    total_avg = statistics.mean(_step_total_us) / 1000.0
+    total_med = statistics.median(_step_total_us) / 1000.0
+    total_p90 = sorted(_step_total_us)[int(len(_step_total_us) * 0.9)] / 1000.0
+    lines.append(
+        f"Total step time:   avg={total_avg:7.2f} ms   "
+        f"median={total_med:7.2f} ms   p90={total_p90:7.2f} ms"
+    )
+    lines.append("-" * 78)
+    lines.append(
+        f"{'Operator':<45} {'count/step':>10} {'avg ms/call':>12} {'avg ms/step':>12} {'%step':>6}"
+    )
+    lines.append("-" * 78)
+
+    # For each op, compute average count per step + average time per call.
+    rows = []
+    for name in sorted(_call_records.keys()):
+        per_step_counts = []
+        per_step_times = []
+        for sl in _step_call_indices:
+            s = sl.get(name)
+            if s is None:
+                per_step_counts.append(0)
+                per_step_times.append(0.0)
+                continue
+            calls = _call_records[name][s]
+            per_step_counts.append(len(calls))
+            per_step_times.append(sum(calls))
+        avg_count = statistics.mean(per_step_counts) if per_step_counts else 0
+        avg_time_us = statistics.mean(per_step_times) if per_step_times else 0
+        avg_per_call = avg_time_us / avg_count if avg_count > 0 else 0
+        avg_time_ms = avg_time_us / 1000.0
+        pct = 100.0 * avg_time_ms / total_avg if total_avg > 0 else 0.0
+        rows.append((avg_time_ms, name, avg_count, avg_per_call / 1000.0, avg_time_ms, pct))
+
+    rows.sort(reverse=True)  # sort by avg_time_ms descending
+    sum_pct = 0.0
+    for _, name, avg_count, ms_per_call, ms_per_step, pct in rows:
+        sum_pct += pct
+        lines.append(
+            f"{name:<45} {avg_count:>10.1f} {ms_per_call:>12.3f} {ms_per_step:>12.3f} {pct:>5.1f}%"
+        )
+    lines.append("-" * 78)
+    residual_ms = total_avg - sum_pct * total_avg / 100.0
+    residual_pct = 100.0 - sum_pct
+    lines.append(
+        f"{'(uninstrumented residual / double-count noise)':<45} "
+        f"{'':>10} {'':>12} {residual_ms:>12.3f} "
+        f"{residual_pct:>5.1f}%"
+    )
+    if residual_pct > 90.0:
+        lines.append(
+            "Captured-graph runs attribute most model time to residual; "
+            "use enforce-eager for per-op breakdown."
+        )
+    elif residual_pct < -20.0:
+        lines.append(
+            "Nested timers overlap; do not sum all rows for step time."
+        )
+
+    # P0.5: roll up native-INT8 hotspots so decode vs Linear/MoE/quant
+    # attribution does not require grepping many shape buckets by hand.
+    int8_prefixes = (
+        ("int8.scaled_int8_quant", "int8.scaled_int8_quant"),
+        ("int8.triton_scaled_mm", "int8.triton_scaled_mm"),
+        ("int8.TritonExpertsFL.apply", "int8.TritonExpertsFL.apply"),
+        ("op.invoke_fused_moe_triton_kernel", "op.invoke_fused_moe_triton_kernel"),
+        ("MoERunner.forward", "MoERunner.forward"),
+        ("FusedMoE.forward", "FusedMoE.forward"),
+    )
+    rollup_rows = []
+    for prefix, label in int8_prefixes:
+        matched = [
+            (ms, name, cnt, mpc, mps, pct)
+            for ms, name, cnt, mpc, mps, pct in rows
+            if name == prefix or name.startswith(prefix + "[")
+        ]
+        if not matched:
+            continue
+        ms_step = sum(r[4] for r in matched)
+        pct_sum = sum(r[5] for r in matched)
+        calls = sum(r[2] for r in matched)
+        rollup_rows.append((ms_step, label, calls, pct_sum))
+    if rollup_rows:
+        lines.append("-" * 78)
+        lines.append("Native INT8 / MoE rollup (sum of matching buckets):")
+        lines.append(
+            f"{'Bucket':<45} {'count/step':>10} {'avg ms/step':>12} {'%step':>6}"
+        )
+        for ms_step, label, calls, pct_sum in sorted(rollup_rows, reverse=True):
+            lines.append(
+                f"{label:<45} {calls:>10.1f} {ms_step:>12.3f} {pct_sum:>5.1f}%"
+            )
+    lines.append("=" * 78)
+    return "\n".join(lines)
+
+
+_SUMMARY_FILE = os.environ.get(
+    "VLLM_FL_SUNRISE_PROFILE_FILE", "/tmp/sunrise_profile.txt"
+)
+
+
+def _append_summary_file(text: str) -> None:
+    try:
+        with open(_SUMMARY_FILE, "a") as f:
+            f.write(text)
+    except Exception:
+        pass
+
+
+def _print_summary(prefix: str = "[at exit]") -> None:
+    if not _PROFILE_ENABLED:
+        return
+    text = _format_summary()
+    sys.stderr.write(f"\n{prefix}\n{text}\n")
+    sys.stderr.flush()
+    # Also append to a sidecar file so a hard kill -9 still leaves us
+    # readable artifacts.
+    _append_summary_file(f"\n{prefix}\n{text}\n")
+
+
+atexit.register(_print_summary)
+
+
+def install() -> None:
+    """Apply all monkey-patches. Called from ``patches/__init__.py``."""
+    if not _PROFILE_ENABLED:
+        return
+
+    sys.stderr.write(
+        "[sunrise profile] VLLM_FL_SUNRISE_PROFILE_DECODE=1: "
+        f"capturing first {MAX_DECODE_STEPS} decode-only steps; "
+        f"summary printed at process exit and appended to {_SUMMARY_FILE}.\n"
+    )
+    _append_summary_file(
+        "\n[startup]\n"
+        "Sunrise decode-step profile installed. If this file never grows "
+        "past this marker, the server did not execute any decode-only steps "
+        "or the execute_model wrapper did not install.\n"
+    )
+
+    _patch_attention_impl()
+    _patch_gdn()
+    _patch_kv_write()
+    _patch_misc()
+    _patch_oot_layers()
+    _patch_collectives()
+    _patch_moe_runner()
+    _patch_moe_details()
+    _patch_native_int8()
+    _patch_model_forward()
+
+
+def _patch_native_int8() -> None:
+    """Instrument compressed-tensors INT8 Linear hot path (quant + GEMM + MoE).
+
+    Must run after ``enable_native_int8()`` so wrappers sit on the FlagGems
+    rebinds. Safe no-op when those symbols are absent (BF16 checkpoints).
+    """
+    # 1) Activation quant — vLLM custom op (patched to FlagGems Triton).
+    try:
+        import vllm._custom_ops as _vllm_ops
+
+        orig = getattr(_vllm_ops, "scaled_int8_quant", None)
+        if orig is not None and not getattr(
+            orig, "__sunrise_profile_wrapped__", False
+        ):
+
+            def _wrap_quant(fn):
+                def _w(input, *a, **kw):
+                    if not _in_decode_step:
+                        return fn(input, *a, **kw)
+                    device = input.device if isinstance(input, torch.Tensor) else None
+                    _device_sync(device)
+                    t0 = _now_us()
+                    out = fn(input, *a, **kw)
+                    _device_sync(device)
+                    t1 = _now_us()
+                    try:
+                        tag = (
+                            f"int8.scaled_int8_quant"
+                            f"[M={input.shape[0]},K={input.shape[-1]}]"
+                        )
+                    except Exception:
+                        tag = "int8.scaled_int8_quant[?]"
+                    _call_records[tag].append(t1 - t0)
+                    return out
+
+                _w.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+                return _w
+
+            _vllm_ops.scaled_int8_quant = _wrap_quant(orig)
+            sys.stderr.write(
+                "[sunrise profile] hooked vllm._custom_ops.scaled_int8_quant\n"
+            )
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[sunrise profile] could not hook scaled_int8_quant: {e}\n"
+        )
+
+    # 2) Linear INT8 GEMM — wrap whatever currently sits on triton_scaled_mm
+    #    (FlagGems scaled_mm after patch_int8_native, else stock Triton).
+    try:
+        import sys as _sys
+
+        import vllm.model_executor.kernels.linear.scaled_mm.triton as _mm_mod
+
+        orig_mm = getattr(_mm_mod, "triton_scaled_mm", None)
+        if orig_mm is not None and not getattr(
+            orig_mm, "__sunrise_profile_wrapped__", False
+        ):
+
+            def _wrap_mm(fn):
+                def _w(input, weight, *a, **kw):
+                    if not _in_decode_step:
+                        return fn(input, weight, *a, **kw)
+                    device = input.device if isinstance(input, torch.Tensor) else None
+                    _device_sync(device)
+                    t0 = _now_us()
+                    out = fn(input, weight, *a, **kw)
+                    _device_sync(device)
+                    t1 = _now_us()
+                    try:
+                        m, k = int(input.shape[0]), int(input.shape[1])
+                        # weight may be [N,K] or [K,N]
+                        if weight.shape[1] == k:
+                            n = int(weight.shape[0])
+                        else:
+                            n = int(weight.shape[1])
+                        tag = f"int8.triton_scaled_mm[M={m},K={k},N={n}]"
+                    except Exception:
+                        tag = "int8.triton_scaled_mm[?]"
+                    _call_records[tag].append(t1 - t0)
+                    return out
+
+                _w.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+                # Preserve FlagGems markers so rebinding logic still recognizes
+                # the patched callable.
+                for attr in ("_fl_native_int8_mm", "_fl_original"):
+                    if hasattr(fn, attr):
+                        setattr(_w, attr, getattr(fn, attr))
+                return _w
+
+            wrapped = _wrap_mm(orig_mm)
+            _mm_mod.triton_scaled_mm = wrapped
+            for mod in list(_sys.modules.values()):
+                if mod is None:
+                    continue
+                if getattr(mod, "triton_scaled_mm", None) is orig_mm:
+                    mod.triton_scaled_mm = wrapped
+            sys.stderr.write(
+                "[sunrise profile] hooked triton_scaled_mm (Linear INT8 GEMM)\n"
+            )
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[sunrise profile] could not hook triton_scaled_mm: {e}\n"
+        )
+
+    # 3) MoE experts apply — exclusive envelope for TritonExpertsFL (INT8/BF16).
+    try:
+        from vllm_fl.ops.fused_moe.fused_moe_utils import TritonExpertsFL
+
+        orig_apply = TritonExpertsFL.apply
+        if not getattr(orig_apply, "__sunrise_profile_wrapped__", False):
+
+            def _wrapped_apply(self, output, hidden_states, w1=None, *a, **kw):
+                if not _in_decode_step:
+                    return orig_apply(self, output, hidden_states, w1, *a, **kw)
+                device = (
+                    hidden_states.device
+                    if isinstance(hidden_states, torch.Tensor)
+                    else None
+                )
+                _device_sync(device)
+                t0 = _now_us()
+                out = orig_apply(self, output, hidden_states, w1, *a, **kw)
+                _device_sync(device)
+                t1 = _now_us()
+                try:
+                    m = int(hidden_states.shape[0])
+                    k = int(hidden_states.shape[-1])
+                    q = getattr(self, "quant_config", None)
+                    if q is None:
+                        kind = "no_qcfg"
+                    elif getattr(q, "use_int8_w8a8", False):
+                        kind = "w8a8"
+                    elif getattr(q, "use_int8_w8a16", False):
+                        kind = "w8a16"
+                    else:
+                        kind = "bf16"
+                    wdt = getattr(w1, "dtype", None)
+                    wdt_s = str(wdt).replace("torch.", "") if wdt is not None else "?"
+                    tag = (
+                        f"int8.TritonExpertsFL.apply"
+                        f"[{kind},w={wdt_s},M={m},K={k}]"
+                    )
+                except Exception:
+                    tag = "int8.TritonExpertsFL.apply[?]"
+                _call_records[tag].append(t1 - t0)
+                return out
+
+            _wrapped_apply.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+            TritonExpertsFL.apply = _wrapped_apply
+            sys.stderr.write(
+                "[sunrise profile] hooked TritonExpertsFL.apply\n"
+            )
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[sunrise profile] could not hook TritonExpertsFL.apply: {e}\n"
+        )
+
+
+def _patch_oot_layers() -> None:
+    """Time RMSNormFL/RotaryEmbeddingFL forward directly.
+
+    These OOT layers route through ``call_op`` -> ``OpManager.call`` in
+    eager mode, but the vLLM-side custom-op path can shortcut to a
+    cached ``_forward_method`` that bypasses our dispatcher hook on
+    some configurations (notably when CustomOp.dispatch_forward picks
+    forward_oot at construction time but then later replaces it via
+    inline torch.compile boundaries). To make sure we capture them,
+    hook the OOT classes' ``forward_oot`` directly.
+    """
+    try:
+        from vllm_fl.ops.layernorm import RMSNormFL
+        from vllm_fl.ops.activation import SiluAndMulFL
+        from vllm_fl.ops.rotary_embedding import RotaryEmbeddingFL
+    except Exception:
+        return
+
+    def _wrap(cls, attr, tag):
+        orig = getattr(cls, attr, None)
+        if orig is None or getattr(orig, "__sunrise_profile_wrapped__", False):
+            return
+
+        def _w(self, *a, **kw):
+            if not _in_decode_step:
+                return orig(self, *a, **kw)
+            device = None
+            for v in a:
+                if isinstance(v, torch.Tensor):
+                    device = v.device
+                    break
+            _device_sync(device)
+            t0 = _now_us()
+            out = orig(self, *a, **kw)
+            _device_sync(device)
+            t1 = _now_us()
+            _call_records[tag].append(t1 - t0)
+            return out
+
+        _w.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+        setattr(cls, attr, _w)
+
+    _wrap(RMSNormFL, "forward_oot", "RMSNormFL.forward_oot")
+    _wrap(SiluAndMulFL, "forward_oot", "SiluAndMulFL.forward_oot")
+    _wrap(RotaryEmbeddingFL, "forward_oot", "RotaryEmbeddingFL.forward_oot")
+    sys.stderr.write(
+        "[sunrise profile] hooked RMSNormFL/SiluAndMulFL/RotaryEmbeddingFL.forward_oot\n"
+    )
+
+
+
+
+def _patch_attention_impl() -> None:
+    from ..impl import attention as _attn_mod
+
+    cls = _attn_mod.AttentionFLImpl
+    orig_forward = cls.forward
+
+    def wrapped_forward(self, query, key, value, kv_cache, *args, **kwargs):
+        if not _in_decode_step:
+            return orig_forward(self, query, key, value, kv_cache, *args, **kwargs)
+        device = query.device if isinstance(query, torch.Tensor) else None
+        _device_sync(device)
+        t0 = _now_us()
+        out = orig_forward(self, query, key, value, kv_cache, *args, **kwargs)
+        _device_sync(device)
+        t1 = _now_us()
+        _call_records["full_attention.layer (8 layers)"].append(t1 - t0)
+        return out
+
+    cls.forward = wrapped_forward
+
+    # Also wrap flag_gems.flash_attn_varlen_func at the call-site import.
+    if hasattr(_attn_mod, "flash_attn_varlen_func"):
+        orig = _attn_mod.flash_attn_varlen_func
+
+        def _wrapped(*args, **kwargs):
+            if not _in_decode_step:
+                return orig(*args, **kwargs)
+            q = args[0] if args else kwargs.get("q")
+            device = q.device if isinstance(q, torch.Tensor) else None
+            _device_sync(device)
+            t0 = _now_us()
+            out = orig(*args, **kwargs)
+            _device_sync(device)
+            t1 = _now_us()
+            _call_records[
+                "  └─ flash_attn_varlen_func (FlagGems)"
+            ].append(t1 - t0)
+            return out
+
+        _attn_mod.flash_attn_varlen_func = _wrapped
+
+
+def _patch_kv_write() -> None:
+    from ..impl import attention as _attn_mod
+
+    orig = getattr(_attn_mod, "reshape_and_cache_flash", None)
+    if orig is None:
+        return
+
+    def _wrapped(key, value, *args, **kwargs):
+        if not _in_decode_step:
+            return orig(key, value, *args, **kwargs)
+        device = key.device if isinstance(key, torch.Tensor) else None
+        _device_sync(device)
+        t0 = _now_us()
+        out = orig(key, value, *args, **kwargs)
+        _device_sync(device)
+        t1 = _now_us()
+        _call_records[
+            "  └─ kv_write (FlagGems reshape_and_cache_flash)"
+        ].append(t1 - t0)
+        return out
+
+    _attn_mod.reshape_and_cache_flash = _wrapped
+
+
+def _patch_gdn() -> None:
+    """Hook the GDN body operators at every module that uses them.
+
+    Symbols like ``fused_recurrent_gated_delta_rule_packed_decode`` and
+    ``fused_sigmoid_gating_delta_rule_update`` are imported with ``from
+    ... import ...`` at module-load time inside
+    ``vllm.model_executor.layers.mamba.gdn_linear_attn``. So patching only
+    the source module misses the actual callsite. We patch at every
+    namespace where these names live.
+    """
+
+    def _make_wrap(orig, tag):
+        if getattr(orig, "__sunrise_profile_wrapped__", False):
+            return orig
+
+        def _wrapped(*args, **kwargs):
+            if not _in_decode_step:
+                return orig(*args, **kwargs)
+            device = None
+            for a in args:
+                if isinstance(a, torch.Tensor):
+                    device = a.device
+                    break
+            if device is None:
+                for v in kwargs.values():
+                    if isinstance(v, torch.Tensor):
+                        device = v.device
+                        break
+            _device_sync(device)
+            t0 = _now_us()
+            out = orig(*args, **kwargs)
+            _device_sync(device)
+            t1 = _now_us()
+            _call_records[tag].append(t1 - t0)
+            return out
+
+        _wrapped.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+        return _wrapped
+
+    # Patch sunrise's PTPU rebind in fused_sigmoid_gating module (the one
+    # actually called for the spec/mixed path).
+    try:
+        from ..impl.fla import fused_sigmoid_gating as _fsg_mod
+
+        orig = _fsg_mod.fused_sigmoid_gating_delta_rule_update
+        _fsg_mod.fused_sigmoid_gating_delta_rule_update = _make_wrap(
+            orig, "GDN spec/mixed: fused_sigmoid_gating (PTPU)"
+        )
+    except Exception:
+        pass
+
+    # Patch the GDN call-site in vllm so that ALL paths (spec/mixed and
+    # steady packed_decode) end up timed via the rebinding done at the
+    # gdn_linear_attn import. ``patch_fla_ops.apply_patch`` runs BEFORE us
+    # (see ``patches/__init__.py``), so the bound callable is already
+    # the PTPU wrapper.
+    packed_decode_tag = "GDN steady decode: packed_decode (PTPU)"
+
+    try:
+        from vllm.model_executor.layers.mamba import (
+            gdn_linear_attn as _gdn_mod,
+        )
+
+        for sym, tag in (
+            (
+                "fused_sigmoid_gating_delta_rule_update",
+                "GDN spec/mixed: fused_sigmoid_gating (PTPU)",
+            ),
+            (
+                "fused_recurrent_gated_delta_rule_packed_decode",
+                packed_decode_tag,
+            ),
+            (
+                "fla_chunk_gated_delta_rule",
+                "GDN prefill: chunk_gated_delta_rule (FLA Triton)",
+            ),
+        ):
+            f = getattr(_gdn_mod, sym, None)
+            if f is None:
+                continue
+            setattr(_gdn_mod, sym, _make_wrap(f, tag))
+    except Exception:
+        pass
+
+    # Same for the FLA package re-exports (in case some consumer imports
+    # them from there). The module attribute has already been rebound to
+    # the PTPU wrapper by ``patch_fla_ops.apply_patch``, so ``_make_wrap``
+    # wraps the PTPU path.
+    try:
+        import fla.ops.fused_recurrent as _fla_fr_mod
+
+        f = _fla_fr_mod.fused_recurrent_gated_delta_rule_packed_decode
+        _fla_fr_mod.fused_recurrent_gated_delta_rule_packed_decode = (
+            _make_wrap(f, packed_decode_tag)
+        )
+    except Exception:
+        pass
+
+
+def _patch_misc() -> None:
+    """Hook the dispatch manager + ``F.linear`` to time all gemms.
+
+    Wrapping ``OpManager.call`` catches every flagos / vendor op call
+    (rms_norm, silu_and_mul, rotary_embedding, etc.). However, gemms in
+    Linear layers go through ``torch.nn.functional.linear`` directly,
+    bypassing OpManager.call. We hook both call sites so that gemms are
+    broken out of the residual.
+
+    Hook also breaks down by gemm output-feature size, which is useful
+    for telling the QKV / o_proj gemms apart from gate_up / down_proj.
+    """
+    try:
+        from vllm_fl.dispatch.manager import OpManager
+    except Exception:
+        return
+
+    if getattr(OpManager.call, "__sunrise_profile_wrapped__", False):
+        return
+
+    orig_call = OpManager.call
+
+    def _wrapped_call(self, op_name, *args, **kwargs):
+        if not _in_decode_step:
+            return orig_call(self, op_name, *args, **kwargs)
+        device = None
+        for a in args:
+            if isinstance(a, torch.Tensor):
+                device = a.device
+                break
+        if device is None:
+            for v in kwargs.values():
+                if isinstance(v, torch.Tensor):
+                    device = v.device
+                    break
+        _device_sync(device)
+        t0 = _now_us()
+        out = orig_call(self, op_name, *args, **kwargs)
+        _device_sync(device)
+        t1 = _now_us()
+        _call_records[f"op.{op_name}"].append(t1 - t0)
+        return out
+
+    _wrapped_call.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+    OpManager.call = _wrapped_call
+    sys.stderr.write("[sunrise profile] OpManager.call wrapped\n")
+
+    # Hook causal_conv1d_update / causal_conv1d_fn at the gdn import
+    # site so we can break out the GDN front-end conv that is NOT
+    # routed through OpManager.call (it is directly imported as a
+    # symbol).
+    try:
+        from vllm.model_executor.layers.mamba import (
+            gdn_linear_attn as _gdn_src_mod,
+        )
+    except Exception:
+        return
+
+    for fn_name in ("causal_conv1d_update", "causal_conv1d_fn"):
+        orig = getattr(_gdn_src_mod, fn_name, None)
+        if orig is None:
+            continue
+        if getattr(orig, "__sunrise_profile_wrapped__", False):
+            continue
+
+        def _make(fn, full_name):
+            def _w(*a, **kw):
+                if not _in_decode_step:
+                    return fn(*a, **kw)
+                device = None
+                for v in (*a, *kw.values()):
+                    if isinstance(v, torch.Tensor):
+                        device = v.device
+                        break
+                _device_sync(device)
+                t0 = _now_us()
+                out = fn(*a, **kw)
+                _device_sync(device)
+                t1 = _now_us()
+                _call_records[full_name].append(t1 - t0)
+                return out
+
+            _w.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+            return _w
+
+        setattr(_gdn_src_mod, fn_name, _make(orig, f"GDN.{fn_name}"))
+
+    # Hook torch.nn.functional.linear so we time every gemm done by a
+    # Linear layer (q/k/v/o_proj, gate_up_proj, down_proj, lm_head, ...).
+    # We bucket calls by the output feature size so that the report
+    # tells QKV/MLP gemms apart from each other.
+    import torch.nn.functional as _F
+
+    if not getattr(_F.linear, "__sunrise_profile_wrapped__", False):
+        _orig_linear = _F.linear
+
+        def _wrapped_linear(input, weight, bias=None):
+            if not _in_decode_step:
+                return _orig_linear(input, weight, bias)
+            device = (
+                input.device if isinstance(input, torch.Tensor) else None
+            )
+            _device_sync(device)
+            t0 = _now_us()
+            out = _orig_linear(input, weight, bias)
+            _device_sync(device)
+            t1 = _now_us()
+            try:
+                in_feat = weight.shape[-1]
+                out_feat = weight.shape[-2]
+                tag = f"F.linear[in={in_feat},out={out_feat}]"
+            except Exception:
+                tag = "F.linear[?]"
+            _call_records[tag].append(t1 - t0)
+            return out
+
+        _wrapped_linear.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+        _F.linear = _wrapped_linear
+        # Also patch torch.nn.functional.linear at the module level
+        # because the symbol may already be cached at the call site.
+        torch.nn.functional.linear = _wrapped_linear
+
+
+def _patch_collectives() -> None:
+    """Instrument TP/PP/world collectives for decode profiling."""
+    try:
+        from vllm.distributed.parallel_state import GroupCoordinator
+    except Exception as e:
+        sys.stderr.write(
+            f"[sunrise profile] could not import GroupCoordinator: {e}\n"
+        )
+        return
+
+    def _wrap_collective(attr: str, default_tag: str):
+        orig = getattr(GroupCoordinator, attr, None)
+        if orig is None or getattr(orig, "__sunrise_profile_wrapped__", False):
+            return
+
+        def _w(self, *a, **kw):
+            if not _in_decode_step:
+                return orig(self, *a, **kw)
+            # world_size == 1 short-circuit is essentially free; don't
+            # bother timing those (they don't actually hit the device).
+            if getattr(self, "world_size", 1) == 1:
+                return orig(self, *a, **kw)
+            # Find the first tensor arg to pick a device for sync.
+            device = None
+            for v in a:
+                if isinstance(v, torch.Tensor):
+                    device = v.device
+                    break
+            if device is None:
+                for v in kw.values():
+                    if isinstance(v, torch.Tensor):
+                        device = v.device
+                        break
+            # Group tag — TP / PP / DP / EP / world. ``unique_name``
+            # looks like "tp:1" / "pp:0" / "world:0"; we strip the
+            # numeric suffix to get a clean "tp" / "pp" / ... tag.
+            try:
+                uname = getattr(self, "unique_name", default_tag)
+                tag = uname.split(":", 1)[0] if uname else default_tag
+            except Exception:
+                tag = default_tag
+            _device_sync(device)
+            t0 = _now_us()
+            out = orig(self, *a, **kw)
+            _device_sync(device)
+            t1 = _now_us()
+            _call_records[f"op.{attr}.{tag}"].append(t1 - t0)
+            return out
+
+        _w.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+        setattr(GroupCoordinator, attr, _w)
+
+    _wrap_collective("all_reduce", default_tag="?")
+    _wrap_collective("all_gather", default_tag="?")
+    _wrap_collective("reduce_scatter", default_tag="?")
+    sys.stderr.write(
+        "[sunrise profile] hooked GroupCoordinator.{all_reduce,all_gather,reduce_scatter}\n"
+    )
+
+
+def _patch_moe_runner() -> None:
+    """Instrument MoE forward paths for decode profiling."""
+    try:
+        from vllm.model_executor.layers.fused_moe.runner.moe_runner import (
+            MoERunner,
+        )
+        from vllm.model_executor.layers.fused_moe import FusedMoE
+    except Exception as e:
+        sys.stderr.write(
+            f"[sunrise profile] could not import MoE classes: {e}\n"
+        )
+        return
+
+    def _wrap_method(cls, attr: str, tag: str, infer_device_arg_idx: int = 1):
+        orig = getattr(cls, attr, None)
+        if orig is None or getattr(orig, "__sunrise_profile_wrapped__", False):
+            return
+
+        def _w(self, *a, **kw):
+            if not _in_decode_step:
+                return orig(self, *a, **kw)
+            device = None
+            if len(a) > infer_device_arg_idx - 1 and isinstance(
+                a[infer_device_arg_idx - 1], torch.Tensor
+            ):
+                device = a[infer_device_arg_idx - 1].device
+            if device is None:
+                for v in (*a, *kw.values()):
+                    if isinstance(v, torch.Tensor):
+                        device = v.device
+                        break
+            _device_sync(device)
+            t0 = _now_us()
+            out = orig(self, *a, **kw)
+            _device_sync(device)
+            t1 = _now_us()
+            _call_records[tag].append(t1 - t0)
+            return out
+
+        _w.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+        setattr(cls, attr, _w)
+
+    _wrap_method(MoERunner, "forward", "MoERunner.forward")
+    _wrap_method(FusedMoE, "forward", "FusedMoE.forward (incl. runner)")
+    sys.stderr.write(
+        "[sunrise profile] hooked MoERunner.forward + FusedMoE.forward\n"
+    )
+
+
+def _patch_moe_details() -> None:
+    """Instrument MoE routing and shared experts.
+
+    These are nested below ``MoERunner.forward``. They make the eager profile
+    actionable when the top-level MoE envelope dominates: we can separate
+    router/top-k, shared experts, and the INT8 native stack before deciding
+    which cudagraph-visible device kernels are worth optimizing.
+    """
+    try:
+        from vllm.model_executor.layers.fused_moe.router.base_router import (
+            BaseRouter,
+        )
+    except Exception as e:
+        sys.stderr.write(
+            f"[sunrise profile] could not import MoE BaseRouter: {e}\n"
+        )
+        BaseRouter = None
+
+    if BaseRouter is not None:
+        orig_select = getattr(BaseRouter, "select_experts", None)
+        if orig_select is not None and not getattr(
+            orig_select, "__sunrise_profile_wrapped__", False
+        ):
+
+            def _wrapped_select_experts(
+                self,
+                hidden_states,
+                router_logits,
+                *,
+                input_ids=None,
+            ):
+                if not _in_decode_step:
+                    return orig_select(
+                        self,
+                        hidden_states,
+                        router_logits,
+                        input_ids=input_ids,
+                    )
+                device = (
+                    hidden_states.device
+                    if isinstance(hidden_states, torch.Tensor)
+                    else None
+                )
+                _device_sync(device)
+                t0 = _now_us()
+                out = orig_select(
+                    self,
+                    hidden_states,
+                    router_logits,
+                    input_ids=input_ids,
+                )
+                _device_sync(device)
+                t1 = _now_us()
+                _call_records["MoE.router.select_experts"].append(t1 - t0)
+                return out
+
+            _wrapped_select_experts.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+            BaseRouter.select_experts = _wrapped_select_experts
+
+    try:
+        from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
+            SharedExperts,
+        )
+    except Exception as e:
+        sys.stderr.write(
+            f"[sunrise profile] could not import MoE SharedExperts: {e}\n"
+        )
+        SharedExperts = None
+
+    if SharedExperts is not None:
+        orig_apply = getattr(SharedExperts, "apply", None)
+        if orig_apply is not None and not getattr(
+            orig_apply, "__sunrise_profile_wrapped__", False
+        ):
+
+            def _wrapped_shared_apply(self, shared_experts_input, order):
+                if not _in_decode_step:
+                    return orig_apply(self, shared_experts_input, order)
+                device = (
+                    shared_experts_input.device
+                    if isinstance(shared_experts_input, torch.Tensor)
+                    else None
+                )
+                _device_sync(device)
+                t0 = _now_us()
+                out = orig_apply(self, shared_experts_input, order)
+                _device_sync(device)
+                t1 = _now_us()
+                try:
+                    order_name = getattr(order, "name", str(order))
+                except Exception:
+                    order_name = "?"
+                _call_records[f"MoE.shared_experts.apply[{order_name}]"].append(
+                    t1 - t0
+                )
+                return out
+
+            _wrapped_shared_apply.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+            SharedExperts.apply = _wrapped_shared_apply
+
+    def _wrap_mlp_forward(cls, tag: str) -> None:
+        orig = getattr(cls, "forward", None)
+        if orig is None or getattr(orig, "__sunrise_profile_wrapped__", False):
+            return
+
+        def _wrapped_forward(self, x, *args, **kwargs):
+            if not _in_decode_step:
+                return orig(self, x, *args, **kwargs)
+            device = x.device if isinstance(x, torch.Tensor) else None
+            _device_sync(device)
+            t0 = _now_us()
+            out = orig(self, x, *args, **kwargs)
+            _device_sync(device)
+            t1 = _now_us()
+            _call_records[tag].append(t1 - t0)
+            return out
+
+        _wrapped_forward.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+        cls.forward = _wrapped_forward
+
+    try:
+        from vllm.model_executor.models.qwen2_moe import Qwen2MoeMLP
+
+        _wrap_mlp_forward(
+            Qwen2MoeMLP, "MoE.shared_expert.Qwen2MoeMLP.forward"
+        )
+    except Exception as e:
+        sys.stderr.write(
+            f"[sunrise profile] could not hook Qwen2MoeMLP.forward: {e}\n"
+        )
+
+    try:
+        from vllm.model_executor.models.qwen3_moe import Qwen3MoeMLP
+
+        _wrap_mlp_forward(
+            Qwen3MoeMLP, "MoE.shared_expert.Qwen3MoeMLP.forward"
+        )
+    except Exception as e:
+        sys.stderr.write(
+            f"[sunrise profile] could not hook Qwen3MoeMLP.forward: {e}\n"
+        )
+
+    try:
+        from vllm.model_executor.layers.activation import SiluAndMul
+    except Exception as e:
+        sys.stderr.write(
+            f"[sunrise profile] could not import SiluAndMul: {e}\n"
+        )
+        SiluAndMul = None
+
+    if SiluAndMul is not None:
+        orig_forward = getattr(SiluAndMul, "forward", None)
+        if orig_forward is not None and not getattr(
+            orig_forward, "__sunrise_profile_wrapped__", False
+        ):
+
+            def _wrapped_silu_and_mul(self, x, *args, **kwargs):
+                if not _in_decode_step:
+                    return orig_forward(self, x, *args, **kwargs)
+                device = x.device if isinstance(x, torch.Tensor) else None
+                _device_sync(device)
+                t0 = _now_us()
+                out = orig_forward(self, x, *args, **kwargs)
+                _device_sync(device)
+                t1 = _now_us()
+                try:
+                    in_feat = x.shape[-1]
+                    out_feat = in_feat // 2
+                    tag = f"SiluAndMul.forward[in={in_feat},out={out_feat}]"
+                except Exception:
+                    tag = "SiluAndMul.forward[?]"
+                _call_records[tag].append(t1 - t0)
+                return out
+
+            _wrapped_silu_and_mul.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+            SiluAndMul.forward = _wrapped_silu_and_mul
+
+    sys.stderr.write(
+        "[sunrise profile] hooked MoE router/shared-experts/shared-MLP\n"
+    )
+
+
+_runner_patch_state = {"installed": False, "execute_model_calls": 0}
+
+
+def _make_execute_model_wrapper(orig, cls_name):
+    state = _runner_patch_state
+
+    def _wrapped(self, scheduler_output, intermediate_tensors=None, *a, **kw):
+        state["execute_model_calls"] += 1
+        was_decode_only = False
+        try:
+            counts = getattr(scheduler_output, "num_scheduled_tokens", None)
+            if counts is not None and len(counts) > 0:
+                # Pure single-token decode: every scheduled request asks
+                # for exactly one token. Anything else (prefill chunks)
+                # is excluded so the per-op aggregation stays apples-to-
+                # apples for steady-state decode timing.
+                was_decode_only = all(int(c) == 1 for c in counts.values())
+        except Exception:
+            pass
+
+        if state["execute_model_calls"] <= 3:
+            try:
+                counts = getattr(scheduler_output, "num_scheduled_tokens", None)
+                sys.stderr.write(
+                    f"[sunrise profile] {cls_name}.execute_model call "
+                    f"#{state['execute_model_calls']}: was_decode_only="
+                    f"{was_decode_only} num_scheduled_tokens="
+                    f"{dict(counts) if counts else None}\n"
+                )
+                sys.stderr.flush()
+            except Exception:
+                pass
+
+        device = getattr(self, "device", None)
+        begin_decode_step(device)
+        try:
+            return orig(self, scheduler_output, intermediate_tensors, *a, **kw)
+        finally:
+            end_decode_step(device, was_decode_only)
+
+    return _wrapped
+
+
+def _try_install_execute_model_patch() -> bool:
+    """Install ``execute_model`` patches if the runner classes are already loaded.
+
+    Returns True if the patch was installed (or had been installed previously).
+    Importing ``vllm_fl.worker.model_runner`` early (e.g. at sunrise/__init__
+    time) snapshots ``current_platform.dist_backend`` BEFORE vLLM finishes
+    initializing the platform, which then breaks ``graph_capture`` on PTPU. So
+    we instead poll ``sys.modules`` and patch lazily once the runner module
+    has been loaded by vLLM's normal startup path.
+    """
+    state = _runner_patch_state
+    if state["installed"]:
+        return True
+
+    candidates = []
+    fl_mod = sys.modules.get("vllm_fl.worker.model_runner")
+    if fl_mod is not None and hasattr(fl_mod, "ModelRunnerFL"):
+        candidates.append(("ModelRunnerFL", fl_mod.ModelRunnerFL))
+    core_mod = sys.modules.get("vllm.v1.worker.gpu_model_runner")
+    if core_mod is not None and hasattr(core_mod, "GPUModelRunner"):
+        candidates.append(("GPUModelRunner", core_mod.GPUModelRunner))
+
+    if not candidates:
+        return False
+
+    for cls_name, cls in candidates:
+        if getattr(cls.execute_model, "__sunrise_profile_wrapped__", False):
+            continue
+        orig = cls.execute_model
+        wrapped = _make_execute_model_wrapper(orig, cls_name)
+        wrapped.__sunrise_profile_wrapped__ = True  # type: ignore[attr-defined]
+        cls.execute_model = wrapped
+        sys.stderr.write(
+            f"[sunrise profile] {cls_name}.execute_model wrapper installed (lazy)\n"
+        )
+    state["installed"] = True
+    return True
+
+
+def _patch_model_forward() -> None:
+    """Schedule the ``execute_model`` patch.
+
+    We do NOT eagerly import the runner module here. Instead, we install a
+    short polling thread that retries every few hundred milliseconds until
+    the runner class shows up in ``sys.modules`` (it always does, just
+    after vLLM finishes initializing the platform). This avoids forcing
+    ``vllm_fl.worker.model_runner`` to be imported before
+    ``current_platform`` is ready, which previously broke ``graph_capture``
+    by capturing the wrong branch (non-PTPU) at module-load time.
+    """
+    import threading
+
+    if _try_install_execute_model_patch():
+        return
+
+    def _poll():
+        for _ in range(600):  # up to ~60 s
+            if _try_install_execute_model_patch():
+                return
+            time.sleep(0.1)
+        sys.stderr.write(
+            "[sunrise profile] timed out waiting for ModelRunner; total-step "
+            "timing disabled.\n"
+        )
+
+    t = threading.Thread(target=_poll, name="sunrise-profile-patcher", daemon=True)
+    t.start()
+    sys.stderr.write(
+        "[sunrise profile] execute_model patch scheduled (will install once "
+        "the runner module loads)\n"
+    )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_profiler.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patches/patch_profiler.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Map torch profiler CUDA activity to PrivateUse1 on PTPU."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_patched = False
+
+
+def install() -> None:
+    """Alias ``TorchProfilerActivityMap['CUDA']`` to ``PrivateUse1`` on PTPU.
+
+    Idempotent. Silent no-op when:
+      * not on PTPU,
+      * ``vllm.profiler.wrapper`` cannot be imported,
+      * ``torch.profiler.ProfilerActivity.PrivateUse1`` is unavailable,
+      * the alias has already been installed (by this function or any
+        other patch).
+    """
+    global _patched
+    if _patched:
+        return
+
+    pid = os.getpid()
+
+    try:
+        from vllm.platforms import current_platform
+    except Exception as exc:
+        logger.info(
+            "[FL_INIT] profile.install skipped: cannot import current_platform "
+            "(%s) pid=%d",
+            exc,
+            pid,
+        )
+        return
+
+    device_type = getattr(current_platform, "device_type", None)
+    if device_type != "ptpu":
+        logger.info(
+            "[FL_INIT] profile.install skipped: device_type=%r != 'ptpu' pid=%d",
+            device_type,
+            pid,
+        )
+        return
+
+    try:
+        import torch.profiler
+    except Exception as exc:
+        logger.info(
+            "[FL_INIT] profile.install skipped: torch.profiler unavailable "
+            "(%s) pid=%d",
+            exc,
+            pid,
+        )
+        return
+
+    private_use1 = getattr(
+        torch.profiler.ProfilerActivity, "PrivateUse1", None
+    )
+    if private_use1 is None:
+        logger.info(
+            "[FL_INIT] profile.install skipped: "
+            "torch.profiler.ProfilerActivity.PrivateUse1 not present "
+            "(torch=%s) pid=%d",
+            getattr(__import__("torch"), "__version__", "?"),
+            pid,
+        )
+        return
+
+    try:
+        from vllm.profiler import wrapper as _vllm_profiler_wrapper
+    except Exception as exc:
+        logger.info(
+            "[FL_INIT] profile.install skipped: cannot import "
+            "vllm.profiler.wrapper (%s) pid=%d",
+            exc,
+            pid,
+        )
+        return
+
+    activity_map = getattr(
+        _vllm_profiler_wrapper, "TorchProfilerActivityMap", None
+    )
+    if activity_map is None or "CUDA" not in activity_map:
+        logger.info(
+            "[FL_INIT] profile.install skipped: "
+            "vllm.profiler.wrapper.TorchProfilerActivityMap missing or has no "
+            "'CUDA' entry pid=%d",
+            pid,
+        )
+        return
+
+    prev = activity_map.get("CUDA")
+    if prev is private_use1:
+        _patched = True
+        logger.info(
+            "[FL_INIT] profile.install installed (no-op): "
+            "TorchProfilerActivityMap['CUDA'] is already PrivateUse1 pid=%d",
+            pid,
+        )
+        return
+
+    activity_map["CUDA"] = private_use1
+    _patched = True
+    logger.info(
+        "[FL_INIT] profile.install installed: "
+        "TorchProfilerActivityMap['CUDA'] -> ProfilerActivity.PrivateUse1 "
+        "(was %s) pid=%d",
+        prev,
+        pid,
+    )

--- a/vllm_fl/dispatch/backends/vendor/sunrise/register_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/register_ops.py
@@ -46,6 +46,47 @@ def register_builtins(registry) -> None:
             vendor="sunrise",
             priority=BackendPriority.VENDOR,
         ),
+        OpImpl(
+            op_name="silu_and_mul",
+            impl_id="vendor.sunrise",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.silu_and_mul, is_avail),
+            vendor="sunrise",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="rotary_embedding",
+            impl_id="vendor.sunrise",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.rotary_embedding, is_avail),
+            vendor="sunrise",
+            priority=BackendPriority.VENDOR,
+        ),
+        # MoE helper fallbacks.
+        OpImpl(
+            op_name="topk_softmax",
+            impl_id="vendor.sunrise",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.topk_softmax, is_avail),
+            vendor="sunrise",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="moe_sum",
+            impl_id="vendor.sunrise",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.moe_sum, is_avail),
+            vendor="sunrise",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="moe_align_block_size",
+            impl_id="vendor.sunrise",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.moe_align_block_size, is_avail),
+            vendor="sunrise",
+            priority=BackendPriority.VENDOR,
+        ),
     ]
 
     registry.register_many(impls)

--- a/vllm_fl/dispatch/backends/vendor/sunrise/sunrise.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/sunrise.py
@@ -9,7 +9,7 @@ This backend provides operator implementations for Sunrise GPUs.
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 
@@ -48,6 +48,83 @@ class SunriseBackend(Backend):
         return SunriseBackend._available
 
     # ==================== Operator Implementations ====================
+    def silu_and_mul(self, obj, x: torch.Tensor) -> torch.Tensor:
+        """SiLU + element-wise multiply backed by ``torch_ptpu.sgl_kernel``."""
+        from .impl.activation import silu_and_mul_sunrise
+
+        return silu_and_mul_sunrise(obj, x)
+
+    def rotary_embedding(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        rotary_interleaved: bool = False,
+        inplace: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Apply RoPE using ``torch_ptpu.sgl_kernel.apply_rope_with_cos_sin_cache``."""
+        from .impl.rotary import rotary_embedding_sunrise
+
+        return rotary_embedding_sunrise(
+            obj,
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            rotary_interleaved=rotary_interleaved,
+            inplace=inplace,
+        )
+
+    def topk_softmax(
+        self,
+        topk_weights: torch.Tensor,
+        topk_indices: torch.Tensor,
+        token_expert_indices: torch.Tensor,
+        gating_output: torch.Tensor,
+        renormalize: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Router top-k over ``softmax(gating_output)`` (PyTorch fallback)."""
+        from .impl.fused_moe import topk_softmax_sunrise
+
+        return topk_softmax_sunrise(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+        )
+
+    def moe_sum(self, inp: torch.Tensor, out: torch.Tensor) -> None:
+        """Sum across the top-k expert axis (PyTorch fallback)."""
+        from .impl.fused_moe import moe_sum_sunrise
+
+        moe_sum_sunrise(inp, out)
+
+    def moe_align_block_size(
+        self,
+        topk_ids: torch.Tensor,
+        block_size: int,
+        num_experts: int,
+        expert_map: Optional[torch.Tensor] = None,
+        pad_sorted_ids: bool = False,
+        ignore_invalid_experts: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Align MoE token blocks (PyTorch fallback; FlagGems stays default)."""
+        from .impl.fused_moe import moe_align_block_size_sunrise
+
+        return moe_align_block_size_sunrise(
+            topk_ids,
+            block_size,
+            num_experts,
+            expert_map,
+            pad_sorted_ids,
+            ignore_invalid_experts,
+        )
+
     def attention_backend(self, use_mla: bool = False, use_sparse: bool = False) -> str:
         """
         Get the attention backend class path for Sunrise.
@@ -59,12 +136,15 @@ class SunriseBackend(Backend):
         Returns:
             Fully qualified class path string
         """
-        from vllm.v1.attention.backends.registry import AttentionBackendEnum
+        if use_sparse:
+            raise NotImplementedError(
+                "Sunrise does not support sparse MLA (DSA) yet; "
+                "use_sparse=True requires a dedicated backend."
+            )
 
         if use_mla:
-            raise NotImplementedError("NOT support mla now!")
-
-        if use_sparse:
-            raise ValueError("use_sparse=True requires use_mla=True.")
+            return (
+                "vllm_fl.dispatch.backends.vendor.sunrise.impl.mla.SunriseMLABackend"
+            )
 
         return "vllm_fl.dispatch.backends.vendor.sunrise.impl.attention.AttentionFLBackend"

--- a/vllm_fl/dispatch/config/sunrise.yaml
+++ b/vllm_fl/dispatch/config/sunrise.yaml
@@ -43,8 +43,8 @@ strict: false
 op_backends:
   # All operators: prioritize FlagGems (Triton), fallback to vendor, then reference
   attention_backend:
-    - flagos
     - vendor:sunrise
+    - flagos
     - reference
 
   rms_norm:
@@ -58,6 +58,21 @@ op_backends:
     - reference
 
   rotary_embedding:
+    - vendor:sunrise
+    - flagos
+    - reference
+
+  topk_softmax:
+    - flagos
+    - vendor:sunrise
+    - reference
+
+  moe_sum:
+    - flagos
+    - vendor:sunrise
+    - reference
+
+  moe_align_block_size:
     - flagos
     - vendor:sunrise
     - reference
@@ -65,7 +80,8 @@ op_backends:
 # FlagOS operator blacklist
 # Sunrise is CUDA-compatible, so most FlagGems ops should work
 # Blacklist only ops that are known to have issues
-flagos_blacklist: []
+flagos_blacklist:
+  - linear
 
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.

--- a/vllm_fl/distributed/device_communicators/flagcx.py
+++ b/vllm_fl/distributed/device_communicators/flagcx.py
@@ -96,9 +96,17 @@ class PyFlagcxCommunicator:
         self.available = True
         self.disabled = False
 
+        self._legacy_unique_id_api = (
+            hasattr(self.flagcx, "handler")
+            and not hasattr(self.flagcx, "devHandle")
+        )
+
         if self.rank == 0:
             # get the unique id from NCCL
-            self.unique_id = self.flagcx.flagcxGetUniqueId().contents
+            if self._legacy_unique_id_api:
+                self.unique_id = self.flagcx.flagcxGetUniqueId().contents
+            else:
+                self.unique_id = self.flagcx.flagcxGetUniqueId()
         else:
             # construct an empty unique id
             self.unique_id = flagcxUniqueId()
@@ -133,8 +141,12 @@ class PyFlagcxCommunicator:
             device_ctx = torch.cuda.device(self.device)
 
         with device_ctx:
-            self.comm = self.flagcx.flagcxCommInitRank(
-                self.world_size, ctypes.byref(self.unique_id), self.rank)
+            if self._legacy_unique_id_api:
+                self.comm = self.flagcx.flagcxCommInitRank(
+                    self.world_size, ctypes.pointer(self.unique_id), self.rank)
+            else:
+                self.comm = self.flagcx.flagcxCommInitRank(
+                    self.world_size, self.unique_id, self.rank)
 
             stream = current_stream()
             # A small all_reduce for warmup.

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -74,6 +74,7 @@ except ImportError as e:
 
 EngineId = str
 ReqId = str
+TransferId = str
 
 TRANS_DONE = b"trans_done"
 TRANS_ERROR = b"trans_error"
@@ -109,8 +110,7 @@ class FlagCXAgentMetadata(
     remote_port: int
     remote_tp_size: int
     remote_tp_rank: int
-    # req_id -> per KV-cache-group block ids on the Decode (receiver) side.
-    req_blocks: dict[ReqId, list[list[int]]]
+    req_blocks: dict[ReqId, tuple[TransferId, list[list[int]]]]
     kv_caches_base_addr: list[int]
     block_lens: list[int]
     kv_block_lens: list[int]
@@ -124,11 +124,14 @@ class RecvReqMeta:
     local_block_ids: list[list[int]]
     remote_host: str
     remote_port: int
+    transfer_id: TransferId
     remote_tp_size: int = 0
 
 
 @dataclass
 class SendBlockMeta:
+    p_req_id: ReqId
+    transfer_id: TransferId
     local_block_ids: list[list[int]]
     ready: threading.Event
     expire_time: float = float("inf")
@@ -138,7 +141,7 @@ class SendBlockMeta:
 
 @dataclass
 class SendReqMeta:
-    reqs: dict[ReqId, SendBlockMeta]
+    reqs: dict[TransferId, SendBlockMeta]
     lock: threading.Lock
 
 
@@ -158,7 +161,9 @@ class FlagCXConnectorMetadata(KVConnectorMetadata):
     def __init__(self):
         self.reqs_to_recv: dict[ReqId, RecvReqMeta] = {}
         # Per-request, per KV-cache-group block ids.
-        self.reqs_to_send: dict[ReqId, list[list[int]]] = {}
+        self.reqs_to_send: dict[
+            ReqId, tuple[TransferId, list[list[int]]]
+        ] = {}
 
     def add_new_req(
         self,
@@ -167,15 +172,17 @@ class FlagCXConnectorMetadata(KVConnectorMetadata):
         kv_transfer_params: dict[str, Any],
         load_remote_cache: bool = True,
     ):
+        transfer_id = kv_transfer_params["transfer_id"]
         if load_remote_cache:
             self.reqs_to_recv[request_id] = RecvReqMeta(
                 local_block_ids=local_block_ids,
                 remote_host=kv_transfer_params["remote_host"],
                 remote_port=kv_transfer_params["remote_port"],
+                transfer_id=transfer_id,
                 remote_tp_size=kv_transfer_params.get("remote_tp_size", 0),
             )
         else:
-            self.reqs_to_send[request_id] = local_block_ids
+            self.reqs_to_send[request_id] = (transfer_id, local_block_ids)
 
 
 class FlagCXConnector(KVConnectorBase_V1, SupportsHMA):
@@ -334,7 +341,9 @@ class FlagCXConnectorScheduler:
         ]
 
         self._reqs_need_recv: dict[ReqId, tuple[Request, list[list[int]]]] = {}
-        self._reqs_need_send: dict[ReqId, list[list[int]]] = {}
+        self._reqs_need_send: dict[
+            ReqId, tuple["Request", list[list[int]]]
+        ] = {}
 
     def get_sw_clipped_blocks(
         self,
@@ -415,7 +424,9 @@ class FlagCXConnectorScheduler:
 
         if params.get("do_remote_prefill"):
             assert self.kv_role != "kv_producer"
-            if all(p in params for p in ("remote_host", "remote_port")):
+            if all(
+                p in params for p in ("remote_host", "remote_port", "transfer_id")
+            ):
                 unhashed_block_ids = (
                     blocks.get_unhashed_block_ids_all_groups()
                     if num_external_tokens > 0
@@ -431,7 +442,10 @@ class FlagCXConnectorScheduler:
             params["do_remote_prefill"] = False
 
         elif params.get("do_remote_decode"):
-            self._reqs_need_send[request.request_id] = []
+            if not params.get("transfer_id"):
+                logger.warning("Missing transfer_id in KVTransferParams: %s", params)
+            else:
+                self._reqs_need_send[request.request_id] = (request, [])
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
@@ -449,11 +463,12 @@ class FlagCXConnectorScheduler:
             self._reqs_need_recv.clear()
 
         if self.kv_role != "kv_consumer":
-            for req_id, block_ids in self._reqs_need_send.items():
+            for req_id, (req, block_ids) in self._reqs_need_send.items():
+                assert req.kv_transfer_params is not None
                 meta.add_new_req(
                     request_id=req_id,
                     local_block_ids=block_ids,
-                    kv_transfer_params={},
+                    kv_transfer_params=req.kv_transfer_params,
                     load_remote_cache=False,
                 )
             self._reqs_need_send.clear()
@@ -464,7 +479,7 @@ class FlagCXConnectorScheduler:
         self, request: "Request", block_ids: tuple[list[int], ...]
     ) -> tuple[bool, dict[str, Any] | None]:
         params = request.kv_transfer_params
-        if not params:
+        if not params or not params.get("transfer_id"):
             return False, None
 
         if params.get("do_remote_prefill"):
@@ -483,8 +498,9 @@ class FlagCXConnectorScheduler:
         delay_free_blocks = any(len(group) > 0 for group in block_ids)
 
         if delay_free_blocks:
-            self._reqs_need_send[request.request_id] = self.get_sw_clipped_blocks(
-                block_ids
+            self._reqs_need_send[request.request_id] = (
+                request,
+                self.get_sw_clipped_blocks(block_ids),
             )
 
         return delay_free_blocks, dict(
@@ -493,6 +509,7 @@ class FlagCXConnectorScheduler:
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             remote_tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
+            transfer_id=params["transfer_id"],
         )
 
 
@@ -920,19 +937,30 @@ class FlagCXConnectorWorker:
 
         ready_reqs: list[tuple[ReqId, SendBlockMeta]] = []
         with self.reqs_need_send.lock:
-            for req_id in meta.req_blocks:
-                send_meta = self.reqs_need_send.reqs.get(req_id)
+            for d_req_id, (transfer_id, _) in meta.req_blocks.items():
+                send_meta = self.reqs_need_send.reqs.get(transfer_id)
                 if send_meta is None:
-                    logger.warning("Request %s not found in reqs_need_send", req_id)
-                    return
+                    send_meta = SendBlockMeta(
+                        p_req_id="",
+                        transfer_id=transfer_id,
+                        local_block_ids=[],
+                        ready=threading.Event(),
+                    )
+                    self.reqs_need_send.reqs[transfer_id] = send_meta
                 # Mark it as not expired. We will send it now.
                 send_meta.expire_time = float("inf")
                 send_meta.need_send = need
-                ready_reqs.append((req_id, send_meta))
+                ready_reqs.append((d_req_id, send_meta))
 
         # Wait until the scheduler has committed each request's blocks.
-        for _, send_meta in ready_reqs:
-            send_meta.ready.wait()
+        deadline = time.perf_counter() + self._abort_request_timeout
+        for d_req_id, send_meta in ready_reqs:
+            remaining = deadline - time.perf_counter()
+            if remaining <= 0 or not send_meta.ready.wait(timeout=remaining):
+                raise RuntimeError(
+                    "Timed out waiting for prefill blocks of transfer "
+                    f"{send_meta.transfer_id} (decode request {d_req_id})."
+                )
 
         remote_session = f"{meta.remote_hostname}:{meta.remote_port}"
         conn = self._get_conn(remote_session)
@@ -980,11 +1008,15 @@ class FlagCXConnectorWorker:
 
         finished: list[ReqId] = []
         with self.reqs_need_send.lock:
-            for req_id, send_meta in ready_reqs:
+            for _, send_meta in ready_reqs:
                 send_meta.sent += 1
                 if send_meta.sent >= max(send_meta.need_send, 1):
-                    self.reqs_need_send.reqs.pop(req_id, None)
-                    finished.append(req_id)
+                    self.reqs_need_send.reqs.pop(send_meta.transfer_id, None)
+                    if not send_meta.p_req_id:
+                        raise RuntimeError(
+                            f"Missing Prefill request ID for {send_meta.transfer_id}."
+                        )
+                    finished.append(send_meta.p_req_id)
         if finished:
             with self.finished_sending_reqs.lock:
                 self.finished_sending_reqs.set.update(finished)
@@ -1011,7 +1043,7 @@ class FlagCXConnectorWorker:
         group_specs = self.kv_cache_config.kv_cache_groups
 
         for d_req_id, send_meta in ready_reqs:
-            remote_block_ids_per_group = agent_meta.req_blocks[d_req_id]
+            _, remote_block_ids_per_group = agent_meta.req_blocks[d_req_id]
             if not remote_block_ids_per_group or all(
                 len(g) == 0 for g in remote_block_ids_per_group
             ):
@@ -1129,7 +1161,7 @@ class FlagCXConnectorWorker:
     async def _receive_kv(
         self,
         path: str,
-        req_blocks: dict[ReqId, list[list[int]]],
+        req_blocks: dict[ReqId, tuple[TransferId, list[list[int]]]],
     ):
         req_ids = list(req_blocks.keys())
 
@@ -1152,7 +1184,9 @@ class FlagCXConnectorWorker:
         sock: zmq.asyncio.Socket = make_zmq_socket(
             self.async_zmq_ctx, path, zmq.REQ, bind=False, linger=0
         )
-        sock.setsockopt(zmq.RCVTIMEO, 60000)
+        sock.setsockopt(
+            zmq.RCVTIMEO, (self._abort_request_timeout + 60) * 1000
+        )
 
         try:
             await sock.send(encoded_data)
@@ -1193,13 +1227,21 @@ class FlagCXConnectorWorker:
 
         if self.kv_role != "kv_consumer":
             with self.reqs_need_send.lock:
-                for req_id, block_ids in metadata.reqs_to_send.items():
-                    send_meta = self.reqs_need_send.reqs.get(req_id)
+                for p_req_id, (
+                    transfer_id,
+                    block_ids,
+                ) in metadata.reqs_to_send.items():
+                    send_meta = self.reqs_need_send.reqs.get(transfer_id)
                     if send_meta is None:
                         send_meta = SendBlockMeta(
-                            local_block_ids=[], ready=threading.Event()
+                            p_req_id=p_req_id,
+                            transfer_id=transfer_id,
+                            local_block_ids=[],
+                            ready=threading.Event(),
                         )
-                        self.reqs_need_send.reqs[req_id] = send_meta
+                        self.reqs_need_send.reqs[transfer_id] = send_meta
+                    else:
+                        send_meta.p_req_id = p_req_id
                     # Non-empty means request_finished() has committed the
                     # per-group block ids; arm the send.
                     if block_ids:
@@ -1223,7 +1265,9 @@ class FlagCXConnectorWorker:
         loop; populates ``_pull_pending`` and launches the per-peer pulls
         without an intervening await, so it is atomic w.r.t. other coroutines.
         """
-        kv_pulls: dict[str, dict[ReqId, list[list[int]]]] = defaultdict(dict)
+        kv_pulls: dict[
+            str, dict[ReqId, tuple[TransferId, list[list[int]]]]
+        ] = defaultdict(dict)
         for req_id, meta in reqs_to_recv.items():
             remote_tp_size = meta.remote_tp_size or self.tp_size
             target_p_ranks = self.kv_topo.handshake_target_ranks(remote_tp_size)
@@ -1232,7 +1276,10 @@ class FlagCXConnectorWorker:
                 path = make_zmq_path(
                     "tcp", meta.remote_host, meta.remote_port + p_rank
                 )
-                kv_pulls[path][req_id] = meta.local_block_ids
+                kv_pulls[path][req_id] = (
+                    meta.transfer_id,
+                    meta.local_block_ids,
+                )
         for path, req_blocks in kv_pulls.items():
             asyncio.ensure_future(self._receive_kv(path, req_blocks))
 
@@ -1261,15 +1308,17 @@ class FlagCXConnectorWorker:
         now = time.perf_counter()
         with self.reqs_need_send.lock:
             expired = [
-                rid
-                for rid, sm in self.reqs_need_send.reqs.items()
+                transfer_id
+                for transfer_id, sm in self.reqs_need_send.reqs.items()
                 if sm.expire_time < now
             ]
-            for rid in expired:
-                logger.warning("Request %s send timed out, freeing blocks", rid)
-                del self.reqs_need_send.reqs[rid]
-            if expired:
-                finished_sending.update(expired)
+            for transfer_id in expired:
+                send_meta = self.reqs_need_send.reqs.pop(transfer_id)
+                logger.warning(
+                    "Transfer %s send timed out, freeing blocks", transfer_id
+                )
+                if send_meta.p_req_id:
+                    finished_sending.add(send_meta.p_req_id)
 
         return finished_sending or None, finished_recving or None
 

--- a/vllm_fl/ops/_C_ops_registry.py
+++ b/vllm_fl/ops/_C_ops_registry.py
@@ -4,11 +4,42 @@
 # reference them for pattern matching even when the native vllm._C extension
 # is not compiled for this platform.
 
+import importlib
 import logging
 
 import torch
 
 logger = logging.getLogger(__name__)
+
+_LEGACY_C_EXTENSION = "vllm._C"
+_STABLE_C_EXTENSION = "vllm._C_stable_libtorch"
+
+
+def _import_extension(module_name: str) -> None:
+    importlib.import_module(module_name)
+
+
+def load_vllm_native_extensions() -> bool:
+    """Load native vLLM extensions before defining fallback ``_C`` schemas.
+
+    vLLM wheels may split native operators between ``vllm._C`` and
+    ``vllm._C_stable_libtorch`` on any supported platform. Some versions ship
+    only one of them, so each extension must be attempted independently.
+    """
+    module_names = (
+        _LEGACY_C_EXTENSION,
+        _STABLE_C_EXTENSION,
+    )
+    loaded = False
+    for module_name in module_names:
+        try:
+            _import_extension(module_name)
+        except (ImportError, OSError) as exc:
+            logger.debug("Could not import %s: %s", module_name, exc)
+        else:
+            logger.debug("Loaded native vLLM extension %s", module_name)
+            loaded = True
+    return loaded
 
 
 # Fallback implementations for query ops
@@ -48,16 +79,14 @@ def register_op_schemas():
     if getattr(register_op_schemas, "_lib", None) is not None:
         return
 
-    try:
-        import vllm._C  # noqa: F401
+    if load_vllm_native_extensions():
         return
-    except (ImportError, OSError):
-        pass
 
     # Pre-load mcoplib._C (MetaX) so its TORCH_LIBRARY registrations land
     # before our FRAGMENT definitions.  The hasattr check below will then
     # skip any ops already registered by mcoplib, avoiding c10::Error.
     import importlib.util
+
     if importlib.util.find_spec("mcoplib") is not None:
         try:
             import mcoplib._C  # noqa: F401

--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 
 import logging
-from typing import Optional, List
 
 from vllm.model_executor.custom_op import CustomOp, PluggableLayer
-from .layernorm import *  # noqa F403 F401
+
 from .activation import *  # noqa F403 F401
-from .rotary_embedding import *  # noqa F403 F401
+from .deepseek_v4_attention import (
+    DeepseekV4MultiHeadLatentAttentionFLWrapper,  # noqa F403 F401
+)
 from .fused_moe import *  # noqa F403 F401
-from .deepseek_v4_attention import DeepseekV4MultiHeadLatentAttentionFLWrapper # noqa F403 F401
+from .layernorm import *  # noqa F403 F401
+from .rotary_embedding import *  # noqa F403 F401
 
 logger = logging.getLogger(__name__)
 
@@ -31,10 +33,11 @@ OOT_OPS = {
     ),
     "deepseek_v4_multi_head_latent_attention": (
         DeepseekV4MultiHeadLatentAttentionFLWrapper,
-        "DeepseekV4MultiHeadLatentAttentionWrapper"
+        "DeepseekV4MultiHeadLatentAttentionWrapper",
     ),  # noqa F405
     "gated_layer": (GateLinearFL, "GateLinear"),
 }
+
 
 def _patch_unquantized_moe_oracle() -> None:
     """
@@ -48,15 +51,40 @@ def _patch_unquantized_moe_oracle() -> None:
     would get (OOT, None), skip _setup_kernel, and crash at inference time.
     """
     import vllm.model_executor.layers.fused_moe.oracle.unquantized as _oracle_mod
+
     from vllm_fl.ops.fused_moe.fused_moe_utils import select_unquantized_moe_backend_oot
+
     _oracle_mod.select_unquantized_moe_backend = select_unquantized_moe_backend_oot
     # Also patch the import in unquantized_fused_moe_method module
     import vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method as _method_mod
+
     _method_mod.select_unquantized_moe_backend = select_unquantized_moe_backend_oot
     logger.info("Patched select_unquantized_moe_backend to bypass OOT short-circuit")
 
 
-def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
+def _patch_w8a8_moe_oracle() -> None:
+    """Route dynamic-token INT8 MoE to vLLM's functional experts path."""
+    from vllm_fl.quantization.w8a8.moe import (
+        install_fl_w8a8_moe_selector,
+    )
+
+    install_fl_w8a8_moe_selector()
+    logger.info("Configured dynamic-token W8A8 MoE for the FL OOT platform")
+
+
+def _patch_wna16_moe() -> None:
+    """Route pack-quantized WNA16 MoE to an available FL backend."""
+    from vllm_fl.quantization.marlin import configure_wna16_moe_backend
+    from vllm_fl.quantization.wna16.moe import (
+        install_fl_wna16_moe_method,
+    )
+
+    if install_fl_wna16_moe_method():
+        backend = configure_wna16_moe_backend()
+        logger.info("Configured WNA16 MoE backend for FL: %s", backend)
+
+
+def register_oot_ops(whitelist: list[str] | None = None) -> None:
     """
     Register OOT (out-of-tree) custom operators.
 
@@ -72,7 +100,25 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
     the upstream select_unquantized_moe_backend oracle is monkey-patched
     so it picks native CUDA backends instead of returning (OOT, None).
     """
-    from vllm_fl.utils import get_oot_blacklist, get_oot_whitelist, is_oot_enabled, use_flaggems_op
+    from vllm_fl.utils import (
+        get_oot_blacklist,
+        get_oot_whitelist,
+        is_oot_enabled,
+        use_flaggems_op,
+    )
+
+    # This is independent of PluggableLayer registration. In particular, MUSA
+    # skips the generic linear-kernel import path, but still needs the INT8 MoE
+    # oracle patched before model construction.
+    try:
+        _patch_w8a8_moe_oracle()
+    except (ImportError, AttributeError, OSError, RuntimeError) as exc:
+        logger.warning("Could not configure FL W8A8 MoE: %s", exc)
+
+    try:
+        _patch_wna16_moe()
+    except (ImportError, AttributeError, OSError, RuntimeError) as exc:
+        logger.warning("Could not configure FL WNA16 MoE: %s", exc)
 
     # Check if OOT registration is enabled
     if not is_oot_enabled():
@@ -113,7 +159,9 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
         op_cls, registration_name = OOT_OPS[op_name]
         logger.info(f"Registering oot op: {op_name} as '{registration_name}'")
         if issubclass(op_cls, PluggableLayer):
-            PluggableLayer.register_oot(_decorated_layer_cls=op_cls, name=registration_name)
+            PluggableLayer.register_oot(
+                _decorated_layer_cls=op_cls, name=registration_name
+            )
         else:
             CustomOp.register_oot(_decorated_op_cls=op_cls, name=registration_name)
         # Apply Ascend NPU monkey-patches if running on NPU.

--- a/vllm_fl/ops/fused_moe/fused_moe_utils.py
+++ b/vllm_fl/ops/fused_moe/fused_moe_utils.py
@@ -85,6 +85,11 @@ def _get_priority_backends(moe_config: FusedMoEConfig) -> list[UnquantizedMoeBac
         _AVAILABLE_BACKENDS = [UnquantizedMoeBackend.XPU]
     elif current_platform.is_cpu():
         _AVAILABLE_BACKENDS = [UnquantizedMoeBackend.CPU]
+    elif current_platform.is_out_of_tree():
+        _AVAILABLE_BACKENDS = [
+            UnquantizedMoeBackend.TRITON,
+            UnquantizedMoeBackend.BATCHED_TRITON,
+        ]
     return _AVAILABLE_BACKENDS
 
 ## Adopt from select_unquantized_moe_backend

--- a/vllm_fl/ops/fused_moe/fused_moe_utils.py
+++ b/vllm_fl/ops/fused_moe/fused_moe_utils.py
@@ -378,7 +378,6 @@ class TritonExpertsFL(TritonExperts):
             torch.bfloat16,
             torch.float8_e4m3fn,
             torch.float8_e4m3fnuz,
-            torch.int8,
         ]
 
         E, num_tokens, N, K, top_k_num = self.moe_problem_size(
@@ -406,7 +405,6 @@ class TritonExpertsFL(TritonExperts):
         elif (
             hidden_states.dtype == torch.float8_e4m3fn
             or hidden_states.dtype == torch.float8_e4m3fnuz
-            or hidden_states.dtype == torch.int8
         ):
             compute_type = tl.bfloat16
         else:

--- a/vllm_fl/ops/fused_moe/fused_moe_utils.py
+++ b/vllm_fl/ops/fused_moe/fused_moe_utils.py
@@ -13,30 +13,37 @@
 # limitations under the License.
 
 
-from enum import Enum
 from typing import Any
 
 import torch
 
 import vllm.envs as envs
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
-from vllm._aiter_ops import rocm_aiter_ops
-from vllm.config.kernel import MoEBackend
 from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
 )
-from vllm.platforms import current_platform
-from vllm.utils.flashinfer import has_flashinfer_cutlass_fused_moe
-from vllm.model_executor.layers.fused_moe.oracle.unquantized import UnquantizedMoeBackend, map_unquantized_backend, backend_to_kernel_cls
-from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-from vllm.model_executor.layers.fused_moe.fused_moe import TritonExperts, try_get_optimal_moe_config
-from vllm.model_executor.layers.fused_moe.utils import _resize_cache, moe_kernel_quantize_input
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    TritonExperts,
+    try_get_optimal_moe_config,
+)
+from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
+    UnquantizedMoeBackend,
+    backend_to_kernel_cls,
+    map_unquantized_backend,
+)
+from vllm.model_executor.layers.fused_moe.utils import (
+    _resize_cache,
+    moe_kernel_quantize_input,
+)
 from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
     FlashinferMoeBackend,
     get_flashinfer_moe_backend,
 )
-from vllm.triton_utils import tl, triton
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl
+
 from vllm_fl.dispatch import CachedOp
 from vllm_fl.ops.fused_moe.activation import apply_moe_activation
 from vllm_fl.utils import use_flaggems
@@ -92,8 +99,10 @@ def _get_priority_backends(moe_config: FusedMoEConfig) -> list[UnquantizedMoeBac
         ]
     return _AVAILABLE_BACKENDS
 
+
 ## Adopt from select_unquantized_moe_backend
-def select_unquantized_moe_backend_oot(moe_config: FusedMoEConfig,
+def select_unquantized_moe_backend_oot(
+    moe_config: FusedMoEConfig,
 ) -> tuple[UnquantizedMoeBackend, type[mk.FusedMoEExperts] | None]:
     """
     Select the primary Unquantized MoE backend.
@@ -239,6 +248,7 @@ def select_unquantized_moe_backend_oot(moe_config: FusedMoEConfig,
         "No Unquantized MoE backend supports the deployment configuration."
     )
 
+
 def _prepare_expert_assignment(
     topk_ids: torch.Tensor,
     config: dict[str, Any],
@@ -287,6 +297,7 @@ def _prepare_expert_assignment(
         ignore_invalid_experts=ignore_invalid_experts,
     )
 
+
 class TritonExpertsFL(TritonExperts):
     def apply(
         self,
@@ -306,35 +317,45 @@ class TritonExpertsFL(TritonExperts):
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         apply_router_weight_on_input: bool,
     ):
-        # Fast path (no LoRA, NVIDIA only): single fused FlagGems call. This
-        # implementation supports both quantized and BF16 experts.
+        # Dynamic W8A8 is handled by TritonW8A8Experts so vLLM owns
+        # activation quantization. Do not allow it to fall back into the
+        # FlagGems contract, which expects floating-point input here.
+        if self.quant_config.use_int8_w8a8:
+            raise RuntimeError(
+                "W8A8 MoE must use TritonW8A8Experts, not TritonExpertsFL"
+            )
+
+        # Fast path (no LoRA, NVIDIA only): let FlagGems own both expert GEMMs
+        # for unquantized and W8A16 inputs.
         if self._lora_context is None and current_platform.is_cuda():
             import flag_gems
 
-            output.copy_(flag_gems.fused_experts_impl(
-                hidden_states,
-                w1,
-                w2,
-                topk_weights,
-                topk_ids,
-                inplace=False,
-                activation=activation.value,
-                apply_router_weight_on_input=apply_router_weight_on_input,
-                use_fp8_w8a8=self.quant_config.use_fp8_w8a8,
-                use_int8_w8a8=self.quant_config.use_int8_w8a8,
-                use_int8_w8a16=self.quant_config.use_int8_w8a16,
-                use_int4_w4a16=self.quant_config.use_int4_w4a16,
-                per_channel_quant=self.per_act_token_quant,
-                global_num_experts=global_num_experts,
-                expert_map=expert_map,
-                w1_scale=self.w1_scale,
-                w2_scale=self.w2_scale,
-                a1_scale=a1q_scale,
-                a2_scale=a2_scale,
-                block_shape=self.block_shape,
-                w1_bias=self.w1_bias,
-                w2_bias=self.w2_bias,
-            ))
+            output.copy_(
+                flag_gems.fused_experts_impl(
+                    hidden_states,
+                    w1,
+                    w2,
+                    topk_weights,
+                    topk_ids,
+                    inplace=False,
+                    activation=activation.value,
+                    apply_router_weight_on_input=apply_router_weight_on_input,
+                    use_fp8_w8a8=self.quant_config.use_fp8_w8a8,
+                    use_int8_w8a8=False,
+                    use_int8_w8a16=self.quant_config.use_int8_w8a16,
+                    use_int4_w4a16=self.quant_config.use_int4_w4a16,
+                    per_channel_quant=self.per_act_token_quant,
+                    global_num_experts=global_num_experts,
+                    expert_map=expert_map,
+                    w1_scale=self.w1_scale,
+                    w2_scale=self.w2_scale,
+                    a1_scale=a1q_scale,
+                    a2_scale=a2_scale,
+                    block_shape=self.block_shape,
+                    w1_bias=self.w1_bias,
+                    w2_bias=self.w2_bias,
+                )
+            )
             return
 
         # LoRA path: step-by-step pipeline (call_op dispatch) so LoRA

--- a/vllm_fl/ops/fused_moe/fused_moe_utils.py
+++ b/vllm_fl/ops/fused_moe/fused_moe_utils.py
@@ -352,6 +352,7 @@ class TritonExpertsFL(TritonExperts):
             torch.bfloat16,
             torch.float8_e4m3fn,
             torch.float8_e4m3fnuz,
+            torch.int8,
         ]
 
         E, num_tokens, N, K, top_k_num = self.moe_problem_size(
@@ -379,6 +380,7 @@ class TritonExpertsFL(TritonExperts):
         elif (
             hidden_states.dtype == torch.float8_e4m3fn
             or hidden_states.dtype == torch.float8_e4m3fnuz
+            or hidden_states.dtype == torch.int8
         ):
             compute_type = tl.bfloat16
         else:

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -399,7 +399,7 @@ class PlatformFL(Platform):
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:
-        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon", "mthreads","iluvatar", "thead", "gcu", "sunrise"]:
+        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon", "mthreads", "iluvatar", "thead", "gcu", "sunrise"]:
             return True
         return False
 

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -194,6 +194,9 @@ class PlatformFL(Platform):
 
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        if cls.device_type == "ptpu":
+            import vllm_fl.dispatch.backends.vendor.sunrise  # noqa: F401
+
         parallel_config = vllm_config.parallel_config
         model_config = vllm_config.model_config
 
@@ -396,7 +399,7 @@ class PlatformFL(Platform):
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:
-        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon", "mthreads", "iluvatar", "thead", "gcu"]:
+        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon", "mthreads","iluvatar", "thead", "gcu", "sunrise"]:
             return True
         return False
 
@@ -447,6 +450,8 @@ class PlatformFL(Platform):
             import vllm_fl.dispatch.backends.vendor.ascend
         elif cls.device_name == "gcu":
             import vllm_fl.dispatch.backends.vendor.gcu  # noqa: F401
+        elif cls.device_type == "ptpu":
+            import vllm_fl.dispatch.backends.vendor.sunrise  # noqa: F401
 
     @classmethod
     def supports_fp8(cls) -> bool:

--- a/vllm_fl/quantization/compressed_tensors.py
+++ b/vllm_fl/quantization/compressed_tensors.py
@@ -79,6 +79,79 @@ class WNA16Scheme:
             raise ValueError("WNA16 is weight-only; input_activations must be omitted")
 
 
+@dataclass(frozen=True)
+class W8A8DynamicTokenScheme:
+    weight_num_bits: int
+    weight_type: str
+    weight_strategy: str
+    weight_symmetric: bool
+    weight_dynamic: bool
+    weight_group_size: int | None
+    input_num_bits: int
+    input_type: str
+    input_strategy: str
+    input_symmetric: bool
+    input_dynamic: bool
+
+    @classmethod
+    def from_group(cls, group: dict[str, Any]) -> W8A8DynamicTokenScheme:
+        weights = group.get("weights") or {}
+        inputs = group.get("input_activations") or {}
+        return cls(
+            weight_num_bits=int(weights.get("num_bits", 0)),
+            weight_type=str(weights.get("type", "")),
+            weight_strategy=str(weights.get("strategy", "")),
+            weight_symmetric=bool(weights.get("symmetric", False)),
+            weight_dynamic=bool(weights.get("dynamic", False)),
+            weight_group_size=weights.get("group_size"),
+            input_num_bits=int(inputs.get("num_bits", 0)),
+            input_type=str(inputs.get("type", "")),
+            input_strategy=str(inputs.get("strategy", "")),
+            input_symmetric=bool(inputs.get("symmetric", False)),
+            input_dynamic=bool(inputs.get("dynamic", False)),
+        )
+
+    def validate(self) -> None:
+        if self.weight_num_bits != 8 or self.input_num_bits != 8:
+            raise ValueError("W8A8 requires 8-bit weights and activations")
+        if self.weight_type != "int" or self.input_type != "int":
+            raise ValueError("W8A8 requires integer weights and activations")
+        if self.weight_strategy != "channel":
+            raise ValueError("W8A8 requires per-channel weights")
+        if self.weight_dynamic:
+            raise ValueError("W8A8 checkpoint weights must be statically quantized")
+        if self.weight_group_size is not None:
+            raise ValueError("Per-channel W8A8 weights must not set group_size")
+        if self.input_strategy != "token":
+            raise ValueError("W8A8 requires per-token input activations")
+        if not self.weight_symmetric or not self.input_symmetric:
+            raise ValueError("FL W8A8 currently requires symmetric quantization")
+        if not self.input_dynamic:
+            raise ValueError("W8A8 per-token input quantization must be dynamic")
+
+
+def validate_compressed_tensors_w8a8_config(
+    config: dict[str, Any],
+) -> list[W8A8DynamicTokenScheme]:
+    """Validate the canonical compressed-tensors dynamic-token W8A8 subset."""
+    if config.get("quant_method") != "compressed-tensors":
+        raise ValueError("quant_method must be 'compressed-tensors'")
+    if config.get("format") != "int-quantized":
+        raise ValueError("W8A8 requires compressed-tensors format 'int-quantized'")
+    groups = config.get("config_groups")
+    if not isinstance(groups, dict) or not groups:
+        raise ValueError("compressed-tensors config_groups must be a non-empty mapping")
+
+    schemes: list[W8A8DynamicTokenScheme] = []
+    for name, group in groups.items():
+        if not isinstance(group, dict) or not group.get("targets"):
+            raise ValueError(f"config group {name!r} must declare targets")
+        scheme = W8A8DynamicTokenScheme.from_group(group)
+        scheme.validate()
+        schemes.append(scheme)
+    return schemes
+
+
 def validate_compressed_tensors_wna16_config(
     config: dict[str, Any],
 ) -> list[WNA16Scheme]:
@@ -169,17 +242,38 @@ def inspect_vllm_compressed_tensors_api() -> CompatibilityReport:
 
 
 def register_compressed_tensors_oot() -> CompatibilityReport:
-    """Configure upstream WNA16 runtime selection for the FL platform.
+    """Configure compressed-tensors runtime selection for the FL platform.
 
-    No-op unless the plugin-local WNA16 MoE operator is actually built.
-    This keeps the upstream vLLM path (Marlin on CUDA, generic elsewhere)
-    fully untouched until the FL kernel is available.
+    W8A8 uses vLLM's native INT8 Linear and functional Triton MoE kernels.
+    W8A16 linear uses the portable Triton kernel, while routed WNA16 MoE uses
+    an FL backend when enabled.
     """
     report = inspect_vllm_compressed_tensors_api()
 
-    from vllm_fl.quantization.wna16.kernels import is_wna16_moe_available
+    from vllm_fl.utils import is_oot_enabled
 
-    if not is_wna16_moe_available():
+    if is_oot_enabled():
+        try:
+            from vllm_fl.quantization.w8a8.moe import (
+                install_fl_w8a8_moe_selector,
+            )
+            from vllm_fl.quantization.w8a8.packed import (
+                install_packed_w8a8_scheme,
+            )
+
+            install_packed_w8a8_scheme()
+            install_fl_w8a8_moe_selector()
+        except (ImportError, AttributeError, OSError, RuntimeError) as exc:
+            logger.warning(
+                "Could not configure FL compressed-tensors W8A8 MoE: %s",
+                exc,
+            )
+
+    from vllm_fl.quantization.wna16.moe import (
+        is_fl_wna16_moe_available,
+    )
+
+    if not is_fl_wna16_moe_available():
         return report
 
     # Linear registration is independent and handled by
@@ -193,8 +287,6 @@ def register_compressed_tensors_oot() -> CompatibilityReport:
         )
         return report
 
-    from vllm_fl.utils import is_oot_enabled
-
     if is_oot_enabled():
         try:
             from vllm_fl.quantization.marlin import configure_wna16_moe_backend
@@ -204,7 +296,7 @@ def register_compressed_tensors_oot() -> CompatibilityReport:
 
             if not install_fl_wna16_moe_method():
                 logger.warning(
-                    "FL WNA16 MoE operator disappeared during registration; "
+                    "FL WNA16 MoE backend disappeared during registration; "
                     "leaving vLLM's upstream backend selection unchanged"
                 )
                 return report

--- a/vllm_fl/quantization/marlin.py
+++ b/vllm_fl/quantization/marlin.py
@@ -67,10 +67,17 @@ def configure_wna16_moe_backend() -> str:
     from vllm_fl.quantization.wna16.kernels import (
         is_wna16_moe_available,
     )
+    from vllm_fl.quantization.wna16.moe import (
+        is_flaggems_wna16_moe_available,
+    )
 
     _install_platform_guard()
     if is_wna16_moe_available():
         return "plugin-local"
+    if is_flaggems_wna16_moe_available():
+        if is_marlin_moe_platform(current_platform):
+            return "marlin"
+        return "FlagGems"
     if not is_marlin_moe_platform(current_platform):
         return "generic"
     return "marlin"

--- a/vllm_fl/quantization/quant_linear.py
+++ b/vllm_fl/quantization/quant_linear.py
@@ -1,11 +1,9 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 
-import os
 from vllm.platforms import PlatformEnum, current_platform
-from vllm_fl.utils import use_flaggems_op
 
 from .fp8 import FlagGemsFp8BlockScaledMMLinearKernel
-
+from vllm_fl.utils import use_flaggems_op
 
 FLAGGEMS_FP8_BLOCK_GEMM_OP = "flaggems_fp8_block_gemm"
 
@@ -39,17 +37,16 @@ def add_oot_quant_kernel() -> None:
     is_supported() / can_implement() will filter at runtime.
     """
     from vllm.model_executor.kernels.linear import (
-        _POSSIBLE_INT8_KERNELS,
-        _POSSIBLE_FP8_KERNELS,
-        _POSSIBLE_KERNELS,
         _POSSIBLE_FP8_BLOCK_KERNELS,
+        _POSSIBLE_FP8_KERNELS,
+        _POSSIBLE_INT8_KERNELS,
+        _POSSIBLE_KERNELS,
     )
+
     source = _resolve_source_platform()
 
     if PlatformEnum.OOT not in _POSSIBLE_KERNELS:
-        _POSSIBLE_KERNELS[PlatformEnum.OOT] = list(
-            _POSSIBLE_KERNELS.get(source, [])
-        )
+        _POSSIBLE_KERNELS[PlatformEnum.OOT] = list(_POSSIBLE_KERNELS.get(source, []))
 
     if PlatformEnum.OOT not in _POSSIBLE_INT8_KERNELS:
         _POSSIBLE_INT8_KERNELS[PlatformEnum.OOT] = list(
@@ -76,10 +73,9 @@ def add_oot_quant_kernel() -> None:
             0, FlagGemsFp8BlockScaledMMLinearKernel
         )
 
-    # WNA16 hooks below are self-gated on kernel availability and are a
-    # no-op until the plugin's csrc-side operators are built.
-    from .wna16.linear import register_fl_wna16_linear_kernel
+    # Quantization hooks are self-gated on backend/kernel availability.
     from .compressed_tensors import register_compressed_tensors_oot
+    from .wna16.linear import register_fl_wna16_linear_kernel
 
     register_fl_wna16_linear_kernel(_POSSIBLE_KERNELS)
     register_compressed_tensors_oot()

--- a/vllm_fl/quantization/w8a8/__init__.py
+++ b/vllm_fl/quantization/w8a8/__init__.py
@@ -5,28 +5,21 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Quantization compatibility and out-of-tree kernel registration."""
+"""W8A8 adapters for dynamic per-token INT8 inference."""
 
-from .compressed_tensors import (
-    CompatibilityReport,
-    W8A8DynamicTokenScheme,
-    WNA16Scheme,
-    inspect_vllm_compressed_tensors_api,
-    validate_compressed_tensors_w8a8_config,
-    validate_compressed_tensors_wna16_config,
+from .reference import (
+    dynamic_per_token_quant_int8,
+    unpack_uint8b128_int32,
+    w8a8_linear_reference,
 )
 
 __all__ = [
-    "CompatibilityReport",
-    "W8A8DynamicTokenScheme",
-    "WNA16Scheme",
-    "inspect_vllm_compressed_tensors_api",
-    "validate_compressed_tensors_w8a8_config",
-    "validate_compressed_tensors_wna16_config",
+    "dynamic_per_token_quant_int8",
+    "unpack_uint8b128_int32",
+    "w8a8_linear_reference",
 ]

--- a/vllm_fl/quantization/w8a8/int8_mode.py
+++ b/vllm_fl/quantization/w8a8/int8_mode.py
@@ -1,0 +1,79 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Selection policy for FlagOS-Compressor packed INT8 checkpoints."""
+
+from __future__ import annotations
+
+from compressed_tensors.config import CompressionFormat
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationStrategy,
+    QuantizationType,
+)
+
+
+def is_packed_int8_weight(
+    weight_quant: QuantizationArgs | None,
+    quant_format: str | None,
+) -> bool:
+    """Match supported packed INT8 weight metadata."""
+    if weight_quant is None:
+        return False
+    return (
+        quant_format == CompressionFormat.pack_quantized.value
+        and weight_quant.num_bits == 8
+        and weight_quant.type == QuantizationType.INT
+        and weight_quant.symmetric
+        and not weight_quant.dynamic
+        and weight_quant.strategy
+        in (QuantizationStrategy.CHANNEL, QuantizationStrategy.GROUP)
+    )
+
+
+def is_dynamic_token_int8(input_quant: QuantizationArgs | None) -> bool:
+    """Match canonical dynamic per-token INT8 activation metadata."""
+    if input_quant is None:
+        return False
+    return (
+        input_quant.num_bits == 8
+        and input_quant.type == QuantizationType.INT
+        and input_quant.strategy == QuantizationStrategy.TOKEN
+        and input_quant.symmetric
+        and input_quant.dynamic
+    )
+
+
+def should_use_packed_w8a8(
+    weight_quant: QuantizationArgs | None,
+    input_quant: QuantizationArgs | None,
+    quant_format: str | None,
+) -> bool:
+    """Select packed W8A8 from the model's compressed-tensors config."""
+    if not is_packed_int8_weight(weight_quant, quant_format):
+        return False
+    if input_quant is None:
+        return False
+    if not is_dynamic_token_int8(input_quant):
+        return False
+    if weight_quant.strategy != QuantizationStrategy.CHANNEL:
+        raise ValueError(
+            "Packed W8A8 requires per-channel weights in quantization_config"
+        )
+    return True
+
+
+__all__ = [
+    "is_dynamic_token_int8",
+    "is_packed_int8_weight",
+    "should_use_packed_w8a8",
+]

--- a/vllm_fl/quantization/w8a8/moe.py
+++ b/vllm_fl/quantization/w8a8/moe.py
@@ -1,0 +1,152 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Route vLLM's W8A8 INT8 MoE scheme to native functional experts."""
+
+from importlib import import_module
+from inspect import Parameter, signature
+
+_ADAPTER_MARKER = "_vllm_fl_w8a8_int8_moe"
+_CONFIG_BUILDER_MARKER = "_vllm_fl_dynamic_w8a8_config"
+_ORACLE_MODULE = "vllm.model_executor.layers.fused_moe.oracle.int8"
+_SCHEME_MODULE = (
+    "vllm.model_executor.layers.quantization.compressed_tensors."
+    "compressed_tensors_moe.compressed_tensors_moe_w8a8_int8"
+)
+
+
+def _call_with_supported_kwargs(function, /, **kwargs):
+    """Call a vLLM helper while tolerating additive signature differences."""
+    parameters = signature(function).parameters
+    if any(
+        parameter.kind is Parameter.VAR_KEYWORD for parameter in parameters.values()
+    ):
+        return function(**kwargs)
+    return function(
+        **{name: value for name, value in kwargs.items() if name in parameters}
+    )
+
+
+def install_fl_w8a8_moe_selector() -> bool:
+    """Use vLLM's functional Triton path for canonical W8A8 MoE."""
+    oracle_module = import_module(_ORACLE_MODULE)
+    scheme_module = import_module(_SCHEME_MODULE)
+
+    # vLLM 0.20.2 through 0.24.0 treat missing activation scales as W8A16 in
+    # the shared helper. Dynamic per-token W8A8 intentionally has no checkpoint
+    # scale, so preserve the scheme's explicit per_act_token_quant signal.
+    current_builder = scheme_module.make_int8_moe_quant_config
+    if not getattr(current_builder, _CONFIG_BUILDER_MARKER, False):
+
+        def make_int8_moe_quant_config_fl(
+            w1_scale,
+            w2_scale,
+            a1_scale=None,
+            a2_scale=None,
+            w1_bias=None,
+            w2_bias=None,
+            per_act_token_quant=False,
+        ):
+            if not per_act_token_quant:
+                return _call_with_supported_kwargs(
+                    current_builder,
+                    w1_scale=w1_scale,
+                    w2_scale=w2_scale,
+                    a1_scale=a1_scale,
+                    a2_scale=a2_scale,
+                    w1_bias=w1_bias,
+                    w2_bias=w2_bias,
+                    per_act_token_quant=False,
+                )
+
+            from vllm.model_executor.layers.fused_moe.config import (
+                int8_w8a8_moe_quant_config,
+            )
+
+            return _call_with_supported_kwargs(
+                int8_w8a8_moe_quant_config,
+                w1_scale=w1_scale,
+                w2_scale=w2_scale,
+                a1_scale=a1_scale,
+                a2_scale=a2_scale,
+                w1_bias=w1_bias,
+                w2_bias=w2_bias,
+                per_act_token_quant=True,
+            )
+
+        setattr(
+            make_int8_moe_quant_config_fl,
+            _CONFIG_BUILDER_MARKER,
+            True,
+        )
+        scheme_module.make_int8_moe_quant_config = make_int8_moe_quant_config_fl
+
+    current_selector = oracle_module.select_int8_moe_backend
+    if getattr(current_selector, _ADAPTER_MARKER, False):
+        # Keep the scheme module in sync even if it was imported after a prior
+        # installation.
+        scheme_module.select_int8_moe_backend = current_selector
+        return True
+
+    def select_int8_moe_backend_fl(
+        config,
+        weight_key=None,
+        activation_key=None,
+    ):
+        from vllm.model_executor.layers.quantization.utils.quant_utils import (
+            kInt8DynamicTokenSym,
+            kInt8StaticChannelSym,
+        )
+        from vllm.platforms import current_platform
+
+        from vllm_fl.utils import is_oot_enabled
+
+        canonical_w8a8 = weight_key in (
+            None,
+            kInt8StaticChannelSym,
+        ) and activation_key in (None, kInt8DynamicTokenSym)
+        use_fl = (
+            current_platform.is_out_of_tree() and is_oot_enabled() and canonical_w8a8
+        )
+        if not use_fl:
+            return current_selector(
+                config,
+                weight_key=weight_key,
+                activation_key=activation_key,
+            )
+
+        if getattr(config, "is_lora_enabled", False):
+            raise NotImplementedError(
+                "The vLLM functional W8A8 MoE adapter does not support LoRA"
+            )
+        if config.moe_parallel_config.use_batched_activation_format:
+            raise ValueError(
+                "FL W8A8 MoE currently requires the standard activation "
+                "format; batched-experts dispatch is not supported"
+            )
+
+        from vllm_fl.quantization.w8a8.moe_experts import TritonW8A8Experts
+
+        return (
+            oracle_module.Int8MoeBackend.TRITON,
+            TritonW8A8Experts,
+        )
+
+    setattr(select_int8_moe_backend_fl, _ADAPTER_MARKER, True)
+    oracle_module.select_int8_moe_backend = select_int8_moe_backend_fl
+    # compressed_tensors_w8a8_int8 imports the selector by name, so patch its
+    # module-local binding as well.
+    scheme_module.select_int8_moe_backend = select_int8_moe_backend_fl
+    return True
+
+
+__all__ = ["install_fl_w8a8_moe_selector"]

--- a/vllm_fl/quantization/w8a8/moe_experts.py
+++ b/vllm_fl/quantization/w8a8/moe_experts.py
@@ -1,0 +1,129 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""vLLM-native experts adapter for dynamic per-token W8A8 MoE."""
+
+from __future__ import annotations
+
+from inspect import signature
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    fused_experts,
+)
+
+try:
+    # vLLM 0.24+
+    from vllm.model_executor.layers.fused_moe.experts.triton_moe import (
+        TritonExperts,
+    )
+except ModuleNotFoundError as exc:
+    if exc.name != "vllm.model_executor.layers.fused_moe.experts.triton_moe":
+        raise
+    # vLLM 0.20.x
+    from vllm.model_executor.layers.fused_moe.fused_moe import (
+        TritonExperts,
+    )
+
+_FUSED_EXPERTS_HAS_INPLACE = "inplace" in signature(fused_experts).parameters
+
+
+class TritonW8A8Experts(TritonExperts):
+    """Run W8A8 MoE through vLLM's functional Triton implementation.
+
+    The modular prepare stage must leave the first activation unquantized.
+    ``fused_experts`` then owns both dynamic per-token quantization steps and
+    consumes the checkpoint's per-channel INT8 weight scales.
+    """
+
+    @property
+    def expects_unquantized_inputs(self) -> bool:
+        return True
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ) -> None:
+        del a2_scale, workspace13, workspace2, expert_tokens_meta
+
+        if not self.quant_config.use_int8_w8a8:
+            raise ValueError("TritonW8A8Experts requires an INT8 W8A8 quant config")
+        if getattr(self, "_lora_context", None) is not None:
+            raise NotImplementedError(
+                "The vLLM functional W8A8 MoE adapter does not support LoRA"
+            )
+        if a1q_scale is not None:
+            raise ValueError(
+                "W8A8 activation was quantized before the functional experts "
+                "adapter; expected an unquantized floating-point input"
+            )
+        if hidden_states.dtype not in {
+            torch.float32,
+            torch.float16,
+            torch.bfloat16,
+        }:
+            raise TypeError(
+                "W8A8 functional experts require floating-point hidden states, "
+                f"got {hidden_states.dtype}"
+            )
+
+        if _FUSED_EXPERTS_HAS_INPLACE:
+            result = fused_experts(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                inplace=False,
+                activation=activation,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+                global_num_experts=global_num_experts,
+                expert_map=expert_map,
+                quant_config=self.quant_config,
+            )
+        else:
+            result = fused_experts(
+                hidden_states=hidden_states,
+                w1=w1,
+                w2=w2,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                activation=activation,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+                global_num_experts=global_num_experts,
+                expert_map=expert_map,
+                quant_config=self.quant_config,
+            )
+        output.copy_(result)
+
+
+__all__ = [
+    "TritonW8A8Experts",
+]

--- a/vllm_fl/quantization/w8a8/packed.py
+++ b/vllm_fl/quantization/w8a8/packed.py
@@ -1,0 +1,154 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run channelwise pack-quantized INT8 checkpoints as dynamic W8A8."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import torch
+from compressed_tensors.quantization import QuantizationStrategy
+
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsW8A8Int8,
+)
+from vllm.model_executor.parameter import (
+    BasevLLMParameter,
+    PackedvLLMParameter,
+)
+
+from .int8_mode import (
+    is_dynamic_token_int8,
+    is_packed_int8_weight,
+    should_use_packed_w8a8,
+)
+from .reference import unpack_uint8b128_int32
+
+_PATCH_MARKER = "_vllm_fl_packed_w8a8"
+
+
+class CompressedTensorsPackedW8A8Int8(CompressedTensorsW8A8Int8):
+    """Adapt packed weights to vLLM's native dynamic-token W8A8 scheme."""
+
+    def __init__(self, layer_name: str | None = None) -> None:
+        super().__init__(
+            strategy=QuantizationStrategy.CHANNEL,
+            is_static_input_scheme=False,
+            input_symmetric=True,
+        )
+        self.input_size_per_partition = 0
+        self.layer_name = layer_name
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        output_partition_sizes: list[int],
+        input_size_per_partition: int,
+        params_dtype: torch.dtype,
+        weight_loader: Callable,
+        **kwargs,
+    ) -> None:
+        if input_size_per_partition % 4:
+            raise ValueError(
+                "Packed INT8 requires input_size_per_partition divisible by 4"
+            )
+
+        super().create_weights(
+            layer=layer,
+            output_partition_sizes=output_partition_sizes,
+            input_size_per_partition=input_size_per_partition,
+            params_dtype=params_dtype,
+            weight_loader=weight_loader,
+            **kwargs,
+        )
+        self.input_size_per_partition = input_size_per_partition
+        output_size_per_partition = sum(output_partition_sizes)
+
+        delattr(layer, "weight")
+        weight = PackedvLLMParameter(
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+            packed_factor=4,
+            packed_dim=1,
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // 4,
+                dtype=torch.int32,
+            ),
+        )
+        weight_shape = BasevLLMParameter(
+            data=torch.empty(2, dtype=torch.int64),
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_packed", weight)
+        layer.register_parameter("weight_shape", weight_shape)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        unpacked = unpack_uint8b128_int32(
+            layer.weight_packed,
+            in_features=self.input_size_per_partition,
+        )
+        delattr(layer, "weight_packed")
+        layer.register_parameter(
+            "weight",
+            torch.nn.Parameter(unpacked, requires_grad=False),
+        )
+        super().process_weights_after_loading(layer)
+
+
+def install_packed_w8a8_scheme() -> bool:
+    """Patch vLLM scheme selection for channelwise packed INT8 weights."""
+    from vllm.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors as ct_module,
+    )
+
+    config_cls = ct_module.CompressedTensorsConfig
+    current = config_cls._get_scheme_from_parts
+    if getattr(current, _PATCH_MARKER, False):
+        return True
+
+    def get_scheme_from_parts_fl(
+        self,
+        weight_quant,
+        input_quant,
+        format=None,
+        layer_name=None,
+    ):
+        effective_format = format if format is not None else self.quant_format
+        if should_use_packed_w8a8(
+            weight_quant,
+            input_quant,
+            effective_format,
+        ):
+            return CompressedTensorsPackedW8A8Int8(layer_name=layer_name)
+        return current(
+            self,
+            weight_quant,
+            input_quant,
+            format=format,
+            layer_name=layer_name,
+        )
+
+    setattr(get_scheme_from_parts_fl, _PATCH_MARKER, True)
+    config_cls._get_scheme_from_parts = get_scheme_from_parts_fl
+    return True
+
+
+__all__ = [
+    "CompressedTensorsPackedW8A8Int8",
+    "install_packed_w8a8_scheme",
+    "is_dynamic_token_int8",
+    "is_packed_int8_weight",
+    "should_use_packed_w8a8",
+]

--- a/vllm_fl/quantization/w8a8/reference.py
+++ b/vllm_fl/quantization/w8a8/reference.py
@@ -1,0 +1,105 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Portable W8A8 reference operations and activation quantization."""
+
+from __future__ import annotations
+
+import torch
+
+
+def unpack_uint8b128_int32(
+    weight_packed: torch.Tensor,
+    *,
+    in_features: int | None = None,
+) -> torch.Tensor:
+    """Unpack compressed-tensors offset-binary INT8 words."""
+    if weight_packed.ndim != 2 or weight_packed.dtype != torch.int32:
+        raise ValueError("weight_packed must be a 2D int32 tensor")
+    codes = weight_packed.contiguous().view(torch.uint8)
+    if in_features is not None:
+        if in_features < 0 or in_features > codes.shape[1]:
+            raise ValueError("in_features is incompatible with weight_packed")
+        codes = codes[:, :in_features]
+    return (codes.to(torch.int16) - 128).to(torch.int8)
+
+
+def dynamic_per_token_quant_int8(
+    x: torch.Tensor,
+    *,
+    eps: float = 1e-10,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Symmetrically quantize the last dimension with one scale per token."""
+    if x.ndim < 2:
+        raise ValueError("x must have at least two dimensions")
+    if not x.is_floating_point():
+        raise TypeError(f"x must be floating point, got {x.dtype}")
+    if eps <= 0:
+        raise ValueError("eps must be positive")
+
+    original_shape = x.shape
+    x_2d = x.reshape(-1, original_shape[-1])
+    absmax = x_2d.abs().amax(dim=-1, keepdim=True)
+    scale = absmax.clamp(min=eps).to(torch.float32) / 127.0
+    quantized = (x_2d.to(torch.float32) / scale).round().clamp(-127, 127).to(torch.int8)
+    return (
+        quantized.reshape(original_shape),
+        scale.reshape(*original_shape[:-1], 1),
+    )
+
+
+def _normalize_channel_scale(
+    weight_scale: torch.Tensor,
+    out_features: int,
+) -> torch.Tensor:
+    if weight_scale.numel() != out_features:
+        raise ValueError(
+            "weight_scale must contain one value per output channel; "
+            f"expected {out_features}, got {weight_scale.numel()}"
+        )
+    return weight_scale.reshape(1, out_features).to(torch.float32)
+
+
+def w8a8_linear_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Reference dynamic-token/per-channel W8A8 linear operation.
+
+    ``weight`` follows the compressed-tensors checkpoint layout ``[N, K]``.
+    This materializes a floating-point accumulator and is intended for tests,
+    not runtime kernel selection.
+    """
+    if weight.ndim != 2 or weight.dtype != torch.int8:
+        raise ValueError("weight must be a 2D int8 tensor")
+    if x.ndim < 2 or x.shape[-1] != weight.shape[1]:
+        raise ValueError("x and weight have incompatible input dimensions")
+
+    x_q, x_scale = dynamic_per_token_quant_int8(x)
+    x_q_2d = x_q.reshape(-1, x_q.shape[-1]).to(torch.float32)
+    channel_scale = _normalize_channel_scale(weight_scale, weight.shape[0])
+    output = x_q_2d @ weight.to(torch.float32).t()
+    output = output * x_scale.reshape(-1, 1) * channel_scale
+    if bias is not None:
+        if bias.numel() != weight.shape[0]:
+            raise ValueError("bias must contain one value per output channel")
+        output = output + bias.reshape(1, -1).to(output.dtype)
+    return output.to(x.dtype).reshape(*x.shape[:-1], weight.shape[0])
+
+
+__all__ = [
+    "dynamic_per_token_quant_int8",
+    "unpack_uint8b128_int32",
+    "w8a8_linear_reference",
+]

--- a/vllm_fl/quantization/wna16/kernels/__init__.py
+++ b/vllm_fl/quantization/wna16/kernels/__init__.py
@@ -17,10 +17,15 @@ Implementations live in this package and are called directly. They are not
 registered with vllm-fl's general operator dispatch.
 """
 
-from .gemm import is_wna16_gemm_available, wna16_gemm
+from .gemm import (
+    is_w8a16_gemm_available,
+    is_wna16_gemm_available,
+    wna16_gemm,
+)
 from .moe import is_wna16_moe_available, wna16_moe
 
 __all__ = [
+    "is_w8a16_gemm_available",
     "is_wna16_gemm_available",
     "is_wna16_moe_available",
     "wna16_gemm",

--- a/vllm_fl/quantization/wna16/kernels/gemm.py
+++ b/vllm_fl/quantization/wna16/kernels/gemm.py
@@ -26,8 +26,24 @@ def _resolve_wna16_gemm():
         return None
 
 
+def _resolve_w8a16_gemm():
+    """Resolve an optional operator that explicitly supports uint8b128."""
+    try:
+        return torch.ops.vllm_fl.w8a16_gemm.default
+    except AttributeError:
+        return None
+
+
 def is_wna16_gemm_available() -> bool:
     return _resolve_wna16_gemm() is not None
+
+
+def is_w8a16_gemm_available() -> bool:
+    if _resolve_w8a16_gemm() is not None:
+        return True
+    from .triton import is_triton_w8a16_available
+
+    return is_triton_w8a16_available()
 
 
 def wna16_gemm(
@@ -36,15 +52,41 @@ def wna16_gemm(
     weight_scale: torch.Tensor,
     group_size: int,
     bias: torch.Tensor | None = None,
+    *,
+    num_bits: int = 4,
 ) -> torch.Tensor:
     """Run fused dequantization GEMM without an intermediate FP tensor."""
+    if num_bits == 8:
+        kernel = _resolve_w8a16_gemm()
+        if kernel is not None:
+            return kernel(
+                x,
+                weight_packed,
+                weight_scale,
+                group_size,
+                bias,
+            )
+        from .triton import triton_w8a16_gemm
+
+        return triton_w8a16_gemm(
+            x,
+            weight_packed,
+            weight_scale,
+            group_size,
+            bias,
+        )
     kernel = _resolve_wna16_gemm()
+    if kernel is not None:
+        return kernel(x, weight_packed, weight_scale, group_size, bias)
     if kernel is None:
         raise RuntimeError(
             "vllm_fl::wna16_gemm is not built; implement it under "
             "vllm_fl/quantization/wna16/kernels"
         )
-    return kernel(x, weight_packed, weight_scale, group_size, bias)
 
 
-__all__ = ["is_wna16_gemm_available", "wna16_gemm"]
+__all__ = [
+    "is_w8a16_gemm_available",
+    "is_wna16_gemm_available",
+    "wna16_gemm",
+]

--- a/vllm_fl/quantization/wna16/kernels/triton.py
+++ b/vllm_fl/quantization/wna16/kernels/triton.py
@@ -1,0 +1,164 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Portable Triton W8A16 GEMM for compressed-tensors uint8b128 weights."""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except (ImportError, OSError):
+    triton = None
+    tl = None
+
+
+if triton is not None:
+
+    @triton.jit
+    def _w8a16_gemm_kernel(
+        x_ptr,
+        weight_ptr,
+        scale_ptr,
+        bias_ptr,
+        output_ptr,
+        M: tl.constexpr,
+        N: tl.constexpr,
+        K: tl.constexpr,
+        GROUP_SIZE: tl.constexpr,
+        NUM_GROUPS: tl.constexpr,
+        HAS_BIAS: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        offsets_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offsets_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        for k_start in range(0, tl.cdiv(K, BLOCK_K)):
+            offsets_k = k_start * BLOCK_K + tl.arange(0, BLOCK_K)
+            x_offsets = offsets_m[:, None] * K + offsets_k[None, :]
+            x = tl.load(
+                x_ptr + x_offsets,
+                mask=(offsets_m[:, None] < M) & (offsets_k[None, :] < K),
+                other=0.0,
+            )
+
+            weight_offsets = offsets_n[:, None] * K + offsets_k[None, :]
+            codes = tl.load(
+                weight_ptr + weight_offsets,
+                mask=(offsets_n[:, None] < N) & (offsets_k[None, :] < K),
+                other=128,
+            )
+            scale_offsets = (
+                offsets_n[:, None] * NUM_GROUPS + offsets_k[None, :] // GROUP_SIZE
+            )
+            scales = tl.load(
+                scale_ptr + scale_offsets,
+                mask=(offsets_n[:, None] < N) & (offsets_k[None, :] < K),
+                other=0.0,
+            )
+            weights = (codes.to(tl.int16) - 128).to(x.dtype) * scales
+            accumulator += tl.dot(x, tl.trans(weights))
+
+        if HAS_BIAS:
+            bias = tl.load(
+                bias_ptr + offsets_n,
+                mask=offsets_n < N,
+                other=0.0,
+            )
+            accumulator += bias[None, :]
+
+        output_offsets = offsets_m[:, None] * N + offsets_n[None, :]
+        tl.store(
+            output_ptr + output_offsets,
+            accumulator,
+            mask=(offsets_m[:, None] < M) & (offsets_n[None, :] < N),
+        )
+
+
+def is_triton_w8a16_available() -> bool:
+    return triton is not None
+
+
+def triton_w8a16_gemm(
+    x: torch.Tensor,
+    weight_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Execute W8A16 without materializing the dequantized weight."""
+    if triton is None:
+        raise RuntimeError("Triton is required for the FL W8A16 fallback")
+    if x.ndim != 2:
+        raise ValueError("x must be a 2D tensor")
+    if weight_packed.ndim != 2 or weight_packed.dtype != torch.int32:
+        raise ValueError("weight_packed must be a 2D int32 tensor")
+    if not weight_packed.is_contiguous():
+        weight_packed = weight_packed.contiguous()
+
+    output_features = weight_packed.shape[0]
+    input_features = x.shape[1]
+    if weight_packed.shape[1] * 4 != input_features:
+        raise ValueError("uint8b128 weight_packed shape is incompatible with x")
+    effective_group_size = input_features if group_size == -1 else group_size
+    if effective_group_size <= 0 or input_features % effective_group_size:
+        raise ValueError("group_size must divide the input feature dimension")
+    num_groups = input_features // effective_group_size
+    expected_scales = output_features * num_groups
+    if weight_scale.numel() != expected_scales:
+        raise ValueError(
+            f"weight_scale must contain {expected_scales} values, "
+            f"got {weight_scale.numel()}"
+        )
+    if bias is not None and bias.numel() != output_features:
+        raise ValueError("bias must contain one value per output feature")
+
+    weight_bytes = weight_packed.view(torch.uint8)
+    scales = weight_scale.reshape(output_features, num_groups).contiguous()
+    output = torch.empty(
+        (x.shape[0], output_features),
+        dtype=x.dtype,
+        device=x.device,
+    )
+    grid = (
+        triton.cdiv(x.shape[0], 32),
+        triton.cdiv(output_features, 32),
+    )
+    bias_arg = bias if bias is not None else output
+    _w8a16_gemm_kernel[grid](
+        x,
+        weight_bytes,
+        scales,
+        bias_arg,
+        output,
+        M=x.shape[0],
+        N=output_features,
+        K=input_features,
+        GROUP_SIZE=effective_group_size,
+        NUM_GROUPS=num_groups,
+        HAS_BIAS=bias is not None,
+        BLOCK_M=32,
+        BLOCK_N=32,
+        BLOCK_K=32,
+        num_warps=4,
+    )
+    return output
+
+
+__all__ = ["is_triton_w8a16_available", "triton_w8a16_gemm"]

--- a/vllm_fl/quantization/wna16/linear.py
+++ b/vllm_fl/quantization/wna16/linear.py
@@ -27,11 +27,11 @@ from . import kernels
 
 
 class FLWNA16LinearKernel(MPLinearKernel):
-    """Consume standard uint4b8 weights through the fixed local operator.
+    """Consume standard uint4b8/uint8b128 compressed-tensors weights.
 
-    vLLM's MPLinear registry selects this adapter only when
-    ``vllm_fl::wna16_gemm`` is registered. The execution path does not fall
-    through to CUDA, FlagGems, or the test-only reference implementation.
+    W4A16 uses the fixed plugin operator when it is built. W8A16 uses its
+    dedicated operator when available and otherwise uses the portable Triton
+    implementation.
     """
 
     @classmethod
@@ -43,24 +43,34 @@ class FLWNA16LinearKernel(MPLinearKernel):
         cls,
         config: MPLinearLayerConfig,
     ) -> tuple[bool, str | None]:
-        if config.weight_type != scalar_types.uint4b8:
-            return False, "FL WNA16 currently requires symmetric uint4b8"
+        if config.weight_type not in {
+            scalar_types.uint4b8,
+            scalar_types.uint8b128,
+        }:
+            return False, "FL WNA16 requires symmetric uint4b8 or uint8b128"
         if config.zero_points:
             return False, "FL WNA16 does not use explicit zero points"
         if config.has_g_idx:
             return False, "FL WNA16 does not support activation ordering"
         if config.act_type not in {torch.bfloat16, torch.float16}:
             return False, "FL WNA16 requires BF16 or FP16 activations"
-        if config.group_size <= 0:
-            return False, "FL WNA16 requires group-wise quantization"
+        is_w8a16 = config.weight_type == scalar_types.uint8b128
+        if config.group_size <= 0 and not (is_w8a16 and config.group_size == -1):
+            return False, "FL WNA16 requires group or channel quantization"
         input_size, output_size = config.partition_weight_shape
-        if input_size % config.group_size:
+        if config.group_size > 0 and input_size % config.group_size:
             return False, "input size must be divisible by group_size"
-        if input_size % 8:
-            return False, "input size must be divisible by the INT4 pack factor"
+        pack_factor = 4 if is_w8a16 else 8
+        if input_size % pack_factor:
+            return False, "input size must be divisible by the pack factor"
         if output_size <= 0:
             return False, "output size must be positive"
-        if not kernels.is_wna16_gemm_available():
+        available = (
+            kernels.is_w8a16_gemm_available()
+            if is_w8a16
+            else kernels.is_wna16_gemm_available()
+        )
+        if not available:
             return False, "the plugin-local wna16_gemm kernel is not built"
         return True, None
 
@@ -81,20 +91,21 @@ class FLWNA16LinearKernel(MPLinearKernel):
     ) -> torch.Tensor:
         weight, scale, _, _ = self._get_weight_params(layer)
         original_shape = x.shape
-        x_2d = x.reshape(-1, original_shape[-1])
+        x_2d = x.reshape(-1, original_shape[-1]).contiguous()
         output = kernels.wna16_gemm(
             x_2d,
             weight,
             scale,
             self.config.group_size,
             bias,
+            num_bits=self.config.weight_type.size_bits,
         )
         return output.reshape(*original_shape[:-1], output.shape[-1])
 
 
 def register_fl_wna16_linear_kernel(registry: dict) -> bool:
-    """Prepend the FL kernel only when its fixed local operator is built."""
-    if not kernels.is_wna16_gemm_available():
+    """Prepend the FL kernel when a W4A16 or W8A16 backend is available."""
+    if not (kernels.is_wna16_gemm_available() or kernels.is_w8a16_gemm_available()):
         return False
     from vllm.platforms import PlatformEnum
 

--- a/vllm_fl/quantization/wna16/moe.py
+++ b/vllm_fl/quantization/wna16/moe.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from importlib import import_module
+from importlib.util import find_spec
 
 import torch
 
@@ -28,11 +29,46 @@ _UPSTREAM_MODULES = (
 )
 
 
+def is_flaggems_wna16_moe_available() -> bool:
+    from vllm_fl.utils import is_oot_enabled, use_flaggems_op
+
+    return (
+        is_oot_enabled()
+        and use_flaggems_op("fused_moe")
+        and find_spec("flag_gems") is not None
+    )
+
+
+def is_fl_wna16_moe_available() -> bool:
+    return kernels.is_wna16_moe_available() or is_flaggems_wna16_moe_available()
+
+
 def _build_local_moe_method(base_method):
     class FLCompressedTensorsWNA16MoEMethod(base_method):
-        """Keep vLLM weight loading but call the fixed plugin operator."""
+        """Keep vLLM loading and route execution to an FL backend."""
 
         _vllm_fl_local_wna16_moe = True
+
+        def select_gemm_impl(
+            self,
+            prepare_finalize,
+            layer,
+        ):
+            if not is_flaggems_wna16_moe_available():
+                return super().select_gemm_impl(
+                    prepare_finalize,
+                    layer,
+                )
+            from vllm_fl.ops.fused_moe.fused_moe_utils import (
+                TritonExpertsFL,
+            )
+
+            layer.w13_weight = layer.w13_weight_packed
+            layer.w2_weight = layer.w2_weight_packed
+            return TritonExpertsFL(
+                moe_config=self.moe,
+                quant_config=self.moe_quant_config,
+            )
 
         def apply(
             self,
@@ -42,6 +78,14 @@ def _build_local_moe_method(base_method):
             topk_ids: torch.Tensor,
             shared_experts_input: torch.Tensor | None,
         ) -> torch.Tensor:
+            if not kernels.is_wna16_moe_available():
+                return super().apply(
+                    layer,
+                    x,
+                    topk_weights,
+                    topk_ids,
+                    shared_experts_input,
+                )
             del shared_experts_input
             return kernels.wna16_moe(
                 x=x,
@@ -64,12 +108,12 @@ def _build_local_moe_method(base_method):
 
 
 def install_fl_wna16_moe_method() -> bool:
-    """Install the local MoE method when the fixed plugin operator is built.
+    """Install the local MoE method when an FL backend is available.
 
     vLLM 0.20.2 selects WNA16 MoE through a scheme class rather than a kernel
     registry, so replacing that class is the installation point.
     """
-    if not kernels.is_wna16_moe_available():
+    if not is_fl_wna16_moe_available():
         return False
 
     module = None
@@ -88,4 +132,8 @@ def install_fl_wna16_moe_method() -> bool:
     return True
 
 
-__all__ = ["install_fl_wna16_moe_method"]
+__all__ = [
+    "install_fl_wna16_moe_method",
+    "is_fl_wna16_moe_available",
+    "is_flaggems_wna16_moe_available",
+]

--- a/vllm_fl/quantization/wna16/reference.py
+++ b/vllm_fl/quantization/wna16/reference.py
@@ -49,6 +49,52 @@ def unpack_uint4b8(
     return (codes.to(torch.int16) - 8).to(torch.int8)
 
 
+def unpack_uint8b128(
+    weight_packed: torch.Tensor,
+    *,
+    in_features: int | None = None,
+) -> torch.Tensor:
+    """Unpack compressed-tensors uint8b128 int32 words to signed int8."""
+    if weight_packed.ndim != 2 or weight_packed.dtype != torch.int32:
+        raise ValueError("weight_packed must be a 2D int32 tensor")
+    codes = weight_packed.contiguous().view(torch.uint8)
+    if in_features is not None:
+        if in_features < 0 or in_features > codes.shape[1]:
+            raise ValueError("in_features is incompatible with weight_packed")
+        codes = codes[:, :in_features]
+    return (codes.to(torch.int16) - 128).to(torch.int8)
+
+
+def _apply_group_scales(
+    x: torch.Tensor,
+    values: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    effective_group_size = x.shape[-1] if group_size == -1 else group_size
+    if effective_group_size <= 0 or x.shape[-1] % effective_group_size:
+        raise ValueError("group_size must divide the input feature dimension")
+    expected_scale_shape = (
+        values.shape[0],
+        x.shape[-1] // effective_group_size,
+    )
+    if tuple(weight_scale.shape) != expected_scale_shape:
+        raise ValueError(
+            f"weight_scale must have shape {expected_scale_shape}, "
+            f"got {tuple(weight_scale.shape)}"
+        )
+    scales = weight_scale.repeat_interleave(
+        effective_group_size,
+        dim=1,
+    )
+    weight = values.to(scales.dtype) * scales
+    output = torch.matmul(x, weight.transpose(0, 1))
+    if bias is not None:
+        output = output + bias
+    return output
+
+
 def wna16_gemm_reference(
     x: torch.Tensor,
     weight_packed: torch.Tensor,
@@ -59,28 +105,45 @@ def wna16_gemm_reference(
     """Materialize dequantized weights for small numerical tests only."""
     if x.ndim < 2:
         raise ValueError("x must have at least two dimensions")
-    if group_size <= 0 or x.shape[-1] % group_size:
-        raise ValueError("group_size must divide the input feature dimension")
-    expected_scale_shape = (
-        weight_packed.shape[0],
-        x.shape[-1] // group_size,
-    )
-    if tuple(weight_scale.shape) != expected_scale_shape:
-        raise ValueError(
-            f"weight_scale must have shape {expected_scale_shape}, "
-            f"got {tuple(weight_scale.shape)}"
-        )
-
     values = unpack_uint4b8(
         weight_packed,
         in_features=x.shape[-1],
     )
-    scales = weight_scale.repeat_interleave(group_size, dim=1)
-    weight = values.to(scales.dtype) * scales
-    output = torch.matmul(x, weight.transpose(0, 1))
-    if bias is not None:
-        output = output + bias
-    return output
+    return _apply_group_scales(
+        x,
+        values,
+        weight_scale,
+        group_size,
+        bias,
+    )
 
 
-__all__ = ["unpack_uint4b8", "wna16_gemm_reference"]
+def w8a16_gemm_reference(
+    x: torch.Tensor,
+    weight_packed: torch.Tensor,
+    weight_scale: torch.Tensor,
+    group_size: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Materialize uint8b128 weights for small numerical tests only."""
+    if x.ndim < 2:
+        raise ValueError("x must have at least two dimensions")
+    values = unpack_uint8b128(
+        weight_packed,
+        in_features=x.shape[-1],
+    )
+    return _apply_group_scales(
+        x,
+        values,
+        weight_scale,
+        group_size,
+        bias,
+    )
+
+
+__all__ = [
+    "unpack_uint4b8",
+    "unpack_uint8b128",
+    "w8a16_gemm_reference",
+    "wna16_gemm_reference",
+]


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->
Vendor

### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->
New Features

### Description
<!-- Describe what this PR does and why. -->
This PR introduce support of cuda-graph and int8 on Sunrise. 
The support list of model is also increased. By now the following model is supported on Sunrise vendor: 
Qwen3/3.5/3.6
MiniCPM-o 4.5
MiniMax-M2.7

### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->

### Changes
<!-- List the key changes made in this PR. -->
-

### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->
-
To test models on this PR with latest sunrise software, you should: 
1. upgrade FlagCX to at least 0.13.0
2. add the following ENV: 
export TA_CLOSE_GRAPH_MEMORY=1
export LIBRARY_PATH=/usr/local/tangrt/targets/linux-x86_64/lib:/usr/local/tangrt/lib/linux-x86_64:${LIBRARY_PATH}
export LD_LIBRARY_PATH=/usr/local/tangrt/targets/linux-x86_64/lib:/usr/local/tangrt/lib/linux-x86_64:${LD_LIBRARY_PATH}

If you start a model with no VL support, here is a example command: 
vllm serve /path/to/Qwen3-32B --tensor-parallel-size 2 --max-num-batched-tokens 16384 --max-num-seqs 16 --gpu-memory-utilization 0.8 --port 7529 --compilation-config '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'

If you start a model with VL (such as Qwen3.5/3.6), here is a example command: 
vllm serve /path/to/Qwen3.5-35B-A3B --tensor-parallel-size 2 --max-num-batched-tokens 16384 --max-num-seqs 16 --gpu-memory-utilization 0.8 --port 7529 --skip-mm-profiling --compilation-config '{"mode": 0, "cudagraph_mode": "FULL_DECODE_ONLY"}'

### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
