### PR TITLE
fix(attention): split KV-cache write from forward for vLLM v1

### DIFF
--- a/vllm_fl/dispatch/backends/flaggems/impl/attention.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/attention.py
@@ -51,6 +51,10 @@ logger = init_logger(__name__)
 class AttentionFLBackend(AttentionBackend):
     accept_output_buffer: bool = True
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
+    # vLLM v1 splits KV-cache write from attention forward: do_kv_cache_update()
+    # writes the cache via reshape_and_cache_flash, then forward() reads from it
+    # via flash_attn_varlen_func. Signal this to vLLM so it calls the write step.
+    forward_includes_kv_cache_update: bool = False
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
@@ -74,7 +78,7 @@ class AttentionFLBackend(AttentionBackend):
 
     @staticmethod
     def get_name() -> str:
-        return "FL"
+        return "CUSTOM"
 
     @classmethod
     def supports_attn_type(cls, attn_type: str) -> bool:
@@ -457,7 +461,7 @@ class AttentionFLImpl(AttentionImpl):
         self.num_queries_per_kv = self.num_heads // self.num_kv_heads
 
         self.attn_type = attn_type
-        self.vllm_flash_attn_version = 2 if current_platform.device_type == "txda" else 3 # 2 #get_flash_attn_version()
+        self.vllm_flash_attn_version = 2  # FlagGems only supports FA2
         # Cache the batch invariant result for use in forward passes
         self.batch_invariant_enabled = _bi_mode
 
@@ -467,6 +471,34 @@ class AttentionFLImpl(AttentionImpl):
             )
         ### TODO(lms): support quant to int8/int4 each query input and low precision compute
         self.supports_quant_query_input = False
+
+    def do_kv_cache_update(
+        self,
+        layer,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ):
+        """Write key/value into the paged KV cache.
+
+        This is called by vLLM's unified_kv_cache_update custom op
+        *before* forward(), so forward() should NOT repeat the write.
+        """
+        if self.attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
+            return
+
+        key_cache, value_cache = kv_cache.unbind(0)
+        reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            self.kv_cache_dtype,
+            layer._k_scale,
+            layer._v_scale,
+        )
 
     def forward(
         self,
@@ -532,34 +564,10 @@ class AttentionFLImpl(AttentionImpl):
                 layer,
             )
 
-        # For decoder and cross-attention, use KV cache as before
+        # For decoder and cross-attention, use KV cache as before.
+        # NOTE: KV cache write is handled by do_kv_cache_update() which is
+        # called separately by vLLM's unified_kv_cache_update custom op.
         key_cache, value_cache = kv_cache.unbind(0)
-
-        # key and value may be None in the case of cross attention. They are
-        # calculated once based on the output from the encoder and then cached
-        # in KV cache.
-        if (
-            self.kv_sharing_target_layer_name is None
-            and key is not None
-            and value is not None
-        ):
-            # Reshape the input keys and values and store them in the cache.
-            # Skip this if sharing KV cache with an earlier attention layer.
-            # NOTE(woosuk): Here, key and value are padded while slot_mapping is
-            # not padded. However, we don't need to do key[:num_actual_tokens]
-            # and value[:num_actual_tokens] because the reshape_and_cache_flash
-            # op uses the slot_mapping's shape to determine the number of
-            # actual tokens.
-            reshape_and_cache_flash(
-                key,
-                value,
-                key_cache,
-                value_cache,
-                attn_metadata.slot_mapping,
-                self.kv_cache_dtype,
-                layer._k_scale,
-                layer._v_scale,
-            )
 
         if not attn_metadata.use_cascade:
             cu_seqlens_q = attn_metadata.query_start_loc
@@ -606,8 +614,8 @@ class AttentionFLImpl(AttentionImpl):
                     q_descale=layer._q_scale.expand(descale_shape),
                     k_descale=layer._k_scale.expand(descale_shape),
                     v_descale=layer._v_scale.expand(descale_shape),
-                    num_splits=attn_metadata.max_num_splits,
-                    s_aux=None, ### self.sinks is support in FA3
+                    num_splits=0,  # FlagGems does not support num_splits > 0
+                    s_aux=None,
                 )
                 return output
 


### PR DESCRIPTION
## Summary

`AttentionFLBackend` inherited `AttentionBackend`'s default `forward_includes_kv_cache_update = True`, telling vLLM v1 that attention `forward()` writes the KV cache itself. Under vLLM v1's split KV-cache-update path, vLLM only invokes the dedicated write step when a backend declares it does **not** fold the write into `forward()`. With the default `True`, the write step was skipped — the KV cache stayed empty, `forward()` read back zeros, and **every request produced garbage output**.

This is the root cause of the multi-day "garbage output" bug on the enflame GCU300 backend (the only backend routed through `AttentionFLBackend`, forced by the empty vLLM wheel lacking `_vllm_fa2_C`).

## Changes

- Declare `forward_includes_kv_cache_update = False` on `AttentionFLBackend`.
- Move the `reshape_and_cache_flash` write out of `forward()` into a dedicated `do_kv_cache_update()` hook, which vLLM's `unified_kv_cache_update` custom op calls **before** `forward()`. `forward()` no longer repeats the write.

Three related `AttentionFLBackend` correctness fixes surfaced while tracking this down are folded in:
- `get_name()` → `"CUSTOM"` (avoid vLLM registry special-casing the `"FL"` name)
- pin `vllm_flash_attn_version = 2` (FlagGems only implements FA2)
- `num_splits = 0` (FlagGems `flash_attn_varlen_func` has no split-K path)

## Testing

Verified end-to-end on enflame GCU300 (Qwen3-4B, TP=1, `vllm serve`): greedy inference returns correct coherent English (e.g. "Paris is the capital of France..."). Before this fix the same setup returned garbage tokens.

---
🤖 This PR was written in part with the assistance of generative AI.
