### PR TITLE
[CI] Add Kunlunxin P800 CI support

### DIFF
--- a/.github/configs/kunlunxin.yml
+++ b/.github/configs/kunlunxin.yml
@@ -1,0 +1,42 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Kunlunxin P800 OAM hardware configuration.
+platform: kunlunxin
+
+ci_image: harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl:v0.20.2-kunlunxin-ci
+
+runner_labels:
+  - kunlunxin-p800
+
+container_volumes:
+  - /data:/data
+
+container_options: >-
+  --hostname vllm-plugin-fl
+  --ipc=host
+  --privileged
+  --security-opt seccomp=unconfined
+  --cap-add=SYS_PTRACE
+  --ulimit memlock=-1
+  --ulimit nofile=120000
+  --ulimit stack=67108864
+  --shm-size=128g
+  --env GEMS_VENDOR=kunlunxin
+  --env VLLM_PLUGINS=fl
+  --env FLAGCX_PATH=/workspace/FlagCX
+  --env CUDA_VISIBLE_DEVICES=4,5,6,7
+  --env USE_RESHAPE_AND_CACHE_FLASH=1
+  --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+  --env VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800

--- a/.github/configs/platforms.yml
+++ b/.github/configs/platforms.yml
@@ -32,3 +32,5 @@ platforms:
     enabled: true
   enflame:
     enabled: true
+  kunlunxin:
+    enabled: true

--- a/.github/scripts/kunlunxin/check.sh
+++ b/.github/scripts/kunlunxin/check.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) 2026 BAAI. All rights reserved.
+# Check Kunlunxin P800 availability.
+set -euo pipefail
+
+echo "Current time: $(date '+%Y-%m-%d %H:%M:%S')"
+echo "=== Checking Kunlunxin P800 availability ==="
+
+: "${CUDA_VISIBLE_DEVICES:?CUDA_VISIBLE_DEVICES is not set}"
+
+if command -v xpu-smi >/dev/null 2>&1; then
+  xpu-smi || true
+else
+  echo "::warning::xpu-smi not found; checking through torch.cuda."
+fi
+
+python - <<'PY'
+import torch
+
+if not torch.cuda.is_available():
+    raise RuntimeError("Kunlunxin CUDA-compatible accelerator is unavailable")
+
+count = torch.cuda.device_count()
+print(f"Kunlunxin visible devices: {count}")
+if count < 4:
+    raise RuntimeError(f"At least 4 visible Kunlunxin devices are required, found {count}")
+
+tensor = torch.ones((32, 32), device="cuda:0")
+torch.cuda.synchronize()
+print(f"Tensor smoke: {tensor.device} {tuple(tensor.shape)}")
+PY

--- a/.github/scripts/kunlunxin/setup.sh
+++ b/.github/scripts/kunlunxin/setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright (c) 2026 BAAI. All rights reserved.
+# Setup script for Kunlunxin P800 CI environment.
+set -euo pipefail
+
+if [[ -d /root/miniconda/envs/python310_torch29_cuda/bin ]]; then
+  export PATH="/root/miniconda/envs/python310_torch29_cuda/bin:${PATH}"
+fi
+
+: "${GEMS_VENDOR:?GEMS_VENDOR is not set}"
+: "${VLLM_PLUGINS:?VLLM_PLUGINS is not set}"
+: "${FLAGCX_PATH:?FLAGCX_PATH is not set}"
+: "${CUDA_VISIBLE_DEVICES:?CUDA_VISIBLE_DEVICES is not set}"
+: "${USE_RESHAPE_AND_CACHE_FLASH:?USE_RESHAPE_AND_CACHE_FLASH is not set}"
+
+git config --global --add safe.directory "$(pwd)"
+
+if [[ -d "${FLAGCX_PATH}/build/lib" ]]; then
+  export LD_LIBRARY_PATH="${FLAGCX_PATH}/build/lib:/opt/kunlun/lib:${LD_LIBRARY_PATH:-}"
+else
+  echo "::warning::${FLAGCX_PATH}/build/lib not found; FlagCX may be unavailable."
+fi
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  for name in \
+    PATH \
+    LD_LIBRARY_PATH \
+    GEMS_VENDOR \
+    VLLM_PLUGINS \
+    FLAGCX_PATH \
+    CUDA_VISIBLE_DEVICES \
+    USE_RESHAPE_AND_CACHE_FLASH \
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN \
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS; do
+    echo "${name}=${!name-}" >> "${GITHUB_ENV}"
+  done
+fi
+
+# vLLM, FlagGems, FlagCX, and vendor runtime dependencies are provided by the
+# Kunlunxin image. Install only the checked-out plugin source for this run.
+python -m pip install --no-build-isolation --no-deps -e .
+
+python - <<'PY'
+import os
+import sys
+
+flagcx_path = os.environ.get("FLAGCX_PATH", "")
+if flagcx_path and flagcx_path not in sys.path:
+    sys.path.insert(0, flagcx_path)
+
+import flag_gems
+import torch
+import vllm
+import vllm_fl
+from vllm.platforms import current_platform
+
+print(f"vLLM import ok: {vllm.__version__}")
+print(f"vLLM-FL import ok: {vllm_fl.__file__}")
+print(f"FlagGems import ok: {getattr(flag_gems, '__version__', 'unknown')}")
+print(f"FlagGems vendor: {getattr(flag_gems, 'vendor_name', 'auto-detected')}")
+print(f"Torch import ok: {torch.__version__}")
+print(f"CUDA-compatible accelerator available: {torch.cuda.is_available()}")
+print(f"CUDA-compatible accelerator count: {torch.cuda.device_count()}")
+print(f"Platform: {current_platform}")
+
+try:
+    import flagcx  # noqa: F401
+
+    print("FlagCX import ok")
+except Exception as exc:
+    print(f"::warning::FlagCX import failed: {exc}")
+PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,3 +166,14 @@ jobs:
     with:
       platform: enflame
     secrets: inherit
