### PR TITLE
[Kunlunxin] Fix garbled output with CUDA Graph

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
@@ -739,6 +739,12 @@ class KunlunxinAttentionBackendImpl(AttentionImpl[KunlunxinMetadata]):
         query = query.view(-1, self.num_heads, self.head_size)
         if output is None:
             output = torch.empty_like(query)
+        if (
+            attn_metadata is not None
+            and getattr(attn_metadata, "num_actual_tokens", None) is not None
+            and attn_metadata.num_actual_tokens < output.shape[0]
+        ):
+            output[attn_metadata.num_actual_tokens:].zero_()
         if attn_metadata is None:
             # Profiling run.
 


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->

### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->

### Description

Fix a garbled output issue when CUDA Graph is enabled in the Kunlunxin attention backend. The issue was caused by uninitialized values in the padded region of the attention output buffer.

### Related Issues

None.

### Changes

* Initialize the padding region of the attention output to zero when `num_actual_tokens` is smaller than the output buffer size.

### Testing

* Tested using the Zhiyuan test dataset.
* Ran `python run_eval_lms.py` and verified that the generated `results.json` contains correct results.

### Checklist

* [ ] I have run the existing tests and they pass
* [ ] I have added tests for my changes (if applicable)
* [ ] I have updated the documentation (if applicable)
