### PR TITLE
ascend: blacklist lift_fresh/_to_copy (coreDim=0 on scalar tensor init)

### DIFF
--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -117,6 +117,15 @@ flagos_blacklist:
   - _index_put_impl_
   # --- Reduction (argmax only - Invalid Runtime Function on NPU) ---
   - argmax
+  # --- Constant materialization (coreDim=0 kernel launch on scalar tensors) ---
+  # register_buffer("_k_scale", torch.tensor(1.0)) during model construction
+  # routes torch.tensor(scalar) through aten::lift_fresh; the FlagGems copy
+  # kernel computes a zero grid for a scalar/tiny tensor and the NPU aborts
+  # engine startup with "coreDim is invalid (value 0)". These are trivial
+  # copies, so falling back to torch_npu is lossless.
+  - lift_fresh
+  - lift_fresh_copy
+  - _to_copy
 
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.


### PR DESCRIPTION
Fixes #496

## Problem

`vllm serve` crashes during **EngineCore startup** on Ascend 910B4 (CANN 9.0.0) with:

```
RuntimeError: coreDim is invalid (value 0)
```

The traceback bottoms out in model construction at `register_buffer("_k_scale", torch.tensor(1.0, dtype=torch.float32))`. `torch.tensor(scalar)` materializes the constant via `aten::lift_fresh`, which FlagGems intercepts. Its copy kernel computes a **zero grid** for a scalar/tiny tensor, and the NPU rejects the launch with `coreDim=0` — aborting engine init before any inference runs.

## Fix

Add `lift_fresh`, `lift_fresh_copy`, and `_to_copy` to the ascend `flagos_blacklist`. These are trivial constant-materialization copies, so falling back to `torch_npu` is lossless.

## Verification

E2E on **ascend-cann9.0.0** (910B4 aarch64, Python 3.11, torch/torch_npu 2.10.0, triton 3.5.1, flag_gems 5.3.4):

- Before: EngineCore dies at startup with `coreDim=0`
- After: serve reaches `Application startup complete`; inference coherent — `"The capital of France is"` -> `" Paris. The capital of Germany is Berlin. The capital of Italy is Rome..."` (TP=1, `POST /v1/completions` 200 OK)

Config-only change; no code paths altered.
