### PR TITLE
fix(metax): pass group=device_group in compile-friendly all_reduce

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/metax/patches/pynccl_wrapper.py
+++ b/vllm_fl/dispatch/backends/vendor/metax/patches/pynccl_wrapper.py
@@ -463,7 +463,7 @@ from vllm.distributed.device_communicators.cuda_communicator import CudaCommunic
 
 def _compile_friendly_all_reduce(self, input_):
     """Use torch.distributed all_reduce which Dynamo can trace."""
-    dist.all_reduce(input_, op=dist.ReduceOp.SUM)
+    dist.all_reduce(input_, op=dist.ReduceOp.SUM, group=self.device_group)
     return input_
 
 


### PR DESCRIPTION
## Problem

When running **TP=4 PP=2** on MetaX C550, the job stalls during CUDA graph capture and crashes after 600s with an NCCL timeout:

```
NCCL WARN NCCL_TIMEOUT is set. Timeout 600 seconds has been reached in ncclAllReduce
[Rank 4] Watchdog caught collective timeout. last enqueued work: 7016, last completed work: 6976
```

**Root cause**: `_compile_friendly_all_reduce` in `pynccl_wrapper.py` patches `CudaCommunicator.all_reduce` with a `torch.distributed.all_reduce` call but **omits the `group=` argument**, so it falls back to the **default process group (world group, all 8 ranks)**.

During CUDA graph capture with PP=2:
- PP0 workers (ranks 0–3) finish their capture phase and exit
- PP1 workers (ranks 4–7) continue capturing and trigger ~40 of these world-group ALLREDUCEs
- PP0 is no longer participating → the collective never completes → 600s NCCL timeout → crash

## Fix

Pass `group=self.device_group` to scope the all_reduce to the correct **TP group** (4 ranks within the same pipeline stage), matching the intent of the original `CudaCommunicator.all_reduce`.

```python
# before
dist.all_reduce(input_, op=dist.ReduceOp.SUM)

# after
dist.all_reduce(input_, op=dist.ReduceOp.SUM, group=self.device_group)
```

## Testing

- **Model**: Qwen3.6-35B-A3B (MoE, 256 experts, 40 layers)
- **Hardware**: 8× MetaX C550 64 GB, MACA 3.7.0.37
- **Plugin**: vllm-plugin-FL v0.3.0-dev, vLLM 0.1.dev17937

**Minimum working configuration** (required to reproduce and verify the fix):

```python
llm = LLM(
    model="/workspace/models/Qwen3.6-35B-A3B",
    tensor_parallel_size=4,
    pipeline_parallel_size=2,
    dtype="bfloat16",
    gpu_memory_utilization=0.90,
    max_model_len=8192,
    enforce_eager=False,        # CUDA graph mode — this is what triggers the bug
    async_scheduling=False,     # required on MetaX: MCCL proxy setup fails for PP
                                # broadcast with async_scheduling=True (separate issue)
)
```

> **Note on `async_scheduling=False`**: a separate issue exists where MetaX MCCL fails
> to set up the proxy channel for PP token broadcast (`_pp_broadcast_prev_sampled_token_ids`)
> when `async_scheduling=True` (vLLM default). Setting `async_scheduling=False` bypasses
> that path entirely. This PR does **not** fix that issue; it only fixes the CUDA graph
> capture NCCL timeout. The PP async broadcast failure is tracked as a follow-up.

| Scenario | Before fix | After fix |
|---|---|---|
| CUDA graph capture (PIECEWISE 51 + FULL 35 steps) | Stalls at ~32/51, NCCL timeout after 600s | Completes successfully |
| `llm.generate()` (3 prompts) | `EngineDeadError`, 0/3 processed | All 3 prompts return correct output |

Sample outputs verified:
- `"The capital of France is"` → `Paris, a city renowned for its iconic landmarks…`
- `"请用中文介绍一下人工智能的发展历史："` → correct structured Chinese response

## Notes

- This fix is platform-gated: `pynccl_wrapper.py` is only loaded on MetaX backends via the patch mechanism
- `gpu_memory_utilization=0.90` (not the default 0.92) is required on C550 to avoid OOM during `determine_available_memory` (~858 MiB driver overhead leaves insufficient headroom at 0.92)
