### PR TITLE
feat(hygon): support INT4 inference for Qwen3.6 and GLM-5.2

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -139,6 +139,22 @@ def register_router():
 
 def register_model():
     """Register FL-specific models not yet upstream."""
+
+    # Apply Hygon-specific GLM-5.2 compatibility patches only on Hygon.
+    from vllm.platforms import current_platform
+
+    if getattr(current_platform, "vendor_name", None) == "hygon":
+        from vllm_fl.patches.hygon_glm_kv_cache import apply_hygon_glm_kv_cache_patch
+        from vllm_fl.patches.glm_index_share import apply_glm_index_share_patches
+
+        try:
+            apply_hygon_glm_kv_cache_patch()
+            apply_glm_index_share_patches()
+        except Exception as e:
+            logger.exception(f"Apply GLM IndexShare patches failed: {str(e)}")
+            raise
+
+
     from vllm import ModelRegistry
 
     _register_flagcx_connector()

--- a/vllm_fl/dispatch/backends/flaggems/impl/sparse_mla.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/sparse_mla.py
@@ -1,0 +1,238 @@
+# Copyright 2026 BAAI. All rights reserved.
+
+"""FlagGems-backed sparse MLA integration for vLLM Plugin FL.
+
+This module adapts vLLM's ``FlashMLASparseBackend`` to the Hygon/BW1000
+runtime used by GLM-5.2.  It has three deliberately narrow responsibilities:
+
+1. expose sparse MLA through FL's ``CachedOp`` dispatch layer;
+2. bridge the GLM full/shared Indexer semantics from vLLM PR #45895 to the
+   vLLM 0.20.x constructor contract; and
+3. replace FlagGems' default sparse FlashMLA Triton candidates with a tile
+   that fits BW1000's per-workgroup shared-memory limit.
+
+The GLM sparse Indexer runs before this backend.  By the time
+``_bf16_flash_mla_kernel`` is called, ``topk_indices`` has already been
+converted from per-request logical token positions to physical KV-cache
+slots.  The kernel consumes BF16 query/KV tensors and returns the latent-value
+attention output; this module does not calculate Indexer logits or TopK.
+
+The FlagGems autotuner configuration is process-global.  It is changed lazily,
+only on Hygon, and only once per worker process.  Other platforms retain their
+existing FlagGems candidate list.
+"""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import ClassVar
+
+import torch
+import triton
+
+from vllm.config.cache import CacheDType
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backends.mla.flashmla_sparse import (
+    FlashMLASparseBackend,
+    FlashMLASparseImpl,
+)
+
+from vllm_fl.dispatch import CachedOp
+
+
+_flash_mla_sparse_fwd = CachedOp(
+    "flash_mla_sparse_fwd"
+)
+
+_hygon_sparse_config_lock = Lock()
+_hygon_sparse_configured = False
+
+
+def _configure_hygon_flashmla_sparse() -> None:
+    """Install the BW1000-safe sparse FlashMLA Triton configuration.
+
+    FlagGems currently provides BK=64/BH=64 candidates.  For GLM-5.2's BF16
+    DQK=576 path, that configuration requests 81,920 bytes of shared memory,
+    exceeding BW1000's 65,536-byte limit.
+
+    The platform guard prevents a Hygon-specific tuning decision from changing
+    sparse MLA behavior on other vendors.
+
+    The fast path avoids locking after initialization; the second check prevents
+    two threads from replacing the global candidate list concurrently during the
+    first invocation.
+    """
+
+    from vllm.platforms import current_platform
+
+    if getattr(current_platform, "vendor_name", None) != "hygon":
+        return
+
+    global _hygon_sparse_configured
+    if _hygon_sparse_configured:
+        return
+
+    with _hygon_sparse_config_lock:
+        if _hygon_sparse_configured:
+            return
+
+        from flag_gems.fused import flashmla_sparse
+
+        flashmla_sparse.triton_flash_mla_sparse_fwd.configs = [
+            triton.Config(
+                {"BK": 32, "BH": 32},
+                num_warps=8,
+                num_stages=2,
+            )
+        ]
+        _hygon_sparse_configured = True
+
+
+class _TopKBufferRef:
+    """Construction-only adapter for vLLM 0.20.x.
+
+    vLLM PR #45895 makes FlashMLASparseImpl accept topk_indices_buffer directly
+    when indexer is None.
+
+    vLLM 0.20.x still requires indexer.topk_indices_buffer.
+    This object exists only while calling the upstream constructor;
+    it is not installed into the model and owns no parameters/cache.
+    """
+
+    __slots__ = ("topk_indices_buffer",)
+
+    def __init__(
+        self,
+        topk_indices_buffer: torch.Tensor,
+    ) -> None:
+        self.topk_indices_buffer = topk_indices_buffer
+
+
+class SparseMLAFLImpl(FlashMLASparseImpl):
+    """Sparse MLA implementation with GLM sharing and BW1000 kernel support.
+
+    All metadata construction, logical-to-physical index conversion, and
+    higher-level sparse-attention control flow remain in the upstream
+    ``FlashMLASparseImpl``.  This subclass changes only the constructor bridge
+    needed by shared Indexer layers and the final BF16 kernel invocation.
+    """
+    def __init__(
+        self,
+        *args,
+        topk_indices_buffer: torch.Tensor | None = None,
+        indexer=None,
+        **kwargs,
+    ) -> None:
+        # Backport the semantic change from vLLM PR #45895:
+        #
+        #     indexer.topk_indices_buffer
+        #         if indexer is not None
+        #         else topk_indices_buffer
+        #
+        # Reuse the complete vLLM 0.20.x constructor instead of
+        # copying its implementation.
+        if indexer is None:
+            if topk_indices_buffer is None:
+                raise RuntimeError(
+                    "Sparse MLA requires either a physical "
+                    "Indexer or topk_indices_buffer."
+                )
+
+            upstream_indexer_arg = _TopKBufferRef(
+                topk_indices_buffer
+            )
+        else:
+            upstream_indexer_arg = indexer
+
+        super().__init__(
+            *args,
+            topk_indices_buffer=topk_indices_buffer,
+            indexer=upstream_indexer_arg,
+            **kwargs,
+        )
+
+    def _bf16_flash_mla_kernel(
+        self,
+        q: torch.Tensor,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        topk_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        _configure_hygon_flashmla_sparse()
+        num_tokens = q.shape[0]
+
+        kv = kv_c_and_k_pe_cache.view(
+            -1,
+            1,
+            kv_c_and_k_pe_cache.shape[-1],
+        )
+
+        if self.num_heads % self.prefill_padding != 0:
+            assert (
+                self.prefill_padding % self.num_heads == 0
+            )
+
+            q_padded = q.new_zeros(
+                (
+                    q.shape[0],
+                    self.prefill_padding,
+                    q.shape[2],
+                )
+            )
+
+            q_padded[
+                :, : self.num_heads, :
+            ] = q
+
+            q = q_padded
+
+        topk_indices = topk_indices.view(
+            num_tokens,
+            1,
+            -1,
+        )
+
+        out = torch.empty(
+            (
+                num_tokens,
+                q.shape[1],
+                self.kv_lora_rank,
+            ),
+            dtype=q.dtype,
+            device=q.device,
+        )
+
+        out, _, _ = _flash_mla_sparse_fwd(
+            q=q,
+            kv=kv,
+            indices=topk_indices,
+            sm_scale=self.softmax_scale,
+            attn_sink=None,
+            topk_length=None,
+            out=out,
+        )
+
+        return out[:, : self.num_heads, :]
+
+
+class SparseMLAFLBackend(FlashMLASparseBackend):
+    supported_kv_cache_dtypes: ClassVar[
+        list[CacheDType]
+    ] = [
+        "auto",
+        "bfloat16",
+    ]
+
+    @staticmethod
+    def get_name() -> str:
+        return "FL_SPARSE_MLA"
+
+    @staticmethod
+    def get_impl_cls():
+        return SparseMLAFLImpl
+
+    @classmethod
+    def supports_compute_capability(
+        cls,
+        capability: DeviceCapability,
+    ) -> bool:
+        return True

--- a/vllm_fl/dispatch/backends/vendor/hygon/hygon.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/hygon.py
@@ -129,7 +129,26 @@ class HygonBackend(Backend):
 
         if use_mla:
             if use_sparse:
-                return AttentionBackendEnum.ROCM_AITER_MLA_SPARSE.get_path()
+                sparse_backend = os.environ.get(
+                    "VLLM_FL_HYGON_SPARSE_MLA_BACKEND",
+                    "aiter",
+                ).strip().lower()
+
+                if sparse_backend == "aiter":
+                    return AttentionBackendEnum.ROCM_AITER_MLA_SPARSE.get_path()
+                # Keep AITER as the default for backward compatibility with existing
+                # Hygon deployments. GLM-5.2 on BW1000 can explicitly select the
+                # validated FL/FlagGems path through the environment variable.
+                if sparse_backend == "flag_gems":
+                    return (
+                        "vllm_fl.dispatch.backends.flaggems.impl.sparse_mla."
+                        "SparseMLAFLBackend"
+                    )
+
+                raise ValueError(
+                    "Unsupported VLLM_FL_HYGON_SPARSE_MLA_BACKEND value: "
+                    f"{sparse_backend!r}. Expected 'aiter' or 'flag_gems'."
+                )
 
             from vllm._aiter_ops import rocm_aiter_ops
 
@@ -255,4 +274,103 @@ class HygonBackend(Backend):
             routed_scaling_factor,
             bias,
             scoring_func,
+        )
+
+    def glm_hygon_indexer_fp8_mqa_logits(
+        self,
+        q,
+        kv,
+        weights,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        clean_logits,
+    ):
+        """Compute GLM Indexer logits for the prefill phase.
+
+        """
+        from .impl.indexer_mqa import glm_hygon_indexer_fp8_mqa_logits
+
+        return glm_hygon_indexer_fp8_mqa_logits(
+            q,
+            kv,
+            weights,
+            cu_seqlen_ks,
+            cu_seqlen_ke,
+            clean_logits,
+        )
+
+    def glm_hygon_indexer_fp8_paged_mqa_logits(
+        self,
+        q,
+        kv_cache,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+        head_dim,
+        quant_block_size,
+    ):
+        from .impl.indexer_mqa import (
+            glm_hygon_indexer_fp8_paged_mqa_logits,
+        )
+
+        return glm_hygon_indexer_fp8_paged_mqa_logits(
+            q,
+            kv_cache,
+            weights,
+            context_lens,
+            block_tables,
+            max_model_len,
+            head_dim,
+            quant_block_size,
+        )
+
+    def glm_hygon_top_k_per_row_prefill(
+        self,
+        logits,
+        row_starts,
+        row_ends,
+        indices,
+        num_rows,
+        stride0,
+        stride1,
+        topk_tokens,
+    ):
+        from .impl.top_k_per_row import glm_hygon_top_k_per_row_prefill
+
+        return glm_hygon_top_k_per_row_prefill(
+            logits,
+            row_starts,
+            row_ends,
+            indices,
+            num_rows,
+            stride0,
+            stride1,
+            topk_tokens,
+        )
+
+    def glm_hygon_top_k_per_row_decode(
+        self,
+        logits,
+        next_n,
+        seq_lens,
+        indices,
+        num_rows,
+        stride0,
+        stride1,
+        topk_tokens,
+        max_seq_len,
+    ):
+        from .impl.top_k_per_row import glm_hygon_top_k_per_row_decode
+
+        return glm_hygon_top_k_per_row_decode(
+            logits,
+            next_n,
+            seq_lens,
+            indices,
+            num_rows,
+            stride0,
+            stride1,
+            topk_tokens,
+            max_seq_len,
         )

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/indexer_mqa.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/indexer_mqa.py
@@ -1,0 +1,721 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon MQA-logits implementations for the GLM-5.2 V3.2 FP8 Indexer.
+
+Prefill reuses the installed FlagGems ``fp8_mqa_logits`` implementation.
+
+Decode cannot directly reuse FlagGems ``fp8_paged_mqa_logits`` because the
+vLLM V3.2 Indexer cache uses a split layout inside every physical block:
+
+    [all token FP8 K values][all token FP32 scales]
+
+whereas FlagGems' paged op expects an interleaved per-token layout.
+
+The decode kernel below keeps the existing vLLM/FlagGems cache writer
+unchanged and only changes how paged MQA reads K values and scales.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+# ------------------------------------------------------------
+# Functional bring-up configuration for GLM-5.2 / BW1000.
+#
+# GLM-5.2 V3.2 Indexer:
+#
+#   index_n_heads = 64
+#   index_head_dim = 128
+#
+# Keep these tiles conservative until correctness is established.
+# ------------------------------------------------------------
+
+_BLOCK_KV = 16
+_BLOCK_D = 128
+_BLOCK_H = 16
+
+
+def _cdiv(
+    x: int,
+    y: int,
+) -> int:
+    return (x + y - 1) // y
+
+
+def glm_hygon_indexer_fp8_mqa_logits(
+    q: torch.Tensor,
+    kv: tuple[
+        torch.Tensor,
+        torch.Tensor,
+    ],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool,
+) -> torch.Tensor:
+    """Prefill FP8 MQA logits using the installed FlagGems kernel."""
+
+    from flag_gems.ops.fp8_mqa_logits import fp8_mqa_logits
+
+    return fp8_mqa_logits(
+        q,
+        kv,
+        weights,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        clean_logits,
+    )
+
+
+# ============================================================
+# Decode
+# ============================================================
+
+@triton.jit
+def _fill_neg_inf_kernel(
+    out_ptr,
+    n_elements,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    offsets = (
+        pid * BLOCK
+        + tl.arange(0, BLOCK)
+    )
+
+    mask = offsets < n_elements
+
+    tl.store(
+        out_ptr + offsets,
+        float("-inf"),
+        mask=mask,
+    )
+
+
+@triton.jit
+def _glm_hygon_fp8_paged_mqa_logits_kernel(
+    q_ptr,
+    kv_ptr,
+    weights_ptr,
+    logits_ptr,
+    block_tables_ptr,
+    context_lens_ptr,
+    stride_qb,
+    stride_qn,
+    stride_qh,
+    stride_qd,
+    stride_kvblk,
+    stride_wrow,
+    stride_wh,
+    stride_lrow,
+    stride_lcol,
+    stride_btb,
+    stride_bts,
+    next_n: tl.constexpr,
+    heads: tl.constexpr,
+    dim: tl.constexpr,
+    block_size: tl.constexpr,
+    max_model_len,
+    BLOCK_KV: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """Paged FP8 MQA for vLLM V3.2 split-layout Indexer cache."""
+
+    pid_row = tl.program_id(0)
+    pid_kv_tile = tl.program_id(1)
+
+    batch_idx = (
+        pid_row // next_n
+    )
+
+    next_n_idx = (
+        pid_row % next_n
+    )
+
+    # context_lens_ptr stores one final sequence length per request.
+    #
+    # For speculative decode:
+    #
+    # token 0 attends to L-next_n+1
+    # token 1 attends to L-next_n+2
+    # ...
+    # token next_n-1 attends to L
+    final_context_len = tl.load(
+        context_lens_ptr + batch_idx
+    )
+
+    query_seq_pos = (
+        final_context_len
+        - next_n
+        + next_n_idx
+    )
+
+    effective_context_len = (
+        query_seq_pos + 1
+    )
+
+    kv_start = (
+        pid_kv_tile * BLOCK_KV
+    )
+
+    offs_kv = tl.arange(
+        0,
+        BLOCK_KV,
+    )
+
+    kv_global_pos = (
+        kv_start + offs_kv
+    )
+
+    valid_kv = (
+        (kv_global_pos < effective_context_len)
+        & (kv_global_pos < max_model_len)
+    )
+
+    # --------------------------------------------------------
+    # Logical token position -> paged physical block.
+    # --------------------------------------------------------
+
+    logical_block_idx = (
+        kv_global_pos // block_size
+    )
+
+    intra_block_pos = (
+        kv_global_pos % block_size
+    )
+
+    phys_block_ids = tl.load(
+        block_tables_ptr
+        + batch_idx * stride_btb
+        + logical_block_idx * stride_bts,
+        mask=valid_kv,
+        other=0,
+    )
+
+    # --------------------------------------------------------
+    # V3.2 Indexer physical layout.
+    #
+    # kv_cache nominal tensor:
+    #
+    #   [num_blocks, block_size, head_dim + 4]
+    #
+    # But indexer_k_quant_and_cache flattens every block and stores:
+    #
+    #   values:
+    #       block_size * head_dim bytes
+    #
+    #   scales:
+    #       block_size * 4 bytes
+    #
+    # Therefore:
+    #
+    # block:
+    #
+    #   [K0][K1] ... [K(block_size-1)]
+    #   [S0][S1] ... [S(block_size-1)]
+    # --------------------------------------------------------
+
+    block_base = (
+        phys_block_ids.to(tl.int64)
+        * stride_kvblk
+    )
+
+    value_base = (
+        block_base
+        + intra_block_pos.to(tl.int64)
+        * dim
+    )
+
+    scale_base = (
+        block_base
+        + block_size * dim
+        + intra_block_pos.to(tl.int64)
+        * 4
+    )
+
+    # --------------------------------------------------------
+    # Load one FP32 scale.
+    #
+    # kv_ptr is uint8. Reinterpret the four bytes at scale_base
+    # as one uint32, then bitcast to float32.
+    # --------------------------------------------------------
+
+    scale_ptr = (
+        kv_ptr + scale_base
+    ).to(
+        tl.pointer_type(
+            tl.uint32,
+            1,
+        ),
+        bitcast=True,
+    )
+
+    scale_u32 = tl.load(
+        scale_ptr,
+        mask=valid_kv,
+        other=0,
+    )
+
+    k_scale = scale_u32.to(
+        tl.float32,
+        bitcast=True,
+    )
+
+    # --------------------------------------------------------
+    # Load FP8 K.
+    # --------------------------------------------------------
+
+    offs_d = tl.arange(
+        0,
+        BLOCK_D,
+    )
+
+    d_mask = offs_d < dim
+
+    kv_byte_ptrs = (
+        kv_ptr
+        + value_base[:, None]
+        + offs_d[None, :]
+    )
+
+    kv_u8 = tl.load(
+        kv_byte_ptrs,
+        mask=(
+            valid_kv[:, None]
+            & d_mask[None, :]
+        ),
+        other=0,
+    )
+
+    # Current BW1000 PlatformFL reports:
+    #
+    #   torch.float8_e4m3fn
+    #
+    # Reinterpret raw cache bytes as E4M3 FP8.
+    kv_fp8 = kv_u8.to(
+        tl.float8e4nv,
+        bitcast=True,
+    )
+
+    kv_f32 = kv_fp8.to(
+        tl.float32
+    )
+
+    # --------------------------------------------------------
+    # Query row.
+    # --------------------------------------------------------
+
+    q_base = (
+        q_ptr
+        + batch_idx * stride_qb
+        + next_n_idx * stride_qn
+    )
+
+    logit_accum = tl.zeros(
+        [BLOCK_KV],
+        dtype=tl.float32,
+    )
+
+    # --------------------------------------------------------
+    # Iterate Indexer heads.
+    #
+    # score[n] =
+    #
+    #   sum_h(
+    #       relu(
+    #           dot(q[h], k[n])
+    #       )
+    #       * weights[h]
+    #   )
+    # --------------------------------------------------------
+
+    for h_start in tl.static_range(
+        0,
+        heads,
+        BLOCK_H,
+    ):
+        offs_h = (
+            h_start
+            + tl.arange(
+                0,
+                BLOCK_H,
+            )
+        )
+
+        h_mask = offs_h < heads
+
+        q_ptrs = (
+            q_base
+            + offs_h[:, None]
+            * stride_qh
+            + offs_d[None, :]
+            * stride_qd
+        )
+
+        q_vals = tl.load(
+            q_ptrs,
+            mask=(
+                h_mask[:, None]
+                & d_mask[None, :]
+            ),
+            other=0.0,
+        ).to(
+            tl.float32
+        )
+
+        row_weights = tl.load(
+            weights_ptr
+            + pid_row * stride_wrow
+            + offs_h * stride_wh,
+            mask=h_mask,
+            other=0.0,
+        ).to(
+            tl.float32
+        )
+
+        # [BLOCK_KV, D]
+        #     @
+        # [D, BLOCK_H]
+        #
+        # ->
+        #
+        # [BLOCK_KV, BLOCK_H]
+        partial_dot = tl.dot(
+            kv_f32,
+            tl.trans(q_vals),
+            out_dtype=tl.float32,
+        )
+
+        # K quantization scale.
+        partial_dot = (
+            partial_dot
+            * k_scale[:, None]
+        )
+
+        partial_dot = tl.maximum(
+            partial_dot,
+            0.0,
+        )
+
+        logit_accum += tl.sum(
+            partial_dot
+            * row_weights[None, :],
+            axis=1,
+        )
+
+    # --------------------------------------------------------
+    # Store valid context positions only.
+    # Other positions were initialized to -inf.
+    # --------------------------------------------------------
+
+    out_ptrs = (
+        logits_ptr
+        + pid_row * stride_lrow
+        + kv_global_pos
+        * stride_lcol
+    )
+
+    tl.store(
+        out_ptrs,
+        logit_accum,
+        mask=valid_kv,
+    )
+
+
+def glm_hygon_indexer_fp8_paged_mqa_logits(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+    head_dim: int,
+    quant_block_size: int,
+) -> torch.Tensor:
+    """Decode FP8 paged MQA from the V3.2 split-layout Indexer cache."""
+
+    # --------------------------------------------------------
+    # Input validation.
+    # --------------------------------------------------------
+
+    if q.ndim != 4:
+        raise ValueError(
+            "q must have shape "
+            "[batch, next_n, heads, head_dim], "
+            f"but got {tuple(q.shape)}."
+        )
+
+    if kv_cache.ndim != 3:
+        raise ValueError(
+            "kv_cache must have shape "
+            "[num_blocks, block_size, head_dim + 4], "
+            f"but got {tuple(kv_cache.shape)}."
+        )
+
+    if kv_cache.dtype != torch.uint8:
+        raise TypeError(
+            "GLM Hygon Indexer KV cache must "
+            "be uint8, "
+            f"but got {kv_cache.dtype}."
+        )
+
+    # Keep the initial Hygon implementation deliberately narrow.
+    #
+    # Your current probe reports:
+    #
+    #   current_platform.fp8_dtype()
+    #   == torch.float8_e4m3fn
+    #
+    # Do not silently interpret another FP8 encoding as E4M3FN.
+    if q.dtype != torch.float8_e4m3fn:
+        raise TypeError(
+            "GLM Hygon paged MQA currently "
+            "expects torch.float8_e4m3fn, "
+            f"but got {q.dtype}."
+        )
+
+    if quant_block_size != head_dim:
+        raise NotImplementedError(
+            "GLM Hygon paged MQA currently "
+            "supports one FP32 scale per K "
+            "vector: quant_block_size == head_dim."
+        )
+
+    (
+        batch_size,
+        next_n,
+        heads,
+        dim,
+    ) = q.shape
+
+    (
+        _,
+        block_size,
+        cache_width,
+    ) = kv_cache.shape
+
+    if dim != head_dim:
+        raise ValueError(
+            f"q head dim {dim} does not match "
+            f"head_dim={head_dim}."
+        )
+
+    # First implementation intentionally specializes GLM-5.2's
+    # index_head_dim=128.
+    if head_dim != _BLOCK_D:
+        raise NotImplementedError(
+            "The initial GLM Hygon paged MQA "
+            "kernel is specialized for "
+            f"head_dim={_BLOCK_D}, "
+            f"but got {head_dim}."
+        )
+
+    expected_cache_width = (
+        head_dim + 4
+    )
+
+    if cache_width != expected_cache_width:
+        raise ValueError(
+            "Unexpected V3.2 Indexer cache width: "
+            f"expected {expected_cache_width}, "
+            f"got {cache_width}."
+        )
+
+    expected_weights_shape = (
+        batch_size * next_n,
+        heads,
+    )
+
+    if weights.shape != expected_weights_shape:
+        raise ValueError(
+            "weights must have shape "
+            f"{expected_weights_shape}, "
+            f"but got {tuple(weights.shape)}."
+        )
+
+    if block_tables.ndim != 2:
+        raise ValueError(
+            "block_tables must be 2D, "
+            f"but got ndim={block_tables.ndim}."
+        )
+
+    if block_tables.shape[0] < batch_size:
+        raise ValueError(
+            "block_tables has fewer rows "
+            "than decode batch size."
+        )
+
+    # --------------------------------------------------------
+    # Normalize vLLM seq_lens.
+    #
+    # Normal decode:
+    #
+    #   [B]
+    # or
+    #   [B, 1]
+    #
+    # Native speculative decode:
+    #
+    #   [B, next_n]
+    #
+    # The final column stores the final context length.
+    # The Triton kernel reconstructs the preceding per-token
+    # lengths using next_n.
+    # --------------------------------------------------------
+
+    if context_lens.ndim == 2:
+        if context_lens.shape[0] < batch_size:
+            raise ValueError(
+                "context_lens has fewer rows "
+                "than decode batch size."
+            )
+
+        context_lens_1d = (
+            context_lens[
+                :batch_size,
+                -1,
+            ]
+        )
+
+    elif context_lens.ndim == 1:
+        if context_lens.shape[0] < batch_size:
+            raise ValueError(
+                "context_lens has fewer elements "
+                "than decode batch size."
+            )
+
+        context_lens_1d = (
+            context_lens[
+                :batch_size
+            ]
+        )
+
+    else:
+        raise ValueError(
+            "context_lens must be 1D or 2D, "
+            f"but got ndim={context_lens.ndim}."
+        )
+
+    if context_lens_1d.dtype != torch.int32:
+        raise TypeError(
+            "context_lens must be int32, "
+            f"but got {context_lens_1d.dtype}."
+        )
+
+    if block_tables.dtype != torch.int32:
+        raise TypeError(
+            "block_tables must be int32, "
+            f"but got {block_tables.dtype}."
+        )
+
+    if not kv_cache.is_contiguous():
+        raise ValueError(
+            "GLM Hygon Indexer KV cache "
+            "must be contiguous."
+        )
+
+    q_contig = q.contiguous()
+
+    weights_contig = (
+        weights.contiguous()
+    )
+
+    context_lens_contig = (
+        context_lens_1d.contiguous()
+    )
+
+    block_tables_contig = (
+        block_tables[
+            :batch_size
+        ].contiguous()
+    )
+
+    total_rows = (
+        batch_size * next_n
+    )
+
+    # --------------------------------------------------------
+    # Output.
+    # --------------------------------------------------------
+
+    logits = torch.empty(
+        (
+            total_rows,
+            max_model_len,
+        ),
+        device=q.device,
+        dtype=torch.float32,
+    )
+
+    # Positions outside valid context stay -inf.
+    n_elements = (
+        total_rows * max_model_len
+    )
+
+    fill_block = 1024
+
+    _fill_neg_inf_kernel[
+        (
+            _cdiv(
+                n_elements,
+                fill_block,
+            ),
+        )
+    ](
+        logits,
+        n_elements,
+        BLOCK=fill_block,
+    )
+
+    # Maximum logical KV positions addressable by block table.
+    max_context = (
+        block_tables_contig.shape[1]
+        * block_size
+    )
+
+    grid = (
+        total_rows,
+        _cdiv(
+            max_context,
+            _BLOCK_KV,
+        ),
+    )
+
+    _glm_hygon_fp8_paged_mqa_logits_kernel[
+        grid
+    ](
+        q_contig,
+        kv_cache,
+        weights_contig,
+        logits,
+        block_tables_contig,
+        context_lens_contig,
+        q_contig.stride(0),
+        q_contig.stride(1),
+        q_contig.stride(2),
+        q_contig.stride(3),
+        kv_cache.stride(0),
+        weights_contig.stride(0),
+        weights_contig.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        block_tables_contig.stride(0),
+        block_tables_contig.stride(1),
+        next_n,
+        heads,
+        dim,
+        block_size,
+        max_model_len,
+        BLOCK_KV=_BLOCK_KV,
+        BLOCK_D=_BLOCK_D,
+        BLOCK_H=_BLOCK_H,
+        num_warps=4,
+        num_stages=1,
+    )
+
+    return logits

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/top_k_per_row.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/top_k_per_row.py
@@ -1,0 +1,438 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""GLM-Hygon prefill and decode Top-K helpers."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _mask_outside_row_kernel(
+    logits_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    stride_row,
+    width: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    block = tl.program_id(1)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+    row_start = tl.load(row_starts_ptr + row)
+    row_end = tl.load(row_ends_ptr + row)
+    mask = offsets < width
+    values = tl.load(
+        logits_ptr + row * stride_row + offsets,
+        mask=mask,
+        other=-float("inf"),
+    )
+    values = tl.where(
+        (offsets >= row_start) & (offsets < row_end),
+        values,
+        -float("inf"),
+    )
+    tl.store(
+        logits_ptr + row * stride_row + offsets,
+        values,
+        mask=mask,
+    )
+
+
+@triton.jit
+def _store_relative_indices_kernel(
+    selected_ptr,
+    output_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    selected_stride,
+    output_stride,
+    effective_k: tl.constexpr,
+    topk_tokens: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK)
+    selected_mask = offsets < effective_k
+    absolute_indices = tl.load(
+        selected_ptr + row * selected_stride + offsets,
+        mask=selected_mask,
+        other=-1,
+    )
+    row_start = tl.load(row_starts_ptr + row)
+    row_end = tl.load(row_ends_ptr + row)
+    valid = (
+        selected_mask
+        & (absolute_indices >= row_start)
+        & (absolute_indices < row_end)
+    )
+    relative_indices = tl.where(
+        valid,
+        absolute_indices - row_start,
+        -1,
+    ).to(tl.int32)
+    tl.store(
+        output_ptr + row * output_stride + offsets,
+        relative_indices,
+        mask=offsets < topk_tokens,
+    )
+
+
+@triton.jit
+def _fill_all_valid_relative_indices_kernel(
+    output_ptr,
+    row_starts_ptr,
+    row_ends_ptr,
+    output_stride,
+    topk_tokens: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Emit every request-local index for a full-selection row."""
+
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK)
+    row_start = tl.load(row_starts_ptr + row)
+    row_end = tl.load(row_ends_ptr + row)
+    valid_length = tl.maximum(row_end - row_start, 0)
+    values = tl.where(
+        offsets < valid_length,
+        offsets,
+        -1,
+    ).to(tl.int32)
+    tl.store(
+        output_ptr + row * output_stride + offsets,
+        values,
+        mask=offsets < topk_tokens,
+    )
+
+
+@triton.jit
+def _fill_all_valid_decode_indices_kernel(
+    output_ptr,
+    seq_lens_ptr,
+    output_stride,
+    NEXT_N: tl.constexpr,
+    SEQ_LENS_2D: tl.constexpr,
+    topk_tokens: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Match vLLM's decode shortcut when a row has at most Top-K items."""
+
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK)
+
+    if SEQ_LENS_2D:
+        valid_length = tl.load(seq_lens_ptr + row)
+    else:
+        batch_idx = row // NEXT_N
+        next_n_idx = row % NEXT_N
+        seq_len = tl.load(seq_lens_ptr + batch_idx)
+        valid_length = tl.maximum(
+            seq_len - NEXT_N + next_n_idx + 1,
+            0,
+        )
+
+    values = tl.where(
+        offsets < valid_length,
+        offsets,
+        -1,
+    ).to(tl.int32)
+    tl.store(
+        output_ptr + row * output_stride + offsets,
+        values,
+        mask=offsets < topk_tokens,
+    )
+
+
+@triton.jit
+def _mask_outside_decode_row_kernel(
+    logits_ptr,
+    seq_lens_ptr,
+    stride_row,
+    NEXT_N: tl.constexpr,
+    SEQ_LENS_2D: tl.constexpr,
+    width: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Mask positions outside each decode row's request-local length."""
+
+    row = tl.program_id(0)
+    block = tl.program_id(1)
+    offsets = block * BLOCK + tl.arange(0, BLOCK)
+
+    if SEQ_LENS_2D:
+        valid_length = tl.load(seq_lens_ptr + row)
+    else:
+        batch_idx = row // NEXT_N
+        next_n_idx = row % NEXT_N
+        seq_len = tl.load(seq_lens_ptr + batch_idx)
+        valid_length = tl.maximum(
+            seq_len - NEXT_N + next_n_idx + 1,
+            0,
+        )
+
+    in_width = offsets < width
+    values = tl.load(
+        logits_ptr + row * stride_row + offsets,
+        mask=in_width,
+        other=-float("inf"),
+    )
+    values = tl.where(
+        offsets < valid_length,
+        values,
+        -float("inf"),
+    )
+    tl.store(
+        logits_ptr + row * stride_row + offsets,
+        values,
+        mask=in_width,
+    )
+
+
+@triton.jit
+def _store_decode_selected_indices_kernel(
+    selected_ptr,
+    output_ptr,
+    seq_lens_ptr,
+    selected_stride,
+    output_stride,
+    NEXT_N: tl.constexpr,
+    SEQ_LENS_2D: tl.constexpr,
+    effective_k: tl.constexpr,
+    topk_tokens: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Store valid request-local decode indices and pad the rest with -1."""
+
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK)
+
+    if SEQ_LENS_2D:
+        valid_length = tl.load(seq_lens_ptr + row)
+    else:
+        batch_idx = row // NEXT_N
+        next_n_idx = row % NEXT_N
+        seq_len = tl.load(seq_lens_ptr + batch_idx)
+        valid_length = tl.maximum(
+            seq_len - NEXT_N + next_n_idx + 1,
+            0,
+        )
+
+    selected_mask = offsets < effective_k
+    selected = tl.load(
+        selected_ptr + row * selected_stride + offsets,
+        mask=selected_mask,
+        other=-1,
+    )
+    valid = (
+        selected_mask
+        & (selected >= 0)
+        & (selected < valid_length)
+    )
+    values = tl.where(valid, selected, -1).to(tl.int32)
+    tl.store(
+        output_ptr + row * output_stride + offsets,
+        values,
+        mask=offsets < topk_tokens,
+    )
+
+
+def glm_hygon_top_k_per_row_prefill(
+    logits: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    topk_tokens: int,
+) -> None:
+    """Select request-local positions and pad unused slots with ``-1``.
+
+    The FlagGems implementation raises when ``topk_tokens > logits.shape[1]``.
+    GLM commonly has K=2048 with fewer candidates during initial prefill. Select
+    only
+    ``min(K, width)`` candidates, keep valid entries first, convert them to
+    request-local positions, and fill the unused output slots with -1.
+    """
+
+    if logits.ndim != 2:
+        raise ValueError("logits must be a 2D tensor")
+    if indices.ndim != 2:
+        raise ValueError("indices must be a 2D tensor")
+    if logits.dtype != torch.float32:
+        raise TypeError("logits must be float32")
+    if indices.dtype != torch.int32:
+        raise TypeError("indices must be int32")
+    if row_starts.dtype != torch.int32 or row_ends.dtype != torch.int32:
+        raise TypeError("row starts/ends must be int32")
+    if stride1 != 1 or logits.stride(1) != 1:
+        raise ValueError("logits must be contiguous in its last dimension")
+    if num_rows <= 0 or topk_tokens <= 0:
+        return
+    if logits.shape[0] < num_rows or indices.shape[0] < num_rows:
+        raise ValueError("num_rows exceeds input/output rows")
+    if indices.shape[1] < topk_tokens:
+        raise ValueError("indices width is smaller than topk_tokens")
+
+    width = logits.shape[1]
+    effective_k = min(topk_tokens, width)
+    if effective_k <= 0:
+        indices[:num_rows, :topk_tokens].fill_(-1)
+        return
+
+    # This is a sufficient chunk-wide fast path for vLLM's per-row rule
+    # ``row_end - row_start <= topK``: if the whole logits workspace fits in K,
+    # every row fits as well. Every causal position must then be selected, so
+    # emit request-local indices directly. Besides being cheaper, this avoids
+    # FlagGems' radix TopK, whose small-width path currently fails HCU LLVM
+    # translation on BW1000.
+    if width <= topk_tokens:
+        output_block = triton.next_power_of_2(topk_tokens)
+        _fill_all_valid_relative_indices_kernel[(num_rows,)](
+            indices,
+            row_starts,
+            row_ends,
+            indices.stride(0),
+            topk_tokens=topk_tokens,
+            BLOCK=output_block,
+            num_warps=8,
+            num_stages=1,
+        )
+        return
+
+    mask_block = 1024
+    _mask_outside_row_kernel[
+        (num_rows, triton.cdiv(width, mask_block))
+    ](
+        logits,
+        row_starts,
+        row_ends,
+        stride0,
+        width=width,
+        BLOCK=mask_block,
+        num_warps=4,
+        num_stages=1,
+    )
+
+    # sorted=True is intentional: all finite valid scores precede the masked
+    # -inf entries, so the output remains compact before its -1 padding.
+    _, selected = torch.topk(
+        logits[:num_rows],
+        effective_k,
+        dim=1,
+        largest=True,
+        sorted=True,
+    )
+
+    output_block = triton.next_power_of_2(topk_tokens)
+    _store_relative_indices_kernel[(num_rows,)](
+        selected,
+        indices,
+        row_starts,
+        row_ends,
+        selected.stride(0),
+        indices.stride(0),
+        effective_k=effective_k,
+        topk_tokens=topk_tokens,
+        BLOCK=output_block,
+        num_warps=8,
+        num_stages=1,
+    )
+
+
+def glm_hygon_top_k_per_row_decode(
+    logits: torch.Tensor,
+    next_n: int,
+    seq_lens: torch.Tensor,
+    indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    topk_tokens: int,
+    max_seq_len: int,
+) -> None:
+    """Select decode indices with vLLM-compatible short-row semantics."""
+
+    if logits.ndim != 2 or indices.ndim != 2:
+        raise ValueError("logits and indices must be 2D tensors")
+    if seq_lens.ndim not in (1, 2):
+        raise ValueError("seq_lens must be a 1D or 2D tensor")
+    if logits.dtype != torch.float32:
+        raise TypeError("logits must be float32")
+    if indices.dtype != torch.int32 or seq_lens.dtype != torch.int32:
+        raise TypeError("indices and seq_lens must be int32")
+    if stride1 != 1 or logits.stride(1) != 1:
+        raise ValueError("logits must be contiguous in its last dimension")
+    if num_rows <= 0 or topk_tokens <= 0:
+        return
+    if indices.shape[0] < num_rows or indices.shape[1] < topk_tokens:
+        raise ValueError("indices is smaller than the requested output")
+
+    # vLLM's CUDA topKPerRowJob directly emits all valid indices whenever
+    # rowLen <= topK. max_seq_len is metadata, so this avoids a GPU-to-CPU sync
+    # on every decode step while proving that the condition holds for all rows.
+    if max_seq_len <= topk_tokens:
+        output_block = triton.next_power_of_2(topk_tokens)
+        _fill_all_valid_decode_indices_kernel[(num_rows,)](
+            indices,
+            seq_lens,
+            indices.stride(0),
+            NEXT_N=next_n,
+            SEQ_LENS_2D=seq_lens.ndim == 2,
+            topk_tokens=topk_tokens,
+            BLOCK=output_block,
+            num_warps=8,
+            num_stages=1,
+        )
+        return
+
+    # FlagGems' decode selector asserts num_rows == 1, which is not true for
+    # vLLM's batched decode and CUDAGraph warmup. Use the same batched masking
+    # and selection strategy as the Hygon prefill implementation instead.
+    width = logits.shape[1]
+    effective_k = min(topk_tokens, width)
+    if effective_k <= 0:
+        indices[:num_rows, :topk_tokens].fill_(-1)
+        return
+
+    mask_block = 1024
+    _mask_outside_decode_row_kernel[
+        (num_rows, triton.cdiv(width, mask_block))
+    ](
+        logits,
+        seq_lens,
+        stride0,
+        NEXT_N=next_n,
+        SEQ_LENS_2D=seq_lens.ndim == 2,
+        width=width,
+        BLOCK=mask_block,
+        num_warps=4,
+        num_stages=1,
+    )
+
+    _, selected = torch.topk(
+        logits[:num_rows],
+        effective_k,
+        dim=1,
+        largest=True,
+        sorted=True,
+    )
+
+    output_block = triton.next_power_of_2(topk_tokens)
+    _store_decode_selected_indices_kernel[(num_rows,)](
+        selected,
+        indices,
+        seq_lens,
+        selected.stride(0),
+        indices.stride(0),
+        NEXT_N=next_n,
+        SEQ_LENS_2D=seq_lens.ndim == 2,
+        effective_k=effective_k,
+        topk_tokens=topk_tokens,
+        BLOCK=output_block,
+        num_warps=8,
+        num_stages=1,
+    )

--- a/vllm_fl/dispatch/backends/vendor/hygon/register_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/register_ops.py
@@ -113,6 +113,50 @@ def register_builtins(registry) -> None:
             vendor="hygon",
             priority=BackendPriority.VENDOR,
         ),
+        OpImpl(
+            op_name="glm_indexer_fp8_mqa_logits",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(
+                backend.glm_hygon_indexer_fp8_mqa_logits,
+                is_avail,
+            ),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="glm_indexer_fp8_paged_mqa_logits",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(
+                backend.glm_hygon_indexer_fp8_paged_mqa_logits,
+                is_avail,
+            ),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="glm_top_k_per_row_prefill",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(
+                backend.glm_hygon_top_k_per_row_prefill,
+                is_avail,
+            ),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="glm_top_k_per_row_decode",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(
+                backend.glm_hygon_top_k_per_row_decode,
+                is_avail,
+            ),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
     ]
 
     registry.register_many(impls)

--- a/vllm_fl/ops/glm_hygon_sparse_attn_indexer.py
+++ b/vllm_fl/ops/glm_hygon_sparse_attn_indexer.py
@@ -1,0 +1,565 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""GLM-5.2 Hygon-specific sparse attention Indexer.
+
+This module is intentionally isolated from ``vllm_fl.ops.sparse_attn_indexer``.
+It is injected only for ``glm_moe_dsa`` physical Indexer layers on Hygon by
+``vllm_fl.patches.glm_index_share``.
+
+The implementation supports the vLLM V3.2 FP8 Indexer path only:
+
+* Q is FP8; its per-token scale has already been folded into ``weights``.
+* K is inserted into the existing split-layout FP8 Indexer cache.
+* Prefill MQA logits reuse FlagGems ``fp8_mqa_logits`` through FL dispatch.
+* Decode paged MQA logits use a Hygon-specific split-layout kernel.
+
+It deliberately does not support the DeepSeek-V4 MXFP4 Indexer path.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import vllm.envs as envs
+from vllm.forward_context import get_forward_context
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _encode_layer_name,
+    _resolve_layer_name,
+    direct_register_custom_op,
+)
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerMetadata,
+)
+from vllm.v1.worker.workspace import current_workspace_manager
+
+from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
+from vllm_fl.dispatch import CachedOp
+
+
+# Existing FL operators that have already been adapted.
+_indexer_k_quant_and_cache = CachedOp("indexer_k_quant_and_cache")
+_cp_gather_indexer_k_quant_cache = CachedOp("cp_gather_indexer_k_quant_cache")
+_glm_hygon_top_k_per_row_prefill = CachedOp("glm_top_k_per_row_prefill")
+_glm_hygon_top_k_per_row_decode = CachedOp("glm_top_k_per_row_decode")
+_pack_seq_triton = CachedOp("pack_seq_triton")
+_unpack_seq_triton = CachedOp("unpack_seq_triton")
+
+# GLM-5.2 + Hygon-only MQA logits operators.
+_glm_hygon_indexer_fp8_mqa_logits = CachedOp("glm_indexer_fp8_mqa_logits")
+_glm_hygon_indexer_fp8_paged_mqa_logits = CachedOp("glm_indexer_fp8_paged_mqa_logits")
+
+
+RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
+
+
+def _assert_hygon() -> None:
+    """Fail if this GLM-specific implementation is used on another vendor."""
+
+    vendor_name = getattr(
+        current_platform,
+        "vendor_name",
+        None,
+    )
+
+    if vendor_name != "hygon":
+        raise RuntimeError(
+            "GlmHygonSparseAttnIndexer can only run on Hygon, "
+            f"but current vendor is {vendor_name!r}."
+        )
+
+
+def _fp8_workspace_shapes(
+    total_seq_lens: int,
+    head_dim: int,
+    fp8_dtype: torch.dtype,
+) -> tuple[
+    tuple[tuple[int, int], torch.dtype],
+    tuple[tuple[int, int], torch.dtype],
+]:
+    """Workspace for gathered FP8 K values and one FP32 scale per token."""
+
+    return (
+        (
+            (total_seq_lens, head_dim),
+            fp8_dtype,
+        ),
+        (
+            (total_seq_lens, 4),
+            torch.uint8,
+        ),
+    )
+
+
+def glm_hygon_sparse_attn_indexer_fl(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q_quant: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    quant_block_size: int,
+    scale_fmt: str | None,
+    topk_tokens: int,
+    head_dim: int,
+    max_model_len: int,
+    total_seq_lens: int,
+    topk_indices_buffer: torch.Tensor,
+    skip_k_cache_insert: bool,
+) -> torch.Tensor:
+    """Run the GLM-5.2 V3.2 FP8 sparse Indexer on Hygon."""
+
+    _assert_hygon()
+
+    # GLM-5.2 V3.2 currently has:
+    #
+    #   head_dim = 128
+    #   quant_block_size = 128
+    #
+    # so every K vector owns exactly one FP32 scale.
+    if quant_block_size != head_dim:
+        raise NotImplementedError(
+            "GLM Hygon FP8 Indexer currently requires one quantization "
+            "block per K vector: quant_block_size == head_dim."
+        )
+
+    fp8_dtype = current_platform.fp8_dtype()
+
+    if q_quant.dtype != fp8_dtype:
+        raise TypeError(
+            "GLM Hygon Indexer expects q_quant to use "
+            "current_platform.fp8_dtype(), "
+            f"but got {q_quant.dtype}."
+        )
+
+    # During dummy/profile run attn_metadata is not a per-layer dict.
+    attn_metadata = get_forward_context().attn_metadata
+
+    k_cache_prefix = _resolve_layer_name(
+        k_cache_prefix
+    )
+
+    if not isinstance(attn_metadata, dict):
+        values_spec, scales_spec = (
+            _fp8_workspace_shapes(
+                total_seq_lens,
+                head_dim,
+                fp8_dtype,
+            )
+        )
+
+        current_workspace_manager().get_simultaneous(
+            values_spec,
+            scales_spec,
+            (
+                (
+                    RADIX_TOPK_WORKSPACE_SIZE,
+                ),
+                torch.uint8,
+            ),
+        )
+
+        # Preserve vLLM sparse-indexer memory profiling behavior.
+        max_logits_elems = (
+            envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB
+            * 1024
+            * 1024
+        )
+
+        _ = torch.empty(
+            max_logits_elems,
+            dtype=torch.uint8,
+            device=hidden_states.device,
+        )
+
+        return glm_hygon_sparse_attn_indexer_fl_fake(
+            hidden_states,
+            k_cache_prefix,
+            kv_cache,
+            q_quant,
+            k,
+            weights,
+            quant_block_size,
+            scale_fmt,
+            topk_tokens,
+            head_dim,
+            max_model_len,
+            total_seq_lens,
+            topk_indices_buffer,
+            skip_k_cache_insert,
+        )
+
+    attn_metadata_narrowed = (
+        attn_metadata[k_cache_prefix]
+    )
+
+    assert isinstance(
+        attn_metadata_narrowed,
+        DeepseekV32IndexerMetadata,
+    )
+
+    slot_mapping = attn_metadata_narrowed.slot_mapping
+    has_decode = attn_metadata_narrowed.num_decodes > 0
+    has_prefill = attn_metadata_narrowed.num_prefills > 0
+    num_decode_tokens = attn_metadata_narrowed.num_decode_tokens
+
+    # During speculative decoding K can be padded to the graph batch
+    # size while slot_mapping only covers actual tokens.
+    num_tokens = slot_mapping.shape[0]
+
+    if k is not None:
+        k = k[:num_tokens]
+
+    # ------------------------------------------------------------
+    # Insert current K into the Indexer FP8 cache.
+    # ------------------------------------------------------------
+    if not skip_k_cache_insert:
+        if scale_fmt is None:
+            raise RuntimeError(
+                "GLM Hygon FP8 Indexer requires "
+                "a non-null scale_fmt."
+            )
+
+        _indexer_k_quant_and_cache(
+            k,
+            kv_cache,
+            slot_mapping,
+            quant_block_size,
+            scale_fmt,
+        )
+
+    topk_indices_buffer[
+        : hidden_states.shape[0]
+    ] = -1
+
+    # ============================================================
+    # Prefill
+    # ============================================================
+    if has_prefill:
+        prefill_metadata = attn_metadata_narrowed.prefill
+
+        assert prefill_metadata is not None
+
+        workspace_manager = current_workspace_manager()
+
+        values_spec, scales_spec = (
+            _fp8_workspace_shapes(
+                total_seq_lens,
+                head_dim,
+                fp8_dtype,
+            )
+        )
+
+        (
+            k_quant_full,
+            k_scale_full,
+        ) = workspace_manager.get_simultaneous(
+            values_spec,
+            scales_spec,
+        )
+
+        for chunk in prefill_metadata.chunks:
+            k_quant = k_quant_full[
+                : chunk.total_seq_lens
+            ]
+
+            k_scale = k_scale_full[
+                : chunk.total_seq_lens
+            ]
+
+            if not chunk.skip_kv_gather:
+                _cp_gather_indexer_k_quant_cache(
+                    kv_cache,
+                    k_quant,
+                    k_scale,
+                    chunk.block_table,
+                    chunk.cu_seq_lens,
+                )
+
+            q_slice = q_quant[
+                chunk.token_start:
+                chunk.token_end
+            ]
+
+            # Gather workspace stores the FP32 scale as four raw
+            # bytes per token.
+            k_scale_fp32 = (
+                k_scale.view(torch.float32)
+                .squeeze(-1)
+            )
+
+            # GLM-Hygon prefill:
+            #
+            #   FlagGems fp8_mqa_logits(
+            #       q_fp8,
+            #       (k_fp8, k_scale),
+            #       ...
+            #   )
+            #
+            # q_scale is not passed because the Indexer already folds
+            # q_scale into weights during fused_indexer_q_rope_quant.
+            logits = (
+                _glm_hygon_indexer_fp8_mqa_logits(
+                    q_slice,
+                    (
+                        k_quant,
+                        k_scale_fp32,
+                    ),
+                    weights[
+                        chunk.token_start:
+                        chunk.token_end
+                    ],
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                    False,
+                )
+            )
+
+            num_rows = logits.shape[0]
+
+            topk_indices = (
+                topk_indices_buffer[
+                    chunk.token_start:
+                    chunk.token_end,
+                    :topk_tokens,
+                ]
+            )
+
+            _glm_hygon_top_k_per_row_prefill(
+                logits,
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
+                topk_indices,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
+            )
+
+    # ============================================================
+    # Decode
+    # ============================================================
+    if has_decode:
+        decode_metadata = (
+            attn_metadata_narrowed.decode
+        )
+
+        assert decode_metadata is not None
+
+        decode_lens = (
+            decode_metadata.decode_lens
+        )
+
+        # Preserve the existing V3.2 padding behavior.
+        if decode_metadata.requires_padding:
+            padded_q_quant_decode_tokens = (
+                _pack_seq_triton(
+                    q_quant[:num_decode_tokens],
+                    decode_lens,
+                )
+            )
+
+        else:
+            padded_q_quant_decode_tokens = (
+                q_quant[:num_decode_tokens]
+                .reshape(
+                    decode_lens.shape[0],
+                    -1,
+                    *q_quant.shape[1:],
+                )
+            )
+
+        batch_size = (
+            padded_q_quant_decode_tokens.shape[0]
+        )
+
+        next_n = (
+            padded_q_quant_decode_tokens.shape[1]
+        )
+
+        num_padded_tokens = (
+            batch_size * next_n
+        )
+
+        seq_lens = (
+            decode_metadata.seq_lens[
+                :batch_size
+            ]
+        )
+
+        # IMPORTANT:
+        #
+        # Pass the original raw V3.2 Indexer cache here.
+        #
+        # Do NOT call kv_cache_as_quant_view(), because that helper is
+        # for the DeepGEMM view.  The Hygon decode kernel reads the
+        # split physical layout directly:
+        #
+        # [all K values][all FP32 scales].
+        logits = (
+            _glm_hygon_indexer_fp8_paged_mqa_logits(
+                padded_q_quant_decode_tokens,
+                kv_cache,
+                weights[:num_padded_tokens],
+                seq_lens,
+                decode_metadata.block_table,
+                max_model_len,
+                head_dim,
+                quant_block_size,
+            )
+        )
+
+        num_rows = logits.shape[0]
+
+        topk_indices = (
+            topk_indices_buffer[
+                :num_padded_tokens,
+                :topk_tokens,
+            ]
+        )
+
+        _glm_hygon_top_k_per_row_decode(
+            logits,
+            next_n,
+            seq_lens,
+            topk_indices,
+            num_rows,
+            logits.stride(0),
+            logits.stride(1),
+            topk_tokens,
+            attn_metadata_narrowed.max_seq_len,
+        )
+
+        if decode_metadata.requires_padding:
+            topk_indices = (
+                _unpack_seq_triton(
+                    topk_indices.reshape(
+                        batch_size,
+                        -1,
+                        topk_indices.shape[-1],
+                    ),
+                    decode_lens,
+                )
+            )
+
+            topk_indices_buffer[
+                : topk_indices.shape[0],
+                : topk_indices.shape[-1],
+            ] = topk_indices
+
+    return topk_indices_buffer
+
+
+def glm_hygon_sparse_attn_indexer_fl_fake(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q_quant: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    quant_block_size: int,
+    scale_fmt: str | None,
+    topk_tokens: int,
+    head_dim: int,
+    max_model_len: int,
+    total_seq_lens: int,
+    topk_indices_buffer: torch.Tensor,
+    skip_k_cache_insert: bool,
+) -> torch.Tensor:
+    """Fake implementation used by torch.compile/profile."""
+
+    return topk_indices_buffer
+
+
+direct_register_custom_op(
+    op_name=(
+        "glm_hygon_sparse_attn_indexer_fl"
+    ),
+    op_func=glm_hygon_sparse_attn_indexer_fl,
+    mutates_args=[
+        "topk_indices_buffer",
+    ],
+    fake_impl=(
+        glm_hygon_sparse_attn_indexer_fl_fake
+    ),
+    dispatch_key=current_platform.dispatch_key,
+)
+
+
+class GlmHygonSparseAttnIndexer(
+    SparseAttnIndexer
+):
+    """Sparse Indexer used only by GLM-5.2 on Hygon."""
+
+    def forward_native(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: (
+            torch.Tensor
+            | tuple[
+                torch.Tensor,
+                torch.Tensor,
+            ]
+        ),
+        k: torch.Tensor,
+        weights: torch.Tensor,
+    ):
+        return self.forward_oot(
+            hidden_states,
+            q_quant,
+            k,
+            weights,
+        )
+
+    def forward_oot(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: (
+            torch.Tensor
+            | tuple[
+                torch.Tensor,
+                torch.Tensor,
+            ]
+        ),
+        k: torch.Tensor,
+        weights: torch.Tensor,
+    ):
+        _assert_hygon()
+
+        # This class is deliberately not used for DeepSeek-V4 MXFP4.
+        if self.use_fp4_cache:
+            raise NotImplementedError(
+                "GlmHygonSparseAttnIndexer "
+                "supports the V3.2 FP8 Indexer "
+                "cache only; MXFP4 is intentionally "
+                "not routed here."
+            )
+
+        if isinstance(q_quant, tuple):
+            raise TypeError(
+                "GlmHygonSparseAttnIndexer expects "
+                "a single FP8 q_quant tensor."
+            )
+
+        return (
+            torch.ops.vllm
+            .glm_hygon_sparse_attn_indexer_fl(
+                hidden_states,
+                _encode_layer_name(
+                    self.k_cache.prefix
+                ),
+                self.k_cache.kv_cache,
+                q_quant,
+                k,
+                weights,
+                self.quant_block_size,
+                self.scale_fmt,
+                self.topk_tokens,
+                self.head_dim,
+                self.max_model_len,
+                self.max_total_seq_len,
+                self.topk_indices_buffer,
+                self.skip_k_cache_insert,
+            )
+        )

--- a/vllm_fl/patches/glm_index_share.py
+++ b/vllm_fl/patches/glm_index_share.py
@@ -1,0 +1,687 @@
+# Copyright 2026 FlagOS Contributors
+
+"""GLM5.2 IndexShare compatibility patch for vLLM 0.20.0"""
+
+from __future__ import annotations
+
+import inspect
+import re
+import threading
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from functools import wraps
+from typing import Any
+from contextvars import ContextVar
+
+import torch
+from torch import nn
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_GLM_MODEL_TYPE = "glm_moe_dsa"
+
+# Construction-time bridge for vLLM 0.20.x.
+#
+# PR #45895 passes topk_indices_buffer explicitly through the MLA stack.
+# vLLM 0.20.x does not yet pass that argument from
+# MultiHeadLatentAttentionWrapper to MLAAttention.
+#
+# Keep the buffer only during construction of one GLM MLA layer.
+_GLM_SHARED_TOPK_BUFFER: ContextVar[
+    torch.Tensor | None
+] = ContextVar(
+    "fl_glm_shared_topk_buffer",
+    default=None,
+)
+
+
+_LAYER_ID_PATTERN = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
+
+# DeepseekV2MLAAttention.__init__ accesses Indexer through the module-global
+# symbol in deepseek_v2.py. A reentrant lock makes the temporary replacement
+# deterministic if model initialization is ever entered concurrently.
+_INDEXER_OVERRIDE_LOCK = threading.RLock()
+
+
+def _normalize_schedule_value(value: Any) -> str:
+    """Normalize an IndexShare schedule marker."""
+
+    return str(value).strip().lower()
+
+
+def _is_shared_schedule_value(value: Any) -> bool:
+    """Return whether a schedule marker represents a shared layer."""
+
+    return _normalize_schedule_value(value) in {
+        "s",
+        "share",
+        "shared",
+        "skip",
+    }
+
+
+def _get_indexer_pattern(config: Any) -> Any:
+    """Get an explicit per-layer IndexShare pattern when available.
+
+    ``index_topk_pattern`` is the upstream field. ``indexer_types`` is
+    accepted as a compatibility alias for some GLM checkpoint configs.
+    """
+
+    pattern = getattr(config, "index_topk_pattern", None)
+
+    if pattern is None:
+        pattern = getattr(config, "indexer_types", None)
+
+    return pattern
+
+
+def _is_glm_index_share_config(config: Any) -> bool:
+    """Return whether the configuration requires GLM IndexShare handling."""
+
+    if config is None:
+        return False
+
+    if getattr(config, "model_type", None) != _GLM_MODEL_TYPE:
+        return False
+
+    if not hasattr(config, "index_topk"):
+        return False
+
+    pattern = _get_indexer_pattern(config)
+
+    if pattern is not None:
+        try:
+            return any(_is_shared_schedule_value(value) for value in pattern)
+        except TypeError:
+            logger.warning(
+                "Ignoring invalid GLM IndexShare pattern of type %s",
+                type(pattern).__name__,
+            )
+            return False
+
+    try:
+        frequency = int(getattr(config, "index_topk_freq", 1))
+    except (TypeError, ValueError):
+        return False
+
+    # frequency == 1 means every layer owns a full Indexer and therefore
+    # there is no IndexShare behavior to patch.
+    return frequency > 1
+
+
+def _extract_layer_id(prefix: str) -> int | None:
+    """Extract the decoder layer index from an Indexer module prefix."""
+
+    match = _LAYER_ID_PATTERN.search(prefix)
+
+    if match is None:
+        return None
+
+    return int(match.group(1))
+
+
+def _should_build_full_indexer(config: Any, layer_id: int) -> bool:
+    """Return whether a layer must construct a physical vLLM Indexer.
+
+    Backbone layers follow either:
+
+    1. an explicit ``index_topk_pattern`` / ``indexer_types`` list; or
+    2. ``index_topk_freq`` and ``index_skip_topk_offset``.
+
+    MTP/next-n layers are outside the backbone schedule and always retain
+    a full Indexer.
+    """
+
+    num_hidden_layers = getattr(config, "num_hidden_layers", None)
+
+    # MTP layers are normally appended after the backbone layers. They must
+    # keep their own Indexer instead of sharing a backbone layer's result.
+    if (
+        num_hidden_layers is not None
+        and layer_id >= int(num_hidden_layers)
+    ):
+        return True
+
+    pattern = _get_indexer_pattern(config)
+
+    if pattern is not None:
+        if 0 <= layer_id < len(pattern):
+            return not _is_shared_schedule_value(pattern[layer_id])
+
+        # If an explicit pattern does not cover this layer, preserve the
+        # original vLLM behavior instead of incorrectly skipping an Indexer.
+        return True
+
+    try:
+        frequency = int(getattr(config, "index_topk_freq", 1))
+        offset = int(getattr(config, "index_skip_topk_offset", 2))
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            "GLM IndexShare fields index_topk_freq and "
+            "index_skip_topk_offset must be integers."
+        ) from error
+
+    if frequency <= 0:
+        raise ValueError(
+            "GLM index_topk_freq must be greater than zero, "
+            f"but got {frequency}."
+        )
+
+    # This is the same schedule formula used by the upstream IndexCache
+    # implementation. A False result means this layer reuses indices
+    # generated by the preceding full Indexer layer.
+    skip_topk = (
+        max(layer_id - offset + 1, 0) % frequency != 0
+    )
+
+    return not skip_topk
+
+
+def _call_original_indexer(
+    original_indexer: type[nn.Module],
+    *,
+    vllm_config: Any,
+    config: Any,
+    hidden_size: int,
+    q_lora_rank: int,
+    quant_config: Any,
+    cache_config: Any,
+    topk_indices_buffer: torch.Tensor | None,
+    prefix: str,
+    extra_args: tuple[Any, ...],
+    extra_kwargs: dict[str, Any],
+) -> nn.Module:
+    """Construct the original vLLM Indexer without changing its behavior."""
+
+    return original_indexer(
+        vllm_config,
+        config,
+        hidden_size,
+        q_lora_rank,
+        quant_config,
+        cache_config,
+        topk_indices_buffer,
+        prefix,
+        *extra_args,
+        **extra_kwargs,
+    )
+
+
+def _get_glm_sparse_attn_indexer_cls():
+    """Select the sparse Indexer implementation used by physical GLM layers.
+
+    Only GLM + Hygon uses the dedicated implementation. Other platforms
+    preserve the existing SparseAttnIndexerFL behavior.
+    """
+
+    from vllm.platforms import current_platform
+
+    vendor_name = getattr(
+        current_platform,
+        "vendor_name",
+        None,
+    )
+
+    if vendor_name == "hygon":
+        # Importing this module registers:
+        #
+        # torch.ops.vllm.glm_hygon_sparse_attn_indexer_fl
+        from vllm_fl.ops.glm_hygon_sparse_attn_indexer import (
+            GlmHygonSparseAttnIndexer,
+        )
+
+        return GlmHygonSparseAttnIndexer
+
+    # Preserve the existing behavior for non-Hygon GLM platforms.
+    from vllm_fl.ops.sparse_attn_indexer import SparseAttnIndexerFL
+
+    return SparseAttnIndexerFL
+
+
+def _make_glm_indexer_factory(
+    original_indexer: type[nn.Module],
+):
+    """Create the GLM-5.2 IndexShare Indexer factory.    """
+
+    def glm_indexer_factory(
+        vllm_config,
+        config,
+        hidden_size,
+        q_lora_rank,
+        quant_config,
+        cache_config,
+        topk_indices_buffer,
+        prefix="",
+        *args,
+        **kwargs,
+    ):
+        # Preserve original behavior outside GLM IndexShare.
+        if not _is_glm_index_share_config(config):
+            return _call_original_indexer(
+                original_indexer,
+                vllm_config=vllm_config,
+                config=config,
+                hidden_size=hidden_size,
+                q_lora_rank=q_lora_rank,
+                quant_config=quant_config,
+                cache_config=cache_config,
+                topk_indices_buffer=topk_indices_buffer,
+                prefix=prefix,
+                extra_args=args,
+                extra_kwargs=kwargs,
+            )
+
+        layer_id = _extract_layer_id(prefix)
+
+        if layer_id is None:
+            logger.warning(
+                "Cannot extract GLM decoder layer id from Indexer "
+                "prefix %r; constructing the original Indexer.",
+                prefix,
+            )
+
+            return _call_original_indexer(
+                original_indexer,
+                vllm_config=vllm_config,
+                config=config,
+                hidden_size=hidden_size,
+                q_lora_rank=q_lora_rank,
+                quant_config=quant_config,
+                cache_config=cache_config,
+                topk_indices_buffer=topk_indices_buffer,
+                prefix=prefix,
+                extra_args=args,
+                extra_kwargs=kwargs,
+            )
+
+        if _should_build_full_indexer(
+            config,
+            layer_id,
+        ):
+            logger.debug(
+                "GLM layer %d constructs a physical Indexer.",
+                layer_id,
+            )
+
+            return _call_original_indexer(
+                original_indexer,
+                vllm_config=vllm_config,
+                config=config,
+                hidden_size=hidden_size,
+                q_lora_rank=q_lora_rank,
+                quant_config=quant_config,
+                cache_config=cache_config,
+                topk_indices_buffer=topk_indices_buffer,
+                prefix=prefix,
+                extra_args=args,
+                extra_kwargs=kwargs,
+            )
+
+        # PR #45895 semantics:
+        #
+        # shared backbone layers do NOT construct an Indexer.
+        #
+        # Save only the shared buffer reference temporarily so the
+        # vLLM 0.20.x MLA construction bridge can pass it to the
+        # sparse MLA implementation.
+        if topk_indices_buffer is None:
+            raise RuntimeError(
+                "GLM IndexShare layer requires "
+                "topk_indices_buffer."
+            )
+
+        _GLM_SHARED_TOPK_BUFFER.set(
+            topk_indices_buffer
+        )
+
+        logger.debug(
+            "GLM layer %d skips physical Indexer construction "
+            "and reuses topk_indices_buffer.",
+            layer_id,
+        )
+
+        return None
+
+    return glm_indexer_factory
+
+
+def _make_mla_attention_factory(
+    original_mla_attention,
+):
+    """Backport PR #45895 top-k buffer propagation.
+
+    vLLM 0.20.x MLAAttention already accepts arbitrary MLA
+    implementation kwargs via **extra_impl_args, but
+    MultiHeadLatentAttentionWrapper does not yet pass the shared
+    topk_indices_buffer.
+
+    Inject it only while constructing a GLM IndexShare shared layer.
+    """
+
+    def mla_attention_factory(
+        *args,
+        **kwargs,
+    ):
+        use_sparse = bool(
+            kwargs.get(
+                "use_sparse",
+                False,
+            )
+        )
+
+        indexer = kwargs.get(
+            "indexer",
+            None,
+        )
+
+        if use_sparse and indexer is None:
+            topk_indices_buffer = (
+                _GLM_SHARED_TOPK_BUFFER.get()
+            )
+
+            if topk_indices_buffer is None:
+                raise RuntimeError(
+                    "Sparse GLM MLA has indexer=None but no "
+                    "shared topk_indices_buffer is available."
+                )
+
+            kwargs["topk_indices_buffer"] = (
+                topk_indices_buffer
+            )
+
+        return original_mla_attention(
+            *args,
+            **kwargs,
+        )
+
+    return mla_attention_factory
+
+
+@contextmanager
+def _temporary_indexer_override(
+    deepseek_v2_module,
+):
+    """Install GLM-5.2 construction-time overrides.
+
+    1. Indexer
+       Skip physical Indexer construction on IndexShare layers.
+
+    2. SparseAttnIndexer
+       Physical Indexers use the platform-specific FL implementation.
+
+    3. MLAAttention
+       Backport PR #45895 shared top-k buffer propagation without
+       modifying vLLM source.
+    """
+
+    from vllm.model_executor.layers import (
+        mla as mla_module,
+    )
+
+    sparse_attn_indexer_cls = (
+        _get_glm_sparse_attn_indexer_cls()
+    )
+
+    with _INDEXER_OVERRIDE_LOCK:
+        original_indexer = (
+            deepseek_v2_module.Indexer
+        )
+
+        original_sparse_attn_indexer = (
+            deepseek_v2_module.SparseAttnIndexer
+        )
+
+        original_mla_attention = (
+            mla_module.MLAAttention
+        )
+
+        indexer_factory = (
+            _make_glm_indexer_factory(
+                original_indexer
+            )
+        )
+
+        mla_attention_factory = (
+            _make_mla_attention_factory(
+                original_mla_attention
+            )
+        )
+
+        deepseek_v2_module.Indexer = indexer_factory
+        deepseek_v2_module.SparseAttnIndexer = sparse_attn_indexer_cls
+        mla_module.MLAAttention = mla_attention_factory
+
+        try:
+            yield
+        finally:
+            mla_module.MLAAttention = original_mla_attention
+            deepseek_v2_module.SparseAttnIndexer = original_sparse_attn_indexer
+            deepseek_v2_module.Indexer = original_indexer
+
+
+def _get_mla_config(
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Read ``config`` from DeepseekV2MLAAttention.__init__ arguments."""
+
+    if "config" in kwargs:
+        return kwargs["config"]
+
+    # The patched method receives arguments after ``self``.
+    # Original positional order:
+    #   vllm_config, config, hidden_size, ...
+    if len(args) >= 2:
+        return args[1]
+
+    return None
+
+
+def _validate_vllm_api() -> None:
+    """Fail early when the installed vLLM API is incompatible.
+
+    This patch targets the vLLM 0.20.x DeepSeek-v2 implementation. Explicit
+    signature checks prevent a future vLLM upgrade from silently applying an
+    invalid monkey patch.
+    """
+
+    from vllm.model_executor.models import deepseek_v2
+
+    mla_parameters = set(
+        inspect.signature(
+            deepseek_v2.DeepseekV2MLAAttention.__init__
+        ).parameters
+    )
+
+    required_mla_parameters = {
+        "vllm_config",
+        "config",
+        "topk_indices_buffer",
+        "prefix",
+    }
+
+    missing_mla_parameters = (
+        required_mla_parameters - mla_parameters
+    )
+
+    if missing_mla_parameters:
+        raise RuntimeError(
+            "Unsupported vLLM DeepseekV2MLAAttention API. "
+            "Missing constructor parameters: "
+            f"{sorted(missing_mla_parameters)}"
+        )
+
+    indexer_parameters = set(
+        inspect.signature(
+            deepseek_v2.Indexer.__init__
+        ).parameters
+    )
+
+    required_indexer_parameters = {
+        "vllm_config",
+        "config",
+        "hidden_size",
+        "q_lora_rank",
+        "quant_config",
+        "cache_config",
+        "topk_indices_buffer",
+        "prefix",
+    }
+
+    missing_indexer_parameters = (
+        required_indexer_parameters - indexer_parameters
+    )
+
+    if missing_indexer_parameters:
+        raise RuntimeError(
+            "Unsupported vLLM Indexer API. "
+            "Missing constructor parameters: "
+            f"{sorted(missing_indexer_parameters)}"
+        )
+
+    if not hasattr(
+        deepseek_v2,
+        "GlmMoeDsaForCausalLM",
+    ):
+        raise RuntimeError(
+            "The installed vLLM does not provide "
+            "GlmMoeDsaForCausalLM."
+        )
+
+    if not hasattr(
+        deepseek_v2,
+        "SparseAttnIndexer",
+    ):
+        raise RuntimeError(
+            "The installed vLLM deepseek_v2 module does not expose "
+            "SparseAttnIndexer."
+        )
+
+    sparse_attn_indexer_cls = (
+        _get_glm_sparse_attn_indexer_cls()
+    )
+
+    upstream_sparse_indexer = (
+        deepseek_v2.SparseAttnIndexer
+    )
+
+    if not issubclass(
+        sparse_attn_indexer_cls,
+        upstream_sparse_indexer,
+    ):
+        raise RuntimeError(
+            f"{sparse_attn_indexer_cls.__name__} "
+            "is incompatible with the installed "
+            "vLLM SparseAttnIndexer implementation."
+        )
+
+
+def _add_hygon_indexer_splitting_op(vllm_config: Any) -> None:
+    """Keep the stateful Indexer write outside adjacent compiled regions."""
+
+    from vllm.platforms import current_platform
+
+    if getattr(current_platform, "vendor_name", None) != "hygon":
+        return
+
+    compilation_config = vllm_config.compilation_config
+    splitting_op = "vllm::glm_hygon_sparse_attn_indexer_fl"
+    splitting_ops = compilation_config.splitting_ops
+
+    if splitting_ops is None:
+        splitting_ops = list(compilation_config._attention_ops)
+        compilation_config.splitting_ops = splitting_ops
+
+    if splitting_op not in splitting_ops:
+        splitting_ops.append(splitting_op)
+        logger.info(
+            "Added %s to GLM compilation splitting_ops.",
+            splitting_op,
+        )
+
+
+def _patch_glm_indexer_construction() -> None:
+    """Patch GLM MLA initialization to honor the IndexShare schedule."""
+
+    from vllm.model_executor.models import deepseek_v2
+
+    attention_class = deepseek_v2.DeepseekV2MLAAttention
+
+    if getattr(
+        attention_class,
+        "_fl_glm_index_share_patched",
+        False,
+    ):
+        return
+
+    original_init = attention_class.__init__
+
+    @wraps(original_init)
+    def patched_init(
+        self,
+        *args,
+        **kwargs,
+    ):
+        config = _get_mla_config(
+            args,
+            kwargs,
+        )
+
+        # Preserve the exact original behavior for:
+        #
+        # - non-GLM models
+        # - GLM without IndexShare
+        if not _is_glm_index_share_config(config):
+            return original_init(
+                self,
+                *args,
+                **kwargs,
+            )
+
+        vllm_config = kwargs.get(
+            "vllm_config",
+            args[0] if args else None,
+        )
+        if vllm_config is None:
+            raise RuntimeError(
+                "GLM IndexShare patch cannot locate vllm_config."
+            )
+
+        _add_hygon_indexer_splitting_op(vllm_config)
+
+        # This ContextVar is only a construction-time bridge for
+        # vLLM 0.20.x.
+        token = _GLM_SHARED_TOPK_BUFFER.set(
+            None
+        )
+
+        try:
+            with _temporary_indexer_override(
+                deepseek_v2
+            ):
+                return original_init(
+                    self,
+                    *args,
+                    **kwargs,
+                )
+        finally:
+            _GLM_SHARED_TOPK_BUFFER.reset(
+                token
+            )
+
+    attention_class.__init__ = patched_init
+    attention_class._fl_glm_index_share_patched = True
+    attention_class._fl_original_init = original_init
+
+    logger.info(
+        "Applied GLM IndexShare construction patch."
+    )
+
+
+def apply_glm_index_share_patches() -> None:
+    """Backport GLM-5.2 IndexShare semantics from vLLM PR #45895."""
+
+    _validate_vllm_api()
+    _patch_glm_indexer_construction()

--- a/vllm_fl/patches/hygon_glm_kv_cache.py
+++ b/vllm_fl/patches/hygon_glm_kv_cache.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon compatibility patch for GLM/DSA multi-KV-cache binding.
+
+vLLM allows multiple cache-backed attention modules to share the same
+decoder-layer index on CUDA-like, XPU and CPU runners.
+
+GLM DSA has this layout on physical Indexer layers:
+
+    decoder layer
+      ├── MLA KV cache
+      └── Indexer K cache
+
+Hygon uses the FL GPU runner, but PlatformFL is intentionally registered as
+an OOT platform and reports ``is_cuda_alike() == False``. Therefore upstream
+``bind_kv_cache()`` rejects this otherwise valid multi-cache layout.
+
+This patch is deliberately narrow:
+
+* it does not modify PlatformFL;
+* it does not modify the FL model runner;
+* it does not affect non-Hygon platforms;
+* it does not affect ordinary Hygon models without an Indexer cache;
+* it only bypasses the upstream platform guard for the Indexer multi-cache
+  layout.
+
+All other calls are delegated to the original vLLM implementation.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from functools import wraps
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _group_cache_layers(
+    kv_caches,
+    num_attn_module: int,
+):
+    """Group KV-cache layer names by decoder-layer index."""
+
+    from vllm.model_executor.models.utils import (
+        extract_layer_index,
+    )
+
+    index2name = defaultdict(list)
+
+    for layer_name in kv_caches:
+        layer_index = extract_layer_index(
+            layer_name,
+            num_attn_module,
+        )
+        index2name[layer_index].append(layer_name)
+
+    return index2name
+
+
+def _is_hygon_indexer_multi_cache(
+    kv_caches,
+    num_attn_module: int,
+) -> bool:
+    """Return whether this is the Hygon DSA Indexer multi-cache case.
+
+    The check intentionally errs on the conservative side. Any layout that
+    does not clearly contain an Indexer cache falls back to upstream vLLM.
+    """
+
+    from vllm.platforms import current_platform
+
+    if (
+        getattr(
+            current_platform,
+            "vendor_name",
+            None,
+        )
+        != "hygon"
+    ):
+        return False
+
+    # Ordinary models such as Qwen have no Indexer cache and must keep the
+    # exact upstream bind_kv_cache path.
+    if not any(
+        ".indexer" in layer_name
+        for layer_name in kv_caches
+    ):
+        return False
+
+    index2name = _group_cache_layers(
+        kv_caches,
+        num_attn_module,
+    )
+
+    duplicate_groups = [
+        layer_names
+        for layer_names in index2name.values()
+        if len(layer_names) > 1
+    ]
+
+    if not duplicate_groups:
+        return False
+
+    # Only accept the expected DSA layout:
+    # one ordinary MLA cache plus one Indexer cache under the same
+    # decoder-layer index.
+    #
+    # Unknown multi-cache layouts deliberately fall back to upstream vLLM.
+    for layer_names in duplicate_groups:
+        if len(layer_names) != 2:
+            return False
+
+        indexer_count = sum(
+            ".indexer" in layer_name
+            for layer_name in layer_names
+        )
+
+        if indexer_count != 1:
+            return False
+
+    return True
+
+
+def _bind_hygon_indexer_kv_cache(
+    kv_caches,
+    forward_context,
+    runner_kv_caches,
+    num_attn_module: int,
+) -> None:
+    """Bind the known-safe Hygon DSA multi-cache layout.
+
+    The implementation below intentionally mirrors vLLM 0.20.0
+    ``bind_kv_cache()``. The only omitted part is its platform guard.
+    """
+
+    assert len(runner_kv_caches) == 0
+
+    index2name = _group_cache_layers(
+        kv_caches,
+        num_attn_module,
+    )
+
+    # Preserve vLLM's layer-index ordering.
+    for layer_index in sorted(index2name.keys()):
+        layer_names = index2name[layer_index]
+
+        for layer_name in layer_names:
+            runner_kv_caches.append(
+                kv_caches[layer_name]
+            )
+
+    # Bind each allocated cache back to its Attention object.
+    for layer_name, kv_cache in kv_caches.items():
+        forward_context[layer_name].kv_cache = kv_cache
+
+
+def apply_hygon_glm_kv_cache_patch() -> None:
+    """Install the Hygon GLM/DSA KV-cache compatibility patch.
+
+    This function must run before ``vllm_fl.worker.model_runner`` imports
+    ``bind_kv_cache`` from ``vllm.v1.worker.utils``.
+
+    The patch is idempotent.
+    """
+
+    from vllm.v1.worker import utils as worker_utils
+
+    current_bind = worker_utils.bind_kv_cache
+
+    if getattr(
+        current_bind,
+        "_fl_hygon_glm_kv_cache_patched",
+        False,
+    ):
+        return
+
+    original_bind = current_bind
+
+    @wraps(original_bind)
+    def patched_bind_kv_cache(
+        kv_caches,
+        forward_context,
+        runner_kv_caches,
+        num_attn_module=1,
+    ):
+        # Every non-target case executes the original vLLM function.
+        if not _is_hygon_indexer_multi_cache(
+            kv_caches,
+            num_attn_module,
+        ):
+            return original_bind(
+                kv_caches,
+                forward_context,
+                runner_kv_caches,
+                num_attn_module,
+            )
+
+        logger.info_once(
+            "Using Hygon DSA multi-KV-cache binding compatibility path."
+        )
+
+        return _bind_hygon_indexer_kv_cache(
+            kv_caches,
+            forward_context,
+            runner_kv_caches,
+            num_attn_module,
+        )
+
+    patched_bind_kv_cache._fl_hygon_glm_kv_cache_patched = True
+    patched_bind_kv_cache._fl_original_bind_kv_cache = original_bind
+
+    worker_utils.bind_kv_cache = patched_bind_kv_cache
+
+    logger.info(
+        "Applied Hygon GLM/DSA KV-cache binding compatibility patch."
+    )

--- a/vllm_fl/quantization/compressed_tensors.py
+++ b/vllm_fl/quantization/compressed_tensors.py
@@ -241,6 +241,42 @@ def inspect_vllm_compressed_tensors_api() -> CompatibilityReport:
     )
 
 
+def _configure_hygon_generic_wna16_moe(
+    report: CompatibilityReport,
+) -> None:
+    """Route Hygon WNA16 MoE away from NVIDIA Marlin."""
+
+    from vllm.platforms import current_platform
+
+    if getattr(current_platform, "vendor_name", None) != "hygon":
+        return
+
+    if not report.moe_wna16:
+        return
+
+    from vllm_fl.utils import is_oot_enabled
+
+    if not is_oot_enabled():
+        return
+
+    try:
+        from vllm_fl.quantization.marlin import (
+            configure_wna16_moe_backend,
+        )
+
+        backend = configure_wna16_moe_backend()
+        logger.info(
+            "compressed-tensors WNA16 MoE backend for Hygon: %s",
+            backend,
+        )
+    except (ImportError, AttributeError, OSError, RuntimeError) as exc:
+        logger.warning(
+            "Could not configure Hygon compressed-tensors WNA16 MoE; "
+            "vLLM's upstream backend selection remains unchanged: %s",
+            exc,
+        )
+
+
 def register_compressed_tensors_oot() -> CompatibilityReport:
     """Configure compressed-tensors runtime selection for the FL platform.
 
@@ -274,6 +310,7 @@ def register_compressed_tensors_oot() -> CompatibilityReport:
     )
 
     if not is_fl_wna16_moe_available():
+        _configure_hygon_generic_wna16_moe(report)
         return report
 
     # Linear registration is independent and handled by

--- a/vllm_fl/quantization/wna16/linear.py
+++ b/vllm_fl/quantization/wna16/linear.py
@@ -23,6 +23,11 @@ from vllm.model_executor.kernels.linear import (
 )
 from vllm.scalar_type import scalar_types
 
+from vllm.model_executor.kernels.linear.mixed_precision.triton_w4a16 import (
+    TRITON_W4A16_SUPPORTED_GROUP_SIZES,
+    TritonW4A16LinearKernel,
+)
+
 from . import kernels
 
 
@@ -102,17 +107,103 @@ class FLWNA16LinearKernel(MPLinearKernel):
         )
         return output.reshape(*original_shape[:-1], output.shape[-1])
 
+class HygonTritonWNA16LinearKernel(TritonW4A16LinearKernel):
+    """Reuse vLLM's Triton W4A16 kernel on Hygon OOT devices."""
+
+    @classmethod
+    def can_implement(
+        cls,
+        config: MPLinearLayerConfig,
+    ) -> tuple[bool, str | None]:
+        from vllm.platforms import current_platform
+
+        if getattr(current_platform, "vendor_name", None) != "hygon":
+            return False, "Hygon Triton WNA16 only targets Hygon"
+
+        if config.weight_type not in cls.SUPPORTED_QUANT_TYPES:
+            return (
+                False,
+                f"Quant type {config.weight_type} not supported; "
+                f"supported: {cls.SUPPORTED_QUANT_TYPES}",
+            )
+
+        if config.act_type not in (torch.float16, torch.bfloat16):
+            return False, "Only float16/bfloat16 activations are supported"
+
+        output_size = config.partition_weight_shape[1]
+        if output_size % 8 != 0:
+            return (
+                False,
+                f"Output features ({output_size}) must be divisible by 8 "
+                "(8 int4 values packed per int32)",
+            )
+
+        if config.has_g_idx:
+            return (
+                False,
+                "Activation reordering (g_idx) is not supported by "
+                "HygonTritonWNA16LinearKernel",
+            )
+
+        group_size = config.group_size
+        full_input_size = config.full_weight_shape[0]
+
+        if (
+            group_size != -1
+            and group_size not in TRITON_W4A16_SUPPORTED_GROUP_SIZES
+            and group_size != full_input_size
+        ):
+            return (
+                False,
+                f"Group size {group_size} not supported; "
+                f"supported: {TRITON_W4A16_SUPPORTED_GROUP_SIZES} "
+                f"or full K ({full_input_size})",
+            )
+
+        input_size = config.partition_weight_shape[0]
+        effective_group_size = (
+            group_size if group_size != -1 else input_size
+        )
+
+        if input_size % effective_group_size != 0:
+            return (
+                False,
+                f"Input features {input_size} not divisible by "
+                f"group size {effective_group_size}",
+            )
+
+        return True, None
+
 
 def register_fl_wna16_linear_kernel(registry: dict) -> bool:
     """Prepend the FL kernel when a W4A16 or W8A16 backend is available."""
-    if not (kernels.is_wna16_gemm_available() or kernels.is_w8a16_gemm_available()):
+    from vllm.platforms import PlatformEnum, current_platform
+
+    has_fl_kernel = (
+        kernels.is_wna16_gemm_available()
+        or kernels.is_w8a16_gemm_available()
+    )
+    is_hygon = getattr(current_platform, "vendor_name", None) == "hygon"
+
+    if not (has_fl_kernel or is_hygon):
         return False
-    from vllm.platforms import PlatformEnum
 
     candidates = registry.setdefault(PlatformEnum.OOT, [])
-    if FLWNA16LinearKernel not in candidates:
+
+    # Hygon is represented as an OOT platform, but its
+    # HIP Triton runtime can execute the upstream Triton W4A16 kernel.
+    if is_hygon and HygonTritonWNA16LinearKernel not in candidates:
+        candidates.insert(0, HygonTritonWNA16LinearKernel)
+
+    # Prefer the plugin-local fixed operator when it is available.
+    if has_fl_kernel and FLWNA16LinearKernel not in candidates:
         candidates.insert(0, FLWNA16LinearKernel)
+
     return True
 
 
-__all__ = ["FLWNA16LinearKernel", "register_fl_wna16_linear_kernel"]
+__all__ = [
+    "FLWNA16LinearKernel",
+    "HygonTritonWNA16LinearKernel",
+    "register_fl_wna16_linear_kernel",
+]

--- a/vllm_fl/quantization/wna16/moe.py
+++ b/vllm_fl/quantization/wna16/moe.py
@@ -31,6 +31,12 @@ _UPSTREAM_MODULES = (
 
 def is_flaggems_wna16_moe_available() -> bool:
     from vllm_fl.utils import is_oot_enabled, use_flaggems_op
+    from vllm.platforms import current_platform
+
+    # Hygon WNA16 packed MoE weights require the generic vLLM loading path.
+    # The FlagGems path currently creates an incompatible parameter layout.
+    if getattr(current_platform, "vendor_name", None) == "hygon":
+        return False
 
     return (
         is_oot_enabled()


### PR DESCRIPTION
…3B, and GLM-5.2

<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->
Vendor

### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->
New Features

### Description
<!-- Describe what this PR does and why. -->
Add Hygon FL INT4 inference support for Qwen3.6-27B, Qwen3.6-35B-A3B and GLM-5.2 on BW1000.

This PR adds W4A16 linear and MoE compatibility paths for Hygon, along with the sparse MLA, Indexer, Top-K, IndexShare, and multi-KV-cache adaptations required by GLM-5.2.

For GLM-5.2 sparse MLA inference on BW1000, configure:

```bash
export FLAGGEMS_FLASHMLA_SPARSE_TLE=0
export VLLM_FL_HYGON_SPARSE_MLA_BACKEND=flag_gems
```

### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->
N/A

### Changes
<!-- List the key changes made in this PR. -->
- Add Hygon W4A16 linear kernel selection for compressed-tensors models.
- Route Hygon WNA16 MoE weight loading through the compatible generic backend.
- Add a FlagGems-backed sparse MLA implementation with a BW1000-safe Triton configuration.
- Add Hygon GLM-5.2 FP8 Indexer MQA and Top-K kernels.
- Backport the GLM-5.2 IndexShare construction semantics required by the installed vLLM version.
- Add Hygon GLM/DSA multi-KV-cache binding compatibility.
- Add backend registration and selection for the new Hygon operations.

### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->
Tested on Hygon BW1000 hardware. End-to-end inference smoke tests passed for:
- Qwen3.6-27B-INT4
- Qwen3.6-35B-A3B-INT4
- GLM-5.2-INT4