+
+  # ============================================================
+  # Job 4g: Kunlunxin platform testing
+  # ============================================================
+  test-kunlunxin:
+    needs: discover
+    if: contains(fromJson(needs.discover.outputs.platforms), 'kunlunxin')
+    uses: ./.github/workflows/_platform_test.yml
+    with:
+      platform: kunlunxin
+    secrets: inherit

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -49,6 +49,14 @@ ENFLAME_BASE_IMAGE="${ENFLAME_BASE_IMAGE:-harbor.baai.ac.cn/plugin/enflame001-ge
 ENFLAME_DRIVER_VERSION="${ENFLAME_DRIVER_VERSION:-1.9.29}"
 ENFLAME_PYTHON_VERSION="${ENFLAME_PYTHON_VERSION:-3.12}"
 ENFLAME_VLLM_VERSION="${ENFLAME_VLLM_VERSION:-0.20.2}"
+KUNLUNXIN_BASE_IMAGE="${KUNLUNXIN_BASE_IMAGE:-harbor.baai.ac.cn/plugin/xvllm-ubuntu2204-py310-torch29-0200:v20.0.10.0}"
+KUNLUNXIN_DRIVER_VERSION="${KUNLUNXIN_DRIVER_VERSION:-5.0.21.43}"
+KUNLUNXIN_PYTHON_VERSION="${KUNLUNXIN_PYTHON_VERSION:-3.10}"
+KUNLUNXIN_TORCH_VERSION="${KUNLUNXIN_TORCH_VERSION:-2.9.0}"
+KUNLUNXIN_VLLM_VERSION="${KUNLUNXIN_VLLM_VERSION:-0.20.2}"
+KUNLUNXIN_FLAGGEMS_REF="${KUNLUNXIN_FLAGGEMS_REF:-v5.0.0}"
+KUNLUNXIN_FLAGCX_REF="${KUNLUNXIN_FLAGCX_REF:-v0.13.0}"
+KUNLUNXIN_PLUGIN_FL_REF="${KUNLUNXIN_PLUGIN_FL_REF:-38e7dbc20197e2db742c4e4c9687d36ea4df9900}"
 HYGON_BASE_IMAGE="${HYGON_BASE_IMAGE:-harbor.sourcefind.cn:5443/dcu/admin/base/custom:vllm0.20.0-ubuntu22.04-dtk26.04-py3.10-MiniCPM-V-4.6}"
 HYGON_VLLM_VERSION="${HYGON_VLLM_VERSION:-0.20.2}"
 HYGON_DTK_VERSION="${HYGON_DTK_VERSION:-26.04}"
@@ -155,7 +163,7 @@ Usage: $(basename "$0") [OPTIONS]
 Build the vllm-plugin-FL Docker image.
 
 OPTIONS:
