### PR TITLE
feat(ascend): add NPU device context, head_dim>192 attention fallback, and FLAGCX_PATH-free backend resolution

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/attention.py
@@ -28,6 +28,7 @@ from typing import Any, ClassVar, List, Optional, Tuple, Type
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionImpl,
@@ -719,6 +720,86 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 actual_seq_kvlen=attn_metadata.actual_seq_lengths_q,
             )[0]
 
+
+    def forward_sdpa(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_metadata: "AscendMetadata",
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        """NPU fusion attention fallback for unsupported head_dim.
+
+        The npu_fused_infer_attention_score and _npu_paged_attention kernels
+        only support head_dim in {64, 128, 192}. For head_dim=256 (e.g.
+        Qwen3.5 full attention), use npu_fusion_attention which supports
+        arbitrary head_dim.
+
+        query/key/value are TND layout: [num_tokens, num_heads, head_size].
+        output is also [num_tokens, num_heads, head_size].
+        """
+        num_tokens = query.shape[0]
+
+        if attn_metadata.attn_state == AscendAttentionState.PrefillNoCache:
+            # Single-sequence prefill: npu_fusion_attention with causal mask
+            q = query[:num_tokens].contiguous()  # [T, H, D]
+            k = key[:num_tokens].contiguous()    # [T, Hkv, D]
+            v = value[:num_tokens].contiguous()
+            attn_out = torch_npu.npu_fusion_attention(
+                query=q, key=k, value=v,
+                head_num=self.num_heads,
+                input_layout="TND",
+                scale=self.scale,
+                actual_seq_qlen=[num_tokens],
+                actual_seq_kvlen=[num_tokens],
+                sparse_mode=3,  # causal
+            )[0]
+            output[:num_tokens] = attn_out[:num_tokens]
+            return output
+
+        # Decode / chunked-prefill: gather KV from paged cache, per-sequence
+        k_cache = self.key_cache   # [num_blocks, block_size, Hkv, D]
+        v_cache = self.value_cache
+        _, block_size, _, _ = k_cache.shape
+        block_table = attn_metadata.block_tables
+        seq_lens = attn_metadata.seq_lens_list
+        actual_seq_q = attn_metadata.actual_seq_lengths_q
+
+        if actual_seq_q is None:
+            actual_seq_q = [1] * len(seq_lens)
+
+        idx = 0
+        for i, (seq_len, q_len) in enumerate(zip(seq_lens, actual_seq_q)):
+            if seq_len <= 0 or q_len <= 0:
+                idx += q_len
+                continue
+            blocks = block_table[i]
+            n_blocks = (seq_len + block_size - 1) // block_size
+            # Gather KV for this sequence: [seq_len, Hkv, D]
+            k_seq = k_cache[blocks[:n_blocks]].reshape(
+                -1, self.num_kv_heads, self.head_size)[:seq_len].contiguous()
+            v_seq = v_cache[blocks[:n_blocks]].reshape(
+                -1, self.num_kv_heads, self.head_size)[:seq_len].contiguous()
+
+            q_seq = query[idx:idx + q_len].contiguous()  # [q_len, H, D]
+
+            # sparse_mode: 3=causal (for prefill q_len>1), 0=no mask (decode q_len=1)
+            sparse_mode = 3 if q_len > 1 else 0
+            out_i = torch_npu.npu_fusion_attention(
+                query=q_seq, key=k_seq, value=v_seq,
+                head_num=self.num_heads,
+                input_layout="TND",
+                scale=self.scale,
+                actual_seq_qlen=[q_len],
+                actual_seq_kvlen=[seq_len],
+                sparse_mode=sparse_mode,
+            )[0]
+            output[idx:idx + q_len] = out_i[:q_len]
+            idx += q_len
+
+        return output
+
     def forward_impl(
         self,
         query: torch.Tensor,
@@ -731,8 +812,12 @@ class AscendAttentionBackendImpl(AttentionImpl):
         """Forward implementation dispatching to appropriate attention method."""
         num_tokens = query.shape[0]
 
-        # Use paged attention for decode-only state
-        if (attn_metadata.attn_state == AscendAttentionState.DecodeOnly
+        # head_dim > 192 is not supported by NPU fused attention kernels
+        # (only {64, 128, 192} are supported). Fall back to npu_fusion_attention.
+        if self.head_size > 192:
+            output = self.forward_sdpa(
+                query, key, value, attn_metadata, output)
+        elif (attn_metadata.attn_state == AscendAttentionState.DecodeOnly
                 and self.sliding_window is None):
             output = self.forward_paged_attention(query, attn_metadata, output)
         else:

--- a/vllm_fl/distributed/device_communicators/flagcx.py
+++ b/vllm_fl/distributed/device_communicators/flagcx.py
@@ -137,6 +137,8 @@ class PyFlagcxCommunicator:
             device_ctx = torch.device(self.device)
         elif self.device.type == "txda":
             device_ctx = torch.txda.device(self.device)
+        elif self.device.type == "npu":
+            device_ctx = torch.npu.device(self.device)
         else:
             device_ctx = torch.cuda.device(self.device)
 

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -51,18 +51,12 @@ dist_backend_dict = {
 def _resolve_flagcx_backend() -> bool:
     """Check whether the flagcx torch distributed backend is available."""
     flagcx_path = os.environ.get("FLAGCX_PATH")
-    if not flagcx_path:
-        return False
     try:
-        if flagcx_path not in sys.path:
+        if flagcx_path and flagcx_path not in sys.path:
             sys.path.insert(0, flagcx_path)
         import flagcx  # triggers _C.so load and backend registration
         return torch.distributed.is_backend_available("flagcx")
     except Exception:
-        logger.warning(
-            "FLAGCX_PATH=%s is set but flagcx torch backend could not be loaded.",
-            flagcx_path,
-        )
         return False
 
 


### PR DESCRIPTION
### PR Category
Vendor

### PR Type
Bug Fixes, New Features, Improvements

### Description

FlagOS vLLM plugin currently has three gaps that prevent Ascend NPU from running correctly:

1. **NPU device context missing in FlagCX communicator** — `PyFlagcxCommunicator` handles `musa`, `ptpu`, `txda` device types but not `npu`, causing `ValueError: Expected a cuda device, but got: npu:1` when initializing the FlagCX communicator on Ascend.

2. **head_dim > 192 silent failure in attention** — NPU `npu_fused_infer_attention_score` and `_npu_paged_attention` kernels only support head_dim ∈ {64, 128, 192}. Models with head_dim=256 (e.g. Qwen3.5/3.6 full attention layers) produce silently incorrect output (garbled text) instead of raising an error. The existing `patch.py` only patches the vision encoder (head_dim=72) but misses the text model's full attention layers.

3. **FLAGCX_PATH hard requirement** — `_resolve_flagcx_backend()` returns `False` immediately when `FLAGCX_PATH` env var is unset, even if the `flagcx` package (with bundled `libflagcx.so`) is properly installed. This forces users to manually set environment variables or persist them via conda activate.d scripts, unlike the standard pattern used by `torch`/`torch_npu` where `.so` files ship inside the Python package.

### Related Issues
N/A

### Changes

**1. `flagcx.py` — Add NPU device context branch**

```python
elif self.device.type == "npu":
    device_ctx = torch.npu.device(self.device)
```

Parallel to existing `musa`/`ptpu`/`txda` branches, uses `torch.npu.device()` instead of falling through to `torch.cuda.device()`.

**2. `attention.py` — Add `forward_sdpa()` fallback for head_dim > 192**

New method uses `torch_npu.npu_fusion_attention()` (supports arbitrary head_dim) instead of `npu_fused_infer_attention_score` (limited to {64, 128, 192}). Handles both prefill (single-sequence causal) and decode/chunked-prefill (per-sequence KV gather from paged cache) paths. Key implementation details:
- `npu_fusion_attention` returns a 7-tuple; `[0]` is the attention output
- `head_num` parameter is Q head count (not KV), GQA handled internally
- `sparse_mode=3` for causal mask (prefill), `sparse_mode=0` for no mask (decode)

`forward_impl()` dispatch adds a `if self.head_size > 192` branch before the existing decode/paged-attention logic.

**3. `platform.py` — Remove FLAGCX_PATH hard gate**

`_resolve_flagcx_backend()` no longer returns `False` when `FLAGCX_PATH` is unset. It attempts `import flagcx` directly (the `.so` is shipped inside the flagcx package directory by the build script), only using `FLAGCX_PATH` as a `sys.path` hint when set. This follows the same pattern as `torch`/`torch_npu`.

### Testing

**Environment**: Ascend 910B2C x86_64 / CANN 8.5.1 / Python 3.11 / torch 2.11.0 + torch_npu 2.11.0 / vllm 0.20.2

**Before fix**: 
- Multi-card TP>1 crashes with `RuntimeError: NCCL error` (FlagCX communicator not initialized)
- Single-card returns garbled Thai text (`"ตอบกลับ\n\n"`) instead of correct Chinese/English output

**After fix**:
- 4-card TP=4 launches successfully with `backend=flagcx`, `communicator=CommunicatorFL`
- Qwen3.6-35B-A3B returns correct output: `"Thinking Process:\n\n1. **Analyze the User's Input:** The"`
- `FLAGCX_PATH` unset → smoke test passes (`dist_backend=flagcx`, `communicator=CommunicatorFL`)

```bash
# Smoke test (without FLAGCX_PATH)
unset FLAGCX_PATH
python3 smoke_test.py
# [OK] FlagCX: dist_backend=flagcx, communicator=CommunicatorFL

# End-to-end
vllm serve <model_path> --enforce-eager --tensor-parallel-size 4
curl -s http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"qwen36","messages":[{"role":"user","content":"你好"}],"max_tokens":16}'
# → {"content":"Thinking Process:\n\n1. **Analyze the User's Input:** The"}
```

### Checklist
- [x] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
