### PR TITLE
feat(hygon): add backend and Qwen3.6 W4A16 support

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -152,6 +152,12 @@ def register_model():
     register_quant_linear()
     register_router()
 
+    from vllm_fl.dispatch.backends.vendor.hygon.patch import (
+        apply_hygon_moe_patches,
+    )
+
+    apply_hygon_moe_patches()
+
     # Register GLM-5 (GlmMoeDsa) — config not yet upstream
     try:
         from vllm.transformers_utils.config import _CONFIG_REGISTRY

--- a/vllm_fl/attention/utils.py
+++ b/vllm_fl/attention/utils.py
@@ -29,11 +29,15 @@ def patch_mm_encoder_attention():
             try:
                 from vllm.vllm_flash_attn import flash_attn_varlen_func
 
+                if flash_attn_varlen_func is None:
+                    raise ImportError("vLLM's bundled FlashAttention is unavailable")
+
                 logger.info_once("Using vllm.vllm_flash_attn for vit attention")
             except (ImportError, ModuleNotFoundError):
                 from flash_attn import flash_attn_varlen_func
 
                 logger.info_once("Using flash_attn for vit attention")
+
             return flash_attn_varlen_func
         elif attn_backend == AttentionBackendEnum.ROCM_AITER_FA:
             from aiter import flash_attn_varlen_func

--- a/vllm_fl/dispatch/backends/vendor/hygon/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/__init__.py
@@ -1,0 +1,5 @@
+"""Hygon vendor backend."""
+
+from .hygon import HygonBackend
+
+__all__ = ["HygonBackend"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/hygon.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/hygon.py
@@ -1,0 +1,93 @@
+"""Hygon vendor backend for vLLM-FL."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Optional
+
+import torch
+
+from vllm_fl.dispatch.backends.base import Backend
+
+
+class HygonBackend(Backend):
+    """Operators and backend selection for Hygon BW-series devices."""
+
+    _available: Optional[bool] = None
+
+    @property
+    def name(self) -> str:
+        return "hygon"
+
+    @property
+    def vendor(self) -> Optional[str]:
+        return "hygon"
+
+    def is_available(self) -> bool:
+        if HygonBackend._available is not None:
+            return HygonBackend._available
+
+        try:
+            from vllm.platforms import current_platform
+
+            if getattr(current_platform, "vendor_name", "").lower() == "hygon":
+                HygonBackend._available = True
+                return True
+        except Exception:
+            pass
+
+        if os.environ.get("GEMS_VENDOR", "").strip().lower() == "hygon":
+            HygonBackend._available = True
+            return True
+
+        # Some BW1000 images expose both management commands.
+        HygonBackend._available = bool(shutil.which("hy-smi") and shutil.which("rocm-smi"))
+        return HygonBackend._available
+
+    def rms_norm(self, obj, x: torch.Tensor, residual=None):
+        from .impl.normalization import rms_norm_hygon
+
+        return rms_norm_hygon(obj, x, residual)
+
+    def rotary_embedding(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        rotary_interleaved: bool = False,
+        inplace: bool = True,
+    ):
+        from .impl.rotary import rotary_embedding_hygon
+
+        return rotary_embedding_hygon(
+            obj,
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            rotary_interleaved=rotary_interleaved,
+            inplace=inplace,
+        )
+
+    def attention_backend(self, use_mla: bool = False, use_sparse: bool = False) -> str:
+        from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        if use_mla and use_sparse:
+            return AttentionBackendEnum.ROCM_AITER_MLA_SPARSE.get_path()
+        if use_mla:
+            try:
+                from vllm._aiter_ops import rocm_aiter_ops
+
+                if rocm_aiter_ops.is_mla_enabled():
+                    return AttentionBackendEnum.ROCM_AITER_MLA.get_path()
+            except (ImportError, AttributeError):
+                pass
+            return AttentionBackendEnum.TRITON_MLA.get_path()
+        if use_sparse:
+            raise ValueError("use_sparse=True requires use_mla=True")
+        return AttentionBackendEnum.ROCM_ATTN.get_path()

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/__init__.py
@@ -1,0 +1,1 @@
+"""Hygon operator implementations."""

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/normalization.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/normalization.py
@@ -1,0 +1,17 @@
+"""Hygon normalization fallbacks backed by vLLM native ops."""
+
+from __future__ import annotations
+
+import torch
+
+
+def rms_norm_hygon(obj, x: torch.Tensor, residual=None):
+    from vllm._custom_ops import fused_add_rms_norm, rms_norm
+
+    if residual is not None:
+        fused_add_rms_norm(x, residual, obj.weight, obj.variance_epsilon)
+        return x, residual
+
+    out = torch.empty_like(x)
+    rms_norm(out, x, obj.weight, obj.variance_epsilon)
+    return out

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/rotary.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/rotary.py
@@ -1,0 +1,34 @@
+"""Hygon rotary embedding routed through the backend wrapper patch."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+def rotary_embedding_hygon(
+    obj,
+    query: torch.Tensor,
+    key: Optional[torch.Tensor],
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    rotary_interleaved: bool = False,
+    inplace: bool = True,
+):
+    from vllm._custom_ops import rotary_embedding
+
+    if not inplace:
+        query = query.clone()
+        if key is not None:
+            key = key.clone()
+    rotary_embedding(
+        position_ids,
+        query,
+        key,
+        obj.head_size,
+        torch.cat((cos, sin), dim=-1),
+        not rotary_interleaved,
+    )
+    return query, key

