### PR TITLE
feat(cambricon): enable MLU590 + neuware4.4.3 serve compat

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -17,6 +17,64 @@ else:
         _torch.float4_e2m1fn_x2 = _torch.uint8
 del _torch
 
+# --- torch 2.7.1+cpu (cambricon 4.4.3) compat shims ---------------------
+
+import torch
+
+# torch-mlu registers `_C::get_mlu_view_from_cpu_tensor` as a
+# CompositeImplicitAutograd op that has no Python handle via torch.ops._C.
+# torch._export.utils._materialize_cpp_cia_ops() getattr()s every CIA op and
+# raises AttributeError on it, aborting torch._inductor init (first triggered
+# by vllm.utils.deep_gemm's module-level @torch.compile). Skip CIA ops the
+# dispatcher has no Python handle for.
+try:
+    import torch._export.utils as _export_utils
+
+    def _tolerant_materialize_cpp_cia_ops():
+        for op in torch._C._dispatch_get_registrations_for_dispatch_key(
+            "CompositeImplicitAutograd"
+        ):
+            namespace, full = tuple(op.split("::"))
+            parts = full.split(".")
+            name = parts[0]
+            overload = "default" if len(parts) == 1 else parts[1]
+            try:
+                _ = getattr(getattr(getattr(torch.ops, namespace), name), overload)
+            except AttributeError:
+                continue
+
+    _export_utils._materialize_cpp_cia_ops = _tolerant_materialize_cpp_cia_ops
+except Exception:
+    pass
+
+# flag_gems 5.3.5 populates current_work_registrar.torch_ops_map via
+# torch.library.get_kernel(), which only exists in torch 2.8+. torch 2.7.1+cpu
+# (cambricon 4.4.3) lacks it, so the map stays empty and the generated copy_
+# pre/post hooks raise KeyError: 'aten::copy_'. Provide a torch 2.7.1-compatible
+# get_kernel that redispatches to the native (CompositeExplicitAutograd) kernel.
+if not hasattr(torch.library, "get_kernel"):
+    _FALLBACK_KEYSET = torch._C.DispatchKeySet(
+        torch._C.DispatchKey.CompositeExplicitAutograd
+    )
+
+    class _RedispatchKernel:
+        def __init__(self, qualified_name):
+            self._qualified_name = qualified_name
+
+        def call_boxed(self, keyset, *args, **kwargs):
+            namespace, name = self._qualified_name.split("::")
+            op = getattr(getattr(torch.ops, namespace), name)
+            return op.default.redispatch(_FALLBACK_KEYSET, *args, **kwargs)
+
+    def _get_kernel(name_or_op, dispatch_key):
+        if isinstance(name_or_op, str):
+            qualified_name = name_or_op
+        else:
+            qualified_name = name_or_op._qualified_op_name
+        return _RedispatchKernel(qualified_name)
+
+    torch.library.get_kernel = _get_kernel
+
 from vllm_fl.utils import get_op_config as _get_op_config
 
 from . import version as version  # PyTorch-style: vllm_fl.version.git_version
@@ -184,3 +242,25 @@ def register_model():
         )
     except Exception as e:
         logger.error(f"Register DeepseekV4 model error: {str(e)}")
+
+
+# flag_gems 5.3.5 cambricon backend emits a task_type='block' triton launch
+# kwarg unsupported by triton 3.2.0+mlu1.7.2 (cambricon 4.4.3). Strip it from
+# JITFunction.run. torch_mlu must be imported first — its _inductor module
+# imports triton.Config during triton init, so patching triton earlier raises a
+# circular-import error. Guarded on torch_mlu importability (cambricon only).
+try:
+    import torch_mlu  # noqa: F401
+    import triton.runtime.jit as _tr_jit
+
+    _orig_run = _tr_jit.JITFunction.run
+    if not getattr(_orig_run, "_flagos_task_type_patched", False):
+
+        def _run_no_task_type(self, *args, **kwargs):
+            kwargs.pop("task_type", None)
+            return _orig_run(self, *args, **kwargs)
+
+        _run_no_task_type._flagos_task_type_patched = True
+        _tr_jit.JITFunction.run = _run_no_task_type
+except ImportError:
+    pass

--- a/vllm_fl/compilation/graph.py
+++ b/vllm_fl/compilation/graph.py
@@ -51,6 +51,8 @@ class Graph:
         graph = torch.ptpu.PTPUGraph
     elif current_platform.device_type == "gcu":
         graph = torch.gcu.GCUGraph
+    elif current_platform.device_type == "mlu":
+        graph = torch.mlu.MLUGraph
     elif current_platform.device_type == "txda":
         graph = None
     else:

--- a/vllm_fl/dispatch/config/cambricon.yaml
+++ b/vllm_fl/dispatch/config/cambricon.yaml
@@ -14,7 +14,15 @@ strict: false
 
 # FlagOS operator blacklist
 flagos_blacklist:
