### PR TITLE
[WIP]Restore cudagraph support for kunlunxin backend

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
@@ -32,6 +32,7 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.attention.backend import (
+    AttentionCGSupport,
     AttentionLayer,
     AttentionType,
     AttentionMetadataBuilder,
@@ -335,8 +336,7 @@ class KunlunxinAttentionMetadataBuilder(AttentionMetadataBuilder):
     """Builder for Kunlunxin attention metadata."""
 
     reorder_batch_threshold: ClassVar[int] = 1
-    # _cudagraph_support removed: AttentionCGSupport not available in vllm 0.20.2
-
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
     def __init__(self, kv_cache_spec: AttentionSpec,
                  layer_names: list[str],
                  vllm_config: VllmConfig,
@@ -583,7 +583,7 @@ class KunlunxinPagedAttention(PagedAttention):
 
         Args:
             key (torch.Tensor): Shape [num_tokens, num_heads, head_size], dtype bf16/fp16/fp32.
-            value (torch.Tensor): Shape [num_tokens, num_heads, head_size], same dtype as key. 
+            value (torch.Tensor): Shape [num_tokens, num_heads, head_size], same dtype as key.
             Can be empty; quantization is not supported when value is empty.
             slot_mapping (torch.Tensor): Maps tokens to position indices in the cache.
             k_max (torch.Tensor, optional): Shape [num_heads] (quant_mode=0)
@@ -599,7 +599,7 @@ class KunlunxinPagedAttention(PagedAttention):
             key_cache (torch.Tensor): Output cache for k, shape [num_blocks, block_size,  num_heads, head_size],
                 same dtype as key or int8.
                 When key is bfloat16, key_cache can be float16.
-            value_cache (torch.Tensor): Output cache for v, shape [num_blocks, block_size,  num_heads, head_size], 
+            value_cache (torch.Tensor): Output cache for v, shape [num_blocks, block_size,  num_heads, head_size],
                 same dtype as key.
                 Can be empty; quantization is not supported when value is empty.
         """

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/causal_conv1d.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/causal_conv1d.py
@@ -126,8 +126,8 @@ def causal_conv1d_update_kunlunxin(
             "num_accepted_tokens parameter."
         )
 
-    # Reject varlen mode with query_start_loc: not supported by native kernel
-    if query_start_loc is not None and max_query_len > 0:
+    # Reject varlen mode: not supported by native kernel
+    if query_start_loc is not None or max_query_len > 0:
         raise NotImplementedError(
             "Kunlunxin causal_conv1d_update does not support varlen with query_start_loc. "
             "The native xtorch_ops.causal_conv1d_update kernel does not accept "

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_moe/fused_moe.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/fused_moe/fused_moe.py
@@ -44,7 +44,7 @@ def _klx_fused_experts(
     Pipeline: gen_block_statistic -> moe_pre_sorted -> moe_fc(w1) -> activation -> moe_fc(w2) -> post (weight+sum)
 
     Args:
-        activation: Activation function type. Supported: "silu", "gelu", "relu"
+        activation: Activation function type. Supported: "silu", "gelu", "relu2", "gelu_no_mul", "silu_no_mul"
         w1_bias: Optional bias for gate+up projection [E, 2*ffn_hd]
         w2_bias: Optional bias for down projection [E, hidden_dim]
     """
@@ -96,11 +96,11 @@ def _klx_fused_experts(
         gate = inner_fc_out[:, :ffn_hd]
         up = inner_fc_out[:, ffn_hd:]
         swiglu_out = xtorch_ops.gelu(gate) * up
-    elif activation == "relu":
-        # ReLU: relu(gate) * up
+    elif activation == "relu2":
+        # ReLU²: relu(gate)^2 * up (matches MoEActivation.RELU2)
         gate = inner_fc_out[:, :ffn_hd]
         up = inner_fc_out[:, ffn_hd:]
-        swiglu_out = xtorch_ops.relu(gate) * up
+        swiglu_out = torch.square(xtorch_ops.relu(gate)) * up
     elif activation in ["gelu_no_mul", "silu_no_mul"]:
         # No mul variant: only apply activation, no gating
         if activation == "gelu_no_mul":
@@ -110,7 +110,7 @@ def _klx_fused_experts(
     else:
         raise ValueError(
             f"Unsupported activation '{activation}'. "
-            f"Supported: ['silu', 'gelu', 'relu', 'gelu_no_mul', 'silu_no_mul']"
+            f"Supported: ['silu', 'gelu', 'relu2', 'gelu_no_mul', 'silu_no_mul']"
         )
 
     # Step 5: Outer FC (down projection)
@@ -165,7 +165,7 @@ def fused_experts_impl(
     and is patched in by the Kunlunxin patch system.
 
     Args:
-        activation: Activation function. Supported: "silu", "gelu", "relu", "gelu_no_mul", "silu_no_mul"
+        activation: Activation function. Supported: "silu", "gelu", "relu2", "gelu_no_mul", "silu_no_mul"
         apply_router_weight_on_input: If True, apply router weights on input (NOT SUPPORTED)
         w1_bias: Optional bias for gate+up projection
         w2_bias: Optional bias for down projection
@@ -185,8 +185,12 @@ def fused_experts_impl(
             "Router weights are always applied in the moe_post stage (after down projection)."
         )
 
-    # 1.3: Validate activation function
-    SUPPORTED_ACTIVATIONS = ["silu", "gelu", "relu", "gelu_no_mul", "silu_no_mul"]
+    # 1.3: Normalize and validate activation function
+    # activation may arrive as a MoEActivation enum or a plain string.
+    from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+    if isinstance(activation, MoEActivation):
+        activation = activation.value
+    SUPPORTED_ACTIVATIONS = ["silu", "gelu", "relu2", "gelu_no_mul", "silu_no_mul"]
     if activation not in SUPPORTED_ACTIVATIONS:
         raise NotImplementedError(
             f"Kunlunxin fused_experts does not support activation '{activation}'. "


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
Others

### PR Type
Bug Fixes 

### Description
Restore cudagraph support for kunlunxin backend
The Qwen3.6-35B-A3B and Qwen3.6-27B models have been verified, the test includes high-concurrency input of text and images.
Test command：
export FLAGCX_PATH=/workspace/FlagCX
export USE_RESHAPE_AND_CACHE_FLASH=1
vllm serve /workspace/models/Qwen3.6-27B
--served-model-name qwen3
--tensor-parallel-size 4
--max-model-len 16384
--reasoning-parser qwen3
--block-size 128
--gpu-memory-utilization 0.8
--port 8100



### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->

### Changes
<!-- List the key changes made in this PR. -->
-

### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->
-

### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
