### PR TITLE
feat(ascend): enable generic full-decode graph mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,15 @@ If there are multiple plugins in the current environment, you can specify use vl
     export TRITON_ALL_BLOCKS_PARALLEL=1
     ```
 
-3. Enable eager execution
+3. Select eager or graph execution
 
-    Ascend requires eager execution. Add `enforce_eager=True` to the `LLM` constructor or pass `--enforce-eager` on the command line.
+    Ascend supports eager execution and `FULL_DECODE_ONLY` graph execution for
+    graph-compatible models and backends. Add `enforce_eager=True` to the `LLM`
+    constructor or pass `--enforce-eager` to force eager execution. To enable
+    graph execution, keep eager enforcement disabled and set
+    `compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY"}` (or pass the
+    equivalent `--compilation-config` value to `vllm serve`). Other graph modes
+    currently fall back to eager execution.
 
 
 ### Run a Task

--- a/tests/unit_tests/compilation/test_graph.py
+++ b/tests/unit_tests/compilation/test_graph.py
@@ -47,3 +47,19 @@ class TestGraphEntry:
         assert entry.graph is None
         assert entry.output is None
         assert entry.input_addresses is None
+
+
+def test_ascend_graph_params_are_initialized_per_capture_size():
+    from vllm_fl.compilation.graph import (
+        get_ascend_graph_params,
+        set_ascend_graph_params,
+    )
+
+    set_ascend_graph_params([4, 1, 4])
+    params = get_ascend_graph_params()
+
+    assert params is not None
+    assert set(params.events) == {1, 4}
+    assert set(params.workspaces) == {1, 4}
+    assert set(params.handles) == {1, 4}
+    assert set(params.attention_params) == {1, 4}

--- a/tests/unit_tests/compilation/test_graph_runtime.py
+++ b/tests/unit_tests/compilation/test_graph_runtime.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+
+import logging
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import CUDAGraphMode
+
+
+def test_graph_class_resolution_is_centralized(monkeypatch):
+    import vllm_fl.compilation.graph_runtime as graph_runtime
+
+    cuda_graph = object()
+    monkeypatch.setattr(
+        graph_runtime.torch,
+        "cuda",
+        SimpleNamespace(CUDAGraph=cuda_graph),
+    )
+
+    assert graph_runtime.get_graph_class("cuda") is cuda_graph
+    assert graph_runtime.get_graph_class("txda") is None
+    with pytest.raises(NotImplementedError, match="unknown"):
+        graph_runtime.get_graph_class("unknown")
+
+
+def test_runtime_backend_selection():
+    from vllm_fl.compilation.graph_runtime import (
+        AscendGraphRuntimeBackend,
+        GraphRuntimeBackend,
+        get_graph_runtime_backend,
+    )
+
+    assert isinstance(
+        get_graph_runtime_backend("npu"), AscendGraphRuntimeBackend
+    )
+    assert type(get_graph_runtime_backend("cuda")) is GraphRuntimeBackend
+
+
+def test_prepare_model_compile_is_ascend_only(monkeypatch):
+    from torch._dynamo import config as dynamo_config
+
+    import vllm_fl.dispatch as dispatch
+    from vllm_fl.compilation.graph_runtime import (
+        AscendGraphRuntimeBackend,
+        GraphRuntimeBackend,
+    )
+
+    prewarm_calls = []
+    ignored_logger_methods = set()
+    monkeypatch.setattr(
+        dynamo_config,
+        "ignore_logger_methods",
+        ignored_logger_methods,
+    )
+    monkeypatch.setattr(
+        dispatch,
+        "prewarm_cached_ops",
+        lambda: prewarm_calls.append(True),
+    )
+
+    GraphRuntimeBackend().prepare_model_compile()
+    assert prewarm_calls == []
+    assert ignored_logger_methods == set()
+
+    AscendGraphRuntimeBackend().prepare_model_compile()
+    assert prewarm_calls == [True]
+    assert ignored_logger_methods == {logging.Logger.debug}
+
+
+def test_ascend_synchronizes_before_replay(monkeypatch):
+    import vllm_fl.compilation.graph_runtime as graph_runtime
+
+    synchronize_calls = []
+    monkeypatch.setattr(
+        graph_runtime.current_platform,
+        "torch_device_fn",
+        SimpleNamespace(synchronize=lambda: synchronize_calls.append(True)),
+    )
+
+    graph_runtime.AscendGraphRuntimeBackend().before_replay()
+
+    assert synchronize_calls == [True]
+
+
+def test_ascend_capture_lifecycle_tracks_attention_tasks(monkeypatch):
+    import vllm_fl.compilation.graph as graph
+    from vllm_fl.compilation.graph_runtime import AscendGraphRuntimeBackend
+
+    backend = AscendGraphRuntimeBackend()
+    forward_context = SimpleNamespace()
+
+    backend.prepare_forward_context(forward_context)
+    assert forward_context.capturing is False
+
+    backend.begin_capture(forward_context)
+    assert forward_context.capturing is True
+    assert graph.is_ascend_graph_capturing() is True
+
+    backend.end_capture()
+    assert graph.is_ascend_graph_capturing() is False
+
+
+def test_ascend_updates_attention_params_after_graph_forward(monkeypatch):
+    import vllm.forward_context as forward_context_module
+
+    import vllm_fl.compilation.graph as graph
+    from vllm_fl.compilation.graph_runtime import AscendGraphRuntimeBackend
+
+    forward_context = SimpleNamespace(
+        cudagraph_runtime_mode=CUDAGraphMode.FULL,
+        capturing=False,
+        batch_descriptor=SimpleNamespace(num_tokens=4),
+    )
+    update_calls = []
+    monkeypatch.setattr(
+        forward_context_module,
+        "get_forward_context",
+        lambda: forward_context,
+    )
+    monkeypatch.setattr(
+        graph,
+        "update_ascend_full_graph_params",
+        lambda stream, context, num_tokens: update_calls.append(
+            (stream, context, num_tokens)
+        ),
+    )
+
+    backend = AscendGraphRuntimeBackend()
+    backend._update_stream = object()
+    backend.after_model_forward(SimpleNamespace())
+
+    assert update_calls == [
+        (backend._update_stream, forward_context, 4)
+    ]
+
+
+def test_graph_capture_override_is_ascend_only(monkeypatch):
+    import vllm_fl.compilation.graph_runtime as graph_runtime
+
+    @contextmanager
+    def default_capture(device):
+        yield device
+
+    monkeypatch.setattr(
+        graph_runtime,
+        "current_platform",
+        SimpleNamespace(device_type="cuda", dist_backend="nccl"),
+    )
+    assert graph_runtime.get_graph_capture(default_capture) is default_capture
+
+    monkeypatch.setattr(
+        graph_runtime.current_platform,
+        "device_type",
+        "npu",
+    )
+    assert (
+        graph_runtime.get_graph_capture(default_capture)
+        is graph_runtime._ascend_graph_capture
+    )

