### PR TITLE
perf(gcu): optimize Qwen3.8 GDN and causal-conv

### DIFF
--- a/tests/unit_tests/dispatch/test_gcu_causal_conv1d.py
+++ b/tests/unit_tests/dispatch/test_gcu_causal_conv1d.py
@@ -3,6 +3,7 @@
 from types import SimpleNamespace
 
 from vllm_fl.dispatch.backends.vendor.gcu.impl import causal_conv1d
+from vllm_fl.patches.triton_kernel import KernelLaunchMetaProxy
 
 
 class _FakeKernel:
@@ -15,15 +16,12 @@ class _FakeKernel:
         return launch
 
 
-def test_block_n_kernel_proxy_overrides_launch_meta():
-    proxy = causal_conv1d._BlockNKernelProxy(_FakeKernel(), block_n=2048)
-
-    grid, args, kwargs = proxy["grid"](1, BLOCK_N=256, other=True)
-
-    assert grid == "grid"
-    assert args == (1,)
-    assert kwargs == {"BLOCK_N": 2048, "other": True}
-    assert proxy.marker == "wrapped"
+def test_gcu_causal_conv1d_launch_configs():
+    assert causal_conv1d.CAUSAL_CONV1D_FWD_CONFIG == {
+        "BLOCK_N": 2048,
+        "num_stages": 2,
+    }
+    assert causal_conv1d.CAUSAL_CONV1D_UPDATE_CONFIG == {"BLOCK_N": 1024}
 
 
 def test_apply_causal_conv1d_gcu_patch_is_idempotent(monkeypatch):
@@ -40,5 +38,10 @@ def test_apply_causal_conv1d_gcu_patch_is_idempotent(monkeypatch):
 
     assert module._causal_conv1d_fwd_kernel is fwd_proxy
     assert module._causal_conv1d_update_kernel is update_proxy
-    assert fwd_proxy.block_n == 2048
-    assert update_proxy.block_n == 1024
+    assert isinstance(fwd_proxy, KernelLaunchMetaProxy)
+    assert isinstance(update_proxy, KernelLaunchMetaProxy)
+    assert fwd_proxy.launch_overrides == {
+        "BLOCK_N": 2048,
+        "num_stages": 2,
+    }
+    assert update_proxy.launch_overrides == {"BLOCK_N": 1024}

--- a/tests/unit_tests/dispatch/test_gcu_causal_conv1d.py
+++ b/tests/unit_tests/dispatch/test_gcu_causal_conv1d.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+from types import SimpleNamespace
+
+from vllm_fl.dispatch.backends.vendor.gcu.impl import causal_conv1d
+
+
+class _FakeKernel:
+    marker = "wrapped"
+
+    def __getitem__(self, grid):
+        def launch(*args, **kwargs):
+            return grid, args, kwargs
+
+        return launch
+
+
+def test_block_n_kernel_proxy_overrides_launch_meta():
+    proxy = causal_conv1d._BlockNKernelProxy(_FakeKernel(), block_n=2048)
+
+    grid, args, kwargs = proxy["grid"](1, BLOCK_N=256, other=True)
+
+    assert grid == "grid"
+    assert args == (1,)
+    assert kwargs == {"BLOCK_N": 2048, "other": True}
+    assert proxy.marker == "wrapped"
+
+
+def test_apply_causal_conv1d_gcu_patch_is_idempotent(monkeypatch):
+    module = SimpleNamespace(
+        _causal_conv1d_fwd_kernel=_FakeKernel(),
+        _causal_conv1d_update_kernel=_FakeKernel(),
+    )
+    monkeypatch.setattr(causal_conv1d.importlib, "import_module", lambda _: module)
+
+    causal_conv1d.apply_causal_conv1d_gcu_patch()
+    fwd_proxy = module._causal_conv1d_fwd_kernel
+    update_proxy = module._causal_conv1d_update_kernel
+    causal_conv1d.apply_causal_conv1d_gcu_patch()
+
+    assert module._causal_conv1d_fwd_kernel is fwd_proxy
+    assert module._causal_conv1d_update_kernel is update_proxy
+    assert fwd_proxy.block_n == 2048
+    assert update_proxy.block_n == 1024

