### PR TITLE
CI: Add FlagGems-vllm checkout for test purpose

### DIFF
--- a/.github/scripts/ascend/setup.sh
+++ b/.github/scripts/ascend/setup.sh
@@ -3,6 +3,10 @@
 # Setup script for Ascend NPU CI environment.
 set -euo pipefail
 
+FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
+git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+
 git config --global --add safe.directory "$(pwd)"
 
 pip install --upgrade pip "setuptools>=77.0.3"

--- a/.github/scripts/ascend/setup.sh
+++ b/.github/scripts/ascend/setup.sh
@@ -4,14 +4,14 @@
 set -euo pipefail
 
 # Install FlagGems for test purpose
-FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_VERSION="v5.3.4"
 FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
 rm -rf "${FLAGGEMS_DIR}"
 git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
 python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
 
 # Install FlagGems-vllm for test purpose
-FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
+FLAGGEMS_VLLM_VERSION="main"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/ascend/setup.sh
+++ b/.github/scripts/ascend/setup.sh
@@ -3,11 +3,18 @@
 # Setup script for Ascend NPU CI environment.
 set -euo pipefail
 
+# Install FlagGems for test purpose
+FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
+rm -rf "${FLAGGEMS_DIR}"
+git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
+
 # Install FlagGems-vllm for test purpose
+FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
-git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"

--- a/.github/scripts/ascend/setup.sh
+++ b/.github/scripts/ascend/setup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 # Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/ascend/setup.sh
+++ b/.github/scripts/ascend/setup.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
-pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 

--- a/.github/scripts/ascend/setup.sh
+++ b/.github/scripts/ascend/setup.sh
@@ -3,20 +3,30 @@
 # Setup script for Ascend NPU CI environment.
 set -euo pipefail
 
+# Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 
 pip install --upgrade pip "setuptools>=77.0.3"
+
+# Install vLLM-Plugin-FL
 pip install \
     --no-build-isolation \
     --no-deps \
     -e .
 
 python - <<'PY'
+import flag_gems
+import flaggems_vllm
 import numpy
+import torch
+import torch_npu  # noqa: F401
+import vllm
+import vllm_fl
 
 expected = "1.26.4"
 if numpy.__version__ != expected:
@@ -24,4 +34,11 @@ if numpy.__version__ != expected:
         f"Unexpected NumPy version: {numpy.__version__}; expected {expected}"
     )
 print(f"NumPy version: {numpy.__version__}")
+print(f"vLLM import ok: {vllm.__version__}")
+print(f"vLLM-FL import ok: {vllm_fl.__file__}")
+print(f"FlagGems import ok: {getattr(flag_gems, '__version__', 'unknown')}")
+print(f"FlagGems-vllm grouped_topk: {callable(flaggems_vllm.grouped_topk)}")
+print(f"Torch import ok: {torch.__version__}")
+print(f"Accelerator available: {torch.npu.is_available()}")
+print(f"Accelerator count: {torch.npu.device_count()}")
 PY

--- a/.github/scripts/ascend/setup.sh
+++ b/.github/scripts/ascend/setup.sh
@@ -15,7 +15,7 @@ FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation --no-deps -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 

--- a/.github/scripts/cuda/setup.sh
+++ b/.github/scripts/cuda/setup.sh
@@ -3,6 +3,10 @@
 # Setup script for CUDA CI environment.
 set -euo pipefail
 
+FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
+git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+
 git config --global --add safe.directory "$(pwd)"
 
 uv pip install --system --upgrade pip

--- a/.github/scripts/cuda/setup.sh
+++ b/.github/scripts/cuda/setup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 # Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
 uv pip install --system --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/cuda/setup.sh
+++ b/.github/scripts/cuda/setup.sh
@@ -15,7 +15,7 @@ FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-uv pip install --system --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+uv pip install --system --no-build-isolation --no-deps -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 

--- a/.github/scripts/cuda/setup.sh
+++ b/.github/scripts/cuda/setup.sh
@@ -11,7 +11,7 @@ git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/
 uv pip install --system --no-build-isolation -e "${FLAGGEMS_DIR}"
 
 # Install FlagGems-vllm for test purpose
-FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
+FLAGGEMS_VLLM_VERSION="main"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/cuda/setup.sh
+++ b/.github/scripts/cuda/setup.sh
@@ -3,11 +3,18 @@
 # Setup script for CUDA CI environment.
 set -euo pipefail
 
+# Install FlagGems for test purpose
+FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
+rm -rf "${FLAGGEMS_DIR}"
+git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
+uv pip install --system --no-build-isolation -e "${FLAGGEMS_DIR}"
+
 # Install FlagGems-vllm for test purpose
+FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
-git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 uv pip install --system --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"

--- a/.github/scripts/cuda/setup.sh
+++ b/.github/scripts/cuda/setup.sh
@@ -3,11 +3,31 @@
 # Setup script for CUDA CI environment.
 set -euo pipefail
 
+# Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+uv pip install --system --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 
 uv pip install --system --upgrade pip
+
+# Install vLLM-Plugin-FL
 uv pip install --system --no-build-isolation -e ".[test]"
+
+python - <<'PY'
+import flag_gems
+import flaggems_vllm
+import torch
+import vllm
+import vllm_fl
+
+print(f"vLLM import ok: {vllm.__version__}")
+print(f"vLLM-FL import ok: {vllm_fl.__file__}")
+print(f"FlagGems import ok: {getattr(flag_gems, '__version__', 'unknown')}")
+print(f"FlagGems-vllm grouped_topk: {callable(flaggems_vllm.grouped_topk)}")
+print(f"Torch import ok: {torch.__version__}")
+print(f"Accelerator available: {torch.cuda.is_available()}")
+print(f"Accelerator count: {torch.cuda.device_count()}")
+PY

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -3,11 +3,18 @@
 # Setup script for Enflame S60 CI.
 set -euo pipefail
 
+# Install FlagGems for test purpose
+FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
+rm -rf "${FLAGGEMS_DIR}"
+git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
+
 # Install FlagGems-vllm for test purpose
+FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
-git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 : "${VLLM_PLUGINS:?VLLM_PLUGINS is not set}"

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -11,7 +11,7 @@ git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/
 python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
 
 # Install FlagGems-vllm for test purpose
-FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
+FLAGGEMS_VLLM_VERSION="main"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -3,6 +3,13 @@
 # Setup script for Enflame S60 CI.
 set -euo pipefail
 
+# Install FlagGems for test purpose
+FLAGGEMS_VERSION="v5.3.4"
+FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
+rm -rf "${FLAGGEMS_DIR}"
+git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
+
 # Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
-pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 : "${VLLM_PLUGINS:?VLLM_PLUGINS is not set}"
 : "${TOPS_VISIBLE_DEVICES:?TOPS_VISIBLE_DEVICES is not set}"

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -3,12 +3,19 @@
 # Setup script for Enflame S60 CI.
 set -euo pipefail
 
+# Install FlagGems for test purpose
+FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
+rm -rf "${FLAGGEMS_DIR}"
+git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
+
 # Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation --no-deps -e "${FLAGGEMS_VLLM_DIR}"
 
 : "${VLLM_PLUGINS:?VLLM_PLUGINS is not set}"
 : "${TOPS_VISIBLE_DEVICES:?TOPS_VISIBLE_DEVICES is not set}"

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 # Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -3,6 +3,10 @@
 # Setup script for Enflame S60 CI.
 set -euo pipefail
 
+FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
+git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+
 : "${VLLM_PLUGINS:?VLLM_PLUGINS is not set}"
 : "${TOPS_VISIBLE_DEVICES:?TOPS_VISIBLE_DEVICES is not set}"
 

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -3,13 +3,6 @@
 # Setup script for Enflame S60 CI.
 set -euo pipefail
 
-# Install FlagGems for test purpose
-FLAGGEMS_VERSION="v5.4.0.dev0"
-FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
-rm -rf "${FLAGGEMS_DIR}"
-git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
-python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
-
 # Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"

