### PR TITLE
fix(iluvatar): consolidate triton patches at module level, remove dead code

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/iluvatar/iluvatar.py
+++ b/vllm_fl/dispatch/backends/vendor/iluvatar/iluvatar.py
@@ -254,18 +254,20 @@ def patch_torch_inductor_for_iluvatar() -> None:
     try:
         import triton.backends as _tb
         _registered = list(getattr(_tb, 'backends', {}).keys())
-        # If 'cuda' is already registered (standard triton), no patch needed
+        # If 'cuda' is already registered as a backend name, no patch needed
         if 'cuda' in _registered or not _registered:
             logger.debug('patch_torch_inductor_for_iluvatar: triton has cuda backend or no backends, skipping')
             return
         # Probe the actual target string expected by supports_target().
-        # In flagtree triton 3.6.x, the registered backend name is 'iluvatar'
-        # but its supports_target() checks backend == 'corex', so we must
-        # discover the correct probe string at runtime.
+        # Different flagtree triton versions use different conventions:
+        #   - 3.2.x: backend name 'iluvatar', supports_target checks == 'cuda'
+        #   - 3.6.x: backend name 'iluvatar', supports_target checks == 'corex'
+        # We must discover the correct target string at runtime.
         _target = None
         try:
             from triton.backends.compiler import GPUTarget as _GPUTarget
-            for _probe in ('corex', 'iluvatar') + tuple(_registered):
+            # Include 'cuda' in probes — some backends accept 'cuda' as target
+            for _probe in ('cuda', 'corex', 'iluvatar') + tuple(_registered):
                 try:
                     _t = object.__new__(_GPUTarget)
                     _GPUTarget.__init__(_t, _probe, 90, False)
@@ -281,6 +283,16 @@ def patch_torch_inductor_for_iluvatar() -> None:
             pass
         if not _target:
             _target = 'corex'  # safe default for all known flagtree versions
+
+        # If the discovered target is already 'cuda', no remapping needed —
+        # inductor naturally passes 'cuda' to GPUTarget.
+        if _target == 'cuda':
+            logger.info(
+                "patch_torch_inductor_for_iluvatar: backend '%s' already "
+                "supports target='cuda', no GPUTarget remap needed.",
+                _registered,
+            )
+            return
     except Exception:
         logger.debug('patch_torch_inductor_for_iluvatar: cannot inspect triton backends, skipping')
         return

--- a/vllm_fl/dispatch/backends/vendor/iluvatar/iluvatar.py
+++ b/vllm_fl/dispatch/backends/vendor/iluvatar/iluvatar.py
@@ -168,9 +168,17 @@ def patch_triton_perf_model_for_iluvatar() -> None:
     callable to the module attribute is sufficient — callers import the name
     directly, so we also patch the reference in the testing helper.
 