--- a/tests/unit_tests/patches/test_triton_kernel.py
+++ b/tests/unit_tests/patches/test_triton_kernel.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_fl.patches.triton_kernel import (
+    KernelLaunchMetaProxy,
+    patch_kernel_launch_meta,
+)
+
+
+class _FakeKernel:
+    marker = "wrapped"
+
+    def __getitem__(self, grid):
+        def launch(*args, **kwargs):
+            return grid, args, kwargs
+
+        return launch
+
+
+def test_kernel_launch_meta_proxy_overrides_multiple_parameters():
+    proxy = KernelLaunchMetaProxy(
+        _FakeKernel(),
+        {
+            "BLOCK_N": 2048,
+            "num_warps": 4,
+            "num_stages": 2,
+            "num_ctas": 1,
+            "maxnreg": 64,
+        },
+    )
+
+    grid, args, kwargs = proxy["grid"](
+        1,
+        BLOCK_N=256,
+        num_warps=8,
+        other=True,
+    )
+
+    assert grid == "grid"
+    assert args == (1,)
+    assert kwargs == {
+        "BLOCK_N": 2048,
+        "num_warps": 4,
+        "num_stages": 2,
+        "num_ctas": 1,
+        "maxnreg": 64,
+        "other": True,
+    }
+    assert proxy.marker == "wrapped"
+
+
+def test_patch_kernel_launch_meta_is_idempotent():
+    module = SimpleNamespace(kernel=_FakeKernel())
+    overrides = {"BLOCK_N": 2048, "num_stages": 2}
+
+    patch_kernel_launch_meta(module, "kernel", overrides)
+    proxy = module.kernel
+    patch_kernel_launch_meta(module, "kernel", overrides)
+
+    assert module.kernel is proxy
+
+
+def test_patch_kernel_launch_meta_rejects_conflicting_overrides():
+    module = SimpleNamespace(kernel=_FakeKernel())
+    patch_kernel_launch_meta(module, "kernel", {"BLOCK_N": 2048})
+
+    with pytest.raises(RuntimeError, match="already has launch overrides"):
+        patch_kernel_launch_meta(module, "kernel", {"BLOCK_N": 1024})

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -128,10 +128,9 @@ def register():
 def register_quant_linear():
     from vllm.platforms import current_platform
     # vllm.model_executor.kernels.linear triggers cutlass_scaled_mm_supports_fp8
-    # at module level, which requires torch.ops._C — not available on MUSA and Tsingmicro.
-    if current_platform.device_type == "musa":
-        return
-    elif current_platform.device_type == "txda":
+    # at module level, which requires torch.ops._C — not available on these
+    # platforms.
+    if current_platform.device_type in {"musa", "txda", "gcu"}:
         return
     from vllm_fl.quantization.quant_linear import add_oot_quant_kernel
     add_oot_quant_kernel()

