### PR TITLE
feat(sunrise): port attention backend to vLLM 0.24.0 (CUSTOM registration + ptpu memory_stats shim)

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/sunrise/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/impl/attention.py
@@ -33,6 +33,7 @@ from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionMetadataBuilder,
 )
+from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
 from vllm.v1.attention.backends.utils import (
     CommonAttentionMetadata,
     get_dcp_local_seq_lens,
@@ -74,7 +75,7 @@ class AttentionFLBackend(AttentionBackend):
 
     @staticmethod
     def get_name() -> str:
-        return "TRITON_ATTN"
+        return "CUSTOM"
 
     @classmethod
     def supports_attn_type(cls, attn_type: str) -> bool:
@@ -154,6 +155,13 @@ class AttentionFLBackend(AttentionBackend):
         if has_sink:
             return "not support sink"
         return None
+
+
+register_backend(
+    AttentionBackendEnum.CUSTOM,
+    "vllm_fl.dispatch.backends.vendor.sunrise.impl.attention.AttentionFLBackend",
+)
+
 
 @dataclass
 class AttentionFLMetadata:

--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -23,6 +23,7 @@ def apply_sunrise_patches():
     patch_distributed_runtime()
     patch_op_cls()
     patch_accelerator_empty_cache()
+    patch_accelerator_memory_stats()
 
 
 def patch_flagcx_stream_adapter():
@@ -208,3 +209,30 @@ def patch_accelerator_empty_cache():
         logger.info("Patched torch.accelerator.empty_cache for Sunrise/PTPU")
     except Exception as e:
         logger.warning("Failed to patch torch.accelerator.empty_cache: %s", e)
+
+
+def patch_accelerator_memory_stats():
+    """Provide torch.ptpu.memory_stats() for FL worker memory profiling.
+
+    torch.ptpu exposes max_memory_allocated/memory_reserved but not the
+    torch.cuda-style memory_stats() dict that the FL worker's KV-cache sizing
+    reads ("allocated_bytes.all.peak"). Synthesize the keys the worker uses
+    from the ptpu peak APIs. Guarded: never overrides a real implementation.
+    """
+    try:
+        if getattr(torch.ptpu, "_sunrise_memory_stats_patched", False):
+            return
+        if hasattr(torch.ptpu, "memory_stats"):
+            return
+
+        def _memory_stats(device=None):
+            return {
+                "allocated_bytes.all.peak": torch.ptpu.max_memory_allocated(device),
+                "reserved_bytes.all.peak": torch.ptpu.memory_reserved(device),
+            }
+
+        torch.ptpu.memory_stats = _memory_stats
+        torch.ptpu._sunrise_memory_stats_patched = True
+        logger.info("Patched torch.ptpu.memory_stats for Sunrise/PTPU")
+    except Exception as e:
+        logger.warning("Failed to patch torch.ptpu.memory_stats: %s", e)


### PR DESCRIPTION
## Summary

Ports the Sunrise (曦望 TANGRT 1.2.0) backend to vLLM 0.24.0.

Two changes, both in the sunrise vendor path:

1. **CUSTOM-mode attention backend registration** (`sunrise/impl/attention.py`)
   - `get_name()` returns `"CUSTOM"` instead of `"TRITON_ATTN"`, and the backend
     is registered on the explicit `AttentionBackendEnum.CUSTOM` placeholder.
   - vLLM 0.24.0 dropped support for registering attention backends by arbitrary
     name: `AttentionBackendEnum.__getitem__` raises `ValueError` for unknown
     members at `attention.py` `self.backend = AttentionBackendEnum[...]`, which
     crashed EngineCore init before this change.
   - Same pattern as the ascend port (#387).

2. **`torch.ptpu.memory_stats()` synthesis** (`sunrise/patch.py`)
   - PTPU exposes `max_memory_allocated` / `memory_reserved` but not the
     `torch.cuda`-style `memory_stats()` dict. The FL worker's KV-cache sizing
     reads `"allocated_bytes.all.peak"` from it
     (`determine_available_memory` in `vllm_fl/worker/worker.py`), which crashed
     with `AttributeError: module 'torch_ptpu.ptpu' has no attribute
     'memory_stats'`.
   - The patch synthesizes the two peak keys from the PTPU APIs. Guarded: never
     overrides a real `memory_stats` implementation.

## Verification

E2E-verified on a sunrise node (TANGRT 1.2.0, python 3.10, `vllm-0.24.0+flagos`
cp310 empty wheel, plugin installed editable):

- `compiler triton` (vendor triton 3.6.0.1+git0a5cfb35)
- Qwen3-8B TP1 serve reaches `Application startup complete`
- Inference coherent; all 5 sunrise patches applied at EngineCore init;
  attention backend falls back to `vendor.sunrise` (CUSTOM registration proven
  end-to-end)
- Fingerprint: `vllm-0.24.0-6c831be5`

Delivery path stays on the official Triton compiler: the FlagTree flash-attn
decode hang on Sunrise is an upstream compiler defect (see build-infra
`report-vllm-0.20.2.md` §2.9) and is not addressed here.

This PR was written in part with the assistance of generative AI.