--- a/.github/scripts/enflame/setup.sh
+++ b/.github/scripts/enflame/setup.sh
@@ -3,9 +3,11 @@
 # Setup script for Enflame S60 CI.
 set -euo pipefail
 
+# Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 : "${VLLM_PLUGINS:?VLLM_PLUGINS is not set}"
 : "${TOPS_VISIBLE_DEVICES:?TOPS_VISIBLE_DEVICES is not set}"
@@ -24,11 +26,13 @@ if [[ -n "${GITHUB_ENV:-}" ]]; then
   done
 fi
 
-# The vendor runtime, vLLM, and FlagGems come from the pinned base image.
+# Install vLLM-Plugin-FL
+# The vendor runtime and vLLM come from the pinned base image.
 python -m pip install --no-build-isolation --no-deps -e .
 
 python - <<'PY'
 import flag_gems
+import flaggems_vllm
 import torch
 import torch_gcu  # noqa: F401
 import vllm
@@ -37,6 +41,7 @@ import vllm_fl
 print(f"vLLM import ok: {vllm.__version__}")
 print(f"vLLM-FL import ok: {vllm_fl.__file__}")
 print(f"FlagGems import ok: {getattr(flag_gems, '__version__', 'unknown')}")
+print(f"FlagGems-vllm grouped_topk: {callable(flaggems_vllm.grouped_topk)}")
 print(f"FlagGems vendor: {getattr(flag_gems, 'vendor_name', 'auto-detected')}")
 print(f"Torch import ok: {torch.__version__}")
 print(f"Accelerator available: {torch.gcu.is_available()}")

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -3,6 +3,10 @@
 # Setup script for Hygon DCU CI environment.
 set -euo pipefail
 
+FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
+git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+
 git config --global --add safe.directory "$(pwd)"
 
 : "${GEMS_VENDOR:?GEMS_VENDOR is not set}"

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -11,7 +11,7 @@ git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/
 python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
 
 # Install FlagGems-vllm for test purpose
-FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
+FLAGGEMS_VLLM_VERSION="main"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -3,11 +3,18 @@
 # Setup script for Hygon DCU CI environment.
 set -euo pipefail
 
+# Install FlagGems for test purpose
+FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
+rm -rf "${FLAGGEMS_DIR}"
+git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
+
 # Install FlagGems-vllm for test purpose
+FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
-git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 # Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
-pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -3,9 +3,11 @@
 # Setup script for Hygon DCU CI environment.
 set -euo pipefail
 
+# Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 
@@ -27,10 +29,12 @@ echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}"
 test -e "${HIP_PATH}/lib/libgalaxyhip.so.5"
 test -e "${DTK_HOME}/llvm/lib/libomp.so"
 
+# Install vLLM-Plugin-FL
 python -m pip install --no-build-isolation --no-deps -e .
 
 python - <<'PY'
 import flag_gems
+import flaggems_vllm
 import torch
 import vllm
 import vllm_fl
@@ -38,6 +42,7 @@ import vllm_fl
 print(f"vLLM import ok: {vllm.__version__}")
 print(f"vLLM-FL import ok: {vllm_fl.__file__}")
 print(f"FlagGems import ok: {getattr(flag_gems, '__version__', 'unknown')}")
+print(f"FlagGems-vllm grouped_topk: {callable(flaggems_vllm.grouped_topk)}")
 print(f"Torch import ok: {torch.__version__}")
 print(f"Accelerator available: {torch.cuda.is_available()}")
 print(f"Accelerator count: {torch.cuda.device_count()}")

--- a/.github/scripts/hygon/setup.sh
+++ b/.github/scripts/hygon/setup.sh
@@ -15,7 +15,7 @@ FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation --no-deps -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 

--- a/.github/scripts/metax/setup.sh
+++ b/.github/scripts/metax/setup.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Install FlagGems for test purpose
-FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_VERSION="v5.3.4"
 FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
 rm -rf "${FLAGGEMS_DIR}"
 git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"

--- a/.github/scripts/metax/setup.sh
+++ b/.github/scripts/metax/setup.sh
@@ -3,9 +3,11 @@
 # Setup script for MetaX C550 CI environment.
 set -euo pipefail
 
+# Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 export PATH="/opt/conda/bin:${PATH}"
 
@@ -25,12 +27,14 @@ if [[ -n "${GITHUB_ENV:-}" ]]; then
   done
 fi
 
-# vLLM, FlagGems, and test dependencies are provided by the CI image.
+# Install vLLM-Plugin-FL
+# vLLM and test dependencies are provided by the CI image.
 # Only install the checked-out plugin source for this workflow run.
 python -m pip install --no-build-isolation --no-deps -e .
 
 python - <<'PY'
 import flag_gems
+import flaggems_vllm
 import torch
 import vllm
 import vllm_fl
@@ -38,6 +42,7 @@ import vllm_fl
 print(f"vLLM import ok: {vllm.__version__}")
 print(f"vLLM-FL import ok: {vllm_fl.__file__}")
 print(f"FlagGems import ok: {getattr(flag_gems, '__version__', 'unknown')}")
+print(f"FlagGems-vllm grouped_topk: {callable(flaggems_vllm.grouped_topk)}")
 print(f"Torch import ok: {torch.__version__}")
 print(f"Accelerator available: {torch.cuda.is_available()}")
 print(f"Accelerator count: {torch.cuda.device_count()}")

--- a/.github/scripts/metax/setup.sh
+++ b/.github/scripts/metax/setup.sh
@@ -3,11 +3,18 @@
 # Setup script for MetaX C550 CI environment.
 set -euo pipefail
 
+# Install FlagGems for test purpose
+FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
+rm -rf "${FLAGGEMS_DIR}"
+git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
+
 # Install FlagGems-vllm for test purpose
+FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
-git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 export PATH="/opt/conda/bin:${PATH}"

--- a/.github/scripts/metax/setup.sh
+++ b/.github/scripts/metax/setup.sh
@@ -15,7 +15,7 @@ FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation --no-deps -e "${FLAGGEMS_VLLM_DIR}"
 
 export PATH="/opt/conda/bin:${PATH}"
 

--- a/.github/scripts/metax/setup.sh
+++ b/.github/scripts/metax/setup.sh
@@ -3,6 +3,10 @@
 # Setup script for MetaX C550 CI environment.
 set -euo pipefail
 
+FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
+git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+
 export PATH="/opt/conda/bin:${PATH}"
 
 : "${GEMS_VENDOR:?GEMS_VENDOR is not set}"

--- a/.github/scripts/metax/setup.sh
+++ b/.github/scripts/metax/setup.sh
@@ -11,7 +11,7 @@ git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/
 python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
 
 # Install FlagGems-vllm for test purpose
-FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
+FLAGGEMS_VLLM_VERSION="main"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/metax/setup.sh
+++ b/.github/scripts/metax/setup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 # Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/metax/setup.sh
+++ b/.github/scripts/metax/setup.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
-pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 export PATH="/opt/conda/bin:${PATH}"
 

--- a/.github/scripts/musa/setup.sh
+++ b/.github/scripts/musa/setup.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Install FlagGems for test purpose
-FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_VERSION="v5.3.4"
 FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
 rm -rf "${FLAGGEMS_DIR}"
 git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"

--- a/.github/scripts/musa/setup.sh
+++ b/.github/scripts/musa/setup.sh
@@ -3,11 +3,18 @@
 # Setup script for Moore Threads MUSA CI environment.
 set -euo pipefail
 
+# Install FlagGems for test purpose
+FLAGGEMS_VERSION="v5.4.0.dev0"
+FLAGGEMS_DIR="$(cd .. && pwd -P)/FlagGems"
+rm -rf "${FLAGGEMS_DIR}"
+git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems.git "${FLAGGEMS_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
+
 # Install FlagGems-vllm for test purpose
+FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
-git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"

--- a/.github/scripts/musa/setup.sh
+++ b/.github/scripts/musa/setup.sh
@@ -3,6 +3,10 @@
 # Setup script for Moore Threads MUSA CI environment.
 set -euo pipefail
 
+FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
+git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+
 git config --global --add safe.directory "$(pwd)"
 
 : "${GEMS_VENDOR:?GEMS_VENDOR is not set}"

--- a/.github/scripts/musa/setup.sh
+++ b/.github/scripts/musa/setup.sh
@@ -11,7 +11,7 @@ git clone --branch "${FLAGGEMS_VERSION}" --depth 1 https://github.com/flagos-ai/
 python -m pip install --no-build-isolation -e "${FLAGGEMS_DIR}"
 
 # Install FlagGems-vllm for test purpose
-FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
+FLAGGEMS_VLLM_VERSION="main"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/musa/setup.sh
+++ b/.github/scripts/musa/setup.sh
@@ -3,9 +3,11 @@
 # Setup script for Moore Threads MUSA CI environment.
 set -euo pipefail
 
+# Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
+pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 
@@ -13,10 +15,12 @@ git config --global --add safe.directory "$(pwd)"
 : "${VLLM_PLUGINS:?VLLM_PLUGINS is not set}"
 : "${MTHREADS_VISIBLE_DEVICES:?MTHREADS_VISIBLE_DEVICES is not set}"
 
+# Install vLLM-Plugin-FL
 python -m pip install --no-build-isolation --no-deps -e .
 
 python - <<'PY'
 import flag_gems
+import flaggems_vllm
 import torch
 import torch_musa
 import vllm
@@ -30,6 +34,7 @@ assert current_platform.device_type == "musa", current_platform.device_type
 print(f"vLLM import ok: {vllm.__version__}")
 print(f"vLLM-FL import ok: {vllm_fl.__file__}")
 print(f"FlagGems import ok: {getattr(flag_gems, '__version__', 'unknown')}")
+print(f"FlagGems-vllm grouped_topk: {callable(flaggems_vllm.grouped_topk)}")
 print(f"Torch import ok: {torch.__version__}")
 print(f"MUSA available: {torch.musa.is_available()}")
 print(f"MUSA devices: {torch.musa.device_count()}")

--- a/.github/scripts/musa/setup.sh
+++ b/.github/scripts/musa/setup.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 # Install FlagGems-vllm for test purpose
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
+rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
 python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"

--- a/.github/scripts/musa/setup.sh
+++ b/.github/scripts/musa/setup.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 git clone https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
 git -C "${FLAGGEMS_VLLM_DIR}" checkout main
-pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 

--- a/.github/scripts/musa/setup.sh
+++ b/.github/scripts/musa/setup.sh
@@ -15,7 +15,7 @@ FLAGGEMS_VLLM_VERSION="v0.1.1-rc0"
 FLAGGEMS_VLLM_DIR="$(cd .. && pwd -P)/FlagGems-vllm"
 rm -rf "${FLAGGEMS_VLLM_DIR}"
 git clone --branch "${FLAGGEMS_VLLM_VERSION}" --depth 1 https://github.com/flagos-ai/FlagGems-vllm.git "${FLAGGEMS_VLLM_DIR}"
-python -m pip install --no-build-isolation -e "${FLAGGEMS_VLLM_DIR}"
+python -m pip install --no-build-isolation --no-deps -e "${FLAGGEMS_VLLM_DIR}"
 
 git config --global --add safe.directory "$(pwd)"
 

--- a/tests/platforms/ascend.yaml
+++ b/tests/platforms/ascend.yaml
@@ -82,6 +82,9 @@ env_defaults: {}
 910c:
   name: "910c"
   tests:
+    timeouts:
+      e2e:
+        serving: 120
     e2e:
       # Add or remove test cases per model
       inference:


### PR DESCRIPTION
## Summary

- Clone `flagos-ai/FlagGems-vllm` in each platform setup script
- Use an absolute path under the parent directory of the current workspace
- Checkout the `main` branch before platform-specific setup continues

## Test

- `bash -n .github/scripts/ascend/setup.sh .github/scripts/cuda/setup.sh .github/scripts/enflame/setup.sh .github/scripts/hygon/setup.sh .github/scripts/metax/setup.sh .github/scripts/musa/setup.sh`
- `git diff --check`