### PR TITLE
fix(worker): preserve DP GPU offset for independent engines

### DIFF
--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -327,17 +327,20 @@ class WorkerFL(WorkerBase):
     def init_device(self):
         # This env var set by Ray causes exceptions with graph building.
         if (
-            self.parallel_config.data_parallel_size > 1
-            and self.parallel_config.data_parallel_size_local > 0
-            and self.parallel_config.distributed_executor_backend
+            self.parallel_config.distributed_executor_backend
             not in ["ray", "external_launcher"]
             and self.vllm_config.parallel_config.data_parallel_backend != "ray"
             and self.vllm_config.parallel_config.nnodes_within_dp == 1
         ):
-            # Use local DP rank if available, otherwise use global DP rank.
+            # vLLM keeps the original DP rank in data_parallel_index when a
+            # non-MoE DP replica is reconfigured as an independent engine.
             dp_local_rank = self.parallel_config.data_parallel_rank_local
             if dp_local_rank is None:
-                dp_local_rank = self.parallel_config.data_parallel_rank
+                dp_local_rank = getattr(
+                    self.parallel_config,
+                    "data_parallel_index",
+                    self.parallel_config.data_parallel_rank,
+                )
 
             tp_pp_world_size = (
                 self.parallel_config.pipeline_parallel_size


### PR DESCRIPTION
## Summary

- Fix single-node TP+DP worker device binding for independent non-MoE DP engines.
- Preserve the existing Ray, external-launcher, and multi-node guards.
- Keep compatibility with older vLLM releases that do not expose `data_parallel_index`.

## Problem

vLLM 0.24 reconfigures every non-MoE DP replica as an independent engine. In
that process, `data_parallel_size` and `data_parallel_rank` become `1` and `0`,
while the original replica rank is retained in `data_parallel_index`.

`WorkerFL.init_device()` checked the already-collapsed
`data_parallel_size > 1` before applying its DP device offset, and fell back to
the already-collapsed `data_parallel_rank`. As a result, every DP replica reused
the same TP-local GPU group:

- TP1 x DP8: every worker selected GPU0.
- TP2 x DP4: every replica reused GPU0-1.
- TP4 x DP2: both replicas reused GPU0-3.

## Change

- Apply the local multiprocessing DP offset without relying on the collapsed
  DP-size fields.
- Prefer `data_parallel_rank_local` when it is available.
- Otherwise use `data_parallel_index`, with `data_parallel_rank` as a fallback
  for older vLLM versions.

The resulting single-node PP1 mapping is:

```text
local_rank = dp_rank * tensor_parallel_size + tp_rank
```

## Validation

- `python3 -m py_compile vllm_fl/worker/worker.py`
- External mock-platform mapping test (not part of this PR):
  - TP8 x DP1 -> GPU0-7
  - TP1 x DP8 -> GPU0-7
  - TP2 x DP4 -> GPU0-7
  - TP4 x DP2 -> GPU0-7
- Live single-node 8xH100 validation with `VLLM_PLUGINS=fl`:
  - all four configurations returned HTTP 200 from `/health`;
  - completion requests succeeded;
  - worker `local_rank` covered 0-7 exactly;
  - every GPU had its corresponding primary worker.
