### PR TITLE
[hot-fix] 针对2.0.0 修复 flagrelease 发布中遇到的两个bug。

### DIFF
--- a/.github/workflows/_benchmark_test.yml
+++ b/.github/workflows/_benchmark_test.yml
@@ -1,0 +1,83 @@
+# Reusable benchmark smoke workflow.
+#
+# Runs lightweight benchmark smoke tests for vllm bench throughput,
+# latency, and serve. These tests validate benchmark entrypoints and
+# basic plugin integration, not performance regression.
+
+name: Benchmark Smoke Test
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: "Platform name (e.g., cuda, ascend)"
+        required: true
+        type: string
+      ci_image:
+        description: "Docker image for the test container"
+        required: true
+        type: string
+      runner_labels:
+        description: "JSON array of runner labels"
+        required: true
+        type: string
+      container_volumes:
+        description: "JSON array of volume mounts"
+        required: false
+        type: string
+        default: "[]"
+      container_options:
+        description: "Docker container options string"
+        required: false
+        type: string
+        default: ""
+      timeout:
+        description: "Timeout for the job in minutes"
+        required: false
+        type: number
+        default: 30
+
+jobs:
+  benchmark-test:
+    name: "Benchmark Smoke (${{ inputs.platform }})"
+    runs-on: ${{ fromJson(inputs.runner_labels) }}
+    timeout-minutes: ${{ inputs.timeout }}
+    container:
+      image: ${{ inputs.ci_image }}
+      volumes: ${{ fromJson(inputs.container_volumes) }}
+      options: ${{ inputs.container_options }}
+
+    steps:
+      - name: Checkout (attempt 1)
+        id: checkout1
+        uses: actions/checkout@v4
+        continue-on-error: true
+      - name: Checkout (attempt 2)
+        id: checkout2
+        if: steps.checkout1.outcome == 'failure'
+        uses: actions/checkout@v4
+        continue-on-error: true
+      - name: Checkout (attempt 3)
+        if: steps.checkout2.outcome == 'failure'
+        uses: actions/checkout@v4
+
+      - name: Check device availability
+        run: bash .github/scripts/${{ inputs.platform }}/check.sh
+
+      - name: Install project
+        run: bash .github/scripts/${{ inputs.platform }}/setup.sh
+
+      - name: Run benchmark smoke tests
+        run: |
+          python tests/run.py \
+            --platform ${{ inputs.platform }} \
+            --scope benchmark
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-${{ inputs.platform }}
+          path: |
+            test-results-${{ inputs.platform }}.xml
+            test-results-${{ inputs.platform }}.json

--- a/.github/workflows/_platform_test.yml
+++ b/.github/workflows/_platform_test.yml
@@ -108,6 +108,7 @@ jobs:
       container_volumes: ${{ toJson(fromJson(needs.setup.outputs.config).container_volumes) }}
       container_options: ${{ fromJson(needs.setup.outputs.config).container_options }}
 
+
   # Slow end-to-end model tests (inference, serving).
   # Grouped by (task, device) — all model/case combos for the same task
   # run inside a single job to avoid repeated container startup.
@@ -130,11 +131,23 @@ jobs:
       container_options: ${{ fromJson(needs.setup.outputs.config).container_options }}
       timeout: ${{ matrix.test.timeout || 60 }}
 
+  # Validates vllm bench throughput/latency/serve entrypoints.
+  benchmark:
+    needs: [setup, e2e]
+    uses: ./.github/workflows/_benchmark_test.yml
+    with:
+      platform: ${{ inputs.platform }}
+      ci_image: ${{ fromJson(needs.setup.outputs.config).ci_image }}
+      runner_labels: ${{ toJson(fromJson(needs.setup.outputs.config).runner_labels) }}
+      container_volumes: ${{ toJson(fromJson(needs.setup.outputs.config).container_volumes) }}
+      container_options: ${{ fromJson(needs.setup.outputs.config).container_options }}
+      timeout: 30
+
   # ============================================================
   # Feishu notification — per-platform status
   # ============================================================
   notify:
-    needs: [setup, unit, functional, e2e]
+    needs: [unit, functional, e2e, benchmark]
     if: always()
     uses: ./.github/workflows/_notify_feishu.yml
     with:
@@ -142,11 +155,12 @@ jobs:
       status: >-
         ${{ (needs.unit.result == 'success' &&
              needs.functional.result == 'success' &&
-             (needs.e2e.result == 'success' || needs.e2e.result == 'skipped'))
+             (needs.e2e.result == 'success' || needs.e2e.result == 'skipped') &&
+             (needs.benchmark.result == 'success' || needs.benchmark.result == 'skipped'))
             && 'success'
             || (needs.unit.result == 'cancelled' ||
                 needs.functional.result == 'cancelled' ||
-                needs.e2e.result == 'cancelled')
+                needs.e2e.result == 'cancelled' ||
+                needs.benchmark.result == 'cancelled')
                && 'cancelled'
                || 'failure' }}