--- a/vllm_fl/dispatch/backends/vendor/gcu/impl/causal_conv1d.py
+++ b/vllm_fl/dispatch/backends/vendor/gcu/impl/causal_conv1d.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""GCU launch configuration overrides for vLLM causal-conv kernels."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class _BlockNKernelProxy:
+    """Override ``BLOCK_N`` while preserving the wrapped Triton kernel API."""
+
+    def __init__(self, kernel: Any, block_n: int) -> None:
+        self._kernel = kernel
+        self.block_n = block_n
+
+    def __getitem__(self, grid: Any) -> Any:
+        launch = self._kernel[grid]
+
+        def launch_with_gcu_block_n(*args: Any, **kwargs: Any) -> Any:
+            kwargs["BLOCK_N"] = self.block_n
+            return launch(*args, **kwargs)
+
+        return launch_with_gcu_block_n
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._kernel, name)
+
+
+def _wrap_kernel(module: Any, name: str, block_n: int) -> None:
+    kernel = getattr(module, name)
+    if isinstance(kernel, _BlockNKernelProxy):
+        if kernel.block_n != block_n:
+            raise RuntimeError(
+                f"GCU causal-conv kernel {name} already has BLOCK_N="
+                f"{kernel.block_n}, expected {block_n}."
+            )
+        return
+    setattr(module, name, _BlockNKernelProxy(kernel, block_n))
+
+
+def apply_causal_conv1d_gcu_patch() -> None:
+    """Apply the S60-tuned causal-conv launch tiles to vLLM."""
+    causal_conv1d = importlib.import_module(
+        "vllm.model_executor.layers.mamba.ops.causal_conv1d"
+    )
+    _wrap_kernel(causal_conv1d, "_causal_conv1d_fwd_kernel", block_n=2048)
+    _wrap_kernel(causal_conv1d, "_causal_conv1d_update_kernel", block_n=1024)
+    logger.info(
+        "Patched causal-conv launch tiles for GCU "
+        "(prefill BLOCK_N=2048, decode BLOCK_N=1024)"
+    )

--- a/vllm_fl/dispatch/backends/vendor/gcu/impl/causal_conv1d.py
+++ b/vllm_fl/dispatch/backends/vendor/gcu/impl/causal_conv1d.py
@@ -6,51 +6,37 @@ from __future__ import annotations
 
 import importlib
 import logging
-from typing import Any
+
+from vllm_fl.patches.triton_kernel import patch_kernel_launch_meta
 
 logger = logging.getLogger(__name__)
 
 
-class _BlockNKernelProxy:
-    """Override ``BLOCK_N`` while preserving the wrapped Triton kernel API."""
-
-    def __init__(self, kernel: Any, block_n: int) -> None:
-        self._kernel = kernel
-        self.block_n = block_n
-
-    def __getitem__(self, grid: Any) -> Any:
-        launch = self._kernel[grid]
-
-        def launch_with_gcu_block_n(*args: Any, **kwargs: Any) -> Any:
-            kwargs["BLOCK_N"] = self.block_n
-            return launch(*args, **kwargs)
-
-        return launch_with_gcu_block_n
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._kernel, name)
-
-
-def _wrap_kernel(module: Any, name: str, block_n: int) -> None:
-    kernel = getattr(module, name)
-    if isinstance(kernel, _BlockNKernelProxy):
-        if kernel.block_n != block_n:
-            raise RuntimeError(
-                f"GCU causal-conv kernel {name} already has BLOCK_N="
-                f"{kernel.block_n}, expected {block_n}."
-            )
-        return
-    setattr(module, name, _BlockNKernelProxy(kernel, block_n))
+CAUSAL_CONV1D_FWD_CONFIG = {
+    "BLOCK_N": 2048,
+    # vLLM already launches the forward kernel with num_stages=2.
+    "num_stages": 2,
+}
+CAUSAL_CONV1D_UPDATE_CONFIG = {"BLOCK_N": 1024}
 
 
 def apply_causal_conv1d_gcu_patch() -> None:
-    """Apply the S60-tuned causal-conv launch tiles to vLLM."""
+    """Apply the S60-tuned causal-conv launch configurations to vLLM."""
     causal_conv1d = importlib.import_module(
         "vllm.model_executor.layers.mamba.ops.causal_conv1d"
     )
-    _wrap_kernel(causal_conv1d, "_causal_conv1d_fwd_kernel", block_n=2048)
-    _wrap_kernel(causal_conv1d, "_causal_conv1d_update_kernel", block_n=1024)
+    patch_kernel_launch_meta(
+        causal_conv1d,
+        "_causal_conv1d_fwd_kernel",
+        CAUSAL_CONV1D_FWD_CONFIG,
+    )
+    patch_kernel_launch_meta(
+        causal_conv1d,
+        "_causal_conv1d_update_kernel",
+        CAUSAL_CONV1D_UPDATE_CONFIG,
+    )
     logger.info(
-        "Patched causal-conv launch tiles for GCU "
-        "(prefill BLOCK_N=2048, decode BLOCK_N=1024)"
+        "Patched causal-conv launch configs for GCU (prefill=%s, decode=%s)",
+        CAUSAL_CONV1D_FWD_CONFIG,
+        CAUSAL_CONV1D_UPDATE_CONFIG,
     )