--- a/tests/unit_tests/dispatch/test_call_op.py
+++ b/tests/unit_tests/dispatch/test_call_op.py
@@ -8,26 +8,128 @@ dispatch module's __init__.py, ensuring the full dispatch pipeline
 works correctly from call_op -> manager -> registry -> implementation.
 """
 
+import gc
 import os
+import weakref
 from unittest.mock import patch
 
 import pytest
+import torch
 
+import vllm_fl.dispatch as dispatch
 from vllm_fl.dispatch import (
     PREFER_REFERENCE,
     PREFER_VENDOR,
     BackendImplKind,
     BackendPriority,
+    CachedOp,
     OpImpl,
     SelectionPolicy,
     call_op,
     get_default_manager,
+    prewarm_cached_ops,
     reset_default_manager,
     reset_global_policy,
     resolve_op,
     set_global_policy,
     with_preference,
 )
+
+
+class TestCachedOpPrewarm:
+    """Cached call sites must not resolve Python state during fullgraph trace."""
+
+    @pytest.fixture(autouse=True)
+    def reset_all(self, monkeypatch):
+        reset_default_manager()
+        reset_global_policy()
+        monkeypatch.setattr(dispatch, "_CACHED_OPS", weakref.WeakSet())
+        monkeypatch.setattr(dispatch, "_OP_FAST_PATH_ENABLED", True)
+        yield
+        reset_default_manager()
+        reset_global_policy()
+
+    @staticmethod
+    def register_test_op(op_name, fn):
+        manager = get_default_manager()
+        manager._state.initialized = True
+        manager._state.init_pid = os.getpid()
+        manager.registry.register_impl(
+            OpImpl(
+                op_name=op_name,
+                impl_id=f"default.{op_name}",
+                kind=BackendImplKind.DEFAULT,
+                fn=fn,
+            )
+        )
+        return manager
+
+    def test_prewarm_resolves_without_executing(self):
+        calls = []
+        op = CachedOp("prewarm_only")
+        manager = self.register_test_op(
+            "prewarm_only", lambda x: calls.append(x) or x + 1
+        )
+
+        assert prewarm_cached_ops() == (1, 0)
+        assert op._impl is manager._resolve_impl("prewarm_only")
+        assert calls == []
+
+    def test_prewarm_skips_unavailable_optional_ops(self):
+        available = CachedOp("available")
+        unavailable = CachedOp("unavailable")
+        self.register_test_op("available", lambda x: x)
+
+        assert prewarm_cached_ops() == (1, 1)
+        assert available._impl is not None
+        assert unavailable._impl is None
+
+    def test_prewarmed_call_does_not_resolve_again(self):
+        op = CachedOp("cached")
+        manager = self.register_test_op("cached", lambda x: x * 2)
+        prewarm_cached_ops()
+
+        with patch.object(
+            manager, "_resolve_impl", side_effect=AssertionError("resolved twice")
+        ):
+            assert op(3) == 6
+
+    def test_prewarm_records_only_after_eager_use(self):
+        op = CachedOp("first_use")
+        manager = self.register_test_op("first_use", lambda x: x)
+
+        with patch.object(manager, "_record_first_use") as record_first_use:
+            prewarm_cached_ops()
+            record_first_use.assert_not_called()
+            assert op(3) == 3
+            record_first_use.assert_called_once()
+
+    def test_fullgraph_compile_uses_prewarmed_impl(self):
+        op = CachedOp("fullgraph")
+        manager = self.register_test_op("fullgraph", lambda x: x + 1)
+        prewarm_cached_ops()
+
+        def run(x):
+            return op(x)
+
+        with patch.object(
+            manager, "_resolve_impl", side_effect=AssertionError("resolved in graph")
+        ):
+            compiled = torch.compile(run, backend="eager", fullgraph=True)
+            result = compiled(torch.tensor([1.0]))
+
+        torch.testing.assert_close(result, torch.tensor([2.0]))
+
+    def test_registry_does_not_retain_temporary_call_sites(self):
+        op = CachedOp("temporary")
+        op_ref = weakref.ref(op)
+        assert len(dispatch._CACHED_OPS) == 1
+
+        del op
+        gc.collect()
+
+        assert op_ref() is None
+        assert len(dispatch._CACHED_OPS) == 0
 
 
 class TestCallOp:

--- a/tests/unit_tests/ops/test_rotary_embedding.py
+++ b/tests/unit_tests/ops/test_rotary_embedding.py
@@ -58,3 +58,35 @@ class TestRotaryEmbeddingFL:
         mock_cached_op.assert_called_once()
         call_args = mock_cached_op.call_args
         assert call_args[0][0] is layer
+
+    def test_forward_oot_does_not_replace_cache_buffer(
+        self, mock_parent_init, mock_cached_op
+    ):
+        """Graph tracing must not observe a module buffer assignment."""
+        from vllm_fl.ops.rotary_embedding import RotaryEmbeddingFL
+
+        layer = RotaryEmbeddingFL(
+            head_size=64,
+            rotary_dim=32,
+            max_position_embeddings=2048,
+            base=10000.0,
+            is_neox_style=True,
+            dtype=torch.float32,
+        )
+        layer.head_size = 64
+        layer.rotary_dim = 32
+        layer.is_neox_style = True
+        cache = torch.randn(2048, 64)
+        layer.cos_sin_cache = cache
+
+        mock_cached_op.return_value = (
+            torch.randn(4, 8, 32),
+            torch.randn(4, 8, 32),
+        )
+        positions = torch.tensor([0, 1, 2, 3], device="meta")
+        query = torch.randn(4, 8, 64)
+        key = torch.randn(4, 8, 64)
+
+        layer.forward_oot(positions, query, key)
+
+        assert layer.cos_sin_cache is cache

--- a/tests/unit_tests/test_platform.py
+++ b/tests/unit_tests/test_platform.py
@@ -1,0 +1,200 @@
+"""Focused tests for platform-level Ascend graph-mode policy."""
+
+import ast
+import sys
+from enum import Enum
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+PLATFORM_PATH = Path(__file__).parents[2] / "vllm_fl" / "platform.py"
+
+
+class CompilationMode(Enum):
+    NONE = 0
+    VLLM_COMPILE = 1
+
+
+class CUDAGraphMode(Enum):
+    NONE = 0
+    PIECEWISE = 1
+    FULL = 2
+    FULL_DECODE_ONLY = 3
+
+    def has_full_cudagraphs(self):
+        return self in (self.FULL, self.FULL_DECODE_ONLY)
+
+
+def _load_platform_policy(monkeypatch):
+    module = ast.parse(PLATFORM_PATH.read_text())
+    platform_class = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "PlatformFL"
+    )
+    method = next(
+        node
+        for node in platform_class.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "check_and_update_config"
+    )
+    method.decorator_list = []
+
+    vllm_config = ModuleType("vllm.config")
+    vllm_config.CompilationMode = CompilationMode
+    vllm_config.CUDAGraphMode = CUDAGraphMode
+    monkeypatch.setitem(sys.modules, "vllm", ModuleType("vllm"))
+    monkeypatch.setitem(sys.modules, "vllm.config", vllm_config)
+
+    patch_module = ModuleType("vllm_fl.dispatch.backends.vendor.ascend.patch")
+    patch_module.refresh_block_size = lambda config: None
+    for name in (
+        "vllm_fl",
+        "vllm_fl.dispatch",
+        "vllm_fl.dispatch.backends",
+        "vllm_fl.dispatch.backends.vendor",
+        "vllm_fl.dispatch.backends.vendor.ascend",
+    ):
+        package = ModuleType(name)
+        package.__path__ = []
+        monkeypatch.setitem(sys.modules, name, package)
+    monkeypatch.setitem(sys.modules, patch_module.__name__, patch_module)
+
+    namespace = {
+        "logger": SimpleNamespace(
+            info=lambda *args, **kwargs: None,
+            warning=lambda *args, **kwargs: None,
+        )
+    }
+    exec(
+        compile(
+            ast.Module([method], type_ignores=[]),
+            str(PLATFORM_PATH),
+            "exec",
+        ),
+        namespace,
+    )
+    return namespace["check_and_update_config"]
+
+
+def _graph_config(cudagraph_mode, *, enforce_eager=False):
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(worker_cls=None, data_parallel_size=1),
+        model_config=SimpleNamespace(
+            use_mla=False,
+            enforce_eager=enforce_eager,
+        ),
+        cache_config=None,
+        scheduler_config=None,
+        compilation_config=SimpleNamespace(
+            compile_sizes=None,
+            mode=CompilationMode.VLLM_COMPILE,
+            cudagraph_mode=cudagraph_mode,
+            backend="inductor",
+            use_inductor=True,
+            splitting_ops=["vllm.unified_attention"],
+            pass_config=SimpleNamespace(
+                fuse_norm_quant=True,
+                fuse_act_quant=True,
+                fuse_attn_quant=True,
+            ),
+            cudagraph_num_of_warmups=0,
+        ),
+        attention_config=None,
+    )
+
+
+def test_npu_full_decode_uses_eager_graph_policy(monkeypatch):
+    policy = _load_platform_policy(monkeypatch)
+    config = _graph_config(CUDAGraphMode.FULL_DECODE_ONLY)
+
+    policy(SimpleNamespace(device_type="npu", vendor_name="ascend"), config)
+
+    compilation = config.compilation_config
+    assert compilation.mode == CompilationMode.VLLM_COMPILE
+    assert compilation.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY
+    assert compilation.backend == "eager"
+    assert compilation.use_inductor is False
+    assert compilation.splitting_ops == []
+    assert compilation.pass_config.fuse_norm_quant is False
+    assert compilation.pass_config.fuse_act_quant is False
+    assert compilation.pass_config.fuse_attn_quant is False
+    assert compilation.cudagraph_num_of_warmups == 1
+
+
+@pytest.mark.parametrize(
+    ("cudagraph_mode", "enforce_eager"),
+    [
+        (CUDAGraphMode.NONE, False),
+        (CUDAGraphMode.FULL_DECODE_ONLY, True),
+        (CUDAGraphMode.FULL, False),
+    ],
+)
+def test_npu_non_supported_graph_policy_falls_back_to_none(
+    monkeypatch, cudagraph_mode, enforce_eager
+):
+    policy = _load_platform_policy(monkeypatch)
+    config = _graph_config(cudagraph_mode, enforce_eager=enforce_eager)
+
+    policy(SimpleNamespace(device_type="npu", vendor_name="ascend"), config)
+
+    assert config.compilation_config.mode == CompilationMode.NONE
+    assert config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+
+
+@pytest.mark.parametrize(
+    ("device_type", "expected"),
+    [("npu", "eager"), ("cuda", "inductor"), ("musa", "inductor")],
+)
+def test_simple_compile_backend_is_eager_only_on_npu(device_type, expected):
+    module = ast.parse(PLATFORM_PATH.read_text())
+    platform_class = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "PlatformFL"
+    )
+    assignment = next(
+        node
+        for node in platform_class.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "simple_compile_backend"
+    )
+
+    value = eval(
+        compile(ast.Expression(assignment.value), str(PLATFORM_PATH), "eval"),
+        {"device_type": device_type},
+    )
+    assert value == expected
+
+
+def test_non_ascend_graph_capture_context_is_preserved():
+    model_runner_path = (
+        Path(__file__).parents[2] / "vllm_fl" / "worker" / "model_runner.py"
+    )
+    module = ast.parse(model_runner_path.read_text())
+    graph_capture_if = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(child, ast.FunctionDef) and child.name == "graph_capture"
+            for child in node.body
+        )
+    )
+    condition = compile(
+        ast.Expression(graph_capture_if.test), str(model_runner_path), "eval"
+    )
+
+    def uses_local_capture(device_type, dist_backend="nccl"):
+        platform = SimpleNamespace(
+            device_type=device_type,
+            dist_backend=dist_backend,
+        )
+        return eval(condition, {"current_platform": platform})
+
+    assert uses_local_capture("npu", "hccl") is False
+    assert uses_local_capture("cuda", "nccl") is False
+    assert uses_local_capture("musa", "mccl") is True
+    assert uses_local_capture("cuda", "flagcx") is True

--- a/vllm_fl/compilation/graph.py
+++ b/vllm_fl/compilation/graph.py
@@ -27,6 +27,11 @@ from vllm.forward_context import (
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
+from vllm_fl.compilation.graph_runtime import (
+    get_graph_class,
+    get_graph_runtime_backend,
+)
+
 logger = init_logger(__name__)
 
 
@@ -41,20 +46,11 @@ def weak_ref_tensors(tensor: Any) -> Any:
 
 # FL-specific: platform-agnostic graph class selection
 class Graph:
-    if current_platform.device_type == "cuda":
-        graph = torch.cuda.CUDAGraph
-    elif current_platform.device_type == "npu":
-        graph = torch.npu.NPUGraph
-    elif current_platform.device_type == "musa":
-        graph = torch.musa.MUSAGraph
-    elif current_platform.device_type == "ptpu":
-        graph = torch.ptpu.PTPUGraph
-    elif current_platform.device_type == "gcu":
-        graph = torch.gcu.GCUGraph
-    elif current_platform.device_type == "txda":
-        graph = None
-    else:
-        raise NotImplementedError("not support graph")
+    @staticmethod
+    def graph() -> Any:
+        # Resolve lazily so importing worker modules does not require an
+        # initialized accelerator runtime (for example in CPU-only unit tests).
+        return get_graph_class()()
 
 
 # Re-export CUDAGraphStat for compatibility
@@ -79,6 +75,71 @@ class GraphOptions:
     weak_ref_output: bool = True
 
 
+@dataclasses.dataclass
+class AscendGraphParams:
+    """Host-side task update state for a captured Ascend full graph."""
+
+    events: dict[int, list[Any]]
+    workspaces: dict[int, torch.Tensor | None]
+    handles: dict[int, list[Any]]
+    attention_params: dict[int, list[tuple[Any, ...]]]
+
+
+_ascend_graph_params: AscendGraphParams | None = None
+_ascend_graph_capturing = False
+
+
+def set_ascend_graph_params(capture_sizes: list[int]) -> None:
+    """Initialize per-shape attention task state before graph capture."""
+    global _ascend_graph_params
+    sizes = sorted(set(capture_sizes))
+    _ascend_graph_params = AscendGraphParams(
+        events={size: [] for size in sizes},
+        workspaces={size: None for size in sizes},
+        handles={size: [] for size in sizes},
+        attention_params={size: [] for size in sizes},
+    )
+
+
+def get_ascend_graph_params() -> AscendGraphParams | None:
+    return _ascend_graph_params
+
+
+def weak_ref_ascend_graph_workspaces() -> None:
+    """Release strong references after NPUGraph owns its workspaces."""
+    if _ascend_graph_params is None:
+        return
+    for num_tokens, workspace in _ascend_graph_params.workspaces.items():
+        if workspace is not None:
+            _ascend_graph_params.workspaces[num_tokens] = weak_ref_tensors(
+                workspace
+            )
+
+
+def set_ascend_graph_capturing(capturing: bool) -> None:
+    global _ascend_graph_capturing
+    _ascend_graph_capturing = capturing
+
+
+def is_ascend_graph_capturing() -> bool:
+    return _ascend_graph_capturing
+
+
+def update_ascend_full_graph_params(
+    update_stream: Any,
+    forward_context: Any,
+    num_tokens: int,
+) -> None:
+    """Refresh Ascend attention parameters consumed by the next replay."""
+    from vllm_fl.dispatch.backends.vendor.ascend.impl.attention import (
+        AscendAttentionBackendImpl,
+    )
+
+    AscendAttentionBackendImpl.update_graph_params(
+        update_stream, forward_context, num_tokens
+    )
+
+
 class GraphWrapper:
     """FL-specific graph wrapper that supports multiple device types (CUDA, NPU).
     Adapted from upstream CUDAGraphWrapper with platform-agnostic graph capture."""
@@ -100,6 +161,7 @@ class GraphWrapper:
         self.vllm_config = vllm_config
         self.runtime_mode = runtime_mode
         self.compilation_config = vllm_config.compilation_config
+        self.graph_runtime = get_graph_runtime_backend()
 
         self.first_run_finished = False
         self.is_debugging_mode = envs.VLLM_LOGGING_LEVEL == "DEBUG"
@@ -151,6 +213,7 @@ class GraphWrapper:
             return self.runnable(*args, **kwargs)
 
         forward_context = get_forward_context()
+        self.graph_runtime.prepare_forward_context(forward_context)
         batch_descriptor = forward_context.batch_descriptor
         graph_runtime_mode = forward_context.cudagraph_runtime_mode
 
@@ -213,17 +276,25 @@ class GraphWrapper:
                     current_platform.torch_device_fn.current_stream()
                 )
             # FL-specific: use platform-agnostic graph capture
-            with current_platform.torch_device_fn.graph(graph, **graph_kwargs):
-                # `output` is managed by pytorch's cudagraph pool
-                output = self.runnable(*args, **kwargs)
-                # Join offloader's copy stream after forward if available
-                try:
-                    from vllm.model_executor.offloader.base import get_offloader
-                    get_offloader().join_after_forward()
-                except (ImportError, RuntimeError):
-                    pass
-                if self.cudagraph_options.weak_ref_output:
-                    output = weak_ref_tensors(output)
+            self.graph_runtime.begin_capture(forward_context)
+            try:
+                with current_platform.torch_device_fn.graph(
+                    graph, **graph_kwargs
+                ):
+                    # `output` is managed by pytorch's cudagraph pool
+                    output = self.runnable(*args, **kwargs)
+                    # Join offloader's copy stream after forward if available
+                    try:
+                        from vllm.model_executor.offloader.base import get_offloader
+                        get_offloader().join_after_forward()
+                    except (ImportError, RuntimeError):
+                        pass
+                    if self.cudagraph_options.weak_ref_output:
+                        output = weak_ref_tensors(output)
+            finally:
+                self.graph_runtime.end_capture()
+
+            self.graph_runtime.after_capture()
 
             entry.output = weak_ref_tensors(output)
             entry.graph = graph
@@ -253,7 +324,6 @@ class GraphWrapper:
         except (ImportError, RuntimeError):
             pass
 
-        if current_platform.device_type == "npu":
-            current_platform.torch_device_fn.synchronize()
+        self.graph_runtime.before_replay()
         entry.graph.replay()
         return entry.output

--- a/vllm_fl/compilation/graph_runtime.py
+++ b/vllm_fl/compilation/graph_runtime.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device-specific lifecycle hooks for static graph execution."""
+
+import logging
+from contextlib import contextmanager, nullcontext
+from typing import Any
+
+import torch
+
+from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.distributed.parallel_state import GraphCaptureContext
+from vllm.platforms import current_platform
+
+_GRAPH_CLASS_NAMES = {
+    "cuda": "CUDAGraph",
+    "npu": "NPUGraph",
+    "musa": "MUSAGraph",
+    "ptpu": "PTPUGraph",
+    "gcu": "GCUGraph",
+}
+
+
+@contextmanager
+def _ascend_graph_capture(device: torch.device):
+    """Provide an isolated stream for Ascend NPUGraph capture.
+
+    The capture stream waits for work already queued on the current stream
+    before capture starts. Entering this context makes the capture stream
+    current, while leaving it restores the previously active stream. The
+    returned ``GraphCaptureContext`` exposes the capture stream to callers.
+    """
+    capture_context = GraphCaptureContext(
+        current_platform.torch_device_fn.Stream(device=device)
+    )
+    stream = capture_context.stream
+    current_stream = current_platform.torch_device_fn.current_stream()
+    if current_stream != stream:
+        stream.wait_stream(current_stream)
+
+    with current_platform.torch_device_fn.stream(stream), nullcontext():
+        yield capture_context
+
+
+def get_graph_capture(default_capture: Any) -> Any:
+    """Override graph capture only for Ascend; preserve other vendors."""
+    if current_platform.device_type == "npu":
+        return _ascend_graph_capture
+    return default_capture
+
+
+def get_graph_class(device_type: str | None = None) -> Any:
+    """Resolve the torch graph class for the active accelerator."""
+    device_type = device_type or current_platform.device_type
+    if device_type == "txda":
+        return None
+    graph_class_name = _GRAPH_CLASS_NAMES.get(device_type)
+    if graph_class_name is None:
+        raise NotImplementedError(
+            f"Static graph is not supported on device type {device_type!r}"
+        )
+    try:
+        return getattr(getattr(torch, device_type), graph_class_name)
+    except AttributeError as exc:
+        raise NotImplementedError(
+            f"Torch does not provide {graph_class_name} for {device_type!r}"
+        ) from exc
+
+
+class GraphRuntimeBackend:
+    """No-op lifecycle hooks shared by graph-capable accelerators."""
+
+    def prepare_model_compile(self) -> None:
+        pass
+
+    def prepare_forward_context(self, forward_context: Any) -> None:
+        pass
+
+    def begin_capture(self, forward_context: Any) -> None:
+        pass
+
+    def end_capture(self) -> None:
+        pass
+
+    def after_capture(self) -> None:
+        pass
+
+    def before_replay(self) -> None:
+        pass
+
+    def prepare_graph_wrapper(self) -> None:
+        pass
+
+    def prepare_capture(self, capture_descs: Any) -> None:
+        pass
+
+    def after_model_forward(self, vllm_config: VllmConfig) -> None:
+        pass
+
+
+class AscendGraphRuntimeBackend(GraphRuntimeBackend):
+    """Ascend attention task state and synchronization around NPUGraph."""
+
+    def __init__(self) -> None:
+        self._update_stream: Any | None = None
+
+    def prepare_forward_context(self, forward_context: Any) -> None:
+        forward_context.capturing = False
+
+    def begin_capture(self, forward_context: Any) -> None:
+        from vllm_fl.compilation.graph import set_ascend_graph_capturing
+
+        forward_context.capturing = True
+        set_ascend_graph_capturing(True)
+
+    def end_capture(self) -> None:
+        from vllm_fl.compilation.graph import set_ascend_graph_capturing
+
+        set_ascend_graph_capturing(False)
+
+    def prepare_model_compile(self) -> None:
+        from torch._dynamo import config as dynamo_config
+
+        from vllm_fl.dispatch import prewarm_cached_ops
+
+        # Operator backends can emit debug logs from their Python wrappers.
+        # Logging is a host-only side effect and must not become part of the
+        # fullgraph compiled model.
+        dynamo_config.ignore_logger_methods.add(logging.Logger.debug)
+        prewarm_cached_ops()
+
+    def after_capture(self) -> None:
+        from vllm_fl.compilation.graph import weak_ref_ascend_graph_workspaces
+
+        weak_ref_ascend_graph_workspaces()
+
+    def before_replay(self) -> None:
+        current_platform.torch_device_fn.synchronize()
+
+    def prepare_graph_wrapper(self) -> None:
+        self._update_stream = torch.npu.Stream()
+
+    def prepare_capture(self, capture_descs: Any) -> None:
+        from vllm_fl.compilation.graph import set_ascend_graph_params
+
+        set_ascend_graph_params(
+            [
+                desc.num_tokens
+                for _, descriptors in capture_descs
+                for desc in descriptors
+            ]
+        )
+
+    def after_model_forward(self, vllm_config: VllmConfig) -> None:
+        if self._update_stream is None:
+            return
+
+        from vllm.forward_context import get_forward_context
+
+        from vllm_fl.compilation.graph import update_ascend_full_graph_params
+
+        forward_context = get_forward_context()
+        if (
+            forward_context.cudagraph_runtime_mode != CUDAGraphMode.FULL
+            or getattr(forward_context, "capturing", False)
+        ):
+            return
+
+        batch_descriptor = forward_context.batch_descriptor
+        assert batch_descriptor is not None
+        update_ascend_full_graph_params(
+            self._update_stream,
+            forward_context,
+            batch_descriptor.num_tokens,
+        )
+
+
+_GRAPH_RUNTIME_BACKENDS: dict[str, type[GraphRuntimeBackend]] = {
+    "npu": AscendGraphRuntimeBackend,
+}
+
+
+def get_graph_runtime_backend(
+    device_type: str | None = None,
+) -> GraphRuntimeBackend:
+    """Create lifecycle hooks for the active accelerator."""
+    device_type = device_type or current_platform.device_type
+    backend_cls = _GRAPH_RUNTIME_BACKENDS.get(device_type, GraphRuntimeBackend)
+    return backend_cls()

