### PR TITLE
feat(enflame): GCU300 enablement bundle

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/gcu/gcu.py
+++ b/vllm_fl/dispatch/backends/vendor/gcu/gcu.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+GCU backend implementation.
+"""
+
+from __future__ import annotations
+from typing import Optional, Union
+import sys
+import torch
+from vllm_fl.dispatch.backends.base import Backend
+
+
+class GCUBackend(Backend):
+    """GCU vendor backend (``torch.gcu`` / torch_gcu runtime)."""
+
+    _available: Optional[bool] = None
+
+    @property
+    def name(self) -> str:
+        return "gcu"
+
+    @property
+    def vendor(self) -> Optional[str]:
+        return "gcu"
+
+    def is_available(self) -> bool:
+        if GCUBackend._available is None:
+            gcu = getattr(torch, "gcu", None)
+            if gcu is not None and gcu.is_available() and gcu.device_count() > 0:
+                GCUBackend._available = True
+            else:
+                GCUBackend._available = False
+        return GCUBackend._available
+
+    def silu_and_mul(self, obj, x: torch.Tensor) -> torch.Tensor:
+        from .impl.activation import silu_and_mul_gcu
+
+        return silu_and_mul_gcu(obj, x)
+
+    def rms_norm(
+        self,
+        obj,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        from .impl.normalization import rms_norm_gcu
+
+        return rms_norm_gcu(obj, x, residual)
+
+    def rotary_embedding(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        rotary_interleaved: bool = False,
+        inplace: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from .impl.rotary import rotary_embedding_gcu
+
+        return rotary_embedding_gcu(
+            obj,
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            rotary_interleaved=rotary_interleaved,
+            inplace=inplace,
+        )
+
+    def attention_backend(self, use_mla: bool = False, use_sparse: bool = False) -> str:
+        from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        if use_mla:
+            if use_sparse:
+                raise NotImplementedError("GCU does not support sparse attention yet")
+            raise NotImplementedError("GCU does not support MLA yet")
+
+        try:
+            import flash_attn.vllm_flash_attn
+            import flash_attn.vllm_flash_attn._vllm_fa2_C  # noqa: F401
+        except Exception:
+            # Empty vllm wheel ships no compiled _vllm_fa2_C; fall back to the
+            # plugin flag_gems attention backend instead of asserting later.
+            return "vllm_fl.dispatch.backends.flaggems.impl.attention.AttentionFLBackend"
+
+        sys.modules["vllm.vllm_flash_attn"] = flash_attn.vllm_flash_attn
+
+        return AttentionBackendEnum.FLASH_ATTN.get_path()

--- a/vllm_fl/dispatch/backends/vendor/gcu/impl/slot_mapping.py
+++ b/vllm_fl/dispatch/backends/vendor/gcu/impl/slot_mapping.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""GCU replacement for vLLM's Triton slot-mapping kernel.
+
+vLLM computes the KV-cache slot mapping with a Triton kernel
+(``vllm.v1.worker.block_table._compute_slot_mapping_kernel``) that operates
+on ``int64`` ``positions`` / ``slot_mapping`` buffers.  The GCU300 Triton
+backend rejects 64-bit dtypes outright ("64-bit data type not supported on
+GCU300") - even a bare int64 load/store fails to compile - so the kernel
+cannot run on GCU.
+
+We replace ``BlockTable.compute_slot_mapping`` with a vectorised on-device
+int32 implementation that reproduces the kernel's semantics exactly (including
+context-parallel interleaving).  The cache index space (block numbers x
+block_size, ~1e8 slots for realistic configs) fits comfortably in int32, and
+every operator involved (``searchsorted``, ``//``, ``%``, ``-``, advanced
+indexing, ``where``) compiles cleanly at int32 under ``flag_gems.enable()`` on
+both the vendor Triton and FlagTree backends.  Verified bit-identical to a
+CPU int64 reference on synthetic cases (up to 4096 tokens) and on live serve
+inputs.
+
+Two implementation notes:
+
+- ``searchsorted`` (not ``repeat_interleave``) maps tokens to requests.  The
+  FlagGems GCU300 ``repeat_interleave`` routes through an ``index_select``
+  kernel whose grid.y is capped at 255, so it crashes past ~4080 scheduled
+  tokens; ``searchsorted`` on the monotone request-end boundaries is a single
+  op with no such limit.
+- Staying on-device (vs. computing on CPU) avoids a host round-trip per step
+  and scales to large batches / long contexts.  ``flag_gems.enable()`` reroutes
+  these ops into FlagGems Triton kernels, but at int32 they all compile.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+logger = logging.getLogger(__name__)
+_patched = False
+
+
+def compute_slot_mapping_int32(
+    num_reqs: int,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    total_cp_world_size: int,
+    total_cp_rank: int,
+    cp_kv_cache_interleave_size: int,
+    max_num_batched_tokens: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Standalone on-device int32 slot_mapping computation for GCU300.
+
+    Args:
+        num_reqs: number of requests
+        query_start_loc: cumulative token ends per request, shape [num_reqs+1], int32
+        positions: token positions, shape [num_tokens], int64
+        block_table: block IDs, shape [num_reqs, max_blocks_per_req], int32
+        block_size: KV block size (tokens per block)
+        total_cp_world_size: pcp_world_size * dcp_world_size
+        total_cp_rank: pcp_rank * dcp_world_size + dcp_rank
+        cp_kv_cache_interleave_size: CP interleaving chunk size
+        max_num_batched_tokens: CUDA-graph max (pad tail to this)
+        device: target device
+
+    Returns:
+        slot_mapping tensor, shape [max_num_batched_tokens], int64, padded with PAD_SLOT_ID
+
+    This is a semantic rewrite of vLLM's ``_compute_slot_mapping_kernel``:
+    - Vectorized across all scheduled tokens (not per-request Triton loop)
+    - ``searchsorted`` replaces ``repeat_interleave`` (avoids GCU300 grid.y=255 cap)
+    - All ops at int32 (cache index space fits comfortably; int64 hits GCU300 wall)
+    - Verified bit-identical to CPU int64 reference on synthetic + live inputs
+    """
+    virtual_block_size = block_size * total_cp_world_size
+    total_scheduled = int(query_start_loc[num_reqs].item())
+
+    # Allocate output on device, pad tail for CUDA-graph
+    slot_mapping = torch.full(
+        (max_num_batched_tokens,), PAD_SLOT_ID, dtype=torch.int64, device=device
+    )
+    if total_scheduled == 0:
+        return slot_mapping
+
+    i32 = torch.int32
+    qsl = query_start_loc[: num_reqs + 1].to(device, i32)
+    pos = positions[:total_scheduled].to(device, i32)
+    bt = block_table.to(device, i32)
+
+    # Token -> request mapping via searchsorted (token t belongs to request r
+    # where qsl[r] <= t < qsl[r+1]). This replaces repeat_interleave, whose
+    # GCU300 index_select kernel caps grid.y at 255.
+    tok = torch.arange(total_scheduled, device=device, dtype=i32)
+    token_req = torch.searchsorted(qsl[1:], tok, right=True).to(i32)
+
+    block_indices = pos // virtual_block_size
+    block_numbers = bt[token_req, block_indices]
+
+    virtual_block_offsets = pos - block_indices * virtual_block_size
+    is_local = (
+        virtual_block_offsets // cp_kv_cache_interleave_size
+    ) % total_cp_world_size == total_cp_rank
+    local_block_offsets = (
+        virtual_block_offsets // (total_cp_world_size * cp_kv_cache_interleave_size)
+    ) * cp_kv_cache_interleave_size + (
+        virtual_block_offsets % cp_kv_cache_interleave_size
+    )
+
+    slot_ids = block_numbers * block_size + local_block_offsets
+    slot_ids = torch.where(
+        is_local, slot_ids, torch.full_like(slot_ids, PAD_SLOT_ID)
+    )
+    slot_mapping[:total_scheduled] = slot_ids.to(torch.int64)
+    return slot_mapping
+
+
+def _compute_slot_mapping_torch(
+    self,
+    num_reqs: int,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+) -> None:
+    """vLLM monkey-patch adapter: calls standalone int32 function, writes to self.slot_mapping.gpu."""
+    total_cp_world_size = self.pcp_world_size * self.dcp_world_size
+    total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+
+    result = compute_slot_mapping_int32(
+        num_reqs=num_reqs,
+        query_start_loc=query_start_loc,
+        positions=positions,
+        block_table=self.block_table.gpu,
+        block_size=self.block_size,
+        total_cp_world_size=total_cp_world_size,
+        total_cp_rank=total_cp_rank,
+        cp_kv_cache_interleave_size=self.cp_kv_cache_interleave_size,
+        max_num_batched_tokens=self.max_num_batched_tokens,
+        device=self.slot_mapping.gpu.device,
+    )
+    self.slot_mapping.gpu.copy_(result)
+
+
+def apply_slot_mapping_gcu_patch() -> None:
+    """Replace ``BlockTable.compute_slot_mapping`` with the on-device int32 version."""
+    global _patched
+    if _patched:
+        return
+
+    gcu = getattr(torch, "gcu", None)
+    if gcu is None or not gcu.is_available():
+        return
+
+    try:
+        import vllm.v1.worker.block_table as bt
+
+        bt.BlockTable.compute_slot_mapping = _compute_slot_mapping_torch
+        _patched = True
+        logger.info(
+            "Patched BlockTable.compute_slot_mapping for GCU "
+            "(on-device int32; avoids int64 Triton kernel)."
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Failed to patch compute_slot_mapping for GCU: %s", exc
+        )

