### PR TITLE
Fix CUDA graph disabling for non-DeepEP backends

### DIFF
--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -220,7 +220,8 @@ class PlatformFL(Platform):
             compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
 
         if (
-            parallel_config.data_parallel_size > 1
+            parallel_config.all2all_backend == "deepep_high_throughput"
+            and parallel_config.data_parallel_size > 1
             and compilation_config.cudagraph_mode != CUDAGraphMode.NONE
         ):
             # TODO: Piecewise Cuda graph might be enabled


### PR DESCRIPTION
## Summary

- Restrict WideEP CUDA graph disablement to the deepep_high_throughput all-to-all backend.
- Preserve CUDA graphs for deepep_low_latency, pplx, and allgather_reducescatter when data parallelism is enabled.
- Align the condition with the existing user-facing log message.

## Problem

PlatformFL.check_and_update_config currently disables CUDA graphs whenever data_parallel_size is greater than 1, regardless of the selected all-to-all backend. This contradicts the log message, which recommends other backends for CUDA graph workloads.

## Testing

- python -m py_compile vllm_fl/platform.py
- git diff --check
- Validated five combinations of backend, data-parallel size, and CUDA graph mode.

Full tests were not run because vllm is not installed in the local environment.