--- a/vllm_fl/dispatch/__init__.py
+++ b/vllm_fl/dispatch/__init__.py
@@ -77,6 +77,10 @@ Configuration File (YAML):
 """
 
 import os
+import threading
+import weakref
+
+import torch
 
 from .types import OpImpl, BackendImplKind, BackendPriority, match_token
 from .registry import OpRegistry, OpRegistrySnapshot
@@ -146,6 +150,8 @@ def resolve_op(op_name: str):
 # Fast-path opt-out: set VLLM_FL_OP_FAST_PATH=0 to disable per-op fn caching
 # in hot OOT layers and route every call back through OpManager.call.
 _OP_FAST_PATH_ENABLED = os.environ.get("VLLM_FL_OP_FAST_PATH", "1") == "1"
+_CACHED_OPS = weakref.WeakSet()
+_CACHED_OPS_LOCK = threading.RLock()
 
 
 class CachedOp:
@@ -166,12 +172,14 @@ class CachedOp:
     """
 
     __slots__ = (
+        "__weakref__",
         "_op_name",
         "_impl",
         "_use_manager_call",
         "_manager_id",
         "_manager_epoch",
         "_policy_epoch",
+        "_first_use_pending",
     )
 
     def __init__(self, op_name: str) -> None:
@@ -181,6 +189,26 @@ class CachedOp:
         self._manager_id = -1
         self._manager_epoch = -1
         self._policy_epoch = -1