-    --platform PLATFORM    Platform to build: cuda, ascend, hygon, metax, musa, enflame (default: ${PLATFORM})
+    --platform PLATFORM    Platform to build: cuda, ascend, hygon, metax, musa, enflame, kunlunxin (default: ${PLATFORM})
     --target TARGET        Build target: dev, ci, release (default: ${TARGET})
     --image-name NAME      Image name (default: ${IMAGE_NAME})
     --image-tag TAG        Image tag (default: auto-generated)
@@ -196,6 +204,15 @@ VERSIONS (override via environment variables):
     ENFLAME_DRIVER_VERSION Driver version used in generated image tag (default: ${ENFLAME_DRIVER_VERSION})
     ENFLAME_PYTHON_VERSION Python version in the base image (default: ${ENFLAME_PYTHON_VERSION})
     ENFLAME_VLLM_VERSION   vLLM version in the base image (default: ${ENFLAME_VLLM_VERSION})
+  Kunlunxin:
+    KUNLUNXIN_BASE_IMAGE     Base image (default: ${KUNLUNXIN_BASE_IMAGE})
+    KUNLUNXIN_DRIVER_VERSION Driver version used in generated image tag (default: ${KUNLUNXIN_DRIVER_VERSION})
+    KUNLUNXIN_PYTHON_VERSION Python version in the base image (default: ${KUNLUNXIN_PYTHON_VERSION})
+    KUNLUNXIN_TORCH_VERSION  PyTorch version in the base image (default: ${KUNLUNXIN_TORCH_VERSION})
+    KUNLUNXIN_VLLM_VERSION   vLLM version installed in empty mode (default: ${KUNLUNXIN_VLLM_VERSION})
+    KUNLUNXIN_FLAGGEMS_REF   FlagGems git ref (default: ${KUNLUNXIN_FLAGGEMS_REF})
+    KUNLUNXIN_FLAGCX_REF     FlagCX git ref (default: ${KUNLUNXIN_FLAGCX_REF})
+    KUNLUNXIN_PLUGIN_FL_REF  vllm-plugin-FL git ref (default: ${KUNLUNXIN_PLUGIN_FL_REF})
   Hygon:
     HYGON_BASE_IMAGE     Base image (default: ${HYGON_BASE_IMAGE})
     HYGON_VLLM_VERSION   vLLM version installed in empty mode (default: ${HYGON_VLLM_VERSION})
@@ -228,6 +245,9 @@ EXAMPLES:
 
     # Build Enflame CI image
     ./build.sh --platform enflame --target ci --image-name harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl
+
+    # Build Kunlunxin CI image
+    ./build.sh --platform kunlunxin --target ci --image-name harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl
 
     # Build with custom PyPI mirror
     ./build.sh --target dev --index-url https://pypi.tuna.tsinghua.edu.cn/simple
@@ -369,8 +389,27 @@ elif [[ "${PLATFORM}" == "enflame" ]]; then
     if [[ -z "${IMAGE_TAG}" ]]; then
         IMAGE_TAG="v${ENFLAME_VLLM_VERSION}-enflame-ci"
     fi
+elif [[ "${PLATFORM}" == "kunlunxin" ]]; then
+    PYTHON_VERSION="${KUNLUNXIN_PYTHON_VERSION}"
+    VLLM_VERSION="${KUNLUNXIN_VLLM_VERSION}"
+    if [[ "${IMAGE_NAME}" == "harbor.baai.ac.cn/flagscale/vllm-plugin-fl" ]]; then
+        IMAGE_NAME="harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl"
+    fi
+    BUILD_ARGS+=(
+        --build-arg "KUNLUNXIN_BASE_IMAGE=${KUNLUNXIN_BASE_IMAGE}"
+        --build-arg "VLLM_VERSION=${KUNLUNXIN_VLLM_VERSION}"
+        --build-arg "FLAGGEMS_REF=${KUNLUNXIN_FLAGGEMS_REF}"
+        --build-arg "FLAGCX_REF=${KUNLUNXIN_FLAGCX_REF}"
+        --build-arg "VLLM_PLUGIN_FL_REF=${KUNLUNXIN_PLUGIN_FL_REF}"
+        --build-arg "DRIVER_VERSION=${KUNLUNXIN_DRIVER_VERSION}"
+        --build-arg "INDEX_URL=${INDEX_URL}"
+        --build-arg "EXTRA_INDEX_URL=${EXTRA_INDEX_URL}"
+    )
+    if [[ -z "${IMAGE_TAG}" ]]; then
+        IMAGE_TAG="v${KUNLUNXIN_VLLM_VERSION}-kunlunxin-ci"
+    fi
 else