--- a/vllm_fl/dispatch/backends/vendor/hygon/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/patch.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Thin installers for Hygon-specific empty-vLLM compatibility hooks."""
+
+from __future__ import annotations
+
+import functools
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+_patches_applied = False
+
+
+def _ensure_vit_flash_attn_func():
+    """Install the ViT FlashAttention callable in the current Hygon worker."""
+    import vllm.v1.attention.backends.fa_utils as fa_utils
+
+    flash_attn_varlen_func = getattr(
+        fa_utils,
+        "flash_attn_varlen_func",
+        None,
+    )
+    if flash_attn_varlen_func is not None:
+        return flash_attn_varlen_func
+
+    try:
+        from vllm.vllm_flash_attn import flash_attn_varlen_func
+
+        if flash_attn_varlen_func is None:
+            raise ImportError(
+                "vLLM's bundled FlashAttention is unavailable"
+            )
+
+        logger.info("Using vllm.vllm_flash_attn for Hygon ViT attention")
+    except (ImportError, ModuleNotFoundError):
+        from flash_attn import flash_attn_varlen_func
+
+        logger.info("Using flash_attn for Hygon ViT attention")
+
+    fa_utils.flash_attn_varlen_func = flash_attn_varlen_func
+    return flash_attn_varlen_func
+
+
+def patch_mm_encoder_attention() -> None:
+    """Route Hygon OOT FlashAttention calls through the FA implementation."""
+    import vllm.model_executor.layers.attention.mm_encoder_attention as mm_mod
+
+    current_forward_native = mm_mod.MMEncoderAttention.forward_native
+    if getattr(
+        current_forward_native,
+        "_vllm_fl_hygon_mm_encoder_patch",
+        False,
+    ):
+        return
+
+    original_forward_native = current_forward_native
+
+    @functools.wraps(original_forward_native)
+    def forward_native_hygon(
+        self,
+        query,
+        key,
+        value,
+        cu_seqlens=None,
+        max_seqlen=None,
+        sequence_lengths=None,
+    ):
+        if self.is_flash_attn_backend:
+            _ensure_vit_flash_attn_func()
+            return self._forward_fa(
+                query,
+                key,
+                value,
+                cu_seqlens,
+                max_seqlen,
+            )
+
+        return original_forward_native(
+            self,
+            query,
+            key,
+            value,
+            cu_seqlens,
+            max_seqlen,
+            sequence_lengths,
+        )
+
+    forward_native_hygon._vllm_fl_hygon_mm_encoder_patch = True
+    mm_mod.MMEncoderAttention.forward_native = forward_native_hygon
+    logger.info(
+        "Hygon MMEncoderAttention patched: "
+        "forward_native routes FLASH_ATTN to _forward_fa"
+    )
+
+
+def patch_empty_moe() -> None:
+    """Route empty-vLLM MoE hooks through the shared FL dispatch layer."""
+    import vllm.model_executor.layers.fused_moe.fused_moe as fused_moe_module
+
+    if getattr(
+        fused_moe_module,
+        "_vllm_fl_hygon_empty_moe_patched",
+        False,
+    ):
+        return
+
+    from vllm_fl.dispatch import CachedOp
+    from vllm_fl.ops.fused_moe.activation import (
+        apply_moe_activation as apply_moe_activation_fl,
+    )
+
+    fused_moe_module.moe_align_block_size = CachedOp(
+        "moe_align_block_size"
+    )
+    fused_moe_module.apply_moe_activation = apply_moe_activation_fl
+
+    # Hygon has CUDA-shaped capabilities but cannot execute NVIDIA Marlin.
+    # Force compressed-tensors WNA16 MoE onto the generic Triton path.
+    from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe import (
+        compressed_tensors_moe as ct_moe,
+    )
+
+    current_check = ct_moe.check_moe_marlin_supports_layer
+    if not getattr(current_check, "_vllm_fl_hygon_patched", False):
+
+        @functools.wraps(current_check)
+        def check_moe_marlin_supports_layer_hygon(layer, group_size):
+            from vllm.platforms import current_platform
+
+            vendor = getattr(current_platform, "vendor_name", "").lower()
+            if vendor == "hygon":
+                return False
+            return current_check(layer, group_size)
+
+        check_moe_marlin_supports_layer_hygon._vllm_fl_hygon_patched = True
+        ct_moe.check_moe_marlin_supports_layer = (
+            check_moe_marlin_supports_layer_hygon
+        )
+
+    fused_moe_module._vllm_fl_hygon_empty_moe_patched = True
+
+
+def apply_hygon_moe_patches() -> None:
+    """Install the Hygon MoE compatibility hook before model construction."""
+    from .hygon import HygonBackend
+
+    if not HygonBackend().is_available():
+        return
+
+    patch_empty_moe()
+
+
+def apply_hygon_patches() -> None:
+    """Install Hygon-specific compatibility patches once."""
+    global _patches_applied
+
+    if _patches_applied:
+        return
+
+    from .hygon import HygonBackend
+
+    if not HygonBackend().is_available():
+        return
+
+    patch_mm_encoder_attention()
+    patch_empty_moe()
+    _patches_applied = True
+
+
+__all__ = [
+    "patch_empty_moe",
+    "apply_hygon_moe_patches",
+    "apply_hygon_patches",
+    "patch_mm_encoder_attention",
+]

--- a/vllm_fl/dispatch/backends/vendor/hygon/register_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/register_ops.py
@@ -1,0 +1,42 @@
+"""Register Hygon vendor implementations with the dispatch registry."""
+
+from __future__ import annotations
+
+import functools
+
+from vllm_fl.dispatch.types import BackendImplKind, BackendPriority, OpImpl
+
+
+def _bind_is_available(fn, is_available_fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    wrapper._is_available = is_available_fn
+    return wrapper
+
+
+def register_builtins(registry) -> None:
+    from .hygon import HygonBackend
+    from .patch import apply_hygon_patches
+
+    backend = HygonBackend()
+    if backend.is_available():
+        apply_hygon_patches()
+    available = backend.is_available
+    methods = {
+        "rms_norm": backend.rms_norm,
+        "rotary_embedding": backend.rotary_embedding,
+        "attention_backend": backend.attention_backend,
+    }
+    registry.register_many(
+        OpImpl(
+            op_name=name,
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(method, available),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        )
+        for name, method in methods.items()
+    )

--- a/vllm_fl/quantization/quant_linear.py
+++ b/vllm_fl/quantization/quant_linear.py
@@ -68,3 +68,11 @@ def add_oot_quant_kernel() -> None:
     register_fl_w8a8_linear_kernel(_POSSIBLE_INT8_KERNELS)
     install_packed_w8a8_scheme()
     install_fl_w8a8_moe_selector()
+
+    from vllm_fl.quantization.wna16.linear import (
+        register_fl_triton_wna16_linear_kernel,
+    )
+
+    register_fl_triton_wna16_linear_kernel(
+        _POSSIBLE_KERNELS,
+    )

--- a/vllm_fl/quantization/wna16/__init__.py
+++ b/vllm_fl/quantization/wna16/__init__.py
@@ -1,0 +1,13 @@
+from .linear import (
+    FLTritonWNA16LinearKernel,
+    register_fl_triton_wna16_linear_kernel,
+)
+from .repack import (
+    repack_uint4_kpacked_to_npacked,
+)
+
+__all__ = [
+    "FLTritonWNA16LinearKernel",
+    "register_fl_triton_wna16_linear_kernel",
+    "repack_uint4_kpacked_to_npacked",
+]

--- a/vllm_fl/quantization/wna16/linear.py
+++ b/vllm_fl/quantization/wna16/linear.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Portable OOT adapter for vLLM's Triton W4A16 Linear kernel."""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.model_executor.kernels.linear import (
+    MPLinearLayerConfig,
+)
+from vllm.model_executor.kernels.linear.mixed_precision.triton_w4a16 import (
+    TRITON_W4A16_SUPPORTED_GROUP_SIZES,
+    TritonW4A16LinearKernel,
+)
+from vllm.model_executor.layers.quantization.utils import (
+    replace_parameter,
+)
+from vllm.model_executor.parameter import (
+    BasevLLMParameter,
+    permute_param_layout_,
+)
+
+from .repack import (
+    repack_uint4_kpacked_to_npacked,
+)
+
+
+class FLTritonWNA16LinearKernel(
+    TritonW4A16LinearKernel
+):
+    """
+    Reuse vLLM's Triton W4A16 GEMM on CUDA-shaped OOT devices.
+
+    Selection is capability-based rather than vendor-based. Weight conversion
+    is implemented locally to avoid the FlagGems sum.dim_IntList reduction.
+    """
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return -1
+
+    @classmethod
+    def can_implement(
+        cls,
+        config: MPLinearLayerConfig,
+    ) -> tuple[bool, str | None]:
+        if config.weight_type not in cls.SUPPORTED_QUANT_TYPES:
+            return (
+                False,
+                f"Quant type {config.weight_type} is unsupported; "
+                f"supported: {cls.SUPPORTED_QUANT_TYPES}",
+            )
+
+        if config.act_type not in (
+            torch.float16,
+            torch.bfloat16,
+        ):
+            return (
+                False,
+                "FLTritonWNA16 requires FP16 or BF16 activations",
+            )
+
+        if config.has_g_idx:
+            return (
+                False,
+                "FLTritonWNA16 does not support activation ordering",
+            )
+
+        input_size, output_size = (
+            config.partition_weight_shape
+        )
+
+        if input_size % 8 != 0:
+            return (
+                False,
+                f"Input size {input_size} must be divisible by 8",
+            )
+
+        if output_size % 8 != 0:
+            return (
+                False,
+                f"Output size {output_size} must be divisible by 8",
+            )
+
+        group_size = config.group_size
+        full_input_size = config.full_weight_shape[0]
+
+        if (
+            group_size != -1
+            and group_size
+            not in TRITON_W4A16_SUPPORTED_GROUP_SIZES
+            and group_size != full_input_size
+        ):
+            return (
+                False,
+                f"Group size {group_size} is unsupported; "
+                f"supported: "
+                f"{TRITON_W4A16_SUPPORTED_GROUP_SIZES} "
+                f"or full K ({full_input_size})",
+            )
+
+        effective_group_size = (
+            input_size
+            if group_size == -1
+            else group_size
+        )
+
+        if effective_group_size <= 0:
+            return (
+                False,
+                f"Invalid group size {effective_group_size}",
+            )
+
+        if input_size % effective_group_size != 0:
+            return (
+                False,
+                f"Input size {input_size} is not divisible by "
+                f"group size {effective_group_size}",
+            )
+
+        return True, None
+
+    def process_weights_after_loading(
+        self,
+        layer: torch.nn.Module,
+    ) -> None:
+        def repack_weight(
+            parameter: BasevLLMParameter,
+        ) -> BasevLLMParameter:
+            # Restore canonical checkpoint layout [N, K // 8].
+            permute_param_layout_(
+                parameter,
+                input_dim=1,
+                output_dim=0,
+                packed_dim=1,
+            )
+
+            parameter.data = (
+                repack_uint4_kpacked_to_npacked(
+                    parameter.data,
+                )
+            )
+            return parameter
+
+        def transpose_scale(
+            parameter: BasevLLMParameter,
+        ) -> BasevLLMParameter:
+            # Checkpoint: [N, K // G]
+            # Kernel:     [K // G, N]
+            permute_param_layout_(
+                parameter,
+                input_dim=1,
+                output_dim=0,
+            )
+            parameter.data = (
+                parameter.data
+                .transpose(-2, -1)
+                .contiguous()
+            )
+            return parameter
+
+        self._transform_param(
+            layer,
+            self.w_q_name,
+            repack_weight,
+        )
+        self._transform_param(
+            layer,
+            self.w_s_name,
+            transpose_scale,
+        )
+
+        if self.w_zp_name is not None:
+            zero_point = getattr(
+                layer,
+                self.w_zp_name,
+                None,
+            )
+
+            if zero_point is not None:
+                replace_parameter(
+                    layer,
+                    self.w_zp_name,
+                    torch.nn.Parameter(
+                        zero_point.data
+                        .transpose(-2, -1)
+                        .contiguous(),
+                        requires_grad=False,
+                    ),
+                )
+
+
+def register_fl_triton_wna16_linear_kernel(
+    registry: dict,
+) -> bool:
+    """
+    Register the portable Triton WNA16 adapter for CUDA-shaped OOT devices.
+    """
+    from vllm.platforms import (
+        PlatformEnum,
+        current_platform,
+    )
+
+    if current_platform._enum != PlatformEnum.OOT:
+        return False
+
+    if getattr(
+        current_platform,
+        "device_type",
+        None,
+    ) != "cuda":
+        return False
+
+    candidates = registry.setdefault(
+        PlatformEnum.OOT,
+        [],
+    )
+
+    if FLTritonWNA16LinearKernel not in candidates:
+        candidates.insert(
+            0,
+            FLTritonWNA16LinearKernel,
+        )
+
+    return True
+
+
+__all__ = [
+    "FLTritonWNA16LinearKernel",
+    "register_fl_triton_wna16_linear_kernel",
+]