+        self._first_use_pending = False
+        with _CACHED_OPS_LOCK:
+            _CACHED_OPS.add(self)
+
+    def _refresh_cache(self, mgr, *, record_first_use: bool):
+        impl = mgr._resolve_impl(self._op_name)
+        if record_first_use:
+            mgr._record_first_use(self._op_name, impl)
+        self._impl = impl
+        self._use_manager_call = False
+        self._manager_id = id(mgr)
+        # Resolving can initialize the manager and bump its epoch.
+        self._manager_epoch = mgr.policy_epoch
+        self._policy_epoch = get_policy_epoch()
+        self._first_use_pending = not record_first_use
+        return impl
+
+    def prewarm(self, mgr=None) -> None:
+        """Resolve this call site's implementation without executing it."""
+        self._refresh_cache(mgr or get_default_manager(), record_first_use=False)
 
     def __call__(self, *args, **kwargs):
         mgr = get_default_manager()
@@ -212,23 +240,49 @@ class CachedOp:
             or self._manager_epoch != manager_epoch
             or self._policy_epoch != policy_epoch
         ):
-            impl = mgr._resolve_impl(self._op_name)
+            impl = self._refresh_cache(mgr, record_first_use=True)
+
+        if self._first_use_pending and not torch.compiler.is_compiling():
             mgr._record_first_use(self._op_name, impl)