-  # flag_gems `empty` computes a Triton launch grid from the element count
-  # (e.g. 607744 for the Qwen3 vocab embedding), which exceeds the MLU Triton
-  # grid limit of 65535 and raises OutOfResources. Fall back to torch_mlu.
-  - empty
+  # flag_gems `index` (cambricon backend, ops/index.py) crashes E2E inside the
+  # vLLM inductor wrap: Triton's AutoTileForTritonPass fails with
+  # "'tensor.expand_shape' op expected dimension 0 of collapsed type to be
+  # static value of 4" during the flagtune bench of (15, 4096) shapes
+  # (BLOCK_SIZE0=4 / BLOCK_SIZE1=4096). The RuntimeError escapes the autotuner
+  # (not in its catch list), killing the EngineCore. Fall back to torch_mlu.
+  - index
+
+  # NOTE: `empty` used to be blacklisted here (flag_gems grid 607744 > 65535
+  # MLU Triton grid limit for the Qwen3 vocab embedding). The fix landed in
+  # flag_gems 5.3.4 (_cambricon/ops/empty.py: grid capped at TOTAL_CORE_NUM +
+  # grid-stride loop, PR #4435), so `empty` no longer needs a blacklist entry.

--- a/vllm_fl/dispatch/config/cambricon.yaml
+++ b/vllm_fl/dispatch/config/cambricon.yaml
@@ -1,0 +1,20 @@
+# vLLM-FL Dispatch Configuration for Cambricon MLU (torch_mlu)
+# Auto-loaded when running on Cambricon MLU hardware (vendor_name == "cambricon").
+#
+# There is no dedicated vendor/cambricon dispatch backend; ops route through
+# FlagOS (flag_gems, Triton). Only per-op exceptions are listed below.
+
+# Preferred default backend type: flagos, vendor, reference
+prefer: flagos
+
+# Strict Mode:
+#   true  = Raise an error immediately on failure; do not attempt other backends.
+#   false = Attempt the next available backend in sequence upon failure (Default).
+strict: false
+
+# FlagOS operator blacklist
+flagos_blacklist:
+  # flag_gems `empty` computes a Triton launch grid from the element count
+  # (e.g. 607744 for the Qwen3 vocab embedding), which exceeds the MLU Triton
+  # grid limit of 65535 and raises OutOfResources. Fall back to torch_mlu.
+  - empty

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -53,6 +53,8 @@ VENDOR_DEVICE_MAP: dict[str, dict[str, str]] = {
     "tsingmicro": {"device_type": "txda", "device_name": "txda"},
     # Registered backend: vendor/kunlunxin
     "kunlunxin": {"device_type": "cuda", "device_name": "kunlunxin"},
+    # Cambricon MLU (torch_mlu); ops dispatched via flag_gems
+    "cambricon": {"device_type": "mlu", "device_name": "mlu"},
 }
 
 

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -106,10 +106,12 @@ from vllm.platforms import current_platform
 
 
 def _accelerator_synchronize() -> None:
-    """Synchronize the current device, with MUSA compatibility."""
+    """Synchronize the current device, with MUSA and MLU compatibility."""
     if current_platform.device_type == "musa":
         import torch_musa
         torch_musa.synchronize()
+    elif current_platform.device_type == "mlu":
+        torch.mlu.synchronize()
     else:
         torch.accelerator.synchronize()
 


### PR DESCRIPTION
## What

Enable `vllm-plugin-FL` on Cambricon MLU (`torch_mlu`), verified end-to-end on both neuware stacks (4.7.2 and 4.4.3).

Five touchpoints:

1. **`vllm_fl/utils.py`** — register `cambricon → {device_type: mlu, device_name: mlu}` in `VENDOR_DEVICE_MAP` (otherwise `_get_vendor_device_field` raises `ValueError`).
2. **`vllm_fl/compilation/graph.py`** — select `torch.mlu.MLUGraph` for `device_type == "mlu"` (otherwise `Graph` raises `NotImplementedError`).
3. **`vllm_fl/dispatch/config/cambricon.yaml`** — built-in config auto-resolved by `vendor_name == "cambricon"`; blacklists flag_gems `index` (Triton `AutoTileForTritonPass` crash escapes the autotuner and kills EngineCore). `empty` was blacklisted here originally, but its grid-65535 fix landed in flag_gems 5.3.4, so the entry is dropped.
4. **`vllm_fl/__init__.py`** — three torch 2.7.1 / triton 3.2 shims for the 4.4.3 stack (torch 2.7.1+cpu, triton 3.2.0+mlu1.7.2, flag_gems 5.3.5):
   - tolerant `_materialize_cpp_cia_ops` (skip CIA ops with no Python handle),
   - `torch.library.get_kernel` shim (absent in 2.7.1; redispatch to native kernel),
   - strip `task_type` triton launch kwarg.
5. **`vllm_fl/worker/model_runner.py`** — route `mlu` devices to `torch.mlu.synchronize()`.

## Scope

No dedicated `vendor/cambricon` dispatch backend — ops route through flag_gems (Triton) generically; only per-op blacklist exceptions are listed.

## Verification

- **neuware 4.7.2** (`flagos-runtime-cambricon-neuware4.7.2:2.1.2`, MLU590, Qwen3-8B, vLLM 0.20.2+flagos): serve reaches startup complete; chat completions return 200 with coherent output, no env-var blacklist needed.
- **neuware 4.4.3** (`flagos-runtime-cambricon-neuware4.4.3`, MLU590, Qwen3-8B, vLLM 0.20.2+flagos): serve + `/v1/completions` return 200 with the three shims in `__init__.py`.

This PR was written in part with the assistance of generative AI.