--- a/vllm_fl/dispatch/backends/vendor/gcu/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/gcu/patch.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+import logging
+
+from .impl.bilinear_pos_embed import apply_bilinear_pos_embed_gcu_patch
+from .impl.chunk_delta_h import apply_chunk_delta_h_gcu_patch
+from .impl.fused_recurrent_packed_decode import (
+    apply_fused_recurrent_packed_decode_gcu_patch,
+)
+from .impl.slot_mapping import apply_slot_mapping_gcu_patch
+
+logger = logging.getLogger(__name__)
+_patches_applied = False
+
+
+def apply_gcu_patches() -> None:
+    """Apply all GCU-specific kernel / model monkey-patches."""
+    global _patches_applied
+    if _patches_applied:
+        return
+    
+    apply_bilinear_pos_embed_gcu_patch()
+    apply_chunk_delta_h_gcu_patch()
+    apply_fused_recurrent_packed_decode_gcu_patch()
+    apply_slot_mapping_gcu_patch()
+    _patches_applied = True
+
+
+def apply_op_kernel_patches() -> None:
+    """Alias kept for callers that use the older name."""
+    apply_gcu_patches()

--- a/vllm_fl/dispatch/config/gcu.yaml
+++ b/vllm_fl/dispatch/config/gcu.yaml
@@ -1,0 +1,64 @@
+# vLLM-FL Dispatch Configuration for GCU (Enflame / torch_gcu)
+
+prefer: flagos
+
+strict: false
+
+op_backends:
+  attention_backend:
+    - vendor:gcu
+    - flagos
+    - reference
+  rms_norm:
+    - flagos
+    - vendor:gcu
+    - reference
+  silu_and_mul:
+    - flagos
+    - vendor:gcu
+    - reference
+  rotary_embedding:
+    - flagos
+    - vendor:gcu
+    - reference
+
+flagos_blacklist:
+  - scaled_dot_product_attention
+  # GCU300 triton backend rejects 64-bit dtypes ("64-bit data type not
+  # supported on GCU300").  These input-prep / index ops run on int64 token
+  # positions / counts.  Blacklisting (matched by function __name__) makes
+  # FlagGems skip them so they fall back to torch_gcu, which transparently
+  # substitutes Long->Int.  Note zeroing routes through torch_gcu's factory
+  # wrapper -> zero_, so zero_ is the op that must be excluded (not just
+  # zeros/zeros_like).  Same rationale as ptg.yaml (another int32-only backend).
+  - sub
+  # sort: vLLM sampler's non-greedy path (topk_topp_sampler.apply_top_k_top_p ->
+  # logits.sort(dim=-1)) routes to FlagGems GCU300 radix_sort, whose sweep kernel
+  # scatter-store widens the pointer index to 64-bit (arith.extui) -> GCU300
+  # make_gcuir "failed to legalize arith.extui" -> PassManager execution failed.
+  # This is inside the kernel's address arithmetic, not a boundary cast, so it
+  # can't be intercepted by a torch-level int32 cast (unlike slot_mapping).
+  # Native torch_gcu sort is correct (returns int64 indices matching CPU), so
+  # blacklisting falls through to it.  Greedy sampling (temperature=0) skips
+  # sort entirely, which is why E2E passed without this; non-greedy needs it.
+  - sort
+  - sort_stable  # sort.stable overload (torch.Tensor.sort resolves here); excludes by func __name__
+  # rsub: top-p mask computes `1 - p`; the scalar `1` enters the FlagGems
+  # pointwise kernel as int64 -> same GCU300 "64-bit not supported" wall as sort.
+  # Both overloads (rsub.Scalar/rsub.Tensor) route through these funcs.
+  - rsub_scalar
+  - rsub_tensor
+  # argmax: random_sample's Gumbel-max pick is `probs.div(q).argmax(dim=-1)`.
+  # The FlagGems GCU300 argmax kernel (argmax.py:103) builds its bounds mask with
+  # Python `and` on tensors (`m_offset[:,None] < M and n_offset[None,:] < N`) —
+  # `and` is not elementwise, so the mask is wrong and argmax scans past the
+  # vocab, returning out-of-range token ids (observed 155374/153865 for a
+  # 151936-vocab model) -> degenerate output (".", "\n\n"). Greedy also argmaxes
+  # but over a full-width logits row where the winner is unambiguous, so it
+  # survived; non-greedy's peaked post-softmax distribution exposes it. torch_gcu
+  # argmax is correct, so blacklisting falls through to it.
+  - argmax
+  - add
+  - zeros
+  - zeros_like
+  - zero_