-            self._impl = impl
-            # resolve() can initialize the manager and bump its epoch.
-            self._manager_id = manager_id
-            self._manager_epoch = mgr.policy_epoch
-            self._policy_epoch = get_policy_epoch()
+            self._first_use_pending = False
 
         try:
             return impl.fn(*args, **kwargs)
         except Exception:
             self._impl = None
+            self._first_use_pending = False
             if get_policy().strict:
                 raise
             mgr._mark_failed_impl(self._op_name, impl.impl_id)
             self._use_manager_call = True
             return mgr.call(self._op_name, *args, **kwargs)
+
+
+def prewarm_cached_ops() -> tuple[int, int]:
+    """Resolve loaded CachedOp call sites before full-graph compilation.
+
+    Modules can define CachedOp objects for optional operators that are not
+    available on the active platform. Those call sites are left unresolved and
+    retain their existing lazy error/fallback behavior if they are later used.
+
+    Returns:
+        A ``(prewarmed, unavailable)`` count for diagnostics and tests.
+    """
+    mgr = get_default_manager()
+    mgr.ensure_initialized()
+    with _CACHED_OPS_LOCK:
+        cached_ops = tuple(_CACHED_OPS)
+
+    prewarmed = 0
+    unavailable = 0
+    for cached_op in cached_ops:
+        try:
+            cached_op.prewarm(mgr)
+            prewarmed += 1
+        except RuntimeError:
+            unavailable += 1
+
+    return prewarmed, unavailable
 
 
 __all__ = [
@@ -281,5 +335,6 @@ __all__ = [
     # Convenience functions
     "call_op",
     "resolve_op",
+    "prewarm_cached_ops",
     "CachedOp",
 ]

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/attention.py
@@ -40,6 +40,11 @@ from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
+from vllm_fl.compilation.graph import (
+    get_ascend_graph_params,
+    is_ascend_graph_capturing,
+    weak_ref_tensors,
+)
 from vllm_fl.dispatch.backends.vendor.ascend.impl.attention_mask import (
     AttentionMaskBuilder,
 )
@@ -558,6 +563,72 @@ class AscendAttentionBackendImpl(AttentionImpl):
         self.key_cache = None
         self.value_cache = None
 
+    @staticmethod
+    def update_graph_params(
+        update_stream: Any,
+        forward_context: Any,
+        num_tokens: int,
+    ) -> None:
+        graph_params = get_ascend_graph_params()
+        if (
+            graph_params is None
+            or num_tokens not in graph_params.attention_params
+            or not graph_params.attention_params[num_tokens]
+        ):
+            return
+
+        attn_metadata = forward_context.attn_metadata
+        if not isinstance(attn_metadata, dict):
+            return
+
+        with torch.npu.stream(update_stream):
+            for param, handle, event in zip(
+                graph_params.attention_params[num_tokens],
+                graph_params.handles[num_tokens],
+                graph_params.events[num_tokens],
+            ):
+                (
+                    layer_name,
+                    query,
+                    key_cache,
+                    value_cache,
+                    num_kv_heads,
+                    num_heads,
+                    scale,
+                    block_table,
+                    output,
+                ) = param
+                metadata = attn_metadata.get(layer_name)
+                if not isinstance(metadata, AscendMetadata):
+                    continue
+                seq_lens = metadata.seq_lens
+                workspace = torch_npu._npu_paged_attention_get_workspace(
+                    query=query,
+                    key_cache=key_cache,
+                    value_cache=value_cache,
+                    num_kv_heads=num_kv_heads,
+                    num_heads=num_heads,
+                    scale_value=scale,
+                    block_table=block_table,
+                    context_lens=seq_lens,
+                    out=output,
+                )
+                torch.npu.graph_task_update_begin(update_stream, handle)
+                torch_npu._npu_paged_attention(
+                    query=query,
+                    key_cache=key_cache,
+                    value_cache=value_cache,
+                    num_kv_heads=num_kv_heads,
+                    num_heads=num_heads,
+                    scale_value=scale,
+                    block_table=block_table,
+                    context_lens=seq_lens,
+                    out=output,
+                    workspace=workspace,
+                )
+                torch.npu.graph_task_update_end(update_stream)
+                event.record(update_stream)
+
     def _get_fia_params(
         self,
         key: torch.Tensor,
@@ -666,8 +737,63 @@ class AscendAttentionBackendImpl(AttentionImpl):
         query: torch.Tensor,
         attn_metadata: AscendMetadata,
         output: Optional[torch.Tensor] = None,
+        layer_name: str = "",
     ) -> torch.Tensor:
         """Forward pass using paged attention for decode."""
+        if is_ascend_graph_capturing():
+            graph_params = get_ascend_graph_params()
+            assert graph_params is not None
+            num_tokens = query.shape[0]
+            workspace = graph_params.workspaces[num_tokens]
+            if workspace is None:
+                workspace = torch_npu._npu_paged_attention_get_workspace(
+                    query=query,
+                    key_cache=self.key_cache,
+                    value_cache=self.value_cache,
+                    num_kv_heads=self.num_kv_heads,
+                    num_heads=self.num_heads,
+                    scale_value=self.scale,
+                    block_table=attn_metadata.block_tables,
+                    context_lens=attn_metadata.seq_lens,
+                    out=output,
+                )
+                graph_params.workspaces[num_tokens] = workspace
+
+            stream = torch.npu.current_stream()
+            event = torch.npu.ExternalEvent()
+            event.wait(stream)
+            event.reset(stream)
+            graph_params.events[num_tokens].append(event)
+            graph_params.attention_params[num_tokens].append(
+                (
+                    layer_name,
+                    weak_ref_tensors(query),
+                    weak_ref_tensors(self.key_cache),
+                    weak_ref_tensors(self.value_cache),
+                    self.num_kv_heads,
+                    self.num_heads,
+                    self.scale,
+                    weak_ref_tensors(attn_metadata.block_tables),
+                    weak_ref_tensors(output),
+                )
+            )
+            torch.npu.graph_task_group_begin(stream)
+            torch_npu._npu_paged_attention(
+                query=query,
+                key_cache=self.key_cache,
+                value_cache=self.value_cache,
+                num_kv_heads=self.num_kv_heads,
+                num_heads=self.num_heads,
+                scale_value=self.scale,
+                block_table=attn_metadata.block_tables,
+                context_lens=attn_metadata.seq_lens,
+                out=output,
+                workspace=workspace,
+            )
+            handle = torch.npu.graph_task_group_end(stream)
+            graph_params.handles[num_tokens].append(handle)
+            return output
+
         torch_npu._npu_paged_attention(
             query=query,
             key_cache=self.key_cache,
@@ -727,6 +853,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
         kv_cache: Tuple[torch.Tensor],
         attn_metadata: AscendMetadata,
         output: torch.Tensor,
+        layer_name: str,
     ):
         """Forward implementation dispatching to appropriate attention method."""
         num_tokens = query.shape[0]
@@ -734,7 +861,9 @@ class AscendAttentionBackendImpl(AttentionImpl):
         # Use paged attention for decode-only state
         if (attn_metadata.attn_state == AscendAttentionState.DecodeOnly
                 and self.sliding_window is None):
-            output = self.forward_paged_attention(query, attn_metadata, output)
+            output = self.forward_paged_attention(
+                query, attn_metadata, output, layer_name
+            )
         else:
             output = self.forward_fused_infer_attention(
                 query, key, value, attn_metadata, output)
@@ -809,7 +938,14 @@ class AscendAttentionBackendImpl(AttentionImpl):
 
         # Standard forward
         output = self.forward_impl(
-            query, key, value, kv_cache, attn_metadata, output)
+            query,
+            key,
+            value,
+            kv_cache,
+            attn_metadata,
+            output,
+            layer.layer_name,
+        )
         return output
 
 