--- a/vllm_fl/quantization/wna16/repack.py
+++ b/vllm_fl/quantization/wna16/repack.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Reusable compressed-tensors W4A16 weight layout conversion."""
+
+from __future__ import annotations
+
+import torch
+
+
+def repack_uint4_kpacked_to_npacked(
+    weight_packed: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Convert compressed-tensors uint4 layout:
+
+        [..., N, K // 8]
+
+    to the layout required by vLLM Triton W4A16:
+
+        [..., K, N // 8]
+
+    The leading dimensions are preserved, allowing the same implementation
+    to be extended to batched or expert weights.
+    """
+    if weight_packed.dtype != torch.int32:
+        raise TypeError(
+            "weight_packed must have dtype torch.int32, "
+            f"got {weight_packed.dtype}"
+        )
+
+    if weight_packed.ndim < 2:
+        raise ValueError(
+            "weight_packed must have at least two dimensions"
+        )
+
+    output_size = weight_packed.shape[-2]
+    packed_input_size = weight_packed.shape[-1]
+    input_size = packed_input_size * 8
+
+    if output_size % 8 != 0:
+        raise ValueError(
+            "W4A16 repack requires output size divisible by 8, "
+            f"got {output_size}"
+        )
+
+    batch_shape = weight_packed.shape[:-2]
+
+    shifts = torch.arange(
+        8,
+        dtype=torch.int32,
+        device=weight_packed.device,
+    ) * 4
+
+    # [..., N, K // 8] -> [..., N, K]
+    unpacked = (
+        (
+            weight_packed.contiguous().unsqueeze(-1)
+            >> shifts
+        )
+        & 0xF
+    ).reshape(
+        *batch_shape,
+        output_size,
+        input_size,
+    )
+
+    # [..., N, K] -> [..., K, N]
+    weight_kn = unpacked.transpose(-2, -1).contiguous()
+
+    # [..., K, N] -> [..., K, N // 8, 8]
+    nibble_view = weight_kn.reshape(
+        *batch_shape,
+        input_size,
+        output_size // 8,
+        8,
+    )
+
+    # The eight nibbles occupy disjoint bit ranges. Bitwise OR is therefore
+    # exactly equivalent to sum(..., dim=-1), without invoking a reduction.
+    repacked = torch.bitwise_and(
+        nibble_view[..., 0],
+        0xF,
+    ).to(torch.int32)
+
+    for index in range(1, 8):
+        nibble = torch.bitwise_and(
+            nibble_view[..., index],
+            0xF,
+        )
+        nibble = torch.bitwise_left_shift(
+            nibble,
+            index * 4,
+        )
+        repacked = torch.bitwise_or(
+            repacked,
+            nibble,
+        )
+
+    return repacked.contiguous()
+
+
+__all__ = [
+    "repack_uint4_kpacked_to_npacked",
+]

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -237,7 +237,7 @@ _load_op_config_from_env()
 class DeviceInfo:
     def __init__(self):
         self.device = DeviceDetector()