--- a/vllm_fl/dispatch/config/utils.py
+++ b/vllm_fl/dispatch/config/utils.py
@@ -75,10 +75,24 @@ def get_config_path(platform: Optional[str] = None) -> Optional[Path]:
     if platform is None:
         platform = get_platform_name()
 
-    # Try platform-specific config
+    # Try platform-specific config, keyed on vendor_name.
     config_file = _CONFIG_DIR / f"{platform}.yaml"
     if config_file.exists():
         return config_file
+
+    # Fall back to the device_name alias.  Some vendors ship a config named
+    # after their device family rather than their vendor_name (e.g. enflame's
+    # config is gcu.yaml, mthreads' is musa.yaml).  Without this the config
+    # (op_backends AND flagos_blacklist) silently fails to load.
+    try:
+        from vllm_fl.utils import get_device_name
+        device_name = get_device_name(platform)
+        if device_name and device_name != platform:
+            alias_file = _CONFIG_DIR / f"{device_name}.yaml"
+            if alias_file.exists():
+                return alias_file
+    except Exception:
+        pass
 
     return None
 


### PR DESCRIPTION
## Summary

Full enflame GCU300 backend enablement for vLLM-FL. Brings up `vllm serve` + inference on GCU300 with Qwen3-4B (TP=1), producing coherent output for both greedy and non-greedy sampling.

