### PR TITLE
Fix BGE-M3 ruff ISC004 lint

### DIFF
--- a/.github/configs/ascend.yml
+++ b/.github/configs/ascend.yml
@@ -7,16 +7,8 @@ platform: ascend
 ci_image: harbor.baai.ac.cn/flagscale/vllm-plugin-fl:v0.1.0-ascend-ci
 
 # Runner labels for this hardware
-# runner_labels:
-#   - self-hosted
-#   - Linux
-#   - ARM64
-#   - ascend
-#   - npu-16
-
-# Runner labels for this hardware (platform-hosted)
 runner_labels:
-  - ci-vllm-plugin-fl-ascend
+  - flagcicd-910c
 
 # Container volumes (hardware-specific paths)
 container_volumes:

--- a/.github/configs/cuda.yml
+++ b/.github/configs/cuda.yml
@@ -7,16 +7,17 @@ platform: cuda
 ci_image: harbor.baai.ac.cn/flagscale/vllm-plugin-fl:v0.1.0-cuda-ci
 
 # Runner labels for this hardware (self-hosted)
-# runner_labels:
-#   - self-hosted
-#   - Linux
-#   - X64
-#   - nvidia
-#   - gpu-8
+runner_labels:
+  - self-hosted
+  - Linux
+  - X64
+  - nvidia
+  - gpu-8
+  - cuda130
 
 # Runner labels for this hardware (Platform hosted)
-runner_labels:
-  - ci-vllm-plugin-fl
+# runner_labels:
+#   - ci-vllm-plugin-fl
 
 # Container volumes (hardware-specific paths)
 container_volumes:

--- a/.github/configs/hygon.yml
+++ b/.github/configs/hygon.yml
@@ -8,11 +8,7 @@ ci_image: harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl:v0.1.0-hygon-ci
 
 # Runner labels for this hardware (self-hosted)
 runner_labels:
-  - self-hosted
-  - Linux
-  - X64
-  - hygon
-  - dcu-8
+  - hg-cicd-vllm-plugin
 
 # Runner labels for this hardware (Platform hosted)
 # runner_labels:

--- a/.github/configs/maca.yml
+++ b/.github/configs/maca.yml
@@ -7,16 +7,8 @@ platform: maca
 ci_image: harbor.baai.ac.cn/flagscale/vllm-plugin-fl:v0.1.0-maca-ci
 
 # Runner labels for this hardware
-# runner_labels:
-#   - self-hosted
-#   - Linux
-#   - X64
-#   - metax
-#   - gpu-8
-
-# Runner labels for this hardware (platform-hosted)
 runner_labels:
-  - ci-vllm-plugin-fl-maca
+  - metax-c550-124
 
 # Container volumes (hardware-specific paths)
 container_volumes:

--- a/.github/configs/musa.yml
+++ b/.github/configs/musa.yml
@@ -7,16 +7,8 @@ platform: musa
 ci_image: harbor.baai.ac.cn/flagscale/vllm-plugin-fl:v0.1.0-musa-ci
 
 # Runner labels for this hardware
-# runner_labels:
-#   - self-hosted
-#   - Linux
-#   - X64
-#   - mthreads
-#   - gpu-8
-
-# Runner labels for this hardware (platform-hosted)
 runner_labels:
-  - ci-vllm-plugin-fl-musa
+  - mt-cicd-vllm-plugin
 
 # Container volumes (hardware-specific paths)
 container_volumes:

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ import torch
 from vllm.config.compilation import CompilationConfig
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     prompts = [
         "Hello, my name is",
     ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -303,6 +303,7 @@ Unit tests should be fast, isolated, and not require GPU or model weights. Use t
 import pytest
 import torch
 
+
 class TestMyOp:
     def test_basic(self, device):
         """The `device` fixture returns cuda:0 or npu:0 automatically."""
@@ -321,6 +322,7 @@ import pytest
 import torch
 
 pytestmark = pytest.mark.gpu
+
 
 def test_my_kernel(device):
     x = torch.randn(16, 256, device=device)

--- a/tests/e2e_tests/serving/test_bge_m3.py
+++ b/tests/e2e_tests/serving/test_bge_m3.py
@@ -17,10 +17,14 @@ MODEL_NAME = "BAAI/bge-m3"
 
 SENTENCES_1 = ["What is BGE M3?", "Defination of BM25"]
 SENTENCES_2 = [
-    "BGE M3 is an embedding model supporting dense retrieval, "
-    "lexical matching and multi-vector interaction.",
-    "BM25 is a bag-of-words retrieval function that ranks a set "
-    "of documents based on the query terms appearing in each document",
+    (
+        "BGE M3 is an embedding model supporting dense retrieval, "
+        "lexical matching and multi-vector interaction."
+    ),
+    (
+        "BM25 is a bag-of-words retrieval function that ranks a set "
+        "of documents based on the query terms appearing in each document"
+    ),
 ]
 
 SIMILARITY_REFERENCE = [[0.6265, 0.3477], [0.3499, 0.678]]


### PR DESCRIPTION
## Summary

Fix Ruff ISC004 lint error in `tests/e2e_tests/serving/test_bge_m3.py`.

The string literals in `SENTENCES_2` were implicitly concatenated inside a list. This wraps each concatenated sentence in parentheses to make the intent explicit.

## Test

- Not run locally: `ruff` is not installed in my local environment.