### PR TITLE
[hot-fix] fix GroupedTopKRouterFL routing and MLA decode method name

### DIFF
--- a/vllm_fl/dispatch/backends/flaggems/impl/mla.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/mla.py
@@ -119,7 +119,7 @@ class MLAFLImpl(MLACommonImpl[MLACommonMetadata]):
             return attn_out, lse
         return attn_out
 
-    def _forward_decode(
+    def forward_mqa(
         self,
         q: Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]],
         kv_c_and_k_pe_cache: torch.Tensor,

--- a/vllm_fl/ops/fused_moe/router.py
+++ b/vllm_fl/ops/fused_moe/router.py
@@ -169,7 +169,17 @@ class GroupedTopKRouterFL(GroupedTopKRouter):
         *,
         input_ids: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if not self._valid_grouping(router_logits):
+        # Mirror upstream GroupedTopKRouter._compute_routing, which checks
+        # expert/grouping validity via an inner `valid_grouping()` closure
+        # rather than a `_valid_grouping` method. The earlier port called a
+        # non-existent `self._valid_grouping`, raising AttributeError.
+        def valid_grouping() -> bool:
+            num_experts = router_logits.shape[-1]
+            if num_experts <= self.num_expert_group:
+                return False
+            return num_experts % self.num_expert_group == 0
+
+        if not valid_grouping():
             if self.e_score_correction_bias is not None:
                 topk_weights, topk_ids = fused_topk_bias(
                     hidden_states=hidden_states,


### PR DESCRIPTION
## Summary

基于 `v0.2.0` tag 的 hotfix,修复两个运行时 bug。共两个 commit,各修一处。


## Bug 1 — GroupedTopKRouterFL 路由报错 (`4b6c1b2`)

`vllm_fl/ops/fused_moe/router.py` 中 `GroupedTopKRouterFL._compute_routing`
调用了 `self._valid_grouping(router_logits)`,但上游 `GroupedTopKRouter`
并没有 `_valid_grouping` 方法 —— 它在 `_compute_routing` 内部用一个局部闭包
`valid_grouping()` 做校验。因此启用 grouped top-k 路由(DeepSeek-V2/V3、
GLM-MoE、混元等模型)时会抛 `AttributeError`。

修复:移植 v0.3.0-dev 的做法,用内联的 `valid_grouping()` 闭包替换该调用
(判断逻辑:`num_experts > num_expert_group` 且能被整除)。仅移植该最小修复,
不含 v0.3.0-dev 中无关的 `call_op` → `CachedOp` dispatch 重构。

\`\`\`python
def valid_grouping() -> bool:
    num_experts = router_logits.shape[-1]
    if num_experts <= self.num_expert_group:
        return False
    return num_experts % self.num_expert_group == 0

if not valid_grouping():
    ...
\`\`\`

## Bug 2 — MLA decode 方法签名对不上 (`2bac207`)

`vllm_fl/dispatch/backends/flaggems/impl/mla.py` 中 `MLAFLImpl` 继承自
`MLACommonImpl`。vllm 0.20.0 把基类的 decode 覆写方法从 `_forward_decode`
重命名为 `forward_mqa`(参数签名完全相同)。FL 侧仍定义 `_forward_decode`,
导致该实现永远不会被调用,decode 时命中基类抽象的 `forward_mqa` → 抛
`NotImplementedError`。

修复:将 `MLAFLImpl._forward_decode` 重命名为 `forward_mqa`,方法体不变。
(metax 后端用的是自带 vendored 的 MLA,不受影响,未改动。)

## Test

- 两个改动文件均通过 `python -m py_compile`
- 确认 `router.py` 中不再存在 `self._valid_grouping` 调用
- 确认 `mla.py` 中 decode 方法名为 `forward_mqa`