-    err "Unknown platform '${PLATFORM}'. Must be 'cuda', 'ascend', 'hygon', 'metax', 'musa', or 'enflame'."
+    err "Unknown platform '${PLATFORM}'. Must be 'cuda', 'ascend', 'hygon', 'metax', 'musa', 'enflame', or 'kunlunxin'."
 fi
 
 FULL_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}"
@@ -403,6 +442,13 @@ elif [[ "${PLATFORM}" == "enflame" ]]; then
     msg "  Driver:         ${ENFLAME_DRIVER_VERSION}"
     msg "  Enflame Python: ${ENFLAME_PYTHON_VERSION}"
     msg "  Base image:     ${ENFLAME_BASE_IMAGE}"
+elif [[ "${PLATFORM}" == "kunlunxin" ]]; then
+    msg "  Driver:         ${KUNLUNXIN_DRIVER_VERSION}"
+    msg "  Kunlunxin base: ${KUNLUNXIN_BASE_IMAGE}"
+    msg "  Kunlunxin PyTorch: ${KUNLUNXIN_TORCH_VERSION}"
+    msg "  FlagGems:       ${KUNLUNXIN_FLAGGEMS_REF}"
+    msg "  FlagCX:         ${KUNLUNXIN_FLAGCX_REF}"
+    msg "  Plugin:         ${KUNLUNXIN_PLUGIN_FL_REF}"
 fi
 if [[ "${PLATFORM}" != "ascend" ]]; then
     msg "  Ubuntu:         ${UBUNTU_VERSION}"