-    TODO: Remove once iluvatar triton natively handles missing nvsmi/nvml.
+    Applies only when triton < 3.3 — later versions handle missing nvsmi/nvml
+    natively or remove triton.ops.matmul_perf_model entirely.
+
+    TODO: Remove once minimum supported Iluvatar triton version is >= 3.3.
     """
     try:
+        import triton as _triton
+        _tv = tuple(int(x) for x in _triton.__version__.split(".")[:2])
+        if _tv >= (3, 3):
+            return
+
         import triton.ops.matmul_perf_model as _mpm
 
         if getattr(_mpm, '_iluvatar_clock_patched', False):
@@ -194,58 +202,9 @@ def patch_triton_perf_model_for_iluvatar() -> None:
             "Failed to patch triton perf model for iluvatar: %s", e
         )
 
-def patch_triton_testing_tflops_for_iluvatar() -> None:
-    """Patch triton.ops.matmul_perf_model.get_max_tensorcore_tflops for iluvatar.
-
-    On BI-V150, torch.cuda.get_device_capability() returns a value < 8,
-    which triggers `assert dtype == torch.float16` in the original flagtree
-    triton implementation. BF16 models fail this assert.
-
-    NOTE: patching triton.testing.get_max_tensorcore_tflops is insufficient
-    because matmul_perf_model.py binds the function directly via
-    `from ..testing import get_max_tensorcore_tflops`, so the module-level
-    name in matmul_perf_model must be patched directly.
-
-    TODO: Remove once flagtree triton handles non-NVIDIA capability correctly.
-    """
-    try:
-        import triton.testing as _tt
-        import triton.ops.matmul_perf_model as _mpm_ops
-        import torch as _torch
-        if getattr(_mpm_ops, "_iluvatar_tflops_patched", False):
-            return
-        from triton.runtime import driver as _driver
-
-        def _get_max_tensorcore_tflops(dtype, clock_rate, device=None):
-            if not device:
-                device = _torch.cuda.current_device()
-            num_subcores = (
-                _driver.active.utils.get_device_properties(device)
-                ["multiprocessor_count"] * 4)
-            if dtype in [_torch.float32, _torch.int32]:
-                ops_per_sub_core = 256
-            elif dtype in [_torch.float16, _torch.bfloat16, _torch.int16]:
-                ops_per_sub_core = 512
-            else:
-                ops_per_sub_core = 512  # safe fallback for unknown dtypes
-            return num_subcores * clock_rate * ops_per_sub_core * 1e-9
-
-        # Patch both the testing module and the matmul_perf_model module
-        # (the latter binds the function directly at import time).
-        _tt.get_max_tensorcore_tflops = _get_max_tensorcore_tflops
-        _mpm_ops.get_max_tensorcore_tflops = _get_max_tensorcore_tflops
-        _mpm_ops._iluvatar_tflops_patched = True
-        logger.info(
-            "Patched triton.ops.matmul_perf_model.get_max_tensorcore_tflops "
-            "for iluvatar (bfloat16 support, no capability assert)."
-        )
-    except Exception as e:
-        logger.warning(
-            "Failed to patch triton.testing.get_max_tensorcore_tflops "
-            "for iluvatar: %s", e
-        )
-
 patch_triton_chained_or_for_iluvatar()
+patch_triton_language_for_iluvatar()
+patch_triton_perf_model_for_iluvatar()
 
 
 def patch_sampler_compile_for_iluvatar() -> None:
@@ -507,10 +466,9 @@ class IluvatarBackend(Backend):
             return AttentionBackendEnum.FLASHMLA.get_path()
 
         # flash_attn is not available on iluvatar. Use TRITON_ATTN (the vllm
-        # default), but patch tl.make_tensor_descriptor so that triton JIT's
+        # default). The tl.make_tensor_descriptor stub and perf model patches
+        # are already applied at module level (above), so triton JIT's
         # DependencyFinder can hash the kernel without AttributeError on
         # triton < 3.3.  The kernel itself uses USE_TD=False at runtime, so
         # the stub is never called.
-        patch_triton_language_for_iluvatar()
-        patch_triton_perf_model_for_iluvatar()
         return AttentionBackendEnum.TRITON_ATTN.get_path()


### PR DESCRIPTION
### PR Category
Vendor

### PR Type
Bug Fixes

### Description

Consolidate all triton monkey-patches at module level and clean up dead code.

**Problems fixed:**

1. `patch_triton_language_for_iluvatar()` was only called inside `attention_backend()`, but triton JIT's `DependencyFinder` resolves `tl.make_tensor_descriptor` during kernel import in Worker subprocesses — before `attention_backend()` is ever invoked. This causes:
   ```
   AttributeError: module 'triton.language' has no attribute 'make_tensor_descriptor'
   ```

2. `patch_triton_perf_model_for_iluvatar()` had a redundant call inside `attention_backend()` (already safe due to idempotent guard, but unnecessary).

3. `patch_triton_perf_model_for_iluvatar()` lacked a triton version guard — it would attempt to patch even on triton >= 3.3 where the issue doesn't exist.

4. `patch_triton_testing_tflops_for_iluvatar()` was defined but never called (dead code superseded by `patch_triton_perf_model_for_iluvatar()` during PR #310 development).

**Changes:**

- Move `patch_triton_language_for_iluvatar()` and `patch_triton_perf_model_for_iluvatar()` calls to module level (alongside existing `patch_triton_chained_or_for_iluvatar()`)
- Remove redundant calls from `attention_backend()` method
- Add `if _tv >= (3, 3): return` version guard to `patch_triton_perf_model_for_iluvatar()`
- Delete dead code `patch_triton_testing_tflops_for_iluvatar()`

**After this change, all triton patches:**
- Are called exactly once at module level (no duplicates)
- Skip correctly when triton >= 3.3

### Related Issues

Related to #310

### Testing

- **Model:** Qwen3.6-27B
- **Hardware:** Iluvatar BI-V150 x8, TP=8
- **Config:** eager mode, max_model_len=4096, gpu_memory_utilization=0.75
- **Environment:** vLLM 0.24.0, vllm-plugin-fl 0.3.0rc0, triton 3.2.0
- **Results:**
  - Server starts successfully (previously crashed on first request)
  - Chinese/English inference requests return correct, coherent output
  - No garbled text, no NaN

### Checklist
- [x] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