--- a/vllm_fl/ops/rotary_embedding.py
+++ b/vllm_fl/ops/rotary_embedding.py
@@ -29,7 +29,9 @@ class RotaryEmbeddingFL(RotaryEmbedding):
         query: torch.Tensor,
         key: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-        self.cos_sin_cache: torch.Tensor = self.cos_sin_cache.to(positions.device)
+        # Keep module buffers immutable during forward. Updating a registered
+        # buffer is forbidden when cudagraph is used inside torch.compile.
+        cos_sin_cache = self.cos_sin_cache.to(positions.device)
         positions = positions.flatten()
         num_tokens = positions.shape[0]
 
@@ -44,7 +46,7 @@ class RotaryEmbeddingFL(RotaryEmbedding):
             query_pass = query[..., self.rotary_dim:]
             key_pass = key[..., self.rotary_dim:]
 
-        cos, sin = self.cos_sin_cache.chunk(2, dim=-1)
+        cos, sin = cos_sin_cache.chunk(2, dim=-1)
 
         q_embed, k_embed = _rotary_embedding(
             self,

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -81,6 +81,9 @@ class PlatformFL(Platform):
     device_type = device_info.device_type
     dispatch_key = device_info.dispatch_key
     torch_device_fn = device_info.torch_device_fn
+    # NPU Inductor is not part of FL's Ascend graph path. Keep independently
+    # decorated helper functions on the eager backend.
+    simple_compile_backend: str = "eager" if device_type == "npu" else "inductor"
     ray_device_key: str = "GPU"
     dist_backend: str = (
         "flagcx"
@@ -244,17 +247,35 @@ class PlatformFL(Platform):
         if compilation_config.compile_sizes is None:
             compilation_config.compile_sizes = []
 
-        # Ascend NPU: torch_npu inductor codegen has issues with
-        # multi-device compilation (e.g. reduction scheduling on npu:1).
-        # Disable torch.compile and CUDAGraphs until torch_npu inductor
-        # is stable. check_and_update_config runs after VllmConfig.__init__
-        # processes enforce_eager, so we must set compilation_config directly.
         if cls.device_type == "npu":
             from vllm.config import CompilationMode
-            if compilation_config.mode != CompilationMode.NONE:
+
+            enforce_eager = bool(
+                model_config is not None
+                and getattr(model_config, "enforce_eager", False)
+            )
+            if enforce_eager or compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
+                compilation_config.mode = CompilationMode.NONE
+                compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+            elif compilation_config.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY:
+                compilation_config.mode = CompilationMode.VLLM_COMPILE
+                compilation_config.backend = "eager"
+                compilation_config.use_inductor = False
+                compilation_config.splitting_ops = []
+                # These post-passes are CUDA/Inductor-specific. The eager FX
+                # graph is used only to drive the existing NPUGraph wrapper.
+                compilation_config.pass_config.fuse_norm_quant = False
+                compilation_config.pass_config.fuse_act_quant = False
+                compilation_config.pass_config.fuse_attn_quant = False
+                compilation_config.cudagraph_num_of_warmups = 1
+                logger.info(
+                    "Enabling Ascend FULL_DECODE_ONLY with eager FX and NPUGraph."
+                )
+            else:
                 logger.warning(
-                    "Disabling torch.compile for Ascend NPU to avoid "
-                    "torch_npu inductor codegen issues."
+                    "Ascend FL currently supports only NONE or "
+                    "FULL_DECODE_ONLY graph mode; falling back to NONE from %s.",
+                    compilation_config.cudagraph_mode,
                 )
                 compilation_config.mode = CompilationMode.NONE
                 compilation_config.cudagraph_mode = CUDAGraphMode.NONE

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -147,6 +147,15 @@ if current_platform.dist_backend == "flagcx" or current_platform.device_type == 
             yield graph_capture_context
 else:
     from vllm.distributed.parallel_state import graph_capture
+
+from vllm_fl.compilation.graph_runtime import (
+    get_graph_capture,
+    get_graph_runtime_backend,
+)
+
+graph_capture = get_graph_capture(graph_capture)
+
+
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingType
 from vllm.sequence import IntermediateTensors
@@ -461,6 +470,7 @@ class ModelRunnerFL(
         self.cache_config = vllm_config.cache_config
         self.offload_config = vllm_config.offload_config
         self.compilation_config = vllm_config.compilation_config
+        self.graph_runtime = get_graph_runtime_backend()
         self.lora_config = vllm_config.lora_config
         self.load_config = vllm_config.load_config
         self.parallel_config = vllm_config.parallel_config
@@ -3580,13 +3590,15 @@ class ModelRunnerFL(
         Returns:
             Model output tensor
         """
-        return self.model(
+        model_output = self.model(
             input_ids=input_ids,
             positions=positions,
             intermediate_tensors=intermediate_tensors,
             inputs_embeds=inputs_embeds,
             **model_kwargs,
         )
+        self.graph_runtime.after_model_forward(self.vllm_config)
+        return model_output
 
     @staticmethod
     def _is_uniform_decode(
@@ -4966,6 +4978,12 @@ class ModelRunnerFL(
         ):
             self.eplb_state.start_async_loop()
 
+        if self.vllm_config.compilation_config.mode in (
+            CompilationMode.STOCK_TORCH_COMPILE,
+            CompilationMode.VLLM_COMPILE,
+        ):
+            self.graph_runtime.prepare_model_compile()
+
         if (
             self.vllm_config.compilation_config.mode
             == CompilationMode.STOCK_TORCH_COMPILE
@@ -4987,6 +5005,7 @@ class ModelRunnerFL(
             cudagraph_mode.has_full_cudagraphs()
             and not self.parallel_config.use_ubatching
         ):
+            self.graph_runtime.prepare_graph_wrapper()
             self.model = GraphWrapper(
                 self.model, self.vllm_config, runtime_mode=CUDAGraphMode.FULL
             )
@@ -6019,6 +6038,7 @@ class ModelRunnerFL(
         saved_num_cudagraph_captured = compilation_counter.num_cudagraph_captured
 
         capture_descs = self.cudagraph_dispatcher.get_capture_descs()
+        self.graph_runtime.prepare_capture(capture_descs)
 
         total_graphs = sum(len(descs) for _, descs in capture_descs)
         if total_graphs == 0:
@@ -6152,6 +6172,9 @@ class ModelRunnerFL(
 
         start_time = time.perf_counter()
 
+        capture_descs = self.cudagraph_dispatcher.get_capture_descs()
+        self.graph_runtime.prepare_capture(capture_descs)
+
         # Trigger CUDA graph capture for specific shapes.
         # Capture the large shapes first so that the smaller shapes
         # can reuse the memory pool allocated for the large shapes.
@@ -6161,10 +6184,7 @@ class ModelRunnerFL(
             torch.accelerator.empty_cache()
             start_free_gpu_memory = current_platform.torch_device_fn.mem_get_info()[0]
 
-            for (
-                runtime_mode,
-                batch_descs,
-            ) in self.cudagraph_dispatcher.get_capture_descs():
+            for runtime_mode, batch_descs in capture_descs:
                 self._capture_cudagraphs(
                     batch_descriptors=batch_descs,
                     cudagraph_runtime_mode=runtime_mode,


### PR DESCRIPTION
### PR Category

Vendor

### PR Type

New Features

### Description

为 FL Ascend 平台增加通用 `FULL_DECODE_ONLY` 图模式支持。通过 TorchDynamo eager backend
生成可捕获的 FX graph，并使用独立 NPU stream 完成 decode 阶段的 NPUGraph
capture/replay；相关配置和运行时逻辑统一收敛到 `vllm_fl.compilation`。

### Changes

- 增加 Ascend `NONE` 和 `FULL_DECODE_ONLY` 配置处理，包括编译模式、warmup 和 capture sizes。
- 增加统一图运行时接口，管理 NPU stream、graph pool、capture 和 replay 生命周期。
- 将 NPU ModelRunner 接入 FL `graph_capture`，并集中处理图类型选择和 replay 同步。
- 在 replay 阶段更新 Paged Attention 动态长度参数。
- 预解析 `CachedOp`，处理 fullgraph 下的日志调用和 Rotary cache buffer。
- 增加平台、图运行时、算子派发相关单测及 README 使用说明。

### Testing

**Unit tests**（A2/Ascend 910B1）：

```bash
pytest -q \
  tests/unit_tests/compilation/test_graph_runtime.py \
  tests/unit_tests/compilation/test_graph.py \
  tests/unit_tests/test_platform.py \
  tests/unit_tests/dispatch/test_call_op.py \
  tests/unit_tests/ops/test_rotary_embedding.py
# 43 passed
```

**End-to-end with FlagGems**：

FlagGems 使用 `release/0.2` README 指定版本。

```bash
export VLLM_PLUGINS=fl
export USE_FLAGGEMS=1

# 仅图模式需要
export VLLM_FL_PER_OP='silu_and_mul=reference|vendor|flagos;rms_norm=vendor|flagos|reference;rotary_embedding=vendor|flagos|reference'

vllm serve Qwen/Qwen3-0.6B \
  --dtype bfloat16 \
  --tensor-parallel-size 1 \
  --max-model-len 1024 \
  --max-num-batched-tokens 1024 \
  --max-num-seqs 4 \
  --compilation-config \
    '{"cudagraph_mode":"FULL_DECODE_ONLY","cudagraph_capture_sizes":[1,2,4]}'
```

- eager 仅设置 `USE_FLAGGEMS=1`；`FULL_DECODE_ONLY` 增加 `VLLM_FL_PER_OP`。
- eager 与图模式的中英文确定性请求均返回 HTTP 200，输出正常且不含 `U+FFFD`。
- Capture sizes `1/2/4` 全部成功，decode 实际命中 FULL replay。

**Hardware regression**：A2/Ascend 910B 与 A3/Ascend 910C 均完成 clean build、wheel 安装及
`FULL_DECODE_ONLY` 单卡部署验证。

### Checklist

- [x] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)