-        self.supported_device = ["nvidia", "ascend", "metax", "mthreads", "sunrise", "thead"]
+        self.supported_device = ["nvidia", "ascend", "metax", "mthreads", "sunrise", "thead", "hygon"]
         backend.set_torch_backend_device_fn(self.device.vendor_name)
 
     @property


### PR DESCRIPTION
### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->

Vendor


### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->

New Features

### Description
<!-- Describe what this PR does and why. -->

Add Hygon backend support for Qwen3.6 W4A16 inference.

This PR adapts the Hygon W4A16 inference path to vLLM 0.24.0, which pins `compressed-tensors==0.17.0`.

It introduces the Hygon vendor backend and integrates WNA16 quantized linear operators required to run Qwen3.6-27B and Qwen3.6-35B-A3B W4A16 models.

The changes in this PR are limited to the Hygon backend and Qwen3.6 inference support. 


### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->

N/A


### Changes
<!-- List the key changes made in this PR. -->
- Adapt Hygon W4A16 inference to the `compressed-tensors==0.17.0`  integration used by vLLM 0.24.0.
- Add Hygon vendor backend registration and operator dispatch.
- Add Hygon-specific normalization and rotary embedding implementations.
- Add WNA16 quantized linear and weight-repacking implementations.
- Integrate WNA16 kernel registration into the quantized linear path, following the existing W8A8 registration pattern.
- Reuse the shared FlagOS dispatch paths for activation and fused MoE operations.
- Add Qwen3.6 multimodal FlashAttention compatibility handling.
- Disable the unsupported Marlin path for Hygon WNA16 MoE inference.
- Support the following W4A16 models:
  - Qwen3.6-27B
  - Qwen3.6-35B-A3B



### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->

#### Compatibility

- vLLM: `0.24.0`
- compressed-tensors: `0.17.0`
- Device: Hygon BW1000

#### Functional inference

  Both models were validated with TP4 and graph mode, including text and image inputs.

  The stable long-context serving configuration used after reserving sufficient graph and sampler memory was:

  - Tensor parallel size: 4
  - Maximum model length: 65536
  - GPU memory utilization: 0.80
  - Maximum sequences: 32
  - Maximum batched tokens: 2048
  - Maximum images per prompt: 1

  Results:
  
  | Model | Text inference | Multimodal inference | TP | Graph mode |
  |---|---:|---:|---:|---:|
  | Qwen3.6-27B W4A16 | Passed | Passed | 4 | Enabled |
  | Qwen3.6-35B-A3B W4A16 | Passed | Passed | 4 | Enabled |


#### Multimodal serving benchmark

  Both serving benchmarks used the following common configuration:

  - Tensor parallel size: 4
  - Maximum model length: 8192
  - GPU memory utilization: 0.9
  - Dataset: `random-mm`
  - Input length: 1024 tokens
  - Output length: 256 tokens
  - Image bucket: one 448×448 image per request
  - Maximum concurrency: 2
  - Warm-up requests: 2
  - Measured requests: 18
  - `--ignore-eos`
  - Default graph mode (`--enforce-eager` was not used)

  Benchmark command pattern:
  
  ```bash
  vllm bench serve \
    --backend openai-chat \
    --model <model-path> \
    --served-model-name <served-model-name> \
    --endpoint /v1/chat/completions \
    --host 127.0.0.1 \
    --port <port> \
    --dataset-name random-mm \
    --random-input-len 1024 \
    --random-output-len 256 \
    --random-range-ratio 0 \
    --random-mm-base-items-per-request 1 \
    --random-mm-num-mm-items-range-ratio 0 \
    --random-mm-limit-mm-per-prompt '{"image":1}' \
    --random-mm-bucket-config '{(448,448,1):1.0}' \
    --max-concurrency 2 \
    --num-warmups 2 \
    --num-prompts 18 \
    --ignore-eos
  ```
  
  Results:
  
  | Model                 | Successful / Failed | Output throughput | Total token throughput | Mean TTFT  | Mean TPOT |
  | --------------------- | ------------------- | ----------------- | ---------------------- | ---------- | --------- |
  | Qwen3.6-27B W4A16     | 18 / 0              | 16.78 tok/s       | 97.58 tok/s            | 3407.48 ms | 106.22 ms |
  | Qwen3.6-35B-A3B W4A16 | 18 / 0              | 37.44 tok/s       | 217.68 tok/s           | 2643.82 ms | 43.24 ms  |