> **Depends on #353.** This branch is stacked on the `AttentionFLBackend` KV-cache fix; `GCUBackend`'s empty-wheel fallback routes attention through `AttentionFLBackend`, which needs #353 to write the KV cache. Until #353 merges, this PR's diff also shows the attention.py commit. **Please review/merge #353 first.**

## Changes

- **`gcu.py`** — `GCUBackend` vendor backend: op dispatchers (`silu_and_mul`, `rms_norm`, `rotary_embedding`) and an attention-backend selector that falls back to `AttentionFLBackend` when the empty vLLM wheel ships no compiled `_vllm_fa2_C`.
- **`gcu.yaml`** — dispatch config (`prefer: flagos`) with a comprehensive `flagos_blacklist` for GCU300's int32-only triton backend.
- **`slot_mapping.py`** — on-device int32 replacement for vLLM's int64 slot-mapping triton kernel (which hits the GCU300 64-bit wall). Uses `searchsorted` instead of `repeat_interleave` (whose GCU300 `index_select` caps `grid.y` at 255). Verified bit-identical to a CPU int64 reference on synthetic + live-serve inputs.
- **`patch.py`** — orchestrator applying all GCU kernel monkey-patches (bilinear pos embed, chunk_delta_h, fused_recurrent_packed_decode, slot_mapping).
- **`utils.py`** — `get_config_path()` device-name fallback so `gcu.yaml` (keyed on device name `gcu`) loads when `vendor_name` is `enflame`. Without it the config silently never loaded.

## Sampler root causes (all invisible to greedy E2E; non-greedy exposed them)

GCU300's triton backend rejects 64-bit dtypes and its FlagGems `argmax` kernel is buggy. Three distinct causes, all fixed by blacklisting the offending ops → torch_gcu fallback:

1. **`sort` / `sort_stable` / `rsub_scalar` / `rsub_tensor`** — int64 wall (crash). `apply_top_k_top_p_pytorch`'s `logits.sort()` and top-p `1 - p` route to FlagGems GCU300 kernels whose address arithmetic widens to 64-bit (`arith.extui`) → `make_gcuir` fails to legalize.
2. **`argmax`** — correctness bug (garbage output, no crash). `random_sample`'s `probs.div(q).argmax(-1)` uses FlagGems `argmax.py:103`, whose bounds mask is `m_offset[:,None] < M and n_offset[None,:] < N` — Python `and` on tensors is not elementwise, so the mask is wrong and argmax scans past the vocab, returning out-of-range token IDs (observed 155374/153865 for a 151936-vocab model). Greedy survived because its argmax runs over a full-width logits row with an unambiguous winner.
3. **Seeded requests** — *not fixed here.* torch_gcu's `exponential_()` rejects the `generator` kwarg, so requests with an explicit `seed` still crash in `random_sample`. Non-seeded non-greedy works. Needs a separate plugin patch or a documented limitation.

## Testing

`vllm serve` Qwen3-4B (TP=1, `--enforce-eager`) on GCU300 + curl:
- greedy (`temperature=0`): "Paris is the capital of France..."
- non-greedy (`temperature=0.8`, `top_p=0.9`, `top_k=20`, no seed): coherent — "in which country? The capital of France is Paris, which is located in France"

Standalone repro of the full `apply_top_k_top_p_pytorch` chain + `random_sample` at real vocab confirms the blacklist set is complete and sampling picks the correct token (peaked distribution: intended winner dominates, all indices in-vocab).

---
🤖 This PR was written in part with the assistance of generative AI.
