### PR TITLE
ascend: blacklist pow_scalar (OR'd tl.constexpr() dtype guard)

### DIFF
--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -117,7 +117,12 @@ flagos_blacklist:
   - _index_put_impl_
   # --- Reduction (argmax only - Invalid Runtime Function on NPU) ---
   - argmax
-  # --- Crash: pow_scalar (chained-boolean a < b < c tl.constexpr branch) ---
+  # --- Crash: pow_scalar (OR'd tl.constexpr() dtype guard in pow.py) ---
+  # flag_gems _ascend/ops/pow.py guards the exponent dtype with three OR'd
+  # tl.constexpr() calls; vendor triton rejects the chained constexpr boolean
+  # (T-path on both backends), and flagtree 0.6.0+ascend3.2 (cann8.5.0) also
+  # rejects it (F-path). flagtree 0.6.1+ascend3.5 (cann9.0.0) accepts it, so
+  # there the blacklist only matters for the T-path. Fall back to torch_npu.
   - pow_scalar
 
 # OOT (Out-of-Tree) operator blacklist

--- a/vllm_fl/dispatch/config/ascend.yaml
+++ b/vllm_fl/dispatch/config/ascend.yaml
@@ -117,6 +117,8 @@ flagos_blacklist:
   - _index_put_impl_
   # --- Reduction (argmax only - Invalid Runtime Function on NPU) ---
   - argmax
+  # --- Crash: pow_scalar (chained-boolean a < b < c tl.constexpr branch) ---
+  - pow_scalar
 
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.


### PR DESCRIPTION
## Summary

Adds `pow_scalar` to the Ascend `flagos_blacklist` so vllm 0.20.2 inference falls back to `torch_npu` for this op.

## Root cause

`flag_gems/runtime/backend/_ascend/ops/pow.py` guards the exponent dtype with three `tl.constexpr()` calls joined by `or` (a chained constexpr boolean, not a literal `a < b < c`). The compiler rejects this construct during kernel compilation.

Scope differs by backend, driven by the FlagTree version:

- `ascend-cann8.5.0` (flagtree 0.6.0+ascend3.2): both FlagTree (F) and vendor Triton (T) reject it — blacklist covers F+T.
- `ascend-cann9.0.0` (flagtree 0.6.1+ascend3.5): FlagTree accepts it; only vendor Triton rejects — blacklist strictly needed for T only.

## Verification

- vllm 0.20.2 E2E (Qwen3-4B, 64-token decode) passes on both `ascend-cann8.5.0` and `ascend-cann9.0.0` with this entry present.

## Notes

Companion to #361 (lift_fresh / lift_fresh_copy / _to_copy), a separate root cause.

This PR was written in part with the assistance of generative AI.