--- a/docker/kunlunxin/Dockerfile
+++ b/docker/kunlunxin/Dockerfile
@@ -1,0 +1,190 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG KUNLUNXIN_BASE_IMAGE=harbor.baai.ac.cn/plugin/xvllm-ubuntu2204-py310-torch29-0200:v20.0.10.0
+
+# ---------- base stage ----------
+FROM ${KUNLUNXIN_BASE_IMAGE} AS base
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG KUNLUNXIN_BASE_IMAGE
+ARG VLLM_VERSION=0.20.2
+ARG FLAGGEMS_REF=v5.0.0
+ARG FLAGCX_REF=v0.13.0
+ARG VLLM_PLUGIN_FL_REF=38e7dbc20197e2db742c4e4c9687d36ea4df9900
+ARG DRIVER_VERSION=5.0.21.43
+ARG BUILD_DATE=unknown
+ARG VCS_REF=unknown
+ARG IMAGE_VERSION=unknown
+ARG IMAGE_STAGE=dev
+ARG SOURCE_URL=https://github.com/flagos-ai/vllm-plugin-FL
+ARG INDEX_URL
+ARG EXTRA_INDEX_URL
+
+LABEL org.opencontainers.image.title="vllm-plugin-fl" \
+      org.opencontainers.image.description="Kunlunxin P800 CI image for vllm-plugin-FL" \
+      org.opencontainers.image.source="${SOURCE_URL}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${IMAGE_VERSION}" \
+      org.opencontainers.image.base.name="${KUNLUNXIN_BASE_IMAGE}" \
+      io.flagos.accelerator.backend="kunlunxin" \
+      io.flagos.image.stage="${IMAGE_STAGE}" \
+      io.flagos.vllm.version="${VLLM_VERSION}" \
+      io.flagos.flaggems.revision="${FLAGGEMS_REF}" \
+      io.flagos.flagcx.revision="${FLAGCX_REF}" \
+      io.flagos.plugin.revision="${VLLM_PLUGIN_FL_REF}" \
+      io.flagos.driver.version="${DRIVER_VERSION}"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    GEMS_VENDOR=kunlunxin \
+    VLLM_PLUGINS=fl \
+    FLAGCX_PATH=/workspace/FlagCX \
+    USE_RESHAPE_AND_CACHE_FLASH=1 \
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+    VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800 \
+    PATH="/root/miniconda/envs/python310_torch29_cuda/bin:${PATH}" \
+    LD_LIBRARY_PATH="/workspace/FlagCX/build/lib:/opt/kunlun/lib:${LD_LIBRARY_PATH}"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        ninja-build \
+        patchelf \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip config set global.index-url "${INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}" \
+    && if [[ -n "${EXTRA_INDEX_URL:-}" ]]; then \
+        python -m pip config set global.extra-index-url "${EXTRA_INDEX_URL}"; \
+    fi
+
+# Follow the Kunlunxin validation document source-install order.
+RUN python -m pip uninstall -y vllm vllm_xpu || true \
+    && rm -rf /workspace/vllm \
+    && git clone --depth 1 --branch "v${VLLM_VERSION}" \
+        https://gh-proxy.com/https://github.com/vllm-project/vllm.git /workspace/vllm \
+    && cd /workspace/vllm \
+    && git checkout "v${VLLM_VERSION}" \
+    && python -m pip install setuptools_scm \
+    && VLLM_TARGET_DEVICE=empty python -m pip install -v --no-build-isolation --no-deps . \
+    && python -m pip uninstall -y numpy \
+    && python -m pip install "numpy<2.0"
+
+RUN rm -rf /workspace/vllm-plugin-FL \
+    && git clone https://gh-proxy.com/https://github.com/flagos-ai/vllm-plugin-FL.git /workspace/vllm-plugin-FL \
+    && cd /workspace/vllm-plugin-FL \
+    && git checkout "${VLLM_PLUGIN_FL_REF}" \
+    && python -m pip install --no-build-isolation -e .
+
+RUN rm -rf /workspace/FlagGems \
+    && git clone --depth 1 --branch "${FLAGGEMS_REF}" \
+        https://gh-proxy.org/https://github.com/flagos-ai/FlagGems /workspace/FlagGems \
+    && cd /workspace/FlagGems \
+    && git checkout "${FLAGGEMS_REF}" \
+    && python -m pip install -U scikit-build-core==0.11 \
+        pybind11 \
+        ninja \
+        cmake \
+    && python -m pip install sqlalchemy \
+    && python -m pip install --no-build-isolation --no-deps .
+
+RUN rm -rf "${FLAGCX_PATH}" \
+    && git clone --depth 1 --branch "${FLAGCX_REF}" \
+        https://gh-proxy.com/https://github.com/flagos-ai/FlagCX.git "${FLAGCX_PATH}" \
+    && cd "${FLAGCX_PATH}" \
+    && git checkout "${FLAGCX_REF}" \
+    && git config --global url."https://gh-proxy.org/https://github.com/".insteadOf "https://github.com/" \
+    && git submodule update --init --recursive \
+    && CPATH="/usr/local/cuda-12.8/targets/x86_64-linux/include:/root/miniconda/envs/python310_torch29_cuda/lib/python3.10/site-packages/nvidia/nccl/include:/root/miniconda/envs/python310_torch29_cuda/lib/python3.10/site-packages/torch_xmlir/xre/include:${CPATH:-}" \
+       LIBRARY_PATH="/usr/local/cuda-12.8/targets/x86_64-linux/lib:/usr/local/cuda-12.8/targets/x86_64-linux/lib/stubs:/root/miniconda/envs/python310_torch29_cuda/lib/python3.10/site-packages/torch_xmlir:/root/miniconda/envs/python310_torch29_cuda/xcudart/lib:${LIBRARY_PATH:-}" \
+       CCL_HOME=/root/miniconda/envs/python310_torch29_cuda/lib/python3.10/site-packages/torch_xmlir/xccl \
+       make USE_KUNLUNXIN=1 \
+    && cd plugin/torch \
+    && CPATH="/usr/local/cuda-12.8/targets/x86_64-linux/include:${CPATH:-}" \
+       LIBRARY_PATH="/usr/local/cuda-12.8/targets/x86_64-linux/lib:/usr/local/cuda-12.8/targets/x86_64-linux/lib/stubs:${LIBRARY_PATH:-}" \
+       FLAGCX_ADAPTOR=klx python -m pip install -e . --no-build-isolation \
+    && mkdir -p /opt/kunlun/lib \
+    && cp /root/miniconda/envs/python310_torch29_cuda/lib/python3.10/site-packages/torch_xmlir/libbkcl.so /opt/kunlun/lib/ \
+    && patchelf --set-rpath /opt/kunlun/lib:/workspace/FlagCX/build/lib \
+        /workspace/FlagCX/build/lib/libflagcx.so
+
+WORKDIR /workspace
+
+# ---------- dev stage ----------
+FROM base AS dev
+
+ARG INDEX_URL
+ARG EXTRA_INDEX_URL
+
+RUN python -m pip install --no-cache-dir \
+        ${INDEX_URL:+--index-url ${INDEX_URL}} \
+        ${EXTRA_INDEX_URL:+--extra-index-url ${EXTRA_INDEX_URL}} \
+        pytest \
+        pytest-cov \
+        pytest-json-report \
+        pre-commit \
+        ruff
+
+WORKDIR /workspace
+
+# ---------- ci stage ----------
+FROM base AS ci
+
+ARG INDEX_URL
+ARG EXTRA_INDEX_URL
+
+RUN python -m pip install --no-cache-dir \
+        ${INDEX_URL:+--index-url ${INDEX_URL}} \
+        ${EXTRA_INDEX_URL:+--extra-index-url ${EXTRA_INDEX_URL}} \
+        pytest \
+        pytest-cov \
+        pytest-timeout \
+        pytest-json-report \
+        requests \
+        openai \
+        pillow \
+        decorator \
+        pyyaml \
+        sqlalchemy
+
+RUN python - <<'PY'
+import os
+import sys
+
+flagcx_path = os.environ["FLAGCX_PATH"]
+if flagcx_path not in sys.path:
+    sys.path.insert(0, flagcx_path)
+
+import flag_gems
+import flagcx  # noqa: F401
+import torch
+import vllm
+
+print(f"vLLM: {vllm.__version__}")
+print(f"FlagGems: {getattr(flag_gems, '__version__', 'unknown')}")
+print(f"Torch: {torch.__version__}")
+print("FlagCX import ok")
+PY
+
+WORKDIR /workspace
+
+# ---------- release stage ----------
+FROM base AS release
+
+WORKDIR /workspace