-    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
     pip install --no-build-isolation -e .
     ```
     Note: if on Sunrize platform, depends on FlagGems [PR #2949](https://github.com/flagos-ai/FlagGems/pull/2949)
+          if on Hygon platform, depends on FlagGems [PR #3477](https://github.com/flagos-ai/FlagGems/pull/3477)
 
 4. (Optional) Install [FlagCX](https://github.com/flagos-ai/FlagCX/blob/main/docs/getting_started.md#build-and-installation)
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
 | Iluvatar | Supported | - |
 | Tsingmicro | Merging | [PR #52](https://github.com/flagos-ai/vllm-plugin-FL/pull/52) |
 | Moore Threads | Supported | - |
-| Hygon | Merging | [PR #78](https://github.com/flagos-ai/vllm-plugin-FL/pull/78) |
+| Hygon | Supported | - |
 | Sunrise | Supported | - |
 
 ## Quick Start
 
 ### Setup
 
-1. Install vllm from the official [v0.20.2](https://github.com/vllm-project/vllm/tree/v0.20.2) (optional if the correct version is installed) or from the fork [vllm-FL](https://github.com/flagos-ai/vllm-FL).
+1. Install vllm from the official [v0.20.2](https://github.com/vllm-project/vllm/tree/v0.20.2) (optional if the correct version is installed)
 
 
 2. Install vllm-plugin-FL

--- a/benchmarks/benchmark_throughput_serve.py
+++ b/benchmarks/benchmark_throughput_serve.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+
+# Usage:
+#  1. Start the server as follows (adjust model path and args as needed):
+# vllm serve /models/Qwen3.6-27B --tensor-parallel-size 2 --max-model-len 262144 --no-enable-log-requests --no-enable-prefix-caching
+
+#  2. Run this benchmark script (default: 4 test cases):
+# python benchmarks/benchmark_throughput_serve.py
+#
+# [Optional] Run all 10 test cases:
+# python benchmarks/benchmark_throughput_serve.py --enable-all
+
+
+import argparse
+import csv
+import os
+import re
+import subprocess
+import time
+from datetime import datetime
+from statistics import mean
+
+MODEL = "/models/Qwen3.6-27B"
+
+# total runs for each case
+RUNS = 4
+
+# skip first N runs
+SKIP_FIRST = 1
+
+COMMON_ARGS = [
+    "vllm",
+    "bench",
+    "serve",
+    "--backend",
+    "vllm",
+    "--model",
+    MODEL,
+    "--endpoint",
+    "/v1/completions",
+    "--host",
+    "localhost",
+    "--port",
+    "8000",
+    "--dataset-name",
+    "random",
+    "--ignore-eos",
+]
+
+# Baseline cases used when --enable-all is not set.
+# Each case is a tuple:
+# (random_input_len, random_output_len, max_concurrency, num_prompts)
+DEFAULT_TEST_CASES = [
+    (1024, 1024, 64, 256),
+    (4096, 1024, 64, 256),
+    (16384, 1024, 64, 256),
+    (65536, 1024, 64, 256),
+]
+
+ALL_TEST_CASES = [
+    *DEFAULT_TEST_CASES,
+    (4096, 1024, 1, 256),
+    (4096, 1024, 4, 256),
+    (4096, 1024, 16, 256),
+    (4096, 1024, 256, 256),
+    (131072, 1024, 64, 64),
+    (262144, 1024, 64, 64),
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--enable-all",
+        action="store_true",
+        help="Enable all 10 test cases. If not set, run default 4 cases.",
+    )
+
+    return parser.parse_args()
+
+
+PATTERNS = {
+    "successful_requests": r"Successful requests:\s+([0-9.]+)",
+    "benchmark_duration": r"Benchmark duration \(s\):\s+([0-9.]+)",
+    "total_input_tokens": r"Total input tokens:\s+([0-9.]+)",
+    "total_output_tokens": r"Total generated tokens:\s+([0-9.]+)",
+    "request_throughput": r"Request throughput \(req/s\):\s+([0-9.]+)",
+    "output_throughput": r"Output token throughput \(tok/s\):\s+([0-9.]+)",
+    "peak_output_throughput": r"Peak output token throughput \(tok/s\):\s+([0-9.]+)",
+    "total_token_throughput": r"Total token throughput \(tok/s\):\s+([0-9.]+)",
+    "mean_ttft_ms": r"Mean TTFT \(ms\):\s+([0-9.]+)",
+    "median_ttft_ms": r"Median TTFT \(ms\):\s+([0-9.]+)",
+    "p99_ttft_ms": r"P99 TTFT \(ms\):\s+([0-9.]+)",
+    "mean_tpot_ms": r"Mean TPOT \(ms\):\s+([0-9.]+)",
+    "median_tpot_ms": r"Median TPOT \(ms\):\s+([0-9.]+)",
+    "p99_tpot_ms": r"P99 TPOT \(ms\):\s+([0-9.]+)",
+    "mean_itl_ms": r"Mean ITL \(ms\):\s+([0-9.]+)",
+    "median_itl_ms": r"Median ITL \(ms\):\s+([0-9.]+)",
+    "p99_itl_ms": r"P99 ITL \(ms\):\s+([0-9.]+)",
+}
+
+RAW_CSV_COLUMNS = [
+    "Prefill",
+    "Decode",
+    "Conc",
+    "Num Prompts",
+    "Successful Requests",
+    "Run Status",
+    "Benchmark Duration (s)",
+    "Total Input Tokens",
+    "Total Output Tokens",
+    "Req/s",
+    "Output tok/s",
+    "Peak Output tok/s",
+    "Total tok/s",
+    "Mean TTFT (ms)",
+    "Median TTFT (ms)",
+    "P99 TTFT (ms)",
+    "Mean TPOT (ms)",
+    "Median TPOT (ms)",
+    "P99 TPOT (ms)",
+    "Mean ITL (ms)",
+    "Median ITL (ms)",
+    "P99 ITL (ms)",
+]
+
+SUMMARY_CSV_COLUMNS = [
+    "Prefill",
+    "Decode",
+    "Conc",
+    "Num Prompts",
+    "Benchmark Duration (s)",
+    "Total Input Tokens",
+    "Total Output Tokens",
+    "Req/s",
+    "Output tok/s",
+    "Peak Output tok/s",
+    "Total tok/s",
+    "Mean TTFT (ms)",
+    "Median TTFT (ms)",
+    "P99 TTFT (ms)",
+    "Mean TPOT (ms)",
+    "Median TPOT (ms)",
+    "P99 TPOT (ms)",
+    "Mean ITL (ms)",
+    "Median ITL (ms)",
+    "P99 ITL (ms)",
+]
+
+
+def extract_metrics(output_text):
+    result = {}
+
+    for key, pattern in PATTERNS.items():
+        match = re.search(
+            pattern,
+            output_text,
+            re.IGNORECASE,
+        )
+
+        result[key] = float(match.group(1)) if match else None
+
+    return result
+
+
+def format_result(case, metrics, include_successful_requests=True):
+    input_len, output_len, concurrency, num_prompts = case
+
+    result = {
+        "Prefill": input_len,
+        "Decode": output_len,
+        "Conc": concurrency,
+        "Num Prompts": num_prompts,
+        "Benchmark Duration (s)": metrics.get("benchmark_duration"),
+        "Total Input Tokens": metrics.get("total_input_tokens"),
+        "Total Output Tokens": metrics.get("total_output_tokens"),
+        "Req/s": metrics.get("request_throughput"),
+        "Output tok/s": metrics.get("output_throughput"),
+        "Peak Output tok/s": metrics.get("peak_output_throughput"),
+        "Total tok/s": metrics.get("total_token_throughput"),
+        "Mean TTFT (ms)": metrics.get("mean_ttft_ms"),
+        "Median TTFT (ms)": metrics.get("median_ttft_ms"),
+        "P99 TTFT (ms)": metrics.get("p99_ttft_ms"),
+        "Mean TPOT (ms)": metrics.get("mean_tpot_ms"),
+        "Median TPOT (ms)": metrics.get("median_tpot_ms"),
+        "P99 TPOT (ms)": metrics.get("p99_tpot_ms"),
+        "Mean ITL (ms)": metrics.get("mean_itl_ms"),
+        "Median ITL (ms)": metrics.get("median_itl_ms"),
+        "P99 ITL (ms)": metrics.get("p99_itl_ms"),
+    }
+
+    if include_successful_requests:
+        result["Successful Requests"] = metrics.get("successful_requests")
+
+    return result
+
+
+def append_csv(row, filename, columns):
+    file_exists = os.path.exists(filename)
+
+    with open(filename, "a", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=columns,
+        )
+
+        if not file_exists:
+            writer.writeheader()
+
+        writer.writerow(row)
+
+
+def run_once(case, run_id):
+    input_len, output_len, concurrency, num_prompts = case
+
+    name = f"{input_len}_{output_len}_c{concurrency}"
+
+    print("=" * 80)
+    print(f"Running: {name} | Run {run_id}/{RUNS}")
+    print("=" * 80)
+
+    cmd = COMMON_ARGS + [
+        "--random-input-len",
+        str(input_len),
+        "--random-output-len",
+        str(output_len),
+        "--max-concurrency",
+        str(concurrency),
+        "--num-prompts",
+        str(num_prompts),
+    ]
+
+    print(" ".join(cmd))
+    print()
+
+    start_time = time.time()
+
+    process = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    elapsed = time.time() - start_time
+
+    output = process.stdout
+
+    print(output)
+
+    metrics = extract_metrics(output)
+
+    metrics["elapsed_sec"] = round(elapsed, 2)
+
+    return metrics
+
+
+def average_metrics(results):
+    avg_result = {}
+
+    keys = results[0].keys()
+
+    for key in keys:
+        values = [r[key] for r in results if isinstance(r.get(key), (int, float))]
+
+        if values:
+            avg_result[key] = round(mean(values), 2)
+
+    return avg_result
+
+
+def run_test_case(case, raw_csv):
+    all_runs = []
+
+    for run_id in range(1, RUNS + 1):
+        metrics = run_once(case, run_id)
+
+        raw_row = format_result(case, metrics, include_successful_requests=True)
+        expected_successful_requests = case[3]
+        raw_row["Run Status"] = (
+            "SUCCESS"
+            if metrics.get("successful_requests") == expected_successful_requests
+            else "FAILED"
+        )
+
+        append_csv(raw_row, raw_csv, RAW_CSV_COLUMNS)
+
+        all_runs.append(metrics)
+
+    valid_runs = all_runs[SKIP_FIRST:]
+
+    expected_successful_requests = case[3]
+    has_failed_run = any(
+        run.get("successful_requests") != expected_successful_requests
+        for run in valid_runs
+    )
+
+    avg_metrics = average_metrics(valid_runs)
+
+    summary_row = format_result(
+        case,
+        avg_metrics,
+        include_successful_requests=False,
+    )
+
+    return summary_row, has_failed_run
+
+
+def print_summary(results):
+    print()
+    print("=" * 80)
+    print("Summary")
+    print("=" * 80)
+
+    for r in results:
+        print(
+            f"Prefill={r['Prefill']} "
+            f"Decode={r['Decode']} "
+            f"Conc={r['Conc']} "
+            f"NumPrompts={r['Num Prompts']} "
+            f"Req/s={r['Req/s']} "
+            f"Total tok/s={r['Total tok/s']} "
+            f"TTFT={r['Mean TTFT (ms)']}ms"
+        )
+
+
+def main():
+    args = parse_args()
+
+    test_cases = ALL_TEST_CASES if args.enable_all else DEFAULT_TEST_CASES
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    output_dir = "benchmark_results"
+    os.makedirs(output_dir, exist_ok=True)
+    raw_csv = os.path.join(output_dir, f"raw_runs_{timestamp}.csv")
+    summary_csv = os.path.join(output_dir, f"summary_{timestamp}.csv")
+
+    all_summary = []
+
+    print()
+    print(f"RUNS={RUNS}")
+    print(f"SKIP_FIRST={SKIP_FIRST}")
+    print(f"ENABLE_ALL={args.enable_all}")
+    print(f"TOTAL_CASES={len(test_cases)}")
+    print(f"TEST_CASES={test_cases}")
+    print()
+
+    for case in test_cases:
+        try:
+            summary_row, has_failed_run = run_test_case(
+                case,
+                raw_csv,
+            )
+
+            if has_failed_run:
+                print(f"SKIP SUMMARY ROW (failed case): {case}")
+                continue
+
+            append_csv(summary_row, summary_csv, SUMMARY_CSV_COLUMNS)
+
+            all_summary.append(summary_row)
+
+        except Exception as e:
+            print(f"ERROR: {e}")
+
+    print_summary(all_summary)
+
+    print()
+    print(f"Raw CSV: {raw_csv}")
+    print(f"Summary CSV: {summary_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Benchmark smoke tests for vllm-plugin-FL."""

--- a/tests/benchmarks/configs/smoke.yaml
+++ b/tests/benchmarks/configs/smoke.yaml
@@ -1,0 +1,45 @@
+throughput:
+  - name: throughput_smoke_dummy
+    model: qwen3
+    case: 06b_tp2
+    parameters:
+      dataset_name: random
+      random_input_len: 32
+      random_output_len: 1
+      num_prompts: 4
+      enforce_eager: true
+      load_format: dummy
+
+latency:
+  - name: latency_smoke_dummy
+    model: qwen3
+    case: 06b_tp2
+    parameters:
+      input_len: 32
+      output_len: 1
+      batch_size: 1
+      num_iters_warmup: 1
+      num_iters: 2
+      enforce_eager: true
+      load_format: dummy
+
+serve:
+  - name: serve_smoke_dummy
+    model: qwen3
+    case: 06b_tp2
+    server_parameters:
+      served_model_name: smoke-model
+      tensor_parallel_size: 1
+      max_model_len: 1024
+      enforce_eager: true
+      load_format: dummy
+    client_parameters:
+      model: smoke-model
+      backend: openai-chat
+      endpoint: /v1/chat/completions
+      dataset_name: random
+      random_input_len: 32
+      random_output_len: 4
+      num_prompts: 5
+      percentile_metrics: ttft,tpot,itl,e2el
+      goodput: e2el:10000

--- a/tests/benchmarks/test_benchmark_latency.py
+++ b/tests/benchmarks/test_benchmark_latency.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Smoke test for vllm bench latency."""
+
+import json
+
+import pytest
+
+from tests.benchmarks.utils import load_benchmark_case, run_command, to_cli_args
+
+
+@pytest.mark.benchmark
+def test_benchmark_latency(tmp_path):
+    case = load_benchmark_case()
+    params = case.get("parameters", {})
+
+    output_json = tmp_path / "latency_result.json"
+    command = ["vllm", "bench", "latency"]
+    command.extend(to_cli_args(params))
+    command.extend(["--output-json", str(output_json)])
+
+    result = run_command(command)
+    assert result.returncode == 0, result.stderr
+    assert output_json.exists()
+
+    data = json.loads(output_json.read_text())
+    avg_latency = data.get("avg_latency", data.get("mean_latency", 0))
+    assert avg_latency > 0
+    latencies = data.get("latencies")
+    num_iters = data.get("num_iters", 0)
+    assert (latencies is not None and len(latencies) > 0) or num_iters > 0

--- a/tests/benchmarks/test_benchmark_serve.py
+++ b/tests/benchmarks/test_benchmark_serve.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Smoke test for vllm bench serve."""
+
+import json
+
+import pytest
+
+from tests.benchmarks.utils import load_benchmark_case, run_command, to_cli_args
+from tests.e2e_tests.serving.server_helper import VllmServer
+
+
+@pytest.mark.benchmark
+def test_benchmark_serve(tmp_path):
+    case = load_benchmark_case()
+
+    server_params = dict(case.get("server_parameters", {}))
+    client_params = dict(case.get("client_parameters", {}))
+
+    model = server_params.pop("model")
+    served_model_name = server_params.pop("served_model_name", "")
+    tp_size = int(server_params.pop("tensor_parallel_size", 1))
+    server_extra_args = to_cli_args(server_params)
+
+    result_json = tmp_path / "serve_result.json"
+
+    with VllmServer(
+        model=model,
+        tp_size=tp_size,
+        served_model_name=served_model_name,
+        extra_args=server_extra_args,
+    ) as server:
+        command = [
+            "vllm",
+            "bench",
+            "serve",
+            "--host",
+            server.host,
+            "--port",
+            str(server.port),
+        ]
+        command.extend(to_cli_args(client_params))
+        command.extend(
+            [
+                "--save-result",
+                "--result-dir",
+                str(tmp_path),
+                "--result-filename",
+                result_json.name,
+            ]
+        )
+
+        result = run_command(command)
+
+    assert result.returncode == 0, result.stderr
+    assert result_json.exists()
+
+    data = json.loads(result_json.read_text())
+    assert data.get("completed", 0) > 0
+    assert data.get("failed", 0) == 0

--- a/tests/benchmarks/test_benchmark_throughput.py
+++ b/tests/benchmarks/test_benchmark_throughput.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Smoke test for vllm bench throughput."""
+
+import json
+
+import pytest
+
+from tests.benchmarks.utils import load_benchmark_case, run_command, to_cli_args
+
+
+@pytest.mark.benchmark
+def test_benchmark_throughput(tmp_path):
+    case = load_benchmark_case()
+    params = case.get("parameters", {})
+
+    output_json = tmp_path / "throughput_result.json"
+    command = ["vllm", "bench", "throughput"]
+    command.extend(to_cli_args(params))
+    command.extend(["--output-json", str(output_json)])
+
+    result = run_command(command)
+    assert result.returncode == 0, result.stderr
+    assert output_json.exists()
+
+    data = json.loads(output_json.read_text())
+    num_requests = data.get("num_requests", data.get("num_prompts", 0))
+    tokens_per_second = data.get("tokens_per_second", data.get("output_throughput", 0))
+    assert num_requests > 0
+    assert tokens_per_second > 0

--- a/tests/benchmarks/utils.py
+++ b/tests/benchmarks/utils.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Helpers for benchmark smoke tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from typing import Any
+
+
+def load_benchmark_case() -> dict[str, Any]:
+    """Load benchmark case config injected by tests/run.py."""
+    raw = os.environ.get("FL_BENCHMARK_CASE")
+    if not raw:
+        raise RuntimeError("FL_BENCHMARK_CASE is not set")
+    return json.loads(raw)
+
+
+def to_cli_args(params: dict[str, Any], skip: set[str] | None = None) -> list[str]:
+    """Convert a parameter mapping to CLI args.
+
+    Underscores are converted to dashes to match vLLM CLI conventions.
+    Boolean true and empty string values are treated as flags.
+    """
+    skip = skip or set()
+    args: list[str] = []
+
+    for key, value in params.items():
+        if key in skip or value is None or value is False:
+            continue
+
+        flag = "--" + key.replace("_", "-")
+        if value is True or value == "":
+            args.append(flag)
+        else:
+            args.extend([flag, str(value)])
+
+    return args
+
+
+def run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run command and print captured output for CI logs."""
+    print("[benchmark] Command:", " ".join(command))
+
+    env = os.environ.copy()
+    local_no_proxy = "127.0.0.1,localhost,::1"
+    for key in ("NO_PROXY", "no_proxy"):
+        current = env.get(key, "")
+        env[key] = ",".join(filter(None, [current, local_no_proxy]))
+
+    result = subprocess.run(command, capture_output=True, text=True, env=env)
+    print(result.stdout)
+    print(result.stderr)
+    return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,7 @@ def pytest_configure(config):
         "flaggems: marks tests as requiring the flag_gems library",
         "flagcx: marks tests as requiring the FlagCX library",
         "functional: marks tests as functional tests",
+        "benchmark: marks tests as benchmark smoke tests",
     ]:
         config.addinivalue_line("markers", line)
 

--- a/tests/platforms/cuda.yaml
+++ b/tests/platforms/cuda.yaml
@@ -79,3 +79,7 @@ a100:
       include: "*"
       # Exclude patterns: empty list or list paths to exclude
       exclude: []
+    
+    benchmark:
+      enabled: true
+      smoke: ["throughput", "latency", "serve"]

--- a/tests/run.py
+++ b/tests/run.py
@@ -43,6 +43,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 # Ensure repo root is on sys.path so ``tests.*`` imports work
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
@@ -167,6 +169,7 @@ class TestRunner:
         - ``unit``: unit tests
         - ``functional``: component-level GPU tests (ops, compilation, distributed)
         - ``e2e``: end-to-end model tests (inference, serving)
+        - ``benchmark``: benchmark smoke tests
         - ``all``: all of the above
         """
         cases: list[TestCase] = []
@@ -179,6 +182,9 @@ class TestRunner:
 
         if self.scope in ("all", "e2e"):
             cases.extend(self._discover_e2e_tests())
+
+        if self.scope in ("all", "benchmark"):
+            cases.extend(self._discover_benchmark_tests())
 
         return cases
 
@@ -329,6 +335,93 @@ class TestRunner:
         """End-to-end model tests (inference, serving)."""
         return self._discover_from_yaml("tests/e2e_tests")
 
+    def _discover_benchmark_tests(self) -> list[TestCase]:
+        """Benchmark smoke tests selected by platform YAML."""
+        benchmark = self.config.get_benchmark_tests()
+        if not benchmark.get("enabled", False):
+            return []
+        selected_smoke = benchmark.get("smoke", [])
+
+        if not selected_smoke:
+            return []
+
+        if isinstance(selected_smoke, str):
+            selected_types = {selected_smoke}
+        else:
+            selected_types = set(selected_smoke)
+
+        config_path = Path("tests/benchmarks/configs/smoke.yaml")
+        if not config_path.exists():
+            print(f"[run] Warning: benchmark config not found: {config_path}")
+            return []
+
+        with open(config_path) as f:
+            smoke_config = yaml.safe_load(f) or {}
+
+        cases: list[TestCase] = []
+        for bench_type, case_list in smoke_config.items():
+            if bench_type not in selected_types:
+                continue
+            if not isinstance(case_list, list):
+                continue
+
+            pytest_path = f"tests/benchmarks/test_benchmark_{bench_type}.py"
+            pytest_abspath = _REPO_ROOT / pytest_path
+            if not pytest_abspath.exists():
+                print(f"[run] Warning: benchmark test file not found: {pytest_path}")
+                continue
+
+            for case_cfg in case_list:
+                runtime_case = dict(case_cfg)
+                model_name = str(runtime_case.pop("model"))
+                model_case = str(runtime_case.pop("case"))
+                model_cfg = ModelConfig.load(model_name, model_case)
+
+                if "parameters" in runtime_case:
+                    params = {
+                        "model": model_cfg.model,
+                        "tokenizer": model_cfg.model,
+                        **model_cfg.engine,
+                        **runtime_case.get("parameters", {}),
+                    }
+                    runtime_case["parameters"] = params
+
+                if "server_parameters" in runtime_case:
+                    server_params = {
+                        "model": model_cfg.model,
+                        "tokenizer": model_cfg.model,
+                        **model_cfg.engine,
+                        **runtime_case.get("server_parameters", {}),
+                    }
+                    runtime_case["server_parameters"] = server_params
+
+                if "client_parameters" in runtime_case:
+                    client_params = {
+                        "tokenizer": model_cfg.model,
+                        **runtime_case.get("client_parameters", {}),
+                    }
+                    if model_cfg.engine.get("trust_remote_code"):
+                        client_params.setdefault("trust_remote_code", True)
+                    runtime_case["client_parameters"] = client_params
+
+                name = str(runtime_case.get("name", f"{bench_type}_unnamed"))
+                cases.append(
+                    TestCase(
+                        name=f"benchmark/{bench_type}/{name}",
+                        pytest_path=pytest_path,
+                        task="benchmark",
+                        model=bench_type,
+                        case=name,
+                        extra_args=["-v", "--tb=short", "-s"],
+                        extra_env={
+                            "FL_BENCHMARK_TYPE": bench_type,
+                            "FL_BENCHMARK_CASE": json.dumps(runtime_case),
+                        },
+                    )
+                )
+
+        return cases
+
     # --- Test execution ------------------------------------------------------
 
     def _run_single(self, tc: TestCase) -> TestResult:
@@ -442,10 +535,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--scope",
-        choices=["all", "unit", "functional", "e2e"],
+        choices=["all", "unit", "functional", "e2e", "benchmark"],
         default="all",
         help="Which test scope to run: unit, functional (ops/compilation/"
-        "distributed), e2e (inference/serving), or all (default: all)",
+        "distributed), e2e (inference/serving), benchmark, or all (default: all)",
     )
     parser.add_argument(
         "--task",

--- a/tests/utils/platform_config.py
+++ b/tests/utils/platform_config.py
@@ -303,6 +303,11 @@ class PlatformConfig:
         e2e_raw = dt.get("tests", {}).get("e2e", {})
         return FunctionalTests(tests=e2e_raw)
 
+    def get_benchmark_tests(self) -> dict[str, Any]:
+        """Return benchmark test configuration for the active device."""
+        dt = self.device_tests.get(self.device, {})
+        return dt.get("tests", {}).get("benchmark", {})
+
     def get_functional_filter(self) -> TestFilter:
         """Return functional test include/exclude for the active device."""
         dt = self.device_tests.get(self.device, {})

--- a/vllm_fl/dispatch/backends/flaggems/impl/mla.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/mla.py
@@ -119,7 +119,7 @@ class MLAFLImpl(MLACommonImpl[MLACommonMetadata]):
             return attn_out, lse
         return attn_out
 
-    def _forward_decode(
+    def forward_mqa(
         self,
         q: Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]],
         kv_c_and_k_pe_cache: torch.Tensor,

--- a/vllm_fl/dispatch/config/hygon.yaml
+++ b/vllm_fl/dispatch/config/hygon.yaml
@@ -1,0 +1,59 @@
+# vLLM-FL Dispatch Configuration for hygon GPU
+# Auto-loaded when running on hygon hardware
+
+# Preferred default backend type: flagos, vendor, reference
+prefer: flagos
+
+# Strict Mode:
+#   true  = Raise an error immediately on failure; do not attempt other backends.
+#   false = Attempt the next available backend in sequence upon failure (Default).
+strict: false
+
+# Vendor Whitelist (Optional, allows all if not set)
+# allow_vendors:
+#   - hygon
+
+# Vendor Blacklist (Optional)
+# deny_vendors:
+#   - cuda
+
+
+# Per-operator backend execution order (Optional)
+# Only the backends listed here will be attempted, in the order specified.
+#
+# Supported tokens:
+#   - flagos      : Default FlagGems implementation (Triton)
+#   - reference   : PyTorch reference implementation
+#   - vendor      : Any available vendor backend (auto-detected)
+#   - vendor:hygon : hygon-specific vendor backend
+op_backends:
+  # All operators: prioritize FlagGems (Triton), fallback to vendor, then reference
+  attention_backend:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  rms_norm:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  silu_and_mul:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  rotary_embedding:
+    - flagos
+    - vendor:hygon
+    - reference
+
+# FlagOS operator blacklist
+# Blacklist only ops that are known to have issues
+flagos_blacklist:
+  - cat
+
+# OOT (Out-of-Tree) operator blacklist
+# These operators will NOT be registered as OOT replacements.
+# oot_blacklist:
+#   - fused_moe

--- a/vllm_fl/dispatch/config/nvidia.yaml
+++ b/vllm_fl/dispatch/config/nvidia.yaml
@@ -51,6 +51,10 @@ flagos_blacklist:
   - index
   - mul
   - pow_scalar
+  - index_put_
+  - index_put
+  - _index_put_impl_
+  - nonzero
 
 # OOT (Out-of-Tree) operator blacklist
 # oot_blacklist: []

--- a/vllm_fl/ops/fused_moe/layer.py
+++ b/vllm_fl/ops/fused_moe/layer.py
@@ -43,6 +43,14 @@ class UnquantizedFusedMoEMethodFL(UnquantizedFusedMoEMethod):
             moe_config=self.moe
         )
 
+    @property
+    def is_monolithic(self) -> bool:
+        if self.moe_kernel is None:
+            if self.experts_cls is None:
+                return True
+            return self.experts_cls.is_monolithic()
+        return self.moe_kernel.is_monolithic
+
 
 class FusedMoEFL(FusedMoE):
     """
@@ -70,6 +78,10 @@ class FusedMoEFL(FusedMoE):
         self._routed_input_transform = routed_input_transform
         self._routed_output_transform = routed_output_transform
         self._apply_routed_scale_to_output = apply_routed_scale_to_output
+        # Replace quant_method with FL version that properly handles OOT backend
+        if isinstance(self.quant_method, UnquantizedFusedMoEMethod) and not isinstance(self.quant_method, UnquantizedFusedMoEMethodFL):
+            self.quant_method = UnquantizedFusedMoEMethodFL(self.moe_config)
+            self.base_quant_method = self.quant_method
         # Replace router with FL version that uses call_op for flaggems dispatch
         self._replace_router_with_fl()
 

--- a/vllm_fl/ops/fused_moe/router.py
+++ b/vllm_fl/ops/fused_moe/router.py
@@ -169,7 +169,17 @@ class GroupedTopKRouterFL(GroupedTopKRouter):
         *,
         input_ids: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if not self._valid_grouping(router_logits):
+        # Mirror upstream GroupedTopKRouter._compute_routing, which checks
+        # expert/grouping validity via an inner `valid_grouping()` closure
+        # rather than a `_valid_grouping` method. The earlier port called a
+        # non-existent `self._valid_grouping`, raising AttributeError.
+        def valid_grouping() -> bool:
+            num_experts = router_logits.shape[-1]
+            if num_experts <= self.num_expert_group:
+                return False
+            return num_experts % self.num_expert_group == 0
+
+        if not valid_grouping():
             if self.e_score_correction_bias is not None:
                 topk_weights, topk_ids = fused_topk_bias(
                     hidden_states=hidden_states,

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -52,7 +52,8 @@ class PlatformFL(Platform):
     # cuda_alike (nvidia/metax): device_name = vendor_name (not used in torch.device)
     # non-cuda_alike (iluvatar/ascend): device_name = device_type (used in torch.device)
     device_name = device_info.vendor_name if (
-        device_info.device_type == "cuda" and device_info.vendor_name != "iluvatar"
+        device_info.device_type == "cuda"
+        and device_info.vendor_name not in ("iluvatar", "hygon")
     ) else device_info.device_type
     device_type = device_info.device_type
     dispatch_key = device_info.dispatch_key
@@ -70,6 +71,8 @@ class PlatformFL(Platform):
             return False
         if self.vendor_name == "musa":
             return True
+        if self.vendor_name == "hygon":
+            return False
         return self.device_type == "cuda"
 
     def is_cuda(self) -> bool:
@@ -307,7 +310,7 @@ class PlatformFL(Platform):
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:
-        if cls.vendor_name in ["nvidia", "ascend", "metax"]:
+        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon"]:
             return True
         return False
 
@@ -346,6 +349,8 @@ class PlatformFL(Platform):
 
     @classmethod
     def use_custom_allreduce(cls) -> bool:
+        if cls.vendor_name == "hygon":
+            return False
         if cls.dist_backend == "flagcx":
             return False
         return True

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -38,6 +38,8 @@ VENDOR_DEVICE_MAP: dict[str, dict[str, str]] = {
     "mthreads": {"device_type": "musa", "device_name": "musa"},
     # Registered backend: vendor/sunrise
     "sunrise": {"device_type": "ptpu", "device_name": "ptpu"},
+    # Registered backend: vendor/hygon
+    "hygon": {"device_type": "cuda", "device_name": "cuda"},    
 }
 
 


### PR DESCRIPTION
Title
hotfix/v0.2.0: fix GroupedTopKRouterFL routing and MLA decode method name

Body（Markdown）
## Summary

基于 `v0.2.0` tag 的 hotfix,修复两个运行时 bug。共两个 commit,各修一处。

## Bug 1 — GroupedTopKRouterFL 路由报错 (`4b6c1b2`)

`vllm_fl/ops/fused_moe/router.py` 中 `GroupedTopKRouterFL._compute_routing`
调用了 `self._valid_grouping(router_logits)`,但上游 `GroupedTopKRouter`
并没有 `_valid_grouping` 方法 —— 它在 `_compute_routing` 内部用一个局部闭包
`valid_grouping()` 做校验。因此启用 grouped top-k 路由(DeepSeek-V2/V3、
GLM-MoE、混元等模型)时会抛 `AttributeError`。

修复:移植 v0.3.0-dev 的做法,用内联的 `valid_grouping()` 闭包替换该调用
(判断逻辑:`num_experts > num_expert_group` 且能被整除)。仅移植该最小修复,
不含 v0.3.0-dev 中无关的 `call_op` → `CachedOp` dispatch 重构。

\`\`\`python
def valid_grouping() -> bool:
    num_experts = router_logits.shape[-1]
    if num_experts <= self.num_expert_group:
        return False
    return num_experts % self.num_expert_group == 0

if not valid_grouping():
    ...
\`\`\`

## Bug 2 — MLA decode 方法签名对不上 (`2bac207`)

`vllm_fl/dispatch/backends/flaggems/impl/mla.py` 中 `MLAFLImpl` 继承自
`MLACommonImpl`。vllm 0.20.0 把基类的 decode 覆写方法从 `_forward_decode`
重命名为 `forward_mqa`(参数签名完全相同)。FL 侧仍定义 `_forward_decode`,
导致该实现永远不会被调用,decode 时命中基类抽象的 `forward_mqa` → 抛
`NotImplementedError`。

修复:将 `MLAFLImpl._forward_decode` 重命名为 `forward_mqa`,方法体不变。
(metax 后端用的是自带 vendored 的 MLA,不受影响,未改动。)

## Test

- 两个改动文件均通过 `python -m py_compile`
- 确认 `router.py` 中不再存在 `self._valid_grouping` 调用
- 确认 `mla.py` 中 decode 方法名为 `forward_mqa`
