### PR TITLE
fix(worker): guard kernel_warmup against missing torchvision on OOT runtimes

### DIFF
--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -673,13 +673,13 @@ class WorkerFL(WorkerBase):
         # cuda graph capture.
         try:
             kernel_warmup(self)
-        except ImportError:
+        except ImportError as e:
             # vllm 0.24.0's kernel_warmup unconditionally imports
             # minimax_m3_msa_warmup, whose chain reaches torchvision.
             # torchvision is not installed on OOT runtimes (installing it
             # would overwrite the vendor-matched torch matrix); the warmup
             # is a no-op for any model other than MiniMaxM3, so skip it.
-            logger.warning("kernel_warmup skipped: torchvision unavailable")
+            logger.warning("kernel_warmup skipped: %s", e)
 
         cuda_graph_memory_bytes = 0
         if self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:

--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -671,7 +671,15 @@ class WorkerFL(WorkerBase):
         ### NOTE(lms): can add gems kernel pretune here
         # Warmup and tune the kernels used during model execution before
         # cuda graph capture.
-        kernel_warmup(self)
+        try:
+            kernel_warmup(self)
+        except ImportError:
+            # vllm 0.24.0's kernel_warmup unconditionally imports
+            # minimax_m3_msa_warmup, whose chain reaches torchvision.
+            # torchvision is not installed on OOT runtimes (installing it
+            # would overwrite the vendor-matched torch matrix); the warmup
+            # is a no-op for any model other than MiniMaxM3, so skip it.
+            logger.warning("kernel_warmup skipped: torchvision unavailable")
 
         cuda_graph_memory_bytes = 0
         if self.vllm_config.compilation_config.cudagraph_mode != CUDAGraphMode.NONE:


### PR DESCRIPTION
## Summary

vLLM 0.24.0's `kernel_warmup()` (in `vllm/model_executor/warmup/kernel_warmup.py`)
unconditionally imports `minimax_m3_msa_warmup`, whose import chain reaches
`torchvision.transforms`. OOT runtimes (cambricon, hygon, ascend, mthreads) never
ship torchvision — installing it would overwrite the vendor-matched torch matrix —
so the call raises `ImportError` at EngineCore init and the server fails to start.

The warmup is a no-op for any model other than MiniMaxM3, so we skip it and log a
warning. The existing import-site guard in `worker.py` already protects the import;
this adds the missing call-site guard.

## Verification

Verified E2E on mthreads MUSA 4.3.6 (flagtree 0.6.1, torch 2.9.0+musa.4.3.6,
vLLM 0.24.0 empty-mode wheel, DeepSeek-R1-0528-Qwen3-8B-FlagOS):

- Server reaches `Application startup complete` (previously crashed with
  `ImportError: No module named 'torchvision'`)
- Greedy completion coherent (`1+1=` → `2, 2+2=4, 3+3=6, ...`)
- Chat CoT coherent (`<think>` block)
- Fingerprint `vllm-0.24.0-5936039f`

## Affected backends

All no-torchvision OOT backends in the runtime matrix: cambricon×2, hygon,
ascend×2, mthreads×2.

This PR was written in part with the assistance of generative AI.