--- a/tests/platforms/kunlunxin.yaml
+++ b/tests/platforms/kunlunxin.yaml
@@ -1,0 +1,100 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+platform: kunlunxin
+vendor: kunlunxin
+
+device_types:
+  p800:
+    memory_gb: 96
+    tags: [kunlunxin, p800, bf16, fp16, fp32]
+
+tolerance:
+  inference:
+    default:
+      rtol: 1e-3
+      atol: 1e-3
+    bfloat16:
+      rtol: 1e-2
+      atol: 1e-2
+
+device_overrides:
+  p800:
+    cases:
+      - qwen3_6/27b_tp4_eager
+      - qwen3_6/27b_tp4_graph
+      - qwen3_6/35b_a3b_tp4_eager
+      - qwen3_6/35b_a3b_tp4_graph
+    llm:
+      max_model_len: 16384
+      block_size: 128
+      gpu_memory_utilization: 0.8
+      disable_custom_all_reduce: false
+    serve:
+      served_model_name: "qwen3"
+      startup_retries: 300
+      max_tokens: 256
+      extra_args:
+        - "--reasoning-parser"
+        - "qwen3"
+      chat_cases:
+        - name: text
+          messages:
+            - role: "user"
+              content: "The capital of France is"
+          expected: "Paris"
+        - name: image
+          generated_image: true
+          prompt: "Describe all visible text, colors, and shapes in English."
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+unsupported_features: []
+
+env_defaults:
+  GEMS_VENDOR: "kunlunxin"
+  VLLM_PLUGINS: "fl"
+  FLAGCX_PATH: "/workspace/FlagCX"
+  CUDA_VISIBLE_DEVICES: "4,5,6,7"
+  USE_RESHAPE_AND_CACHE_FLASH: "1"
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
+  VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1800"
+
+p800:
+  name: "p800"
+  tests:
+    e2e:
+      inference:
+        qwen3_6:
+          - "27b_tp4_eager"
+          - "35b_a3b_tp4_graph"
+      serving:
+        qwen3_6:
+          - "27b_tp4_graph"
+          - "35b_a3b_tp4_eager"
+    timeouts:
+      e2e:
+        inference: 180
+        serving: 180
+    functional:
+      include: "*"
+      exclude:
+        - compilation/test_graph_capture.py
+    unit:
+      include: "*"
+      exclude: []
+    benchmark:
+      enabled: true
+      smoke: ["serve"]


### PR DESCRIPTION
## Summary

This PR adds initial CI support for Kunlunxin P800.

Changes include:
- Add Kunlunxin platform config and runner label `kunlunxin-p800`
- Add Kunlunxin CI check/setup scripts
- Add Kunlunxin Docker image build support based on the validated Kunlunxin vLLM 0.20.2 base image
- Enable unit, functional, e2e inference, e2e serving, and benchmark smoke test configuration

## Validation

Manual validation was performed on Kunlunxin P800 with image:

`harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl:v0.20.2-kunlunxin-ci`

Results:
- check/setup: passed
- unit: passed, 402 tests
- functional: passed
- e2e inference: passed
- benchmark smoke: passed
- e2e serving: service startup and text chat passed; image chat case is under investigation due to unstable multimodal/OCR output on Kunlunxin