--- a/vllm_fl/dispatch/backends/vendor/gcu/impl/fused_recurrent_packed_decode.py
+++ b/vllm_fl/dispatch/backends/vendor/gcu/impl/fused_recurrent_packed_decode.py
@@ -222,7 +222,9 @@ def fused_recurrent_gated_delta_rule_packed_decode_gcu(
         raise ValueError(
             f"Packed decode kernel only supports NK=1 (got K={K}, BK={BK})."
         )
-    BV = min(triton.next_power_of_2(V), 32)
+    # Qwen3.8 GDN uses V=128. Covering V in one tile avoids four duplicate
+    # Q/K and scalar loads per value head compared with a 32-element tile.
+    BV = min(triton.next_power_of_2(V), 128)
     num_stages = 3
     num_warps = 1
 

--- a/vllm_fl/dispatch/backends/vendor/gcu/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/gcu/patch.py
@@ -3,6 +3,7 @@
 import logging
 
 from .impl.bilinear_pos_embed import apply_bilinear_pos_embed_gcu_patch
+from .impl.causal_conv1d import apply_causal_conv1d_gcu_patch
 from .impl.chunk_delta_h import apply_chunk_delta_h_gcu_patch
 from .impl.fused_recurrent_packed_decode import (
     apply_fused_recurrent_packed_decode_gcu_patch,
@@ -17,8 +18,9 @@ def apply_gcu_patches() -> None:
     global _patches_applied
     if _patches_applied:
         return
-    
+
     apply_bilinear_pos_embed_gcu_patch()
+    apply_causal_conv1d_gcu_patch()
     apply_chunk_delta_h_gcu_patch()
     apply_fused_recurrent_packed_decode_gcu_patch()
     _patches_applied = True

--- a/vllm_fl/patches/triton_kernel.py
+++ b/vllm_fl/patches/triton_kernel.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Reusable Triton kernel launch override utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+class KernelLaunchMetaProxy:
+    """Override selected launch parameters while preserving the kernel API."""
+
+    def __init__(self, kernel: Any, launch_overrides: Mapping[str, Any]) -> None:
+        if not launch_overrides:
+            raise ValueError("At least one kernel launch override is required.")
+        self._kernel = kernel
+        # Keep a plain dict on this hot path. The public property returns a copy.
+        self._launch_overrides = dict(launch_overrides)
+
+    @property
+    def launch_overrides(self) -> dict[str, Any]:
+        return self._launch_overrides.copy()
+
+    def __getitem__(self, grid: Any) -> Any:
+        launch = self._kernel[grid]
+
+        def launch_with_overrides(*args: Any, **kwargs: Any) -> Any:
+            kwargs.update(self._launch_overrides)
+            return launch(*args, **kwargs)
+
+        return launch_with_overrides
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._kernel, name)
+
+
+def patch_kernel_launch_meta(
+    module: Any,
+    kernel_name: str,
+    launch_overrides: Mapping[str, Any],
+) -> None:
+    """Apply launch overrides to a kernel attribute exactly once."""
+    kernel = getattr(module, kernel_name)
+    if isinstance(kernel, KernelLaunchMetaProxy):
+        if kernel.launch_overrides != dict(launch_overrides):
+            raise RuntimeError(
+                f"Kernel {kernel_name} already has launch overrides "
+                f"{kernel.launch_overrides}, expected {dict(launch_overrides)}."
+            )
+        return
+    setattr(module, kernel_name, KernelLaunchMetaProxy(kernel, launch_overrides))

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -399,7 +399,18 @@ class PlatformFL(Platform):
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:
-        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon", "mthreads", "iluvatar", "thead", "gcu", "kunlunxin"]:
+        if cls.vendor_name in [
+            "nvidia",
+            "ascend",
+            "metax",
+            "hygon",
+            "mthreads",
+            "iluvatar",
+            "thead",
+            "gcu",
+            "enflame",
+            "kunlunxin",
+        ]:
             return True
         return False
 

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -402,7 +402,7 @@ class PlatformFL(Platform):
         # Current detection reports vendor_name="enflame" and
         # device_type="gcu". Keep the legacy "gcu" vendor alias for images
         # built with the earlier detector.
-        if cls.vendor_name in [
+        if cls.vendor_name in {
             "nvidia",
             "ascend",
             "metax",
@@ -413,7 +413,7 @@ class PlatformFL(Platform):
             "gcu",
             "enflame",
             "kunlunxin",
-        ]:
+        }:
             return True
         return False
 

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -399,6 +399,9 @@ class PlatformFL(Platform):
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:
+        # Current detection reports vendor_name="enflame" and
+        # device_type="gcu". Keep the legacy "gcu" vendor alias for images
+        # built with the earlier detector.
         if cls.vendor_name in [
             "nvidia",
             "ascend",


### PR DESCRIPTION
### PR Category
Vendor

### PR Type
Performance

### Description
Enable Enflame GCU static graph and migrate the S60-tuned Qwen3.8 decode/prefill optimizations into the plugin. The causal-conv change wraps vLLM Triton kernel launches and overrides only `BLOCK_N`, keeping the upstream vLLM implementation intact.

### Related Issues
N/A

### Changes
- Recognize `vendor_name=enflame` for static graph while retaining the legacy `gcu` vendor alias.
- Skip CUDA quant-linear registration on `device_type=gcu`.
- Increase packed-decode `BV` from 32 to 128.
- Apply GCU causal-conv launch tiles in the plugin: prefill `BLOCK_N=2048`, decode `BLOCK_N=1024`.
- Add hardware-independent proxy and idempotence unit tests.

### Performance
The formal end-to-end comparison uses Qwen3.8-27B on Enflame S60 with TP4 and the same `1024 input -> 16 output`, 16-request, concurrency-16 workload. Both compared results completed 16/16 requests successfully. The initial eager result completed only 7/16 requests and is therefore retained as a stability record but excluded from the percentage calculation.

| Stage | Successful requests | Output throughput | Total token throughput | Relative to baseline |
| --- | ---: | ---: | ---: | ---: |
| Initial eager (unstable; record only) | 7/16 | 0.27 tok/s | invalid | N/A |
| Pre-optimization stable baseline | 16/16 | 1.70 tok/s | 110.62 tok/s | 1.00x |
| Final optimized, three-run hot mean | 16/16 | 11.51 tok/s | 747.97 tok/s | 6.76x (+576.2%) |

The three final hot runs achieved 747.91, 749.91, and 746.08 total tok/s. Output throughput improved from 1.70 to 11.51 tok/s (6.77x, +577.1%), while end-to-end total token throughput improved from 110.62 to 747.97 tok/s (6.76x, +576.2%).

### Testing
- Hardware: Enflame S60, Qwen3.8-27B, TP4.
- GDN numerical correctness: state max error <= 1.53e-5; BF16 output max error 0.015625.
- GDN microbench: batch 16: 0.46538 -> 0.15840 ms (2.938x); batch 64: 1.85367 -> 0.59191 ms (3.132x); batch 128: 3.66034 -> 1.15357 ms (3.173x).
- Causal-conv proxy/idempotence passed against the actual vLLM module.
- GCU causal decode direct-core vs plugin-patched: output and state max absolute difference 0.0.
- Full service `/health` returned HTTP 200.
- `client.sh` accuracy gate passed and answered Beijing.
- All end-to-end benchmark requests succeeded.
- `git diff --check`, `py_compile`, Ruff check, and Ruff format check passed.

### Checklist
- [x] The changes are limited to the GCU vendor backend.
- [x] Numerical correctness was verified on Enflame S60.
- [x] The PR remains Draft pending upstream review.