#### GPQA Diamond evaluation

  Both models were evaluated using EvalScope against an OpenAI-compatible vLLM endpoint.
  
  Qwen3.6-27B :
  
  ```
  evalscope eval \
    --model qwen36-27b-int4 \
    --api-url http://127.0.0.1:8027/v1 \
    --api-key EMPTY \
    --eval-type openai_api \
    --datasets gpqa_diamond \
    --eval-batch-size 4 \
    --seed 42  \
    --generation-config '{
      "max_tokens":81920,
      "temperature":1.0,
      "top_p":0.95,
      "top_k":20,
      "min_p":0.0,
      "timeout":1800,
      "retries":1,
      "retry_interval":10,
      "stream": true,
      "presence_penalty":0.0,
      "repetition_penalty":1.0
    }' 
  ```
  
  Qwen3.6-35B-A3B :
 
  
  ```
  evalscope eval \
    --model qwen36-35b-int4 \
    --api-url http://127.0.0.1:8035/v1 \
    --api-key EMPTY \
    --eval-type openai_api \
    --datasets gpqa_diamond \
    --eval-batch-size 4 \
    --seed 42 \
    --generation-config '{
      "max_tokens": 81920,
      "temperature": 1.0,
      "top_p": 0.95,
      "top_k": 20,
      "min_p": 0.0,
      "timeout": 1800,
      "retries": 1,
      "stream": true,
      "presence_penalty": 1.5,
      "repetition_penalty": 1.0
    }'
  ```
  
  Results:
  
  | Model                 | Dataset      | Samples | Metric        | Score  |
  | --------------------- | ------------ | ------- | ------------- | ------ |
  | Qwen3.6-27B W4A16     | GPQA Diamond | 198     | Mean accuracy | 84.85% |
  | Qwen3.6-35B-A3B W4A16 | GPQA Diamond | 198     | Mean accuracy | 80.81% |

### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
