### PR TITLE
perf(metax): tune GDN packed decode launch

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/metax/patches/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/metax/patches/__init__.py
@@ -21,6 +21,7 @@ from . import utils_patch
 from . import chunk_delta_h
 from . import topk_topp_sampler
 from . import gdn_linear_attn  # noqa: F401 — register MacaGatedDeltaNetAttention
+from . import fused_recurrent_packed_decode
 
 # --------------------------------------------------
 # MetaX C550 does not support third-party Triton kernels (Triton upgrade required).

--- a/vllm_fl/dispatch/backends/vendor/metax/patches/fused_recurrent_packed_decode.py
+++ b/vllm_fl/dispatch/backends/vendor/metax/patches/fused_recurrent_packed_decode.py
@@ -1,0 +1,44 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vllm.model_executor.layers.fla.ops import fused_recurrent as _fused_recurrent
+
+
+class _PackedDecodeKernel:
+    def __init__(self, kernel):
+        self._kernel = kernel
+
+    def __getitem__(self, grid):
+        launch = self._kernel[grid]
+
+        def tuned_launch(**kwargs):
+            if (
+                kwargs["mixed_qkv"].shape[0] >= 8
+                and kwargs["H"] == 8
+                and kwargs["HV"] == 16
+                and kwargs["K"] == 128
+                and kwargs["V"] == 128
+                and kwargs["BV"] == 32
+            ):
+                kwargs["num_warps"] = 4
+            return launch(**kwargs)
+
+        return tuned_launch
+
+
+_fused_recurrent.fused_recurrent_gated_delta_rule_packed_decode_kernel = (
+    _PackedDecodeKernel(
+        _fused_recurrent.fused_recurrent_gated_delta_rule_packed_decode_kernel
+    )
+)


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category
<!-- One of [Core | Vendor | OP | Tools | Others] -->

Vendor

### PR Type
<!-- One of [User Experience | New Features | Bug Fixes | Improvements | Performance | Breaking Change | Deprecations | Test Case | Docs | Others] -->

Performance

### Description
<!-- Describe what this PR does and why. -->

Tune the MetaX launch configuration of vLLM's existing GDN packed decode
Triton kernel for the Qwen3.6 TP=2 production shape.

The patch changes `num_warps` from 1 to 4 when the local shape is
`H=8, HV=16, K=128, V=128, BV=32` and the decode batch is at least 8. The
kernel implementation and all other launch configurations remain unchanged.

Performance on two MetaX C550 GPUs with TP=2:

| Workload | W1 baseline | W4 tuning | Improvement |
|---|---:|---:|---:|
| B64 packed decode kernel | 0.220504 ms | 0.104668 ms | 2.107x |
| 1K input / 1K output / concurrency 64 | 3278.72 total tok/s | 3624.07 total tok/s | +10.53% |

### Related Issues
<!-- Link any related issues: Fixes #issue, Closes #issue, or Related to #issue -->

Related to #320. This PR contains only the GDN packed decode launch tuning.

### Changes
<!-- List the key changes made in this PR. -->

- Add a MetaX launch proxy around the upstream packed decode Triton kernel.
- Use four warps for the target local shape at batch sizes 8 and above.
- Register the patch through the existing MetaX patch initialization path.

### Testing
<!-- How has this change been tested? Include test commands, hardware used, etc. -->

- Verified with the production kernel shape and Qwen3.6-35B-A3B end-to-end
  workload on two MetaX C550 GPUs.

### Checklist
- [x] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
