### PR TITLE
feat(ascend): port E2E-verified ascend support from 0.20.2 to v0.3.0-dev (vllm 0.24.0)

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/ascend/ascend.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/ascend.py
@@ -146,3 +146,83 @@ class AscendBackend(Backend):
                 raise NotImplementedError("MLA with sparse attention is not implemented for Ascend yet.")
             return "vllm_fl.dispatch.backends.vendor.ascend.impl.attention.AscendMLABackend"
         return "vllm_fl.dispatch.backends.vendor.ascend.impl.attention.AscendAttentionBackend"
+
+    def invoke_fused_moe_triton_kernel(
+        self,
+        A,
+        B,
+        C,
+        A_scale,
+        B_scale,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        mul_routed_weight,
+        top_k,
+        config,
+        compute_type=None,
+        use_fp8_w8a8=False,
+        use_int8_w8a8=False,
+        use_int8_w8a16=False,
+        use_int4_w4a16=False,
+        per_channel_quant=False,
+        block_shape=None,
+        B_bias=None,
+    ):
+        """Ascend NPU fused MoE kernel using torch.mm.
+
+        Replaces the FlagGems Triton kernel which overflows the NPU's
+        unified buffer on certain model shapes.
+        """
+        from .impl.fused_moe_kernel import invoke_fused_moe_torch
+        invoke_fused_moe_torch(
+            A, B, C, A_scale, B_scale, topk_weights,
+            sorted_token_ids, expert_ids, num_tokens_post_padded,
+            mul_routed_weight, top_k, config,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a8=use_int8_w8a8,
+            B_bias=B_bias,
+        )
+
+    def moe_align_block_size(
+        self,
+        topk_ids,
+        block_size,
+        num_experts,
+        expert_map=None,
+        pad_sorted_ids=False,
+        ignore_invalid_experts=False,
+    ):
+        """Pure-torch moe_align_block_size for Ascend NPU.
+
+        Replaces the FlagGems Triton kernel which causes DDR address OOB
+        errors on Ascend NPU hardware.
+        """
+        from .impl.fused_moe_kernel import moe_align_block_size_torch
+        return moe_align_block_size_torch(
+            topk_ids, block_size, num_experts, expert_map,
+            pad_sorted_ids, ignore_invalid_experts,
+        )
+
+    def moe_sum(self, inp, out):
+        """Pure-torch moe_sum: sum over top_k dimension."""
+        # inp is (M, top_k, N), out is (M, N)
+        # Avoid out= parameter which can cause NPU issues
+        result = inp.sum(dim=1)
+        out.copy_(result)
+
+    def topk_softmax(
+        self, topk_weights, topk_indices, token_expert_indices, gating_output,
+        renormalize=False,
+    ):
+        """Pure-torch topk_softmax for Ascend NPU."""
+        scores = torch.softmax(gating_output.float(), dim=-1)
+        topk = topk_weights.shape[1]
+        tk_weights, tk_indices = torch.topk(scores, k=topk, dim=-1)
+        topk_weights.copy_(tk_weights.to(topk_weights.dtype))
+        topk_indices.copy_(tk_indices.to(topk_indices.dtype))
+        if renormalize:
+            s = topk_weights.sum(dim=-1, keepdim=True)
+            topk_weights.div_(s.clamp(min=1e-8))
+        return topk_weights, topk_indices

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/attention.py
@@ -37,6 +37,7 @@ from vllm.v1.attention.backend import (
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
 from vllm_fl.dispatch.backends.vendor.ascend.impl.attention_mask import (
@@ -215,6 +216,7 @@ class AscendAttentionMetadataBuilder:
     # ACL graph support - ALWAYS means full graph capture is supported
     aclgraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.ALWAYS
     reorder_batch_threshold: ClassVar[int] = 1
+    supports_update_block_table: bool = False
 
     @staticmethod
     def get_cudagraph_support(vllm_config, kv_cache_spec) -> AttentionCGSupport:
@@ -433,7 +435,7 @@ class AscendAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_name() -> str:
-        return "ASCEND_FL"
+        return "CUSTOM"
 
     @staticmethod
     def get_impl_cls() -> Type["AscendAttentionBackendImpl"]:
@@ -442,6 +444,15 @@ class AscendAttentionBackend(AttentionBackend):
     @staticmethod
     def get_builder_cls() -> Type["AscendAttentionMetadataBuilder"]:
         return AscendAttentionMetadataBuilder
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int]:
+        # Ascend fused_infer_attention_score and paged_attention kernels
+        # are validated for block size 128 in vllm-ascend. Allowing the
+        # default MultipleOf(1) lets the V1 engine pick unsupported merged
+        # storage block sizes (e.g. 784 for Qwen3.5 hybrid models), which
+        # causes aclnnFusedInferAttentionScoreV3 to fail with error 561002.
+        return [128]
 
     @staticmethod
     def get_kv_cache_shape(
@@ -486,6 +497,12 @@ class AscendAttentionBackend(AttentionBackend):
     @staticmethod
     def get_supported_block_size() -> list[int]:
         return [128]
+
+
+register_backend(
+    AttentionBackendEnum.CUSTOM,
+    "vllm_fl.dispatch.backends.vendor.ascend.impl.attention.AscendAttentionBackend",
+)
 
 
 class AscendAttentionBackendImpl(AttentionImpl):
@@ -561,20 +578,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
             value = self.value_cache.view(num_block, block_size, -1)
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         elif attn_metadata.attn_state == AscendAttentionState.DecodeOnly:
-            # num_block, block_size, _, _ = self.key_cache.shape
-            # key = self.key_cache.view(num_block, block_size, -1)
-            # value = self.value_cache.view(num_block, block_size, -1)
-            key = self.key_cache.view(-1, block_size, 256)
-            value = self.value_cache.view(-1, block_size, 256)
+            num_block, block_size, _, _ = self.key_cache.shape
+            key = self.key_cache.view(num_block, block_size, -1)
+            value = self.value_cache.view(num_block, block_size, -1)
             block_table = attn_metadata.block_tables
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
         else:
             # ChunkedPrefill
-            # num_block, block_size, _, _ = self.key_cache.shape
-            # key = self.key_cache.view(num_block, block_size, -1)
-            # value = self.value_cache.view(num_block, block_size, -1)
-            key = self.key_cache.view(-1, block_size, 256)
-            value = self.value_cache.view(-1, block_size, 256)
+            num_block, block_size, _, _ = self.key_cache.shape
+            key = self.key_cache.view(num_block, block_size, -1)
+            value = self.value_cache.view(num_block, block_size, -1)
             block_table = attn_metadata.block_tables
             actual_seq_lengths_kv = attn_metadata.seq_lens_list
 
@@ -593,16 +606,16 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 self.key_cache, self.value_cache = kv_cache[0], kv_cache[1]
             slots = attn_metadata.slot_mapping
             # torch_npu requires int32 for slot_indices
-            # TODO(yxa): block_table.py: CUDA uses int64, NPU uses int32.
             if slots.dtype != torch.int32:
                 slots = slots.to(torch.int32)
-            # Use torch_npu reshape_and_cache
+
+            num_actual = attn_metadata.num_actual_tokens
             torch_npu._npu_reshape_and_cache(
-                key=key[:attn_metadata.num_actual_tokens],
-                value=value[:attn_metadata.num_actual_tokens],
+                key=key[:num_actual],
+                value=value[:num_actual],
                 key_cache=self.key_cache,
                 value_cache=self.value_cache,
-                slot_indices=slots[:attn_metadata.num_actual_tokens]
+                slot_indices=slots[:num_actual]
             )
         return key, value
 
@@ -625,9 +638,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             key = key[:num_tokens]
             value = value[:num_tokens]
 
-        # Determine sparse_mode based on mask availability
-        # sparse_mode=3 requires attn_mask; sparse_mode=0 does not
-        # sparse_mode = 3 if attn_metadata.attn_mask is not None else 0
+        # sparse_mode: 3 = causal with mask, 0 = no mask
+        sparse_mode = 3 if attn_metadata.attn_mask is not None else 0
+
         attn_output, _ = torch_npu.npu_fused_infer_attention_score(
             query=query,
             key=key,
@@ -641,7 +654,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
             num_key_value_heads=self.num_kv_heads,
             num_heads=self.num_heads,
             scale=self.scale,
-            sparse_mode=3,
+            sparse_mode=sparse_mode,
         )
 
         attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
@@ -779,8 +792,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
             return output.fill_(0)
 
         # Reshape and cache KV
-        if attn_metadata != AscendAttentionState.DecodeOnly:
-            kv_cache = [i.contiguous() for i in kv_cache]
+        # Note: kv_cache[0]/[1] may be non-contiguous views of a
+        # [2, num_blocks, ...] tensor.  _npu_reshape_and_cache handles
+        # them directly via slot_indices — no contiguous copy needed.
         if key is not None and value is not None:
             key = key.contiguous()
             value = value.contiguous()

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/causal_conv1d.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/causal_conv1d.py
@@ -713,3 +713,97 @@ def causal_conv1d_update_npu(
     if unsqueeze:
         out = out.squeeze(-1)
     return out.to(original_x_dtype)
+
+
+def causal_conv1d_update_ref(
+    x: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    activation: bool | str | None = None,
+    conv_state_indices: torch.Tensor | None = None,
+    num_accepted_tokens: torch.Tensor | None = None,
+    query_start_loc: torch.Tensor | None = None,
+    max_query_len: int = -1,
+    pad_slot_id: int = PAD_SLOT_ID,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    validate_data=False,
+):
+    """Pure-PyTorch causal_conv1d_update for decode (single token per seq).
+
+    Handles the simple case: x is [batch, dim] (single token), conv_state
+    is [num_cache_lines, dim, width-1], and we do a sliding window update.
+    """
+    if isinstance(activation, bool):
+        activation = "silu" if activation is True else None
+    elif activation is not None:
+        assert activation in ["silu", "swish"]
+
+    original_x_dtype = x.dtype
+    x = x.to(conv_state.dtype)
+    unsqueeze = query_start_loc is None and x.dim() == 2
+    if unsqueeze:
+        x = x.unsqueeze(-1)  # [batch, dim, 1]
+
+    if query_start_loc is not None:
+        # varlen mode
+        batch = conv_state_indices.size(0)
+        dim = x.size(1)
+    else:
+        batch, dim, seqlen = x.shape
+
+    _, width = weight.shape
+    state_len = width - 1
+
+    out = torch.empty_like(x)
+
+    if query_start_loc is None:
+        # Simple batched mode: x is [batch, dim, seqlen]
+        seqlen = x.shape[-1]
+        for b_idx in range(batch):
+            if conv_state_indices is not None:
+                s_idx = conv_state_indices[b_idx].item()
+                if pad_slot_id is not None and s_idx == pad_slot_id:
+                    out[b_idx] = 0
+                    continue
+            else:
+                s_idx = b_idx
+
+            state = conv_state[s_idx]  # [dim, state_len]
+            for t in range(seqlen):
+                # Shift state left, append new token
+                state = torch.cat([state[:, 1:], x[b_idx, :, t:t+1]], dim=-1)
+                # Dot product with weight for each channel (depthwise conv)
+                val = (state * weight).sum(dim=-1)  # [dim]
+                if bias is not None:
+                    val = val + bias
+                if activation in ["silu", "swish"]:
+                    val = val * torch.sigmoid(val)
+                out[b_idx, :, t] = val
+            conv_state[s_idx] = state
+    else:
+        # Varlen mode
+        cu_cpu = query_start_loc.cpu().tolist()
+        for b_idx in range(batch):
+            s_idx = conv_state_indices[b_idx].item()
+            if pad_slot_id is not None and s_idx == pad_slot_id:
+                continue
+
+            bos = cu_cpu[b_idx] if b_idx < len(cu_cpu) else cu_cpu[-1]
+            eos = cu_cpu[b_idx + 1] if b_idx + 1 < len(cu_cpu) else cu_cpu[-1]
+
+            state = conv_state[s_idx]  # [dim, state_len]
+            for t in range(bos, eos):
+                state = torch.cat([state[:, 1:], x[t:t+1, :].T], dim=-1)
+                val = (state * weight).sum(dim=-1)
+                if bias is not None:
+                    val = val + bias
+                if activation in ["silu", "swish"]:
+                    val = val * torch.sigmoid(val)
+                out[t, :] = val  # varlen: out is [num_tokens, dim]
+            conv_state[s_idx] = state
+
+    if unsqueeze:
+        out = out.squeeze(-1)
+    return out.to(original_x_dtype)

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/fla/gdn_torch_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/fla/gdn_torch_ops.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+#
+# Pure-PyTorch replacements for GDN Triton kernels on Ascend NPU.
+# These implement the same math as the Triton kernels in:
+#   vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
+#   vllm/model_executor/layers/fla/ops/fused_gdn_prefill_post_conv.py
+#   vllm/model_executor/layers/fla/ops/fused_recurrent.py
+#   vllm/model_executor/layers/mamba/gdn_linear_attn.py (fused_gdn_gating)
+#   vllm/model_executor/layers/fla/ops/l2norm.py
+
+import torch
+import torch.nn.functional as F
+
+
+def chunk_gated_delta_rule_torch(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    head_first: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Pure-PyTorch recurrent implementation of chunk_gated_delta_rule.
+
+    Handles GQA where num_v_heads (HV) != num_k_heads (H).
+    Vectorized across all HV heads per timestep using batched matmul.
+    q, k: [B, T, H, K], v: [B, T, HV, V], g/beta: [B, T, HV]
+    state: [N, HV, V, K]
+    """
+    B, T, H, K = q.shape
+    HV = v.shape[2]
+    V = v.shape[-1]
+    groups = HV // H  # value heads per key head
+
+    if scale is None:
+        scale = K ** -0.5
+
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    o = torch.zeros_like(v)
+
+    if initial_state is not None:
+        h = initial_state.clone().float()  # [N, HV, V, K]
+    else:
+        h = torch.zeros(N, HV, V, K, dtype=torch.float32, device=q.device)
+
+    # Expand k/q heads to match v heads: [B, T, H, K] -> [B, T, HV, K]
+    if groups > 1:
+        q_exp = q.repeat_interleave(groups, dim=2)  # [B, T, HV, K]
+        k_exp = k.repeat_interleave(groups, dim=2)  # [B, T, HV, K]
+    else:
+        q_exp = q
+        k_exp = k
+
+    if cu_seqlens is not None:
+        cu_cpu = cu_seqlens.cpu().tolist()
+        for i_n in range(N):
+            bos, eos = cu_cpu[i_n], cu_cpu[i_n + 1]
+            if bos >= eos:
+                continue
+            hi = h[i_n]  # [HV, V, K]
+            for t in range(bos, eos):
+                qt = q_exp[0, t].float() * scale  # [HV, K]
+                kt = k_exp[0, t].float()           # [HV, K]
+                vt = v[0, t].float()               # [HV, V]
+                gt = g[0, t].float()               # [HV]
+                bt = beta[0, t].float()            # [HV]
+
+                # Gated decay: h *= exp(g)  [HV, V, K] *= [HV, 1, 1]
+                hi = hi * torch.exp(gt).unsqueeze(-1).unsqueeze(-1)
+                # h @ k: [HV, V, K] x [HV, K] -> [HV, V]
+                hk = torch.bmm(hi, kt.unsqueeze(-1)).squeeze(-1)
+                # v' = beta * (v - hk)
+                vp = (vt - hk) * bt.unsqueeze(-1)
+                # h += v' outer k: [HV, V, 1] x [HV, 1, K]
+                hi = hi + torch.bmm(vp.unsqueeze(-1), kt.unsqueeze(-2))
+                # o = h @ q: [HV, V, K] x [HV, K] -> [HV, V]
+                ot = torch.bmm(hi, qt.unsqueeze(-1)).squeeze(-1)
+                o[0, t] = ot.to(o.dtype)
+
+            h[i_n] = hi
+    else:
+        for i_n in range(N):
+            hi = h[i_n]
+            for t in range(T):
+                qt = q_exp[i_n, t].float() * scale
+                kt = k_exp[i_n, t].float()
+                vt = v[i_n, t].float()
+                gt = g[i_n, t].float()
+                bt = beta[i_n, t].float()
+
+                hi = hi * torch.exp(gt).unsqueeze(-1).unsqueeze(-1)
+                hk = torch.bmm(hi, kt.unsqueeze(-1)).squeeze(-1)
+                vp = (vt - hk) * bt.unsqueeze(-1)
+                hi = hi + torch.bmm(vp.unsqueeze(-1), kt.unsqueeze(-2))
+                ot = torch.bmm(hi, qt.unsqueeze(-1)).squeeze(-1)
+                o[i_n, t] = ot.to(o.dtype)
+
+            h[i_n] = hi
+
+    final_state = h if output_final_state else None
+    return o, final_state
+
+
+def l2norm_fwd_torch(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """L2-normalize along the last dimension."""
+    x_flat = x.reshape(-1, x.shape[-1]).float()
+    y = x_flat * torch.rsqrt(torch.sum(x_flat * x_flat, dim=-1, keepdim=True) + eps)
+    return y.reshape(x.shape).to(x.dtype)
+
+
+def fused_gdn_gating_torch(
+    A_log: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    dt_bias: torch.Tensor,
+    beta: float = 1.0,
+    threshold: float = 20.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch replacement for the fused_gdn_gating Triton kernel.
+
+    Computes:
+        g = -exp(A_log) * softplus(a + dt_bias)
+        beta_output = sigmoid(b)
+    """
+    x = a.float() + dt_bias.float().unsqueeze(0)
+    sp = F.softplus(x, beta=beta, threshold=threshold)
+    g = -torch.exp(A_log.float()).unsqueeze(0) * sp
+    beta_output = torch.sigmoid(b.float()).to(b.dtype)
+    return g.unsqueeze(0), beta_output.unsqueeze(0)
+
+
+def fused_post_conv_prep_torch(
+    conv_output: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    num_k_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+    apply_l2norm: bool = True,
+    output_g_exp: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch replacement for fused_post_conv_prep Triton kernel."""
+    L = conv_output.shape[0]
+    H = num_k_heads
+    K = head_k_dim
+    V = head_v_dim
+    HV = A_log.shape[0]
+    dtype = conv_output.dtype
+    device = conv_output.device
+
+    if L == 0:
+        q = torch.empty(L, H, K, dtype=dtype, device=device)
+        k = torch.empty(L, H, K, dtype=dtype, device=device)
+        v = torch.empty(L, HV, V, dtype=dtype, device=device)
+        g = torch.empty(L, HV, dtype=torch.float32, device=device)
+        beta_out = torch.empty(L, HV, dtype=torch.float32, device=device)
+        return q, k, v, g, beta_out
+
+    HK = H * K
+
+    # Split conv_output into q, k, v components
+    q_flat = conv_output[:, :HK]                        # [L, H*K]
+    k_flat = conv_output[:, HK:2*HK]                    # [L, H*K]
+    v_flat = conv_output[:, 2*HK:2*HK + HV*V]          # [L, HV*V]
+
+    # Reshape to head layout
+    q = q_flat.reshape(L, H, K)
+    k = k_flat.reshape(L, H, K)
+    v = v_flat.reshape(L, HV, V)
+
+    if apply_l2norm:
+        q = l2norm_fwd_torch(q).to(dtype)
+        k = l2norm_fwd_torch(k).to(dtype)
+
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+
+    # Gating: g = -exp(A_log) * softplus(a + dt_bias)
+    x = a.float() + dt_bias.float().unsqueeze(0)    # [L, HV]
+    sp = F.softplus(x)
+    g = -torch.exp(A_log.float()).unsqueeze(0) * sp  # [L, HV]
+
+    if output_g_exp:
+        g = torch.exp(g)
+
+    beta_out = torch.sigmoid(b.float())  # [L, HV]
+
+    return q, k, v, g, beta_out

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/fused_moe.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/fused_moe.py
@@ -11,6 +11,118 @@ import torch.nn.functional as F
 import torch_npu
 from flag_gems.runtime.backend._ascend import fused
 
+import logging
+logger = logging.getLogger(__name__)
+
+
+def _npu_grouped_matmul_fused_experts(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    inplace: bool = False,
+    activation: str = "silu",
+    apply_router_weight_on_input: bool = False,
+    global_num_experts: int = -1,
+    expert_map: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Optimized MoE using npu_grouped_matmul — single batched kernel for all experts.
+
+    Replaces the Python for-loop over experts with:
+    1. npu_moe_init_routing_v2 — sort tokens by expert, get per-expert counts
+    2. npu_grouped_matmul — batched gate_up projection (all experts in one call)
+    3. npu_swiglu — fused SiLU+mul activation
+    4. npu_grouped_matmul — batched down projection
+    5. npu_moe_token_unpermute — scatter results back with router weights
+    """
+    num_tokens, hidden_dim = hidden_states.shape
+    E, N, _ = w1.shape  # w1: [E, N, K_in]
+    top_k = topk_ids.shape[1]
+
+    if global_num_experts == -1:
+        global_num_experts = E
+
+    # Handle expert_map for tensor parallel
+    if expert_map is not None:
+        local_topk_ids = expert_map[topk_ids.long()]
+        # Mask invalid experts (mapped to -1)
+        valid_mask = local_topk_ids >= 0
+        topk_weights = topk_weights * valid_mask.to(topk_weights.dtype)
+        topk_ids_for_routing = local_topk_ids.to(torch.int32)
+    else:
+        topk_ids_for_routing = topk_ids.to(torch.int32)
+
+    # Apply router weight on input if needed
+    if apply_router_weight_on_input:
+        # Scale hidden states by topk weights before routing
+        # For this path, we need to expand hidden states first
+        pass  # Handled below in the unpermute step
+
+    # Step 1: Sort tokens by expert using npu_moe_init_routing_v2
+    sorted_hidden_states, expanded_row_idx, expert_tokens, _ = (
+        torch_npu.npu_moe_init_routing_v2(
+            hidden_states,
+            topk_ids_for_routing,
+            active_num=num_tokens * top_k,
+            expert_num=E,
+            expert_tokens_num_type=1,  # count mode
+            expert_tokens_num_flag=True,
+            active_expert_range=[0, E],
+            quant_mode=-1,  # no quantization
+        )
+    )
+    expert_tokens = expert_tokens.to(torch.int64)
+
+    # Step 2: Gate-up projection — npu_grouped_matmul
+    # w1 is [E, N, K] — grouped_matmul expects weight as [E, K, N] with split_item=2
+    # split_item=2 means the weight K dimension splits across the group_list
+    gate_up_out = torch_npu.npu_grouped_matmul(
+        x=[sorted_hidden_states],
+        weight=[w1.transpose(1, 2).contiguous()],
+        split_item=2,
+        group_list_type=1,
+        group_type=0,
+        group_list=expert_tokens,
+    )[0]
+
+    # Step 3: Activation
+    if activation == "silu":
+        gate_up_out = torch_npu.npu_swiglu(gate_up_out)
+    elif activation == "gelu":
+        gate_up_out = torch_npu.npu_gelu_mul(gate_up_out)
+    elif activation == "silu_no_mul":
+        gate_up_out = F.silu(gate_up_out)
+    elif activation == "gelu_no_mul":
+        gate_up_out = torch_npu.npu_gelu(gate_up_out)
+    else:
+        raise ValueError(f"Unsupported FusedMoe activation: {activation}.")
+
+    # Step 4: Down projection — npu_grouped_matmul
+    # w2 is [E, K_out, N//2] — need transpose to [E, N//2, K_out]
+    down_out = torch_npu.npu_grouped_matmul(
+        x=[gate_up_out],
+        weight=[w2.transpose(1, 2).contiguous()],
+        split_item=2,
+        group_list_type=1,
+        group_type=0,
+        group_list=expert_tokens,
+    )[0]
+
+    # Step 5: Unpermute and apply router weights
+    # npu_moe_token_unpermute expects sorted_indices as int32
+    expanded_row_idx_abs = torch.abs(expanded_row_idx).to(torch.int32)
+    out = torch_npu.npu_moe_token_unpermute(
+        permuted_tokens=down_out,
+        sorted_indices=expanded_row_idx_abs,
+        probs=topk_weights.to(down_out.dtype) if not apply_router_weight_on_input else None,
+    )
+
+    if inplace:
+        hidden_states.copy_(out)
+        return hidden_states
+    return out
+
 
 def _torch_fused_experts_impl(
     hidden_states: torch.Tensor,
@@ -138,8 +250,30 @@ def fused_experts_impl(
     assert w2.stride(-1) == 1, "Stride of last dimension must be 1"
     assert hidden_states.dtype in [torch.float32, torch.float16, torch.bfloat16]
 
-    # Use pure-torch implementation on NPU to avoid Triton kernel
-    # compatibility issues with the Ascend backend.
+    # Try optimized npu_grouped_matmul path first
+    try:
+        return _npu_grouped_matmul_fused_experts(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            inplace=inplace,
+            activation=activation,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            global_num_experts=global_num_experts,
+            expert_map=expert_map,
+        )
+    except Exception as e:
+        # Fall back to Python loop on first failure, then log warning
+        if not hasattr(fused_experts_impl, '_grouped_matmul_warned'):
+            logger.warning(
+                "npu_grouped_matmul MoE failed (%s), falling back to torch.mm loop. "
+                "This warning will not repeat.", e
+            )
+            fused_experts_impl._grouped_matmul_warned = True
+
+    # Fallback: pure-torch implementation
     return _torch_fused_experts_impl(
         hidden_states=hidden_states,
         w1=w1,

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/fused_moe_kernel.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/fused_moe_kernel.py
@@ -1,0 +1,368 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+Ascend NPU pure-torch MoE kernels.
+
+Replaces FlagGems Triton kernels that crash on Ascend NPU.
+Uses a CPU side-channel to pass moe_align data to the GEMM kernel,
+avoiding any NPU→CPU transfers during the hot path.
+"""
+
+import torch
+import numpy as np
+from vllm.utils.math_utils import round_up
+
+
+def moe_align_block_size_torch(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    expert_map: torch.Tensor | None = None,
+    pad_sorted_ids: bool = False,
+    ignore_invalid_experts: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pure-torch moe_align_block_size for Ascend NPU (CPU-based)."""
+    device = topk_ids.device
+    num_tokens = topk_ids.numel()
+
+    max_num_tokens_padded = num_tokens + num_experts * (block_size - 1)
+    if pad_sorted_ids:
+        max_num_tokens_padded = round_up(max_num_tokens_padded, block_size)
+    if num_tokens < num_experts:
+        max_num_tokens_padded = min(num_tokens * block_size, max_num_tokens_padded)
+
+    topk_ids_flat = topk_ids.view(-1).cpu()
+    padding_value = num_tokens
+
+    expert_counts = torch.bincount(topk_ids_flat.long(), minlength=num_experts)[:num_experts]
+
+    sorted_ids_list = []
+    expert_ids_list = []
+
+    for e in range(num_experts):
+        count = expert_counts[e].item()
+        if count == 0 and ignore_invalid_experts:
+            continue
+        expert_tokens = (topk_ids_flat == e).nonzero(as_tuple=True)[0].to(torch.int32)
+        padded_count = ((count + block_size - 1) // block_size) * block_size
+        num_blocks = padded_count // block_size
+        padded_tokens = torch.full((padded_count,), padding_value, dtype=torch.int32)
+        padded_tokens[:count] = expert_tokens
+        sorted_ids_list.append(padded_tokens)
+        expert_ids_list.extend([e] * num_blocks)
+
+    if not sorted_ids_list:
+        sorted_ids = torch.full((max_num_tokens_padded,), padding_value, dtype=torch.int32)
+        max_num_m_blocks = (max_num_tokens_padded + block_size - 1) // block_size
+        expert_ids_out = torch.full((max_num_m_blocks,), -1, dtype=torch.int32)
+        num_tokens_post_pad = torch.zeros(1, dtype=torch.int32)
+        return sorted_ids.to(device), expert_ids_out.to(device), num_tokens_post_pad.to(device)
+
+    sorted_ids = torch.cat(sorted_ids_list)
+    actual_len = sorted_ids.shape[0]
+
+    if actual_len < max_num_tokens_padded:
+        pad = torch.full((max_num_tokens_padded - actual_len,), padding_value, dtype=torch.int32)
+        sorted_ids = torch.cat([sorted_ids, pad])
+    else:
+        sorted_ids = sorted_ids[:max_num_tokens_padded]
+
+    expert_ids_tensor = torch.tensor(expert_ids_list, dtype=torch.int32)
+    max_num_m_blocks = (max_num_tokens_padded + block_size - 1) // block_size
+    if expert_ids_tensor.shape[0] < max_num_m_blocks:
+        pad = torch.full((max_num_m_blocks - expert_ids_tensor.shape[0],), -1, dtype=torch.int32)
+        expert_ids_tensor = torch.cat([expert_ids_tensor, pad])
+
+    num_tokens_post_pad = torch.tensor([actual_len], dtype=torch.int32)
+
+    if expert_map is not None and not ignore_invalid_experts:
+        expert_map_cpu = expert_map.cpu()
+        valid = expert_ids_tensor >= 0
+        expert_ids_tensor[valid] = expert_map_cpu[expert_ids_tensor[valid].long()]
+
+    return sorted_ids.to(device), expert_ids_tensor.to(device), num_tokens_post_pad.to(device)
+
+
+def invoke_fused_moe_torch(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    A_scale: torch.Tensor | None,
+    B_scale: torch.Tensor | None,
+    topk_weights: torch.Tensor | None,
+    sorted_token_ids: torch.Tensor | None,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    mul_routed_weight: bool,
+    top_k: int,
+    config: dict,
+    use_fp8_w8a8: bool = False,
+    use_int8_w8a8: bool = False,
+    B_bias: torch.Tensor | None = None,
+):
+    """Ascend NPU fused MoE GEMM using per-expert torch.mm loop.
+
+    npu_grouped_matmul is disabled — it crashes aicore on MoE models like
+    Qwen3.6-35B-A3B (error 507015: aicore execution abnormal). The torch.mm
+    loop is slightly slower but reliable.
+    """
+    # Use per-expert torch.mm loop — more reliable on Ascend NPU than
+    # npu_grouped_matmul which can crash aicore on certain model shapes.
+    _invoke_fused_moe_loop(
+        A, B, C, A_scale, B_scale, topk_weights,
+        sorted_token_ids, expert_ids, num_tokens_post_padded,
+        mul_routed_weight, top_k, config,
+        use_fp8_w8a8=use_fp8_w8a8, use_int8_w8a8=use_int8_w8a8,
+        B_bias=B_bias,
+    )
+
+
+def _invoke_fused_moe_grouped_matmul(
+    A, B, C, A_scale, B_scale, topk_weights,
+    sorted_token_ids, expert_ids, num_tokens_post_padded,
+    mul_routed_weight, top_k, config,
+    use_fp8_w8a8=False, use_int8_w8a8=False, B_bias=None,
+):
+    """High-performance path using npu_grouped_matmul.
+
+    Reconstructs the expert->token mapping from sorted_token_ids/expert_ids,
+    then uses npu_grouped_matmul with split_item=2 for a single kernel call.
+    """
+    import torch_npu
+
+    E, N, K = B.shape  # B is [E, N, K] (weight per expert: out x in)
+    c_flat = C.view(-1, N)
+    num_valid_tokens = c_flat.shape[0]
+    block_size = config["BLOCK_SIZE_M"]
+    device = A.device
+
+    if sorted_token_ids is None:
+        # Naive decode path: expert_ids[p] is the expert for pair p.
+        # A[p // top_k] is the input token.
+        num_pairs = min(len(expert_ids), num_valid_tokens)
+        expert_ids_cpu = expert_ids[:num_pairs].cpu()
+
+        # Build per-expert token counts and gather indices
+        # Sort pairs by expert for grouped_matmul
+        sorted_expert_ids, sort_order = expert_ids_cpu.sort()
+        sort_order_dev = sort_order.to(device)
+
+        # Get unique experts and counts
+        unique_experts, counts = torch.unique_consecutive(
+            sorted_expert_ids, return_counts=True
+        )
+
+        # Skip if all invalid
+        valid = unique_experts >= 0
+        if not valid.any():
+            return
+
+        # Build group_list (cumulative token counts per expert, only for active experts)
+        # For npu_grouped_matmul with split_item=2, we need the weight stacked in
+        # expert order matching the group_list. But our experts may be sparse.
+        # Instead, build a dense gathered input and use per-expert weight list.
+
+        # Gather input tokens in sorted-by-expert order
+        a_indices = (sort_order_dev // max(top_k, 1)).long()
+        gathered_a = A[a_indices]  # [num_pairs, K]
+
+        # Build group_list as cumsum of counts for valid experts
+        valid_mask_cpu = unique_experts >= 0
+        valid_experts = unique_experts[valid_mask_cpu]
+        valid_counts = counts[valid_mask_cpu]
+
+        # For npu_grouped_matmul, we need contiguous expert weights
+        # Gather only the active expert weights
+        valid_experts_dev = valid_experts.to(device).long()
+        gathered_B = torch.index_select(B, 0, valid_experts_dev)  # [num_active, N, K]
+        # Transpose: [num_active, N, K] -> [num_active, K, N] for x @ W
+        gathered_B_t = gathered_B.transpose(1, 2).contiguous()
+
+        # Filter out invalid experts from gathered_a
+        # The sort puts negatives first (since -1 < 0 < valid experts)
+        invalid_count = counts[~valid_mask_cpu].sum().item() if (~valid_mask_cpu).any() else 0
+        if invalid_count > 0:
+            gathered_a = gathered_a[invalid_count:]
+            sort_order_dev = sort_order_dev[invalid_count:]
+
+        if gathered_a.shape[0] == 0:
+            return
+
+        # group_list: cumulative counts (group_list_type=1)
+        group_list = valid_counts.to(torch.int64).cumsum(0).to(device)
+
+        # Grouped matmul: one kernel for all experts
+        result = torch_npu.npu_grouped_matmul(
+            x=[gathered_a],
+            weight=[gathered_B_t],
+            split_item=2,
+            group_list_type=1,
+            group_type=0,
+            group_list=group_list,
+        )[0]
+
+        if B_bias is not None:
+            # Apply per-expert bias
+            offset = 0
+            for i, expert_id in enumerate(valid_experts.tolist()):
+                cnt = valid_counts[i].item()
+                result[offset:offset + cnt] += B_bias[expert_id]
+                offset += cnt
+
+        # Apply routing weights
+        if mul_routed_weight and topk_weights is not None:
+            topk_weights_flat = topk_weights.view(-1)
+            w = topk_weights_flat[sort_order_dev].unsqueeze(-1)
+            result = result * w.to(result.dtype)
+
+        # Scatter back to output
+        c_flat[sort_order_dev] = result.to(c_flat.dtype)
+
+    else:
+        # Aligned path: sorted_token_ids + expert_ids from moe_align_block_size
+        total_padded = int(num_tokens_post_padded.cpu().item())
+        sorted_ids_cpu = sorted_token_ids[:total_padded].cpu()
+        expert_ids_cpu = expert_ids.cpu()
+
+        # Build per-expert valid token lists (CPU, fast)
+        expert_to_valid = {}
+        num_blocks = len(expert_ids_cpu)
+        for block_idx in range(num_blocks):
+            eid = int(expert_ids_cpu[block_idx])
+            if eid < 0:
+                continue
+            start = block_idx * block_size
+            end = min(start + block_size, total_padded)
+            if start >= end:
+                break
+            block_ids = sorted_ids_cpu[start:end].numpy()
+            valid = block_ids[block_ids < num_valid_tokens]
+            if len(valid) > 0:
+                expert_to_valid.setdefault(eid, []).append(valid)
+
+        if not expert_to_valid:
+            return
+
+        # Concatenate all valid ids per expert and sort experts
+        sorted_experts = sorted(expert_to_valid.keys())
+        all_valid_ids = []
+        expert_counts = []
+        for eid in sorted_experts:
+            ids = np.concatenate(expert_to_valid[eid]).astype(np.int64)
+            all_valid_ids.append(ids)
+            expert_counts.append(len(ids))
+
+        # Build tensors
+        all_ids_np = np.concatenate(all_valid_ids)
+        all_ids_dev = torch.from_numpy(all_ids_np).to(device)
+        a_indices = all_ids_dev // max(top_k, 1)
+        gathered_a = A[a_indices.long()]
+
+        # Gather expert weights in order
+        expert_ids_tensor = torch.tensor(sorted_experts, dtype=torch.int64, device=device)
+        gathered_B = torch.index_select(B, 0, expert_ids_tensor)
+        gathered_B_t = gathered_B.transpose(1, 2).contiguous()
+
+        # group_list: cumulative counts
+        group_list = torch.tensor(expert_counts, dtype=torch.int64, device=device).cumsum(0)
+
+        # Grouped matmul
+        result = torch_npu.npu_grouped_matmul(
+            x=[gathered_a],
+            weight=[gathered_B_t],
+            split_item=2,
+            group_list_type=1,
+            group_type=0,
+            group_list=group_list,
+        )[0]
+
+        if B_bias is not None:
+            offset = 0
+            for i, eid in enumerate(sorted_experts):
+                cnt = expert_counts[i]
+                result[offset:offset + cnt] += B_bias[eid]
+                offset += cnt
+
+        if mul_routed_weight and topk_weights is not None:
+            topk_weights_flat = topk_weights.view(-1)
+            w = topk_weights_flat[all_ids_dev].unsqueeze(-1)
+            result = result * w.to(result.dtype)
+
+        c_flat[all_ids_dev] = result.to(c_flat.dtype)
+
+
+def _invoke_fused_moe_loop(
+    A, B, C, A_scale, B_scale, topk_weights,
+    sorted_token_ids, expert_ids, num_tokens_post_padded,
+    mul_routed_weight, top_k, config,
+    use_fp8_w8a8=False, use_int8_w8a8=False, B_bias=None,
+):
+    """Fallback per-expert torch.mm loop."""
+    N = B.shape[1]
+    block_size = config["BLOCK_SIZE_M"]
+    c_flat = C.view(-1, N)
+    num_valid_tokens = c_flat.shape[0]
+
+    if topk_weights is not None:
+        topk_weights_flat = topk_weights.view(-1)
+    else:
+        topk_weights_flat = None
+
+    device = A.device
+    expert_indices = {}
+
+    if sorted_token_ids is None:
+        expert_ids_cpu = expert_ids.cpu().numpy()
+        expert_batches = {}
+        for pair_idx in range(len(expert_ids_cpu)):
+            if pair_idx >= num_valid_tokens:
+                break
+            expert_id = int(expert_ids_cpu[pair_idx])
+            if expert_id < 0:
+                continue
+            expert_batches.setdefault(expert_id, []).append(pair_idx)
+        for expert_id, rows in expert_batches.items():
+            valid_ids = torch.tensor(rows, dtype=torch.int64, device=device)
+            a_idx = valid_ids // max(top_k, 1)
+            expert_indices[expert_id] = (valid_ids, a_idx)
+    else:
+        sorted_ids_cpu = sorted_token_ids.cpu().numpy()
+        expert_ids_cpu = expert_ids.cpu().numpy()
+        total_padded = int(num_tokens_post_padded.cpu().item())
+
+        expert_batches = {}
+        num_blocks = len(expert_ids_cpu)
+        for block_idx in range(num_blocks):
+            expert_id = int(expert_ids_cpu[block_idx])
+            if expert_id < 0:
+                continue
+            start = block_idx * block_size
+            end = min(start + block_size, total_padded)
+            if start >= end:
+                break
+            block_ids = sorted_ids_cpu[start:end]
+            valid = block_ids[block_ids < num_valid_tokens]
+            if len(valid) == 0:
+                continue
+            expert_batches.setdefault(expert_id, []).append(valid)
+
+        for expert_id, id_arrays in expert_batches.items():
+            all_valid = np.concatenate(id_arrays).astype(np.int64)
+            valid_ids = torch.from_numpy(all_valid).to(device)
+            a_idx = valid_ids // max(top_k, 1)
+            expert_indices[expert_id] = (valid_ids, a_idx)
+
+    for expert_id, (valid_ids, a_idx) in expert_indices.items():
+        a_block = A[a_idx]
+        out = torch.mm(a_block, B[expert_id].t())
+
+        if B_bias is not None:
+            out = out + B_bias[expert_id]
+
+        if mul_routed_weight and topk_weights_flat is not None:
+            w = topk_weights_flat[valid_ids].unsqueeze(-1)
+            out = out * w.to(out.dtype)
+
+        c_flat[valid_ids] = out.to(c_flat.dtype)
+
+    del expert_indices

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/mm_encoder_attention.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/mm_encoder_attention.py
@@ -17,15 +17,10 @@
 # limitations under the License.
 #
 
-import einops
 import torch
-import torch.nn.functional as F
 import torch_npu
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention
-from vllm.config import MultiModalConfig
 
-MIN_PAD_SIZE = 64  # min_size to pad weight
-MAX_PAD_SIZE = 128  # max_size to pad weight
 
 
 class AscendMMEncoderAttention(MMEncoderAttention):
@@ -37,7 +32,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         scale: float | None = None,
         num_kv_heads: int | None = None,
         prefix: str = "",
-        multimodal_config: MultiModalConfig | None = None,
     ) -> None:
         """
         Args:
@@ -47,7 +41,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             num_kv_heads: number of kv heads.
             prefix: This has no effect, it is only here to make it easier to
                     swap between Attention and MMEncoderAttention.
-            multimodal_config: configs for multi-modal.
         """
         super().__init__(
             num_heads=num_heads,
@@ -55,7 +48,6 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             scale=scale,
             num_kv_heads=num_kv_heads,
             prefix=prefix,
-            multimodal_config=multimodal_config,
         )
 
     def reshape_qkv_to_3d(
@@ -90,54 +82,56 @@ class AscendMMEncoderAttention(MMEncoderAttention):
             cu_seqlens: torch.Tensor | None = None,
             max_seqlen: torch.Tensor
         | None = None,  # Only used for Flash Attention
+            sequence_lengths: torch.Tensor
+        | None = None,  # Only used for FlashInfer CuDNN backend
     ):
         bsz, q_len = query.size()[:2]
         kv_len = key.size(1)
         is_reshaped = query.dim() == 4
 
-        if cu_seqlens is None:
-            cu_seqlens = torch.arange(0, (bsz + 1) * q_len,
-                                      step=q_len,
-                                      dtype=torch.int32,
-                                      device="cpu")
-        cu_seqlens = torch.diff(cu_seqlens).to("cpu")
-
         # q, k, v: [b, s, head, head_dim] -> [b * s, head, head_dim]
         q, k, v = self.reshape_qkv_to_3d(query, key, value, bsz, q_len, kv_len)
 
-        enable_pad = (self.head_size > MIN_PAD_SIZE and self.head_size < MAX_PAD_SIZE)
+        # Pure-PyTorch scaled dot-product attention (matmul path).
+        # Avoids _npu_flash_attention_unpad which can trigger DDR
+        # out-of-range aicore errors on some model configurations.
+        # q,k,v: [B*S, H, D] -> [B, H, S, D] for matmul
+        q4d = q.view(bsz, -1, self.num_heads, self.head_size).transpose(1, 2)
+        k4d = k.view(bsz, -1, self.num_heads, self.head_size).transpose(1, 2)
+        v4d = v.view(bsz, -1, self.num_heads, self.head_size).transpose(1, 2)
 
-        if enable_pad:
-            origin_shape = q.shape[-1]
-            pad_len = MAX_PAD_SIZE - origin_shape
-            # q, k, v: [b * s, head, head_dim] -> [b * s, head, MAX_PAD_SIZE]
-            q = F.pad(q, (0, pad_len), mode="constant", value=0)
-            k = F.pad(k, (0, pad_len), mode="constant", value=0)
-            v = F.pad(v, (0, pad_len), mode="constant", value=0)
+        scale = self.head_size ** -0.5
 
-        context_layer = torch.empty_like(q)
+        def _sdpa(qx, kx, vx):
+            aw = torch.matmul(qx, kx.transpose(-2, -1)) * scale
+            aw = torch.softmax(aw.float(), dim=-1).to(qx.dtype)
+            return torch.matmul(aw, vx)
 
-        # operator requires pta version >= 2.5.1
-        torch_npu._npu_flash_attention_unpad(
-            query=q,
-            key=k,
-            value=v,
-            seq_len=cu_seqlens,
-            scale_value=self.head_size**-0.5,
-            num_heads=self.num_heads,
-            num_kv_heads=self.num_kv_heads,
-            out=context_layer,
-        )
-
-        if enable_pad:
-            context_layer = context_layer[..., :origin_shape]
+        if cu_seqlens is not None:
+            # Block-diagonal (windowed) attention: vision encoders restrict
+            # attention to within each cu_seqlens segment (window / image).
+            # Computing full dense attention here scrambles spatial features
+            # across window boundaries and corrupts image understanding.
+            # Mirror vllm's torch_sdpa_wrapper: split along the sequence dim
+            # and attend within each segment independently.
+            lens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+            q_chunks = torch.split(q4d, lens, dim=2)
+            k_chunks = torch.split(k4d, lens, dim=2)
+            v_chunks = torch.split(v4d, lens, dim=2)
+            outs = [
+                _sdpa(qi, ki, vi)
+                for qi, ki, vi in zip(q_chunks, k_chunks, v_chunks)
+            ]
+            context_layer = torch.cat(outs, dim=2)  # [B, H, S, D]
+        else:
+            context_layer = _sdpa(q4d, k4d, v4d)
 
         if is_reshaped:
-            context_layer = einops.rearrange(context_layer,
-                                             "(b s) h d -> b s h d",
-                                             b=bsz).contiguous()
+            # [B, H, S, D] -> [B, S, H, D]
+            context_layer = context_layer.transpose(1, 2).contiguous()
         else:
-            context_layer = einops.rearrange(context_layer,
-                                             "(b s) h d -> b s (h d)",
-                                             b=bsz).contiguous()
+            # [B, H, S, D] -> [B, S, H*D]
+            context_layer = context_layer.transpose(1, 2).contiguous()
+            context_layer = context_layer.view(bsz, -1, self.num_heads * self.head_size)
         return context_layer
+

--- a/vllm_fl/dispatch/backends/vendor/ascend/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/patch.py
@@ -2,6 +2,8 @@
 
 import logging
 
+import torch
+import torch.nn.functional as F
 import vllm
 
 logger = logging.getLogger(__name__)
@@ -18,6 +20,10 @@ def apply_ascend_patches():
     patch_fla_ops()
     patch_op_cls()
     patch_fused_moe()
+    patch_gdn_warmup()
+    patch_gdn_triton_ops()
+    patch_gdn_state_gather()
+    patch_vit_pos_embed()
 
 def patch_mamba_config():
     """Patch HybridAttentionMambaModelConfig for Ascend."""
@@ -27,21 +33,127 @@ def patch_mamba_config():
     logger.info("Patched HybridAttentionMambaModelConfig for Ascend")
 
 def patch_causal_conv1d():
-    """Patch causal_conv1d ops with Ascend implementations."""
+    """Patch causal_conv1d ops with Ascend implementations.
+
+    Uses the pure-PyTorch causal_conv1d_fn (which internally calls
+    causal_conv1d_ref) and a pure-PyTorch causal_conv1d_update to
+    avoid the Triton kernel that crashes the NPU driver.
+    """
     try:
         import vllm.model_executor.layers.mamba.ops.causal_conv1d as _conv1d_lib
         import vllm.model_executor.models.qwen3_next as _qwen3_next_lib
 
         from .impl.causal_conv1d import causal_conv1d_fn as causal_conv1d_fn_npu
-        from .impl.causal_conv1d import causal_conv1d_update_npu
+        from .impl.causal_conv1d import causal_conv1d_ref
+
+        def causal_conv1d_update_torch(
+            x, conv_state, weight, bias=None, activation=None,
+            conv_state_indices=None, num_accepted_tokens=None,
+            query_start_loc=None, max_query_len=-1,
+            pad_slot_id=-1, block_idx_last_scheduled_token=None,
+            initial_state_idx=None, validate_data=False,
+        ):
+            """Pure-PyTorch causal_conv1d_update for Ascend NPU.
+
+            Uses causal_conv1d_ref for each sequence. Moves small index
+            tensors to CPU once to avoid per-iteration NPU sync.
+            """
+            if isinstance(activation, bool):
+                activation = "silu" if activation else None
+            original_dtype = x.dtype
+            x = x.to(conv_state.dtype)
+            unsqueeze = query_start_loc is None and x.dim() == 2
+            if unsqueeze:
+                x = x.unsqueeze(-1)
+
+            _, width = weight.shape
+
+            # Move small index tensors to CPU once
+            if conv_state_indices is not None:
+                csi_cpu = conv_state_indices.cpu().tolist()
+            else:
+                csi_cpu = None
+
+            if query_start_loc is None:
+                batch = x.shape[0]
+                for i in range(batch):
+                    idx = csi_cpu[i] if csi_cpu is not None else i
+                    if pad_slot_id is not None and csi_cpu is not None and idx == pad_slot_id:
+                        continue
+                    state = conv_state[idx]  # (dim, state_len)
+                    xi = x[i]  # (dim, seqlen)
+                    seqlen = xi.shape[-1]
+                    combined = torch.cat([state[..., -(width-1):], xi], dim=-1)
+                    dim_size = weight.shape[0]
+                    out_i = F.conv1d(
+                        combined.unsqueeze(0),
+                        weight.unsqueeze(1), bias,
+                        padding=0, groups=dim_size,
+                    ).squeeze(0)[..., :seqlen]
+                    conv_state[idx, :, -(width-1):] = combined[..., -(width-1):]
+                    if activation in ["silu", "swish"]:
+                        out_i = F.silu(out_i)
+                    x[i] = out_i
+            else:
+                qsl_cpu = query_start_loc.cpu().tolist()
+                batch = len(qsl_cpu) - 1
+                for i in range(batch):
+                    idx = csi_cpu[i] if csi_cpu is not None else i
+                    if pad_slot_id is not None and csi_cpu is not None and idx == pad_slot_id:
+                        continue
+                    start, end = qsl_cpu[i], qsl_cpu[i+1]
+                    if start >= end:
+                        continue
+                    xi = x[start:end].t().unsqueeze(0)  # (1, dim, seqlen)
+                    state = conv_state[idx]
+                    dim_size = weight.shape[0]
+                    combined = torch.cat([state[..., -(width-1):], xi.squeeze(0)], dim=-1)
+                    out_i = F.conv1d(
+                        combined.unsqueeze(0),
+                        weight.unsqueeze(1), bias,
+                        padding=0, groups=dim_size,
+                    ).squeeze(0)[..., :(end-start)]
+                    conv_state[idx, :, -(width-1):] = combined[..., -(width-1):]
+                    if activation in ["silu", "swish"]:
+                        out_i = F.silu(out_i)
+                    x[start:end] = out_i.t()
+
+            if unsqueeze:
+                x = x.squeeze(-1)
+            return x.to(original_dtype)
 
         _conv1d_lib.causal_conv1d_fn = causal_conv1d_fn_npu
-        _conv1d_lib.causal_conv1d_update = causal_conv1d_update_npu
+        _conv1d_lib.causal_conv1d_update = causal_conv1d_update_torch
         _qwen3_next_lib.causal_conv1d_fn = causal_conv1d_fn_npu
-        _qwen3_next_lib.causal_conv1d_update = causal_conv1d_update_npu
-        logger.info("Patched causal_conv1d ops for Ascend")
+        _qwen3_next_lib.causal_conv1d_update = causal_conv1d_update_torch
+
+        # Also patch the gdn_linear_attn module's local bindings
+        import vllm.model_executor.layers.mamba.gdn_linear_attn as _gdn_lib
+        _gdn_lib.causal_conv1d_fn = causal_conv1d_fn_npu
+        _gdn_lib.causal_conv1d_update = causal_conv1d_update_torch
+
+        logger.info("Patched causal_conv1d ops for Ascend (pure-PyTorch)")
     except Exception as e:
         logger.warning("Failed to patch causal_conv1d ops: %s", e)
+
+def patch_gdn_warmup():
+    """Disable GDN prefill kernel warmup on Ascend NPU.
+
+    The Triton FLA chunk_gated_delta_rule kernel uses tl.insert_slice which
+    is not available on NPU. The warmup failure corrupts the NPU stream,
+    causing all subsequent kernel calls to fail with 'Inner error'.
+    Skipping the warmup avoids the stream corruption entirely.
+    """
+    try:
+        import vllm.model_executor.layers.mamba.gdn_linear_attn as gdn_lib
+
+        def _noop_warmup(self, mixed_qkv):
+            pass
+
+        gdn_lib.GatedDeltaNetAttention._warmup_prefill_kernels = _noop_warmup
+        logger.info("Disabled GDN prefill kernel warmup for Ascend NPU")
+    except Exception as e:
+        logger.warning("Failed to patch GDN warmup: %s", e)
 
 def patch_fused_moe():
     """Patch fused MoE ops with Ascend implementations."""
@@ -57,7 +169,15 @@ def patch_fused_moe():
         logger.warning("Failed to patch fused_moe ops: %s", e)
 
 def patch_fla_ops():
-    """Patch FLA ops and fused_gdn_gating with Ascend implementations."""
+    """Patch FLA ops for Ascend NPU.
+
+    The FlagGems FLA Triton kernels (chunk_gated_delta_rule_fwd, solve_tril,
+    etc.) use tl.insert_slice and other ops not available in triton 3.2.0.
+    Replace chunk_gated_delta_rule_fwd with a no-op that returns zeros,
+    allowing the model to load and serve. The linear_attention layers
+    will produce zero output (degraded quality) but the model will be
+    functional for testing.
+    """
     try:
         import vllm.model_executor.layers.fla.ops as _fla_ops_lib
         import vllm.model_executor.layers.fla.ops.chunk as _fla_chunk_lib
@@ -65,24 +185,363 @@ def patch_fla_ops():
         import vllm.model_executor.layers.fla.ops.layernorm_guard as _fla_layernorm_lib
         import vllm.model_executor.models.qwen3_next as _qwen3_next_lib
         from flag_gems.runtime.backend._ascend.fla import (
-            chunk_gated_delta_rule_fwd,
             fused_recurrent_gated_delta_rule_fwd,
         )
         from flag_gems.runtime.backend._ascend.fla.layernorm_guard import (
             LayerNormFn as ascend_LayerNormFn,
         )
 
-        from .impl.fla import chunk_gated_delta_rule_npu
+        from .impl.fla.gdn_torch_ops import chunk_gated_delta_rule_torch
 
-        _fla_ops_lib.chunk_gated_delta_rule_fwd = chunk_gated_delta_rule_fwd
-        _fla_chunk_lib.chunk_gated_delta_rule_fwd = chunk_gated_delta_rule_fwd
-        _fla_chunk_lib.chunk_gated_delta_rule = chunk_gated_delta_rule_npu
+        def chunk_gated_delta_rule_fwd_proper(
+            q, k, v, g, beta, scale, initial_state,
+            output_final_state, cu_seqlens=None, **kwargs
+        ):
+            if scale is None:
+                scale = q.shape[-1] ** -0.5
+            o, final_state = chunk_gated_delta_rule_torch(
+                q=q, k=k, v=v, g=g, beta=beta,
+                scale=scale,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                cu_seqlens=cu_seqlens,
+            )
+            return g, o, None, final_state, None, None, v
+
+        def chunk_gated_delta_rule_proper(
+            q, k, v, g, beta, scale=None, initial_state=None,
+            output_final_state=False, cu_seqlens=None,
+            head_first=False, use_qk_l2norm_in_kernel=False,
+        ):
+            if use_qk_l2norm_in_kernel:
+                q = l2norm_fwd_torch(q)
+                k = l2norm_fwd_torch(k)
+            if scale is None:
+                scale = q.shape[-1] ** -0.5
+            o, fs = chunk_gated_delta_rule_torch(
+                q=q, k=k, v=v, g=g, beta=beta,
+                scale=scale,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                cu_seqlens=cu_seqlens,
+            )
+            return o, fs
+
+        _fla_ops_lib.chunk_gated_delta_rule_fwd = chunk_gated_delta_rule_fwd_proper
+        _fla_chunk_lib.chunk_gated_delta_rule_fwd = chunk_gated_delta_rule_fwd_proper
+        _fla_chunk_lib.chunk_gated_delta_rule = chunk_gated_delta_rule_proper
         _fla_recurrent_lib.fused_recurrent_gated_delta_rule_fwd = fused_recurrent_gated_delta_rule_fwd
         _fla_layernorm_lib.LayerNormFn = ascend_LayerNormFn
-        _qwen3_next_lib.chunk_gated_delta_rule = chunk_gated_delta_rule_npu
-        logger.info("Patched FLA ops for Ascend")
+        _qwen3_next_lib.chunk_gated_delta_rule = chunk_gated_delta_rule_proper
+
+        # Also patch the FlagGems module and every import site
+        import flag_gems.runtime.backend._ascend.fla as _fg_fla
+        import flag_gems.runtime.backend._ascend.fla.chunk as _fg_chunk
+        _fg_fla.chunk_gated_delta_rule_fwd = chunk_gated_delta_rule_fwd_proper
+        _fg_chunk.chunk_gated_delta_rule_fwd = chunk_gated_delta_rule_fwd_proper
+
+        # Patch the plugin's own FLA chunk module
+        try:
+            from vllm_fl.dispatch.backends.vendor.ascend.impl.fla import chunk as _ascend_chunk
+            _ascend_chunk.chunk_gated_delta_rule_fwd = chunk_gated_delta_rule_fwd_proper
+        except ImportError:
+            pass
+
+        # Patch the gdn_linear_attn module's local name binding
+        import vllm.model_executor.layers.mamba.gdn_linear_attn as _gdn_lib
+        _gdn_lib.fla_chunk_gated_delta_rule = chunk_gated_delta_rule_proper
+
+        # Patch forward_native and forward_oot on ChunkGatedDeltaRule
+        def _proper_forward_native(
+            self, q, k, v, g, beta, initial_state, output_final_state,
+            cu_seqlens=None, chunk_indices=None, chunk_offsets=None,
+            use_qk_l2norm_in_kernel=True,
+        ):
+            return chunk_gated_delta_rule_proper(
+                q=q, k=k, v=v, g=g, beta=beta,
+                initial_state=initial_state,
+                output_final_state=output_final_state,
+                cu_seqlens=cu_seqlens,
+                use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            )
+        _gdn_lib.ChunkGatedDeltaRule.forward_native = _proper_forward_native
+        _gdn_lib.ChunkGatedDeltaRule.forward_oot = _proper_forward_native
+
+
+        # No error-swallowing wrapper — errors propagate for proper debugging.
+
+        logger.info("Patched FLA ops for Ascend NPU (proper recurrent chunk_gated_delta_rule)")
     except Exception as e:
         logger.warning("Failed to patch FLA ops: %s", e)
+
+def patch_gdn_triton_ops():
+    """Replace all GDN Triton kernels with pure-PyTorch implementations.
+
+    The Triton LLVM backend crashes on ARM/Ascend NPU with an assertion
+    failure in PointerUnion::get(). This replaces every Triton kernel
+    used on the GDN inference path:
+      - fused_sigmoid_gating_delta_rule_update (decode path gating+recurrence)
+      - fused_post_conv_prep (prefill path post-conv preparation)
+      - fused_recurrent_gated_delta_rule_packed_decode (packed decode)
+      - fused_gdn_gating (gating computation in gdn_linear_attn.py)
+      - l2norm_fwd (L2 normalization)
+    """
+    try:
+        from .impl.fla.gdn_torch_ops import (
+            chunk_gated_delta_rule_torch,
+            fused_gdn_gating_torch,
+            fused_post_conv_prep_torch,
+            l2norm_fwd_torch,
+        )
+
+        # 1. Patch fused_sigmoid_gating_delta_rule_update (decode path)
+        # Use the proper vectorized bmm implementation
+        def _proper_sigmoid_gating_update(
+            A_log, a, b, dt_bias, q, k, v,
+            beta=1.0, threshold=20.0, scale=None,
+            initial_state=None, inplace_final_state=True,
+            cu_seqlens=None, ssm_state_indices=None,
+            num_accepted_tokens=None, use_qk_l2norm_in_kernel=False,
+            is_kda=False,
+        ):
+            """Pure-PyTorch fused sigmoid gating delta rule update.
+
+            Combines gating computation + recurrent delta rule in one function.
+            This is used for the DECODE path (T=1 typically).
+            """
+            B, T, H, K_dim = q.shape
+            V_dim = v.shape[-1]
+            HV = v.shape[2]
+            groups = HV // H
+
+            if scale is None:
+                scale = K_dim ** -0.5
+
+            # Compute gating: g = -exp(A_log) * softplus(a + dt_bias)
+            # a, b: [num_tokens, HV]
+            a_f = a.float()
+            b_f = b.float()
+            x = a_f + dt_bias.float().unsqueeze(0)
+            sp = F.softplus(x, beta=beta, threshold=threshold)
+            g_vals = -torch.exp(A_log.float()).unsqueeze(0) * sp
+            beta_vals = torch.sigmoid(b_f)  # [tokens, HV]
+
+            N = B if cu_seqlens is None else len(cu_seqlens) - 1
+            o = torch.zeros_like(v)
+
+            if inplace_final_state:
+                final_state = initial_state
+            else:
+                final_state = initial_state.clone()
+
+            if cu_seqlens is not None:
+                cu_cpu = cu_seqlens.cpu().tolist()
+            if ssm_state_indices is not None:
+                ssi_cpu = ssm_state_indices.cpu()
+
+            # Expand q/k to match HV heads
+            if groups > 1:
+                q_exp = q.repeat_interleave(groups, dim=2)
+                k_exp = k.repeat_interleave(groups, dim=2)
+            else:
+                q_exp = q
+                k_exp = k
+
+            for i_n in range(N):
+                if cu_seqlens is not None:
+                    bos = cu_cpu[i_n]
+                    eos = cu_cpu[i_n + 1]
+                else:
+                    bos, eos = i_n * T, (i_n + 1) * T
+
+                if bos >= eos:
+                    continue
+
+                # Get state index
+                if ssm_state_indices is not None:
+                    if num_accepted_tokens is not None:
+                        i_t_init = num_accepted_tokens[i_n].item() - 1
+                    else:
+                        i_t_init = 0
+                    if ssm_state_indices.ndim == 1:
+                        state_idx = ssi_cpu[i_n].item()
+                    else:
+                        state_idx = ssi_cpu[i_n, i_t_init].item()
+                    if state_idx < 0:
+                        continue
+                else:
+                    state_idx = bos
+
+                h = final_state[state_idx].float()  # [HV, V, K]
+
+                for t_offset in range(eos - bos):
+                    t = bos + t_offset
+                    qt = q_exp[0, t].float() if cu_seqlens is not None else q_exp[i_n, t_offset].float()
+                    kt = k_exp[0, t].float() if cu_seqlens is not None else k_exp[i_n, t_offset].float()
+                    vt = v[0, t].float() if cu_seqlens is not None else v[i_n, t_offset].float()
+
+                    t_flat = t if cu_seqlens is not None else i_n * T + t_offset
+                    gt = g_vals[t_flat].float()
+                    bt = beta_vals[t_flat].float()
+
+                    if use_qk_l2norm_in_kernel:
+                        qt = qt * torch.rsqrt(torch.sum(qt * qt, dim=-1, keepdim=True) + 1e-6)
+                        kt = kt * torch.rsqrt(torch.sum(kt * kt, dim=-1, keepdim=True) + 1e-6)
+                    qt = qt * scale
+
+                    # h *= exp(g)
+                    h = h * torch.exp(gt).unsqueeze(-1).unsqueeze(-1)
+                    # hk = h @ k
+                    hk = torch.bmm(h, kt.unsqueeze(-1)).squeeze(-1)
+                    # v' = beta * (v - hk)
+                    vp = (vt - hk) * bt.unsqueeze(-1)
+                    # h += v' outer k
+                    h = h + torch.bmm(vp.unsqueeze(-1), kt.unsqueeze(-2))
+                    # o = h @ q
+                    ot = torch.bmm(h, qt.unsqueeze(-1)).squeeze(-1)
+
+                    if cu_seqlens is not None:
+                        o[0, t] = ot.to(o.dtype)
+                    else:
+                        o[i_n, t_offset] = ot.to(o.dtype)
+
+                    # Store final state
+                    if inplace_final_state and ssm_state_indices is not None:
+                        if ssm_state_indices.ndim == 1:
+                            fidx = ssi_cpu[i_n].item()
+                        else:
+                            fidx = ssi_cpu[i_n, t_offset].item()
+                        if fidx >= 0:
+                            final_state[fidx] = h.to(final_state.dtype)
+                    else:
+                        final_state[state_idx] = h.to(final_state.dtype)
+
+            return o, final_state
+
+        import vllm.model_executor.layers.fla.ops.fused_sigmoid_gating as _fsg_lib
+        _fsg_lib.fused_sigmoid_gating_delta_rule_update = _proper_sigmoid_gating_update
+
+        import vllm.model_executor.layers.mamba.gdn_linear_attn as _gdn_lib
+        _gdn_lib.fused_sigmoid_gating_delta_rule_update = _proper_sigmoid_gating_update
+
+        # 2. Patch fused_post_conv_prep
+        import vllm.model_executor.layers.fla.ops.fused_gdn_prefill_post_conv as _fpc_lib
+        _fpc_lib.fused_post_conv_prep = fused_post_conv_prep_torch
+
+        import vllm.model_executor.layers.fla.ops as _fla_ops_lib
+        _fla_ops_lib.fused_post_conv_prep = fused_post_conv_prep_torch
+        _gdn_lib.fused_post_conv_prep = fused_post_conv_prep_torch
+
+        # 3. Patch fused_recurrent_gated_delta_rule_packed_decode (decode path)
+        # Use proper vectorized bmm implementation
+        def _proper_packed_decode(
+            mixed_qkv, a, b, A_log, dt_bias, scale,
+            initial_state, out, ssm_state_indices,
+            use_qk_l2norm_in_kernel=False,
+        ):
+            """Pure-PyTorch packed decode for GDN recurrence.
+
+            Implements the gated delta rule recurrent update:
+              g = -exp(A_log) * softplus(a + dt_bias)
+              beta = sigmoid(b)
+              h = h * exp(g)
+              h = h + beta * (v - h @ k) ⊗ k
+              o = h @ q
+            """
+            # Sync on first call to ensure prefill NPU ops have completed
+            if not hasattr(_proper_packed_decode, '_synced'):
+                _proper_packed_decode._synced = True
+                import torch_npu
+                torch.npu.synchronize()
+            B_batch = mixed_qkv.shape[0]
+            HV, V_dim, K_dim = initial_state.shape[-3:]
+            qkv_dim = mixed_qkv.shape[1]
+            qk_dim = qkv_dim - HV * V_dim
+            H = qk_dim // (2 * K_dim)
+            groups = HV // H
+            ssi_cpu = ssm_state_indices.cpu().tolist()
+
+            # Compute gating for all tokens at once
+            x = a.float() + dt_bias.float().unsqueeze(0)
+            sp = F.softplus(x, beta=1.0, threshold=20.0)
+            g_vals = (-torch.exp(A_log.float()).unsqueeze(0) * sp)  # [B, HV]
+            beta_vals = torch.sigmoid(b.float())  # [B, HV]
+
+            for i_n in range(B_batch):
+                state_idx = ssi_cpu[i_n]
+                if state_idx < 0:
+                    out[i_n, 0, :, :] = 0
+                    continue
+
+                # Extract q, k, v from packed mixed_qkv
+                q_start, k_start, v_start = 0, H * K_dim, 2 * H * K_dim
+                b_q = mixed_qkv[i_n, q_start:q_start + H * K_dim].view(H, K_dim).float()
+                b_k = mixed_qkv[i_n, k_start:k_start + H * K_dim].view(H, K_dim).float()
+                b_v = mixed_qkv[i_n, v_start:v_start + HV * V_dim].view(HV, V_dim).float()
+
+                if use_qk_l2norm_in_kernel:
+                    b_q = b_q * torch.rsqrt(torch.sum(b_q * b_q, dim=-1, keepdim=True) + 1e-6)
+                    b_k = b_k * torch.rsqrt(torch.sum(b_k * b_k, dim=-1, keepdim=True) + 1e-6)
+                b_q = b_q * scale
+
+                # Expand q/k heads to match value heads (multi-query attention)
+                if groups > 1:
+                    b_q = b_q.repeat_interleave(groups, dim=0)
+                    b_k = b_k.repeat_interleave(groups, dim=0)
+
+                h = initial_state[state_idx].float()  # [HV, V, K]
+                # Safety net: zero out if state contains garbage
+                # (NaN/Inf from uninitialized memory)
+                if torch.isnan(h).any() or torch.isinf(h).any():
+                    h = torch.zeros_like(h)
+
+                gt = g_vals[i_n]  # [HV]
+                bt = beta_vals[i_n]  # [HV]
+
+                # Gated decay
+                h = h * torch.exp(gt).unsqueeze(-1).unsqueeze(-1)
+                # Delta rule update: h += beta * (v - h@k) ⊗ k
+                hk = torch.bmm(h, b_k.unsqueeze(-1)).squeeze(-1)  # [HV, V]
+                vp = (b_v - hk) * bt.unsqueeze(-1)
+                h = h + torch.bmm(vp.unsqueeze(-1), b_k.unsqueeze(-2))
+                # Output: o = h @ q
+                b_o = torch.bmm(h, b_q.unsqueeze(-1)).squeeze(-1)  # [HV, V]
+
+                out[i_n, 0] = b_o.to(out.dtype)
+                initial_state[state_idx] = h.to(initial_state.dtype)
+
+            return out, initial_state
+
+        import vllm.model_executor.layers.fla.ops.fused_recurrent as _fr_lib
+        _fr_lib.fused_recurrent_gated_delta_rule_packed_decode = _proper_packed_decode
+        _fla_ops_lib.fused_recurrent_gated_delta_rule_packed_decode = _proper_packed_decode
+        _gdn_lib.fused_recurrent_gated_delta_rule_packed_decode = _proper_packed_decode
+
+        # 4. Patch fused_gdn_gating (in gdn_linear_attn.py)
+        _gdn_lib.fused_gdn_gating = fused_gdn_gating_torch
+
+        # 5. Patch l2norm_fwd
+        import vllm.model_executor.layers.fla.ops.chunk as _chunk_lib
+        import vllm.model_executor.layers.fla.ops.l2norm as _l2norm_lib
+        _l2norm_lib.l2norm_fwd = l2norm_fwd_torch
+        _chunk_lib.l2norm_fwd = l2norm_fwd_torch
+        _gdn_lib.l2norm_fwd = l2norm_fwd_torch
+
+        # Also patch the plugin's own l2norm if present
+        try:
+            from vllm_fl.dispatch.backends.vendor.ascend.impl.fla import (
+                l2norm as _ascend_l2norm,
+            )
+            _ascend_l2norm.l2norm_fwd = l2norm_fwd_torch
+        except ImportError:
+            pass
+
+        logger.info(
+            "Patched all GDN Triton kernels with pure-PyTorch for Ascend NPU"
+        )
+    except Exception as e:
+        logger.warning("Failed to patch GDN Triton ops: %s", e)
+
 
 def patch_op_cls():
     """Patch MMEncoderAttention to use manual matmul attention on NPU.
@@ -130,3 +589,63 @@ def refresh_block_size(vllm_config, block_size = 128):
         if cache_config.enable_prefix_caching or scheduler_config.enable_chunked_prefill:
             logger.info(f"Block size is set to {block_size} if prefix cache or chunked prefill is enabled.")
             cache_config.block_size = block_size
+
+
+def patch_gdn_state_gather():
+    """Fix GDN ssm_state gather for Ascend NPU.
+
+    torch_npu's advanced-index gather ``ssm_state[index_tensor]`` returns
+    wrong/stale values on NPU (for both int32 and int64 index tensors), while
+    ``torch.index_select`` reads correctly. In GatedDeltaNetAttention._forward_core
+    the broken gather corrupts the initial state of decode sequences batched with
+    a prefill (mixed prefill+decode step), blowing up the recurrent state and
+    producing garbage tokens under concurrency.
+
+    We rebind _forward_core to a copy of the installed method source with that one
+    gather rewritten to torch.index_select, so the patch tracks the vLLM version.
+    """
+    try:
+        import inspect
+        import textwrap
+        import vllm.model_executor.layers.mamba.gdn_linear_attn as _gdn
+
+        cls = _gdn.GatedDeltaNetAttention
+        src = inspect.getsource(cls._forward_core)
+        broken = "ssm_state[non_spec_state_indices_tensor].contiguous()"
+        fixed = ("torch.index_select(ssm_state, 0, "
+                 "non_spec_state_indices_tensor.long()).contiguous()")
+        if broken not in src:
+            logger.warning(
+                "GDN _forward_core gather pattern not found; skipping patch "
+                "(vLLM may already be fixed or changed).")
+            return
+        src = textwrap.dedent(src).replace(broken, fixed)
+        # Exec in the module's namespace so all globals resolve correctly.
+        ns = {}
+        exec(src, _gdn.__dict__, ns)
+        cls._forward_core = ns["_forward_core"]
+        logger.info("Patched GDN _forward_core ssm_state gather for Ascend "
+                    "(index_select).")
+    except Exception as e:
+        logger.warning("Failed to patch GDN state gather: %s", e)
+
+
+def patch_vit_pos_embed():
+    """Force native (pure-torch) ViT position-embedding interpolation on NPU.
+
+    Qwen3-VL's fast_pos_embed_interpolate picks a Triton kernel when HAS_TRITON
+    is True, but Triton is unreliable on Ascend NPU and produces wrong learned
+    2D position embeddings, so the vision encoder loses spatial layout (image
+    understanding degrades badly). The function reads the module-level HAS_TRITON
+    at call time, so flipping it to False routes to pos_embed_interpolate_native.
+    """
+    try:
+        import vllm.model_executor.models.qwen3_vl as _vl
+        if getattr(_vl, "HAS_TRITON", False):
+            _vl.HAS_TRITON = False
+            logger.info("Forced native ViT pos-embed interpolation for Ascend.")
+    except Exception as e:
+        logger.warning("Failed to patch ViT pos-embed interpolation: %s", e)
+
+
+

--- a/vllm_fl/dispatch/backends/vendor/ascend/register_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/register_ops.py
@@ -74,6 +74,42 @@ def register_builtins(registry: OpRegistry) -> None:
             vendor="ascend",
             priority=BackendPriority.VENDOR,
         ),
+        # Fused MoE kernel (torch.mm fallback for Triton UB overflow)
+        OpImpl(
+            op_name="invoke_fused_moe_triton_kernel",
+            impl_id="vendor.ascend",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.invoke_fused_moe_triton_kernel, is_avail),
+            vendor="ascend",
+            priority=BackendPriority.VENDOR,
+        ),
+        # MoE align block size (torch fallback for Triton DDR OOB)
+        OpImpl(
+            op_name="moe_align_block_size",
+            impl_id="vendor.ascend",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.moe_align_block_size, is_avail),
+            vendor="ascend",
+            priority=BackendPriority.VENDOR,
+        ),
+        # MoE sum (torch fallback for Triton crash)
+        OpImpl(
+            op_name="moe_sum",
+            impl_id="vendor.ascend",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.moe_sum, is_avail),
+            vendor="ascend",
+            priority=BackendPriority.VENDOR,
+        ),
+        # topk_softmax (torch fallback for Triton crash)
+        OpImpl(
+            op_name="topk_softmax",
+            impl_id="vendor.ascend",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.topk_softmax, is_avail),
+            vendor="ascend",
+            priority=BackendPriority.VENDOR,
+        ),
     ]
 
     registry.register_many(impls)

--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -80,6 +80,12 @@ flagos_blacklist:
   # --- Arithmetic (Triton compilation hang on MoE 256-expert shapes) ---
   - mm
   - addmm
+  - linear  # flag_gems linear (aten::linear) kernel spins forever on device
+            # under triton_ascend 3.2.0 for decode (M=1) shapes; AICore pinned
+            # at ~111% while EngineCore stalls in get_current_stream; flagtree
+            # 0.6.0+ascend3.2 compiles the same kernel fine. mm/addmm already
+            # blacklisted; linear is the remaining GEMM path in the hot decode
+            # loop. Falling back to torch_npu.linear is exact.
   - add
   - sub
   - mul

--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -44,69 +44,65 @@ op_backends:
     - vendor
     - flagos
     - reference
+  # invoke_fused_moe_triton_kernel: prioritize vendor (torch.mm) because
+  # FlagGems Triton kernel overflows NPU unified buffer on some model shapes
+  invoke_fused_moe_triton_kernel:
+    - vendor
+    - flagos
+  # moe_align_block_size: prioritize vendor (pure-torch) because
+  # FlagGems Triton kernel causes DDR address OOB on NPU
+  moe_align_block_size:
+    - vendor
+    - flagos
+  moe_sum:
+    - vendor
+    - flagos
+  topk_softmax:
+    - vendor
+    - flagos
 
 # FlagOS operator blacklist
 # These operators will NOT use FlagOS implementation even if FlagOS is enabled.
+# Operators are blacklisted because their FlagGems Triton kernels are either
+# incorrect, imprecise, or crash on Ascend NPU during inference.
 flagos_blacklist:
+  # --- Crash: GDN recurrent path precision ---
+  - exp
+  - exp_
+  - log
+  # --- Crash: Indexing (corrupts ViT rotary cos[pos_ids]) ---
+  - index
+  # --- Crash: Fill (ZeroDivisionError on zero-size slices) ---
+  - fill_scalar_
+  - fill_tensor_
+  # --- Crash: Conv (assertion failure with grouped conv) ---
+  - conv1d
+  # --- Arithmetic (Triton compilation hang on MoE 256-expert shapes) ---
+  - mm
+  - addmm
+  - add
+  - sub
+  - mul
+  - true_divide
+  - true_divide_
+  - floor_divide
+  - reciprocal
+  - neg
+  - neg_
+  - abs
+  - abs_
+  # --- Scatter/Gather (worker hard-crash, NPU segfault) ---
   - masked_scatter_
   - masked_scatter
   - scatter_add_
-  - ones
-  - ones_like
-  - isclose
-  - allclose
-  - mean_dim
-  - chunk_gated_delta_rule_fwd
-  - rsqrt # performance loss
-  - index_select
-  - true_divide
-  - silu
-  - silu_and_mul # performance loss end
-  - to_copy
-  - _to_copy
-  - zeros
-  - acos
-  - copy_
-  - fill_scalar_
-  - sum_dim
-  - exponential_
-  - mm
-  - resolve_neg
-  - resolve_conj
-  - eq_scalar
-  - floor_divide
-  - cumsum
-  - cumsum_out
-  - mul
-  - reciprocal
-  - repeat
-  - randn
-  - add
-  - ge_scalar
-  - sub
-  - bitwise_and
-  - bitwise_not
-  - slice_scatter
-  - fill_tensor_
-  - conv1d
-  - conv2d
-  - uniform_
-  - prod
-  - max
-  - amax
-  - cat
-  - stack
-  - flatten
-  - reshape
-  - view
-  - tensor
-  - rand
-  - rand_like
-  - gather
-  - _log_softmax
-  - _flash_attention_forward
   - scatter
   - scatter_
+  - gather
+  - index_put
+  - index_put_
+  - _index_put_impl_
+  # --- Reduction (argmax only - Invalid Runtime Function on NPU) ---
+  - argmax
 
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.

--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -113,6 +113,21 @@ flagos_blacklist:
   - lift_fresh_copy
   - _to_copy
 
+  # --- Compile: triton_ascend fork rejects chained boolean (or) ---
+  # flag_gems ascend pow kernels use `if (A or B or C)` which the
+  # triton_ascend 3.2.0 fork frontend refuses (UnsupportedLanguageConstruct:
+  # chained boolean operators), so the Triton path crashes compiling the
+  # RoPE _compute_inv_freq `10000.0 ** t` (pow.Scalar -> pow_scalar).
+  # config_filter() matches on the impl function name (item[1].__name__),
+  # so the blacklist must list the wrapper names below — the op short name
+  # "pow" does NOT match and is ineffective. Falling back to torch_npu.pow
+  # is exact.
+  - pow_tensor_tensor
+  - pow_tensor_tensor_
+  - pow_tensor_scalar
+  - pow_tensor_scalar_
+  - pow_scalar
+
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.
 # oot_blacklist:

--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -128,6 +128,23 @@ flagos_blacklist:
   - pow_tensor_scalar_
   - pow_scalar
 
+  # --- Crash: cumsum get_num_sms returns None (large-row scan) ---
+  # flag_gems cumsum kernels call get_num_sms(device_idx) ->
+  # torch_device_fn.get_device_properties(idx).multi_processor_count when
+  # N > 16384. On torch_npu 2.9.0 / triton_ascend 3.2.0 (cann8.5.0) the
+  # properties object lacks multi_processor_count -> None * 4 -> TypeError
+  # ("unsupported operand type(s) for *: 'NoneType' and 'int'"), killing
+  # EngineCore on the first decode step (vllm topk_topp_sampler
+  # torch.cumsum(probs_sort, dim=-1, out=probs_sort), batch < 8 -> pytorch
+  # path). hw25 (cann9.0.0, torch_npu 2.10.0) has a working
+  # multi_processor_count, so this is cann8.5.0-specific. Falling back to
+  # torch_npu.cumsum is exact. Both the plain and out= overloads are listed
+  # because config_filter() matches on the impl function name
+  # (item[1].__name__): "cumsum" (aten::cumsum) and "cumsum_out"
+  # (aten::cumsum.out).
+  - cumsum
+  - cumsum_out
+
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.
 # oot_blacklist:

--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -103,6 +103,15 @@ flagos_blacklist:
   - _index_put_impl_
   # --- Reduction (argmax only - Invalid Runtime Function on NPU) ---
   - argmax
+  # --- Constant materialization (coreDim=0 kernel launch on scalar tensors) ---
+  # register_buffer("_k_scale", torch.tensor(1.0)) during model construction
+  # routes torch.tensor(scalar) through aten::lift_fresh; the FlagGems copy
+  # kernel computes a zero grid for a scalar/tiny tensor and the NPU aborts
+  # engine startup with "coreDim is invalid (value 0)". These are trivial
+  # copies, so falling back to torch_npu is lossless.
+  - lift_fresh
+  - lift_fresh_copy
+  - _to_copy
 
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.

--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -145,6 +145,25 @@ flagos_blacklist:
   - cumsum
   - cumsum_out
 
+  # --- Crash: repeat_interleave (triton_ascend 3.2.0 MLIR stride assertion) ---
+  # The ATB rotary path (torch_npu._npu_rotary_embedding -> torch.ops.atb.*)
+  # uses repeat_interleave to expand the cos/sin cache for GQA. With flag_gems
+  # patching it, the pointwise copy kernel (rank-3, t2048) fails to compile on
+  # triton_ascend 3.2.0 / cann8.5.0: ConvertTritonIRToLinalgIR "strides must
+  # not be zero" -> MLIRCompilationError. That exception is raised inside the
+  # vendor rotary impl on its first decode call, which silently poisons the
+  # vendor.ascend impl (CachedOp fast path marks it failed without a warning
+  # log) and forces a fallback to the flag_gems rope kernel -> hangs/garbage
+  # on first request under the triton compiler. Falling back to
+  # torch_npu.repeat_interleave is exact. All three overload wrappers are
+  # listed because config_filter() matches on the impl function name
+  # (item[1].__name__): "repeat_interleave_self_int" (ATB internal),
+  # "repeat_interleave_self_tensor" and "repeat_interleave_tensor" (plugin's
+  # own patch.py / gdn_torch_ops.py / mm_encoder_attention.py calls).
+  - repeat_interleave_self_int
+  - repeat_interleave_self_tensor
+  - repeat_interleave_tensor
+
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.
 # oot_blacklist:

--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -170,6 +170,17 @@ flagos_blacklist:
   - repeat_interleave_self_tensor
   - repeat_interleave_tensor
 
+  # --- Wrong result: ATB rotary cos/sin cache index_select ---
+  # flag_gems generic index_select (flag_gems/ops/index_select.py) computes
+  # wrong and non-deterministic output on cann8.5.0 + triton_ascend 3.2.0 for
+  # the ATB rotary cache shape (inp=(40960,128), dim=0, idx=(n,), ~400 calls
+  # per decode). The ascend-specialized impl is unavailable under the vendor
+  # triton tree (no triton.experimental -> the whole _ascend.ops package fails
+  # to import), so the generic kernel is what gets registered. ATB rotary
+  # swallows the corrupted cos/sin and the pollution reaches every attention
+  # head. Falling back to torch_npu.index_select is exact.
+  - index_select
+
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.
 # oot_blacklist:

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -209,6 +209,36 @@ class PlatformFL(Platform):
         if compilation_config.compile_sizes is None:
             compilation_config.compile_sizes = []
 
+        # Ascend NPU: torch_npu inductor codegen has issues with
+        # multi-device compilation (e.g. reduction scheduling on npu:1).
+        # Disable torch.compile and CUDAGraphs until torch_npu inductor
+        # is stable. check_and_update_config runs after VllmConfig.__init__
+        # processes enforce_eager, so we must set compilation_config directly.
+        if cls.device_type == "npu":
+            from vllm.config import CompilationMode
+            if compilation_config.mode != CompilationMode.NONE:
+                logger.warning(
+                    "Disabling torch.compile for Ascend NPU to avoid "
+                    "torch_npu inductor codegen issues."
+                )
+                compilation_config.mode = CompilationMode.NONE
+                compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+
+        # Ascend NPU: force float32 SSM state cache for GDN linear attention.
+        # The pure-PyTorch recurrence accumulates state in float32 but writes
+        # back to initial_state.dtype each step. If the cache is bf16, the
+        # round-trip truncation compounds across hundreds of tokens, degrading
+        # output quality (especially at temperature > 0). Forcing float32 cache
+        # eliminates this precision loss with negligible memory impact (the SSM
+        # state is small relative to the KV cache).
+        if cls.device_type == "npu":
+            if cache_config and cache_config.mamba_ssm_cache_dtype is None:
+                cache_config.mamba_ssm_cache_dtype = "float32"
+                logger.info(
+                    "Forcing mamba_ssm_cache_dtype to float32 for Ascend NPU "
+                    "to avoid recurrence precision loss in GDN decode."
+                )
+
         if (
             cls.device_type == "musa"
             and compilation_config.cudagraph_mode.has_full_cudagraphs()

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -7096,10 +7096,58 @@ class ModelRunnerFL(
             dict[str, torch.Tensor]: A map between layer names to their
             corresponding memory buffer for KV cache.
         """
+        from vllm.platforms import current_platform
+        from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
+
+        # On NPU, hybrid attention-mamba models cannot share raw tensors
+        # between attention and mamba layers. The contiguous layout required
+        # by NPU attention kernels overlaps in memory with mamba's strided
+        # page-aligned layout when using the same underlying buffer.
+        # Fix: allocate separate tensors for attention vs mamba layers.
+        is_npu_hybrid = (
+            current_platform.device_type == "npu"
+            and kv_cache_config.has_mamba_layers
+        )
+
+        # Build layer→group type mapping for hybrid separation
+        attn_layer_names: set[str] = set()
+        if is_npu_hybrid:
+            for group in kv_cache_config.kv_cache_groups:
+                if isinstance(group.kv_cache_spec, AttentionSpec):
+                    attn_layer_names.update(group.layer_names)
+
         kv_cache_raw_tensors: dict[str, torch.Tensor] = {}
         packed_backing: torch.Tensor | None = None
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
-            if kv_cache_tensor.block_stride > 0:
+            if is_npu_hybrid:
+                # Split into attention and mamba tensors: NPU attention
+                # kernels' contiguous layout overlaps mamba's strided
+                # page-aligned layout when sharing the same underlying buffer.
+                # Also bypass the packed-backing path (below): NPU requires
+                # independent tensors per layer group.
+                mamba_layers = [
+                    n for n in kv_cache_tensor.shared_by
+                    if n not in attn_layer_names
+                ]
+                attn_layers = [
+                    n for n in kv_cache_tensor.shared_by
+                    if n in attn_layer_names
+                ]
+                if mamba_layers:
+                    tensor = torch.zeros(
+                        kv_cache_tensor.size, dtype=torch.int8,
+                        device=self.device
+                    )
+                    for layer_name in mamba_layers:
+                        kv_cache_raw_tensors[layer_name] = tensor
+                if attn_layers:
+                    tensor = torch.zeros(
+                        kv_cache_tensor.size, dtype=torch.int8,
+                        device=self.device
+                    )
+                    for layer_name in attn_layers:
+                        kv_cache_raw_tensors[layer_name] = tensor
+            elif kv_cache_tensor.block_stride > 0:
                 # Allocate once; all packed tensors alias the same backing.
                 if packed_backing is None:
                     packed_backing = torch.zeros(
@@ -7108,12 +7156,14 @@ class ModelRunnerFL(
                         device=self.device,
                     )
                 tensor = packed_backing
+                for layer_name in kv_cache_tensor.shared_by:
+                    kv_cache_raw_tensors[layer_name] = tensor
             else:
                 tensor = torch.zeros(
                     kv_cache_tensor.size, dtype=torch.int8, device=self.device
                 )
-            for layer_name in kv_cache_tensor.shared_by:
-                kv_cache_raw_tensors[layer_name] = tensor
+                for layer_name in kv_cache_tensor.shared_by:
+                    kv_cache_raw_tensors[layer_name] = tensor
 
         layer_names = set()
         for group in kv_cache_config.kv_cache_groups:
@@ -7253,10 +7303,19 @@ class ModelRunnerFL(
         Update the layout of attention layers from (2, num_blocks, ...) to
         (num_blocks, 2, ...).
 
+        On Ascend NPU, skip the re-striding because _npu_reshape_and_cache
+        and npu_fused_infer_attention_score require contiguous kv_cache
+        views. The interleaved layout from as_strided_ makes kv_cache[0]
+        and kv_cache[1] non-contiguous, causing OOM when .contiguous()
+        is called during inference.
+
         Args:
             kv_caches: The KV cache buffer of each layer.
             kernel_block_sizes: The kernel block sizes for each KV cache group.
         """
+        from vllm.platforms import current_platform
+        if current_platform.device_type == "npu":
+            return
 
         for group in self._kv_cache_spec_attn_group_iterator():
             kv_cache_spec = group.kv_cache_spec

--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -77,6 +77,17 @@ if TYPE_CHECKING:
     from vllm.model_executor.model_loader.tensorizer import TensorizerConfig
 
 
+def _patch_accelerator_empty_cache():
+    """Patch torch.accelerator.empty_cache for NPU compatibility.
+
+    torch.accelerator.empty_cache() crashes on NPU with
+    'Allocator for npu is not a DeviceAllocator'. Redirect to
+    torch.npu.empty_cache() which works correctly.
+    """
+    import torch.accelerator
+    torch.accelerator.empty_cache = torch.npu.empty_cache
+
+
 @dataclass
 class MemorySnapshot:
     """Platform-agnostic memory snapshot for FL worker."""
@@ -391,6 +402,10 @@ class WorkerFL(WorkerBase):
                     init_device_properties_triton,
             )
             init_device_properties_triton()
+            import torch_npu._inductor  # noqa: F401
+            # Patch torch.accelerator.empty_cache which crashes on NPU
+            # (device_allocator ASSERT FAILED). Use torch.npu.empty_cache instead.
+            _patch_accelerator_empty_cache()
         # Set random seed.
         set_random_seed(self.model_config.seed)
 
@@ -448,6 +463,10 @@ class WorkerFL(WorkerBase):
         """Profiles the peak memory usage of the model to determine how much
         memory can be used for KV cache without OOMs.
 
+        On Ascend NPU, the full profile_run forward pass can crash the worker
+        due to incompatible Triton kernels. In that case, we fall back to a
+        conservative memory estimate based on model weight size.
+
         The engine will first conduct a profiling of the existing memory usage.
         Then, it calculates the free memory that can be used for KV cache in
         bytes.
@@ -480,13 +499,49 @@ class WorkerFL(WorkerBase):
         current_platform.empty_cache()
         current_platform.torch_device_fn.reset_peak_memory_stats()
 
-        # Execute a forward pass with dummy inputs to profile the memory usage
-        # of the model.
-        with memory_profiling_fl(
-            self.init_snapshot,
-            weights_memory=int(self.model_runner.model_memory_usage),
-        ) as profile_result:
-            self.model_runner.profile_run()
+        # On Ascend NPU, the profile_run forward pass crashes the worker
+        # process (SIGKILL from the NPU driver due to incompatible Triton
+        # kernels in the GDN/FLA layers). Skip profile_run and estimate
+        # KV cache memory from the current free memory after model loading.
+        if current_platform.device_type == "npu":
+            current_platform.empty_cache()
+            free_mem = current_platform.torch_device_fn.mem_get_info(
+                self.device
+            )
+            free_bytes = free_mem[0]
+            total_bytes = free_mem[1]
+            # Respect gpu_memory_utilization: total KV cache + model must
+            # fit within gpu_memory_utilization * total_memory.
+            # model_used = total_bytes - free_bytes
+            model_used = total_bytes - free_bytes
+            util = self.cache_config.gpu_memory_utilization
+            budget = int(util * total_bytes) - model_used
+            # Reserve 50% of the budget for activations and the one-time
+            # contiguous copy of non-contiguous kv_cache views.
+            # The kv_cache is allocated as [2, N, B, H, D] and split into
+            # key/value views that are non-contiguous. The first forward
+            # call creates contiguous copies that coexist temporarily with
+            # the original non-contiguous views.
+            activation_reserve = int(budget * 0.5)
+            self.available_kv_cache_memory_bytes = max(
+                budget - activation_reserve, 0
+            )
+            self.non_torch_memory = 0
+            self.peak_activation_memory = activation_reserve
+            logger.info(
+                "Ascend NPU: Skipped profile_run. Free memory: %.2f GiB, "
+                "KV cache budget: %.2f GiB",
+                GiB(free_bytes),
+                GiB(self.available_kv_cache_memory_bytes),
+            )
+        else:
+            # Execute a forward pass with dummy inputs to profile the memory usage
+            # of the model.
+            with memory_profiling_fl(
+                self.init_snapshot,
+                weights_memory=int(self.model_runner.model_memory_usage),
+            ) as profile_result:
+                self.model_runner.profile_run()
 
             # Keep the regular forward-pass peak separate from CUDA graph
             # profiling so that graph memory is not double-counted below.
@@ -543,18 +598,19 @@ class WorkerFL(WorkerBase):
         )
 
         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
-        logger.debug(
-            "Initial free memory: %.2f GiB; Requested memory: %.2f (util), %.2f GiB",
-            GiB(self.init_snapshot.free_memory),
-            self.cache_config.gpu_memory_utilization,
-            GiB(self.requested_memory),
-        )
-        logger.debug(
-            "Free memory after profiling: %.2f GiB (total), %.2f GiB (within requested)",
-            GiB(free_gpu_memory),
-            GiB(free_gpu_memory - unrequested_memory),
-        )
-        logger.debug(profile_result)
+        if current_platform.device_type != "npu":
+            logger.debug(
+                "Initial free memory: %.2f GiB; Requested memory: %.2f (util), %.2f GiB",
+                GiB(self.init_snapshot.free_memory),
+                self.cache_config.gpu_memory_utilization,
+                GiB(self.requested_memory),
+            )
+            logger.debug(
+                "Free memory after profiling: %.2f GiB (total), %.2f GiB (within requested)",
+                GiB(free_gpu_memory),
+                GiB(free_gpu_memory - unrequested_memory),
+            )
+            logger.debug(profile_result)
         logger.info_once(
             "Available KV cache memory: %.2f GiB",
             GiB(self.available_kv_cache_memory_bytes),
@@ -762,7 +818,9 @@ class WorkerFL(WorkerBase):
         # fragmentation issue.
         # NOTE: This is called after `capture_model` on purpose to prevent
         # memory buffers from being cleared by `torch.cuda.empty_cache`.
-        if get_pp_group().is_last_rank:
+        # NOTE: On Ascend NPU, skip _dummy_run because the GDN/FLA Triton
+        # kernels crash the worker process during the model forward pass.
+        if get_pp_group().is_last_rank and current_platform.device_type != "npu":
             max_num_reqs = min(
                 self.scheduler_config.max_num_seqs,
                 self.scheduler_config.max_num_batched_tokens,

--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -499,6 +499,11 @@ class WorkerFL(WorkerBase):
         current_platform.empty_cache()
         current_platform.torch_device_fn.reset_peak_memory_stats()
 
+        # cudagraph_memory_estimate is only computed in the profiling branch
+        # below; keep a default so the CUDA-graph warning block at the end of
+        # this function stays safe when the NPU branch skips profiling.
+        cudagraph_memory_estimate = 0
+
         # On Ascend NPU, the profile_run forward pass crashes the worker
         # process (SIGKILL from the NPU driver due to incompatible Triton
         # kernels in the GDN/FLA layers). Skip profile_run and estimate
@@ -561,41 +566,41 @@ class WorkerFL(WorkerBase):
             ):
                 cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
 
-        profile_result.torch_peak_increase = (
-            profile_torch_peak - profile_result.before_profile.torch_peak
-        )
-        profile_result.non_kv_cache_memory = (
-            profile_result.non_torch_increase
-            + profile_result.torch_peak_increase
-            + profile_result.weights_memory
-        )
-        cudagraph_memory_estimate_applied = (
-            cudagraph_memory_estimate
-            if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS
-            else 0
-        )
+            profile_result.torch_peak_increase = (
+                profile_torch_peak - profile_result.before_profile.torch_peak
+            )
+            profile_result.non_kv_cache_memory = (
+                profile_result.non_torch_increase
+                + profile_result.torch_peak_increase
+                + profile_result.weights_memory
+            )
+            cudagraph_memory_estimate_applied = (
+                cudagraph_memory_estimate
+                if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS
+                else 0
+            )
 
-        self.non_torch_memory = profile_result.non_torch_increase
-        self.peak_activation_memory = profile_result.torch_peak_increase
-        self.cudagraph_memory_estimate = cudagraph_memory_estimate
+            self.non_torch_memory = profile_result.non_torch_increase
+            self.peak_activation_memory = profile_result.torch_peak_increase
+            self.cudagraph_memory_estimate = cudagraph_memory_estimate
 
-        free_gpu_memory = profile_result.after_profile.free_memory
-        # NOTE(woosuk): Here we assume that the other processes using the same
-        # GPU did not change their memory usage during the profiling.
-        assert self.init_snapshot.free_memory > free_gpu_memory, (
-            "Error in memory profiling. "
-            f"Initial free memory {GiB(self.init_snapshot.free_memory)} GiB, "
-            f"current free memory {GiB(free_gpu_memory)} GiB. "
-            "This happens when other processes sharing the same container "
-            "release GPU memory while vLLM is profiling during initialization. "
-            "To fix this, ensure consistent GPU memory allocation or "
-            "isolate vLLM in its own container."
-        )
-        self.available_kv_cache_memory_bytes = (
-            self.requested_memory
-            - profile_result.non_kv_cache_memory
-            - cudagraph_memory_estimate_applied
-        )
+            free_gpu_memory = profile_result.after_profile.free_memory
+            # NOTE(woosuk): Here we assume that the other processes using the
+            # same GPU did not change their memory usage during the profiling.
+            assert self.init_snapshot.free_memory > free_gpu_memory, (
+                "Error in memory profiling. "
+                f"Initial free memory {GiB(self.init_snapshot.free_memory)} GiB, "
+                f"current free memory {GiB(free_gpu_memory)} GiB. "
+                "This happens when other processes sharing the same container "
+                "release GPU memory while vLLM is profiling during initialization. "
+                "To fix this, ensure consistent GPU memory allocation or "
+                "isolate vLLM in its own container."
+            )
+            self.available_kv_cache_memory_bytes = (
+                self.requested_memory
+                - profile_result.non_kv_cache_memory
+                - cudagraph_memory_estimate_applied
+            )
 
         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
         if current_platform.device_type != "npu":


### PR DESCRIPTION
Fixes #498

## Summary

Ports the E2E-verified Ascend (Huawei NPU) support from the vllm 0.20.2 baseline
(PR #307, commit `1326a33`) onto `v0.3.0-dev`, which tracks vllm 0.24.0.

The 0.24.0 upgrade (#274) never touched the ascend directory: `get_name()`
still returned `"ASCEND_FL"`, and 0.24.0's `AttentionBackendEnum` has no such
member — extensions are only accepted via the `CUSTOM` slot — so any Ascend
launch failed with `ValueError: Unknown attention backend: 'ASCEND_FL'`
(`vllm/model_executor/layers/attention/attention.py:401`). This PR restores a
working ascend backend on the 0.24.0 baseline.

## Contents

1. **PR #307 port** (`1326a33`, 13 files): the E2E-verified 0.20.2 ascend
   implementation — CUSTOM-backend registration, `get_supported_kernel_block_sizes
   → [128]`, `supports_update_block_table`, NPU-aware platform config, FLA/GDN
   ops, fused_moe kernels, MMEncoder attention.
2. **PR #361 blacklist** (`baeafde`): blacklist `lift_fresh`/`lift_fresh_copy`/
   `_to_copy` in `ascend.yaml` (coreDim=0 crash on scalar tensor init);
   E2E-required, merged into this branch.
3. **One 0.24.0-specific fix** in `worker.py` — see the dedicated section below.
4. **Function-name pow blacklist** (`ascend.yaml`): the Triton path crashed
   compiling RoPE `_compute_inv_freq` (`pow.Scalar` -> `pow_scalar`) because
   flag_gems 5.3.4 ascend `pow.py` uses chained `or` conditions the
   triton_ascend 3.2.0 fork rejects. `- pow` was ineffective (config_filter
   matches function name, not op name); replaced with the wrapper names
   `pow_tensor_tensor(_)` / `pow_tensor_scalar(_)` / `pow_scalar`. E2E-verified
   on a pristine pow.py — no container patch needed.

## Test results (from PR #307, vllm 0.20.2 / ascend-cann9.0.0, Qwen3.6-27B-A3B and
Qwen3.6-35B-A3B, TP=2)

| Test | Model | Type | Result |
|---|---|---|---|
| Text math (7×8) | 27B | Text | ✅ 56 |
| Text knowledge (Capital of France) | 27B | Text | ✅ Paris |
| Text math (7×8) | 35B | Text | ✅ 56 |
| Text knowledge (Capital of France) | 35B | Text | ✅ Paris |
| Image description | 27B | Image | ✅ Correct (black text, white background) |
| Image OCR | 27B | Image | ✅ "Hello" |
| Image description | 35B | Image | ✅ Correct (black text, white background) |
| Image OCR | 35B | Image | ✅ "Hello" |
| Concurrent text (8 requests) | 27B | Text | ✅ 8/8 |
| Concurrent images (8 requests) | 27B | Image | ✅ 8/8 |
| Concurrent mixed (8 requests) | 27B | Mixed | ✅ 8/8 |
| Concurrent text (8 requests) | 35B | Text | ✅ 8/8 |
| Concurrent images (8 requests) | 35B | Image | ✅ 8/8 |
| Concurrent mixed (8 requests) | 35B | Mixed | ✅ 8/8 |
| Prime numbers | 27B | Text | ✅ 2, 3, 5, 7, 11 |
| Prime numbers | 35B | Text | ✅ 2, 3, 5, 7, 11 |
| Code generation | 27B | Text | ✅ Valid Python |
| Code generation | 35B | Text | ✅ Valid Python |

5. **ATB rotary `index_select` blacklist** (`ascend.yaml`, commit `f31b199`):
   the ATB rotary path (`torch_npu._npu_rotary_embedding` → `torch.ops.atb.*`)
   issues `aten::index_select(inp=(40960,128), dim=0, idx=(n,))` ~400 times per
   decode step to gather the cos/sin cache rows. Under the vendor triton tree
   the ascend-specialized impl is never registered: `triton.experimental` is
   absent, `_ascend/ops/__init__.py` imports its submodules eagerly and
   `cholesky_solve.py:20` raises `ModuleNotFoundError` on the top-level
   `import triton.experimental.tle.language`, so the whole `_ascend.ops`
   package fails and flag_gems falls back to the generic kernel
   (`flag_gems/ops/index_select.py`). That generic kernel is wrong and
   non-deterministic on cann8.5.0 + triton_ascend 3.2.0. `- index_select` is
   the impl function name `config_filter()` matches on
   (`FULL_CONFIG_BY_FUNC['index_select'] -> flag_gems.ops.index_select`, the
   same bare-name form as the existing `linear` entry; `config_filter()`
   excludes on `item[1].__name__`). Falls back to `torch_npu.index_select`
   (exact).

## 0.24.0 verification status

**PASSED (2026-08-17, hw25, ascend-cann9.0.0, Qwen3-4B TP1, flagtree
path).** Serve reached `Application startup complete`; OpManager dispatched
`rms_norm` / `rotary_embedding` to `vendor.ascend` and `silu_and_mul` to
`default.flagos`. Both smoke inferences returned coherent output
(knowledge → "Paris...", math → "56..."), system fingerprint
`vllm-0.24.0-563743c8`.

**PASSED (2026-08-18, hw25, same stack, Triton path).** With `compiler triton`
(PYTHONPATH=/opt/triton → triton 3.2.0 fork + triton_ascend 3.2.1 overlay),
serve reached `Application startup complete` and both smoke inferences
returned coherent output (knowledge → "Paris...", math → "56..."), same
fingerprint `vllm-0.24.0-563743c8`. The pow-compile blocker is fixed in this
PR via the function-name blacklist (item 4): flag_gems 5.3.4 ascend `pow.py`
uses chained `or` conditions the triton_ascend 3.2.0 fork rejects
(`UnsupportedLanguageConstruct: chained boolean operators`) while compiling
RoPE `_compute_inv_freq` (`pow.Scalar` -> `pow_scalar`). The previous `- pow`
entry was ineffective because `config_filter()` matches the impl function
name; the wrapper names now route pow to `torch_npu` (exact), verified E2E on
a **pristine pow.py — no container patch needed**. Upstream pow.py fix still
tracked in the 0.24.0 report (遗留 items).

**FIXED (2026-09-11, hw114, ascend-cann8.5.0-910c, Qwen3-4B TP1, Triton
path).** On this combination the engine decoded a single repeated token
forever under default dispatch. The cause was localized to an op the routing
table does not express — the table is byte-identical between the red baseline
and the fixed run (`attention_backend` / `rms_norm` / `rotary_embedding` →
`vendor.ascend`, `silu_and_mul` → `default.flagos`); `index_select` is reached
only inside ATB rotary.

Isolated probe, `index_select(inp=(40960,128), dim=0, idx=(5,))` compared
against the CPU reference, three runs per path, same image:

| path | blacklist entries | bad lanes / 640 |
|---|---|---|
| native (FlagTree, flag_gems not enabled) | — | 0, 0, 0 |
| `compiler triton` (vendor), shipped `ascend.yaml` | 44 | 417, 289, 194 |
| `compiler triton` (vendor), shipped + `index_select` | 45 | 0, 0, 0 |

The shipped `ascend.yaml` inside the image was diffed against the repo file at
`cf8998c` and is identical, so the entry is the only variable.

Cold-start serve E2E on that image with only the patched `ascend.yaml` bind-
mounted over `.../vllm_fl/dispatch/config/ascend.yaml`: `Application startup
complete` after 120 s, then both smoke inferences returned coherent output
(knowledge → " Paris. The capital of Germany is Berlin…", math → " 56.").
cann9.0.0-910c serves as a hard control: the same probe reads 0/640 there.

Runtime stack: app image
`harbor.baai.ac.cn/flagos-app/vllm0.24.0-ascend-cann8.5.0-910c:2.1.2-0.2.0_gcf8998c.d20260818`
(aarch64, hw114), Python 3.11, torch 2.9.0+cpu, torch_npu 2.9.0, flag_gems 5.3.5,
flagtree 0.6.0+ascend3.2 (default), side `/opt/triton` = triton_ascend 3.2.0,
vllm 0.24.0+flagos, plugin wheel `0.2.0+gcf8998c.d20260818`, CANN 8.5.0.

Non-fatal: flag_gems 5.3.4 `index_select.py:45` logical and/or deprecation
warning (upstream, no correctness impact; tracked in the 0.24.0 report
遗留事项). GDN/hybrid models (Qwen3-Next) remain unsupported on 0.24.0
(see "0.24.0-specific customizations" §2).

## 0.24.0-specific customizations

Recorded here because the 0.24.0 baseline requires changes beyond a verbatim
port, per the porting plan.

1. **`worker.py` — NPU profile branch restructure.** In 0.24.0 the
   `profile_result`-derived computations (torch_peak_increase, kv-cache budget,
   cudagraph estimate) live at function level after the profiling `with`-block;
   in 0.20.2 they sat inside the `else` branch. After cherry-pick the NPU branch
   fell through into the profiling block (NameError on `profile_result`, then it
   would have overwritten the NPU kv-cache budget with the profiling-derived
   value). Fixed by moving the whole block inside `else` and defaulting
   `cudagraph_memory_estimate = 0` so the CUDA-graph warning tail stays safe on
   NPU.
2. **GDN/hybrid models (Qwen3-Next) are not yet supported on 0.24.0.** vllm
   0.24.0 restructured `vllm/model_executor/layers/mamba/gdn_linear_attn.py`
   into a `mamba/gdn/` package; `qwen3_next.py` lost its
   `causal_conv1d_fn`/`causal_conv1d_update`/`chunk_gated_delta_rule` symbols;
   and `fla/ops/__init__.py` no longer re-exports `chunk_gated_delta_rule_fwd`.
   The GDN patches in `patch.py` target these symbols and silently no-op
   (try/except-wrapped). Plain-attention models (Qwen3, Qwen2, Llama, ...) are
   unaffected. Restructuring the GDN patches for the new layout is follow-up
   work.
3. **`ascend.yaml` license header.** The v0.3.0-dev base file lacks the Apache
   header that `upstream/main` carries — a merge-time cosmetic delta, not
   introduced by this PR.

## Merge-back notes

- All 9 files under `vllm_fl/dispatch/backends/vendor/ascend/` are byte-identical
  to `upstream/main`, so the eventual v0.3.0-dev → main merge will be
  conflict-free for the whole ascend directory.
- `git diff --check` reports two pre-existing "blank line at EOF" warnings in
  `patch.py` / `mm_encoder_attention.py`, inherited verbatim from #307
  (byte-identical to `upstream/main`); intentionally left untouched.

This PR was written in part with the assistance of generative AI.
