### PR TITLE
fix: support official vLLM 0.24 CUDA stable-ABI wheels

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 
+import importlib
 import os
 import logging
 import sys
@@ -77,12 +78,13 @@ def _patch_flash_attn_import():
 
 
 def _patch_custom_ops():
-    """Register torch.ops._C op schemas when vllm._C is unavailable."""
-    try:
-        import vllm._C  # noqa: F401
-        return
-    except (ImportError, OSError):
-        pass
+    """Register fallback schemas when neither vLLM extension ABI is present."""
+    for module_name in ("vllm._C", "vllm._C_stable_libtorch"):
+        try:
+            importlib.import_module(module_name)
+            return
+        except (ImportError, OSError):
+            continue
 
     try:
         import vllm_fl._C  # noqa: F401

--- a/vllm_fl/attention/utils.py
+++ b/vllm_fl/attention/utils.py
@@ -15,6 +15,14 @@ def patch_mm_encoder_attention():
     """
     import vllm.model_executor.layers.attention.mm_encoder_attention as mm_mod
     from vllm.v1.attention.backends.registry import AttentionBackendEnum
+    from vllm.platforms import current_platform
+
+    # PlatformFL is registered as an OOT platform, so CustomOp would otherwise
+    # bind MMEncoderAttention to forward_oot -> forward_native (Torch SDPA).
+    # NVIDIA must keep vLLM's CUDA dispatch so the selected FLASH_ATTN backend
+    # is actually used during multimodal profiling and inference.
+    if current_platform.is_cuda():
+        mm_mod.MMEncoderAttention.forward_oot = mm_mod.MMEncoderAttention.forward_cuda
 
     def _patched_maybe_get_vit_flash_attn_backend(attn_backend):
         if attn_backend == AttentionBackendEnum.FLASH_ATTN:

--- a/vllm_fl/ops/fused_moe/fused_moe_utils.py
+++ b/vllm_fl/ops/fused_moe/fused_moe_utils.py
@@ -154,9 +154,13 @@ def select_unquantized_moe_backend_oot(moe_config: FusedMoEConfig,
 
         return _return_or_raise(requested_backend, moe_config, activation_format)
 
-    # Handle explicit FlashInfer FP16 configuration.
-    if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP16"):
-        if not envs.VLLM_USE_FLASHINFER_MOE_FP16:
+    # Handle explicit FlashInfer FP16 configuration. vLLM 0.24 removed
+    # this legacy name from vllm.envs, so read it directly from os.environ.
+    if "VLLM_USE_FLASHINFER_MOE_FP16" in os.environ:
+        use_flashinfer_moe_fp16 = os.environ[
+            "VLLM_USE_FLASHINFER_MOE_FP16"
+        ].strip().lower() in ("1", "true")
+        if not use_flashinfer_moe_fp16:
             if UnquantizedMoeBackend.FLASHINFER_TRTLLM in AVAILABLE_BACKENDS:
                 AVAILABLE_BACKENDS.remove(UnquantizedMoeBackend.FLASHINFER_TRTLLM)
             if UnquantizedMoeBackend.FLASHINFER_CUTLASS in AVAILABLE_BACKENDS:

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -10,12 +10,15 @@ from typing_extensions import ParamSpec
 
 import torch
 
-# import custom ops, trigger op registration (CUDA only)
-try:
-    import vllm._C  # noqa
-    import vllm._C_stable_libtorch  # noqa
-except (ImportError, OSError):
-    pass  # NPU or other platforms may not have vllm._C
+# Import custom ops and trigger registration on both legacy and stable-ABI
+# vLLM wheels. Keep the attempts independent: official vLLM 0.24 wheels have
+# only the stable-ABI module, so failure of the legacy import must not skip it.
+import importlib
+for _extension in ("vllm._C", "vllm._C_stable_libtorch"):
+    try:
+        importlib.import_module(_extension)
+    except (ImportError, OSError):
+        pass  # Non-CUDA platforms may not ship either extension.
 
 from vllm.logger import init_logger
 from vllm.platforms import Platform, PlatformEnum

--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -226,6 +226,11 @@ class WorkerFL(WorkerBase):
         for k, v in sorted(os.environ.items()):
             logger.debug("%s=%r", k, v)
 
+        # Apply the NVIDIA MM encoder dispatch fix before model construction:
+        # CustomOp caches its selected forward method in __init__.
+        from vllm_fl.attention.utils import patch_mm_encoder_attention
+        patch_mm_encoder_attention()
+
         register_oot_ops()
 
         if fl_envs.USE_FLAGGEMS:


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
Core

### PR Type
Bug Fixes

### Description
The plugin cannot start on the official vLLM 0.24 CUDA wheels/images
(`vllm/vllm-openai:v0.24.0-cu129-ubuntu2404`). Those builds ship the stable-ABI
extension `vllm._C_stable_libtorch` instead of the legacy `vllm._C`, and 0.24
dropped `VLLM_USE_FLASHINFER_MOE_FP16` from `vllm.envs`, so startup aborts with:

```text
AttributeError: module 'vllm.envs' has no attribute 'VLLM_USE_FLASHINFER_MOE_FP16'
```

This PR makes extension detection ABI-agnostic, reads the removed env var from
`os.environ`, and keeps NVIDIA MM encoder attention on vLLM's CUDA dispatch so
registering `PlatformFL` as an OOT platform no longer silently demotes the
selected FLASH_ATTN backend to Torch SDPA.

FlagGems needs a matching stable-ABI extension mapping for the same
environment; that is submitted separately and is not required here.

### Related Issues
N/A

### Changes
- `platform.py`: import `vllm._C` and `vllm._C_stable_libtorch` independently,
  so a missing legacy module no longer skips the stable-ABI extension that
  official 0.24 wheels do ship.
- `__init__.py`: `_patch_custom_ops()` accepts either extension as "vLLM ops
  available", and only registers fallback `torch.ops._C` schemas when neither
  ABI is present.
- `ops/fused_moe/fused_moe_utils.py`: read `VLLM_USE_FLASHINFER_MOE_FP16` from
  `os.environ` instead of `vllm.envs`.
- `attention/utils.py`: on CUDA, alias `MMEncoderAttention.forward_oot` to
  `forward_cuda`; under an OOT platform `CustomOp` would otherwise route to
  `forward_native` (Torch SDPA).
- `worker/worker.py`: apply that patch before model construction, since
  `CustomOp` caches its resolved forward method in `__init__`.

### Testing
Env: official `vllm/vllm-openai:v0.24.0-cu129-ubuntu2404`, vLLM 0.24.0,
torch 2.11.0+cu129, FlagTree 0.5.0, FlagGems 5.0.0, plugin `v0.3.0-dev`
(`4d4645b`) + this diff. Hardware: 2 nodes x 8 H100 80GB, IB/GDRDMA
(8x 400 Gb/s NDR). Model: Qwen3.5-397B-A17B BF16, TP=16, PP=1, `mp` executor,
`enforce_eager=False`, `cudagraph_mode=FULL_AND_PIECEWISE`.

- Regression reproduced and fixed: unpatched `4d4645b` fails at MoE backend
  selection with the `AttributeError` above; with this diff the same command
  reaches `/health` 200 and serves requests.
- Activation confirmed in logs: `Platform plugin fl is activated`,
  `attention_backend`/`topk_softmax` -> `vendor.cuda`, `Using ['PYNCCL']`.
- Serving benchmarks via the image's `vllm bench serve` (random dataset,
  1K/4K input x 1K output, `--ignore-eos`, concurrency 64). Steady-state
  output throughput (tok/s) with MoE backend pinned, so the plugin is the only
  variable:

  | Stack | MoE backend | 1K/1K | 4K/1K |
  |---|---|---:|---:|
  | native 0.24, no FlagOS | `triton` | 2011.30 | 1711.80 |
  | patched plugin, `VLLM_FL_PREFER=vendor` | `triton` | 1996.88 | 1718.91 |
  | native 0.24, no FlagOS | `flashinfer_cutlass` | 2130.74 | 1736.12 |
  | patched plugin, `VLLM_FL_PREFER=vendor` | `flashinfer_cutlass` | 2162.44 | 1748.48 |

  At fixed backend the delta vs native is `-0.72%/+0.42%` (Triton) and
  `+1.49%/+0.71%` (CUTLASS) - no regression from these changes. Every round
  `failed=0`, exit code 0; 72 benchmark rounds total plus 8 steady-state
  `.nsys-rep` traces.
- Not covered: non-CUDA vendor platforms were not re-run. Changes are additive
  there - the extension imports are independent, and the MM encoder alias is
  guarded by `current_platform.is_cuda()`.
- Expected non-blocking warning on stable-ABI-only builds:
  `Failed to import from vllm._C: No module named 'vllm._C'`. Registration
  proceeds via `vllm._C_stable_libtorch`.

No unit test is added: the fixed paths are import-time and platform dispatch,
which require a real vLLM 0.24 stable-ABI install to exercise.

### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
