### PR TITLE
Feature/ascend modelslim w8a8 v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,15 @@ If there are multiple plugins in the current environment, you can specify use vl
     export TRITON_ALL_BLOCKS_PARALLEL=1
     ```
 
-3. Enable eager execution
+3. Select eager or graph execution
 
-    Ascend requires eager execution. Add `enforce_eager=True` to the `LLM` constructor or pass `--enforce-eager` on the command line.
+    Ascend supports eager execution and `FULL_DECODE_ONLY` graph execution for
+    graph-compatible models and backends. Add `enforce_eager=True` to the `LLM`
+    constructor or pass `--enforce-eager` to force eager execution. To enable
+    graph execution, keep eager enforcement disabled and set
+    `compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY"}` (or pass the
+    equivalent `--compilation-config` value to `vllm serve`). Other graph modes
+    currently fall back to eager execution.
 
 
 ### Run a Task

--- a/tests/unit_tests/compilation/test_graph_runtime.py
+++ b/tests/unit_tests/compilation/test_graph_runtime.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_graph_class_resolution_is_centralized(monkeypatch):
+    import vllm_fl.compilation.graph_runtime as graph_runtime
+
+    cuda_graph = object()
+    monkeypatch.setattr(
+        graph_runtime.torch,
+        "cuda",
+        SimpleNamespace(CUDAGraph=cuda_graph),
+    )
+
+    assert graph_runtime.get_graph_class("cuda") is cuda_graph
+    assert graph_runtime.get_graph_class("txda") is None
+    with pytest.raises(NotImplementedError, match="unknown"):
+        graph_runtime.get_graph_class("unknown")
+
+
+def test_runtime_backend_selection():
+    from vllm_fl.compilation.graph_runtime import (
+        AscendGraphRuntimeBackend,
+        GraphRuntimeBackend,
+        get_graph_runtime_backend,
+    )
+
+    assert isinstance(
+        get_graph_runtime_backend("npu"), AscendGraphRuntimeBackend
+    )
+    assert type(get_graph_runtime_backend("cuda")) is GraphRuntimeBackend
+
+
+def test_ascend_synchronizes_before_replay(monkeypatch):
+    import vllm_fl.compilation.graph_runtime as graph_runtime
+
+    synchronize_calls = []
+    monkeypatch.setattr(
+        graph_runtime.current_platform,
+        "torch_device_fn",
+        SimpleNamespace(synchronize=lambda: synchronize_calls.append(True)),
+    )
+
+    graph_runtime.AscendGraphRuntimeBackend().before_replay()
+
+    assert synchronize_calls == [True]
+
+
+def test_graph_capture_override_is_ascend_only(monkeypatch):
+    import vllm_fl.compilation.graph_runtime as graph_runtime
+
+    @contextmanager
+    def default_capture(device):
+        yield device
+
+    monkeypatch.setattr(
+        graph_runtime,
+        "current_platform",
+        SimpleNamespace(device_type="cuda", dist_backend="nccl"),
+    )
+    assert graph_runtime.get_graph_capture(default_capture) is default_capture
+
+    monkeypatch.setattr(
+        graph_runtime.current_platform,
+        "device_type",
+        "npu",
+    )
+    assert (
+        graph_runtime.get_graph_capture(default_capture)
+        is graph_runtime._ascend_graph_capture
+    )

--- a/tests/unit_tests/quantization/test_ascend_modelslim_config.py
+++ b/tests/unit_tests/quantization/test_ascend_modelslim_config.py
@@ -1,0 +1,163 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
+from vllm.model_executor.layers.quantization import get_quantization_config
+from vllm.model_executor.models.utils import WeightsMapper
+
+from vllm_fl.quantization.modelslim import (
+    MODELSLIM_CONFIG_FILENAME,
+    AscendModelSlimConfig,
+    register_modelslim_prefix_mapper,
+    resolve_linear_quant_type,
+)
+from vllm_fl.dispatch.backends.vendor.ascend.impl.quantization.linear import (
+    AscendModelSlimLinearMethod,
+)
+from vllm_fl.dispatch.backends.vendor.ascend.impl.quantization.w8a8 import (
+    AscendW8A8DynamicLinearScheme,
+)
+
+
+class _LinearStub(LinearBase):
+    def __init__(self):
+        torch.nn.Module.__init__(self)
+
+
+def test_registers_ascend_quantization_config():
+    assert get_quantization_config("ascend") is AscendModelSlimConfig
+
+
+def test_loads_descriptor_from_model_directory(tmp_path):
+    descriptor = {
+        "model.layers.0.self_attn.q_proj.weight": "W8A8_DYNAMIC",
+        "model.embed_tokens.weight": "FLOAT",
+    }
+    (tmp_path / MODELSLIM_CONFIG_FILENAME).write_text(
+        __import__("json").dumps(descriptor),
+        encoding="utf-8",
+    )
+    config = AscendModelSlimConfig()
+
+    config.maybe_update_config(
+        str(tmp_path),
+        hf_config=SimpleNamespace(model_type="example"),
+    )
+
+    assert config.quant_description == descriptor
+    assert config.model_type == "example"
+
+
+def test_missing_descriptor_fails_explicitly(tmp_path):
+    config = AscendModelSlimConfig()
+    with pytest.raises(ValueError, match=MODELSLIM_CONFIG_FILENAME):
+        config.maybe_update_config(str(tmp_path))
+
+
+def test_weight_packed_alias_is_normalized():
+    config = AscendModelSlimConfig(
+        {"model.layers.0.proj.weight_packed": "W8A8_DYNAMIC"}
+    )
+    assert (
+        config.quant_description["model.layers.0.proj.weight"]
+        == "W8A8_DYNAMIC"
+    )
+
+
+def test_resolves_packed_layer_only_when_all_shards_match():
+    description = {
+        "model.layers.0.q_proj.weight": "W8A8_DYNAMIC",
+        "model.layers.0.k_proj.weight": "W8A8_DYNAMIC",
+        "model.layers.0.v_proj.weight": "W8A8_DYNAMIC",
+    }
+    mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
+
+    assert (
+        resolve_linear_quant_type(
+            description,
+            "model.layers.0.qkv_proj",
+            mapping,
+        )
+        == "W8A8_DYNAMIC"
+    )
+
+    description["model.layers.0.v_proj.weight"] = "FLOAT"
+    with pytest.raises(ValueError, match="mixes ModelSlim quantization types"):
+        resolve_linear_quant_type(
+            description,
+            "model.layers.0.qkv_proj",
+            mapping,
+        )
+
+
+def test_missing_or_unknown_linear_contract_fails_explicitly():
+    with pytest.raises(ValueError, match="has no quantization entry"):
+        resolve_linear_quant_type({}, "model.layers.0.proj")
+
+    with pytest.raises(NotImplementedError, match="W4A8"):
+        resolve_linear_quant_type(
+            {"model.layers.0.proj.weight": "W4A8"},
+            "model.layers.0.proj",
+        )
+
+
+def test_selects_float_and_dynamic_linear_methods():
+    float_config = AscendModelSlimConfig({"model.proj.weight": "FLOAT"})
+    float_method = float_config.get_quant_method(_LinearStub(), "model.proj")
+    assert isinstance(float_method, UnquantizedLinearMethod)
+
+    dynamic_config = AscendModelSlimConfig(
+        {"model.proj.weight": "W8A8_DYNAMIC"}
+    )
+    dynamic_method = dynamic_config.get_quant_method(
+        _LinearStub(),
+        "model.proj",
+    )
+    assert isinstance(dynamic_method, AscendModelSlimLinearMethod)
+    assert isinstance(dynamic_method.scheme, AscendW8A8DynamicLinearScheme)
+
+
+def test_applies_vllm_weights_mapper_without_losing_entries():
+    config = AscendModelSlimConfig(
+        {
+            "layers.0.proj.weight": "W8A8_DYNAMIC",
+            "layers.0.proj.weight_scale": "W8A8_DYNAMIC",
+        }
+    )
+    mapper = WeightsMapper(orig_to_new_prefix={"layers.": "model.layers."})
+
+    config.apply_vllm_mapper(mapper)
+
+    assert config.quant_description == {
+        "model.layers.0.proj.weight": "W8A8_DYNAMIC",
+        "model.layers.0.proj.weight_scale": "W8A8_DYNAMIC",
+    }
+
+
+def test_model_prefix_adapter_is_registered_outside_generic_config():
+    model_type = "unit_test_modelslim_prefix_adapter"
+    register_modelslim_prefix_mapper(
+        model_type,
+        lambda prefix: f"model.{prefix}",
+    )
+    config = AscendModelSlimConfig({"model.proj.weight": "FLOAT"})
+    config.model_type = model_type
+
+    method = config.get_quant_method(_LinearStub(), "proj")
+
+    assert isinstance(method, UnquantizedLinearMethod)

--- a/tests/unit_tests/quantization/test_ascend_modelslim_linear.py
+++ b/tests/unit_tests/quantization/test_ascend_modelslim_linear.py
@@ -1,0 +1,204 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import vllm.model_executor.parameter as parameter_module
+
+from vllm_fl.dispatch.backends.vendor.ascend.impl.quantization import w8a8
+from vllm_fl.dispatch.backends.vendor.ascend.impl.quantization.linear import (
+    AscendModelSlimLinearMethod,
+)
+from vllm_fl.dispatch.backends.vendor.ascend.impl.quantization.w8a8 import (
+    AscendW8A8DynamicLinearScheme,
+    AscendW8A8StaticLinearScheme,
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_tensor_parallel_state(monkeypatch):
+    """Construct vLLM parameters without a distributed process group."""
+
+    monkeypatch.setattr(
+        parameter_module,
+        "get_tensor_model_parallel_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        parameter_module,
+        "get_tensor_model_parallel_world_size",
+        lambda: 1,
+    )
+
+
+def _weight_loader(*args, **kwargs):
+    del args, kwargs
+
+
+def _make_layer(method, output_partition_sizes, params_dtype=torch.bfloat16):
+    layer = torch.nn.Module()
+    layer.prefix = "model.layers.0.proj"
+    layer.params_dtype = params_dtype
+    method.create_weights(
+        layer,
+        input_size_per_partition=4,
+        output_partition_sizes=output_partition_sizes,
+        input_size=4,
+        output_size=sum(output_partition_sizes),
+        params_dtype=params_dtype,
+        weight_loader=_weight_loader,
+    )
+    return layer
+
+
+def test_static_weight_and_scale_contract_for_packed_linear():
+    method = AscendModelSlimLinearMethod(AscendW8A8StaticLinearScheme())
+    layer = _make_layer(method, [3, 5])
+
+    assert layer.weight.shape == (8, 4)
+    assert layer.weight.dtype == torch.int8
+    assert layer.input_scale.shape == (2,)
+    assert layer.input_offset.shape == (2,)
+    assert layer.quant_bias.shape == (8,)
+    assert layer.deq_scale.shape == (8,)
+    assert layer.deq_scale.dtype == torch.float32
+    assert layer.weight_scale.shape == (8, 1)
+    assert layer.weight_offset.shape == (8, 1)
+
+    layer.input_scale.load_merged_column_weight(
+        torch.tensor([0.5], dtype=torch.bfloat16),
+        shard_id=0,
+    )
+    layer.input_scale.load_merged_column_weight(
+        torch.tensor([0.5], dtype=torch.bfloat16),
+        shard_id=1,
+    )
+    assert torch.equal(
+        layer.input_scale,
+        torch.tensor([0.5, 0.5], dtype=torch.bfloat16),
+    )
+
+
+def test_dynamic_weight_and_scale_contract():
+    method = AscendModelSlimLinearMethod(AscendW8A8DynamicLinearScheme())
+    layer = _make_layer(method, [8])
+
+    assert layer.weight.shape == (8, 4)
+    assert layer.weight.dtype == torch.int8
+    assert layer.weight_scale.shape == (8, 1)
+    assert layer.weight_offset.shape == (8, 1)
+    assert not hasattr(layer, "input_scale")
+
+
+def test_static_post_load_and_apply(monkeypatch):
+    method = AscendModelSlimLinearMethod(AscendW8A8StaticLinearScheme())
+    layer = _make_layer(method, [3, 5])
+    layer.weight.data.zero_()
+    layer.input_scale.data.copy_(torch.tensor([0.5, 0.5]))
+    layer.input_offset.data.zero_()
+    layer.quant_bias.data.zero_()
+    layer.deq_scale.data.fill_(0.25)
+    layer.weight_scale.data.fill_(0.5)
+    layer.weight_offset.data.zero_()
+    monkeypatch.setattr(w8a8, "_npu_format_nz", lambda tensor: tensor)
+
+    method.process_weights_after_loading(layer)
+
+    assert layer.weight.shape == (4, 8)
+    assert layer.weight_scale.shape == (8,)
+    assert layer.weight_offset.shape == (8,)
+    assert layer.aclnn_input_scale.shape == (4,)
+    assert torch.equal(
+        layer.aclnn_input_scale_reciprocal,
+        torch.full((4,), 2.0, dtype=torch.bfloat16),
+    )
+
+    calls = {}
+
+    def fake_static_quant(x, scale_reciprocal, offset):
+        calls["quant"] = (x, scale_reciprocal, offset)
+        return torch.zeros_like(x, dtype=torch.int8)
+
+    def fake_quant_matmul(x, weight, scale, **kwargs):
+        calls["matmul"] = (x, weight, scale, kwargs)
+        return torch.zeros(x.shape[0], weight.shape[1], dtype=torch.bfloat16)
+
+    monkeypatch.setattr(w8a8, "_npu_static_quant", fake_static_quant)
+    monkeypatch.setattr(w8a8, "_npu_quant_matmul", fake_quant_matmul)
+
+    output = method.apply(layer, torch.ones(2, 4, dtype=torch.bfloat16))
+
+    assert output.shape == (2, 8)
+    assert calls["matmul"][3]["bias"] is layer.quant_bias
+    assert calls["matmul"][3]["output_dtype"] == torch.bfloat16
+
+
+def test_static_packed_input_quantization_must_match(monkeypatch):
+    method = AscendModelSlimLinearMethod(AscendW8A8StaticLinearScheme())
+    layer = _make_layer(method, [3, 5])
+    layer.input_scale.data.copy_(torch.tensor([0.5, 0.75]))
+    layer.input_offset.data.zero_()
+    layer.weight_offset.data.zero_()
+    monkeypatch.setattr(w8a8, "_npu_format_nz", lambda tensor: tensor)
+
+    with pytest.raises(ValueError, match="different static input scales"):
+        method.process_weights_after_loading(layer)
+
+
+def test_dynamic_post_load_and_rank_preserving_apply(monkeypatch):
+    method = AscendModelSlimLinearMethod(AscendW8A8DynamicLinearScheme())
+    layer = _make_layer(method, [8])
+    layer.weight.data.zero_()
+    layer.weight_scale.data.fill_(0.5)
+    layer.weight_offset.data.zero_()
+    monkeypatch.setattr(w8a8, "_npu_format_nz", lambda tensor: tensor)
+
+    method.process_weights_after_loading(layer)
+
+    assert layer.weight.shape == (4, 8)
+    assert layer.weight_scale.shape == (8,)
+    assert layer.weight_scale_fp32.dtype == torch.float32
+
+    calls = {}
+
+    def fake_dynamic_quant(x):
+        calls["dynamic_input"] = x
+        return torch.zeros_like(x, dtype=torch.int8), torch.ones(
+            x.shape[0],
+            dtype=torch.float32,
+        )
+
+    def fake_quant_matmul(x, weight, scale, **kwargs):
+        calls["matmul"] = (x, weight, scale, kwargs)
+        return torch.zeros(x.shape[0], weight.shape[1], dtype=torch.bfloat16)
+
+    monkeypatch.setattr(w8a8, "_npu_dynamic_quant", fake_dynamic_quant)
+    monkeypatch.setattr(w8a8, "_npu_quant_matmul", fake_quant_matmul)
+
+    output = method.apply(layer, torch.ones(2, 3, 4, dtype=torch.bfloat16))
+
+    assert calls["dynamic_input"].shape == (6, 4)
+    assert calls["matmul"][3]["pertoken_scale"].shape == (6,)
+    assert output.shape == (2, 3, 8)
+
+
+def test_nonzero_weight_offset_is_rejected(monkeypatch):
+    method = AscendModelSlimLinearMethod(AscendW8A8DynamicLinearScheme())
+    layer = _make_layer(method, [8])
+    layer.weight_offset.data.zero_()
+    layer.weight_offset.data[0, 0] = 1
+    monkeypatch.setattr(w8a8, "_npu_format_nz", lambda tensor: tensor)
+
+    with pytest.raises(ValueError, match="symmetric weights only"):
+        method.process_weights_after_loading(layer)

--- a/tests/unit_tests/quantization/test_ascend_modelslim_moe.py
+++ b/tests/unit_tests/quantization/test_ascend_modelslim_moe.py
@@ -1,0 +1,314 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from vllm.config import DeviceConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    FusedMoeWeightScaleSupported,
+    unquantized_fused_moe_method as unquantized_moe_module,
+)
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+    UnquantizedFusedMoEMethod,
+)
+
+from vllm_fl.dispatch.backends.vendor.ascend.impl.quantization import moe
+from vllm_fl.dispatch.backends.vendor.ascend.impl.quantization.moe import (
+    AscendModelSlimW8A8DynamicMoEMethod,
+)
+from vllm_fl.quantization.modelslim import AscendModelSlimConfig
+
+
+def _weight_loader(*args, **kwargs):
+    del args, kwargs
+
+
+def _moe_config(**overrides):
+    values = {
+        "is_act_and_mul": True,
+        "has_bias": False,
+        "is_lora_enabled": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _FusedMoEStub(FusedMoE):
+    def __init__(self, moe_config):
+        torch.nn.Module.__init__(self)
+        self.moe_config = moe_config
+
+
+def _make_layer(method, *, num_experts=2, hidden_size=2, intermediate_size=1):
+    layer = torch.nn.Module()
+    layer.prefix = "model.layers.0.mlp.experts"
+    layer.activation = MoEActivation.SILU
+    layer.apply_router_weight_on_input = False
+    layer.expert_map = None
+    method.create_weights(
+        layer,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size_per_partition=intermediate_size,
+        params_dtype=torch.float32,
+        weight_loader=_weight_loader,
+    )
+    return layer
+
+
+def _mock_expert_kernels(monkeypatch):
+    monkeypatch.setattr(moe, "_npu_format_nz", lambda tensor: tensor)
+    monkeypatch.setattr(
+        moe,
+        "_npu_dynamic_quant",
+        lambda tensor: (
+            tensor,
+            torch.ones(tensor.shape[0], dtype=torch.float32),
+        ),
+    )
+    monkeypatch.setattr(
+        moe,
+        "_npu_quant_matmul",
+        lambda x, weight, scale, **kwargs: x.float() @ weight.float(),
+    )
+    monkeypatch.setattr(
+        moe,
+        "_npu_moe_activation",
+        lambda activation, tensor: tensor[:, :1] * tensor[:, 1:],
+    )
+
+
+def _load_known_weights(layer):
+    layer.w13_weight.data.copy_(
+        torch.tensor(
+            [
+                [[1, 0], [1, 0]],
+                [[0, 1], [0, 1]],
+            ],
+            dtype=torch.int8,
+        )
+    )
+    layer.w2_weight.data.copy_(
+        torch.tensor(
+            [
+                [[1], [2]],
+                [[3], [4]],
+            ],
+            dtype=torch.int8,
+        )
+    )
+    layer.w13_weight_scale.data.fill_(1)
+    layer.w2_weight_scale.data.fill_(1)
+    layer.w13_weight_offset.data.zero_()
+    layer.w2_weight_offset.data.zero_()
+
+
+def test_config_selects_dynamic_and_float_moe_methods(monkeypatch):
+    monkeypatch.setattr(
+        unquantized_moe_module,
+        "select_unquantized_moe_backend",
+        lambda **kwargs: (None, None),
+    )
+    mapping = {
+        "experts": [
+            "experts.0.w1",
+            "experts.0.w2",
+            "experts.0.w3",
+        ]
+    }
+    dynamic_config = AscendModelSlimConfig(
+        {
+            "model.layers.0.mlp.experts.0.w1.weight": "W8A8_DYNAMIC",
+            "model.layers.0.mlp.experts.0.w2.weight": "W8A8_DYNAMIC",
+            "model.layers.0.mlp.experts.0.w3.weight": "W8A8_DYNAMIC",
+        }
+    )
+    dynamic_config.packed_modules_mapping = mapping
+    layer = _FusedMoEStub(_moe_config())
+
+    vllm_config = VllmConfig(device_config=DeviceConfig("cpu"))
+    with set_current_vllm_config(vllm_config):
+        method = dynamic_config.get_quant_method(
+            layer,
+            "model.layers.0.mlp.experts",
+        )
+
+        assert isinstance(method, AscendModelSlimW8A8DynamicMoEMethod)
+
+        float_config = AscendModelSlimConfig(
+            {
+                "model.layers.0.mlp.experts.0.w1.weight": "FLOAT",
+                "model.layers.0.mlp.experts.0.w2.weight": "FLOAT",
+                "model.layers.0.mlp.experts.0.w3.weight": "FLOAT",
+            }
+        )
+        float_config.packed_modules_mapping = mapping
+        assert isinstance(
+            float_config.get_quant_method(
+                layer,
+                "model.layers.0.mlp.experts",
+            ),
+            UnquantizedFusedMoEMethod,
+        )
+
+
+def test_static_w8a8_moe_is_rejected():
+    config = AscendModelSlimConfig(
+        {"model.layers.0.mlp.experts.weight": "W8A8"}
+    )
+    layer = _FusedMoEStub(_moe_config())
+
+    with pytest.raises(NotImplementedError, match="W8A8 MoE is not supported"):
+        config.get_quant_method(layer, "model.layers.0.mlp.experts")
+
+
+def test_dynamic_moe_weight_and_channel_loader_contract():
+    method = AscendModelSlimW8A8DynamicMoEMethod(_moe_config())
+    layer = _make_layer(method)
+
+    assert layer.w13_weight.shape == (2, 2, 2)
+    assert layer.w2_weight.shape == (2, 2, 1)
+    assert layer.w13_weight.dtype == torch.int8
+    assert layer.w2_weight.dtype == torch.int8
+    assert layer.w13_weight_scale.shape == (2, 2, 1)
+    assert layer.w13_weight_offset.shape == (2, 2, 1)
+    assert layer.w2_weight_scale.shape == (2, 2, 1)
+    assert layer.w2_weight_offset.shape == (2, 2, 1)
+    channel = FusedMoeWeightScaleSupported.CHANNEL.value
+    assert layer.w13_weight_scale.quant_method == channel
+    assert layer.w13_weight_offset.quant_method == channel
+    assert layer.w2_weight_scale.quant_method == channel
+    assert layer.w2_weight_offset.quant_method == channel
+    assert layer.w13_weight.weight_loader is _weight_loader
+
+
+def test_vllm_weight_loader_merges_w1_w3_channel_parameters():
+    method = AscendModelSlimW8A8DynamicMoEMethod(_moe_config())
+    layer = _FusedMoEStub(_moe_config())
+    layer.prefix = "model.layers.0.mlp.experts"
+    layer.quant_config = AscendModelSlimConfig({})
+    layer.quant_method = method
+    layer._expert_map = None
+    layer.moe_parallel_config = SimpleNamespace(tp_rank=0, tp_size=1)
+    method.create_weights(
+        layer,
+        num_experts=2,
+        hidden_size=2,
+        intermediate_size_per_partition=1,
+        params_dtype=torch.float32,
+        weight_loader=layer.weight_loader,
+    )
+    layer.w13_weight_scale.data.zero_()
+    layer.w13_weight_offset.data.zero_()
+    layer.w2_weight_scale.data.zero_()
+
+    layer.weight_loader(
+        layer.w13_weight_scale,
+        torch.tensor([[2.0]]),
+        "w13_weight_scale",
+        "w1",
+        expert_id=0,
+    )
+    layer.weight_loader(
+        layer.w13_weight_scale,
+        torch.tensor([[3.0]]),
+        "w13_weight_scale",
+        "w3",
+        expert_id=0,
+    )
+    layer.weight_loader(
+        layer.w13_weight_offset,
+        torch.zeros(1, 1),
+        "w13_weight_offset",
+        "w3",
+        expert_id=0,
+    )
+    layer.weight_loader(
+        layer.w2_weight_scale,
+        torch.tensor([[5.0], [7.0]]),
+        "w2_weight_scale",
+        "w2",
+        expert_id=0,
+    )
+
+    assert torch.equal(
+        layer.w13_weight_scale[0],
+        torch.tensor([[2.0], [3.0]]),
+    )
+    assert torch.equal(
+        layer.w2_weight_scale[0],
+        torch.tensor([[5.0], [7.0]]),
+    )
+
+
+def test_post_load_and_local_topk_accumulation(monkeypatch):
+    _mock_expert_kernels(monkeypatch)
+    method = AscendModelSlimW8A8DynamicMoEMethod(_moe_config())
+    layer = _make_layer(method)
+    _load_known_weights(layer)
+    method.process_weights_after_loading(layer)
+
+    assert layer.w13_weight.shape == (2, 2, 2)
+    assert layer.w2_weight.shape == (2, 1, 2)
+    assert layer.w13_weight_scale.shape == (2, 2)
+    assert layer.w2_weight_scale.shape == (2, 2)
+
+    output = method.apply(
+        layer,
+        torch.tensor([[2.0, 3.0], [5.0, 7.0]]),
+        topk_weights=torch.tensor([[0.25, 0.75], [0.4, 0.6]]),
+        topk_ids=torch.tensor([[0, 1], [0, 0]]),
+        shared_experts_input=None,
+    )
+
+    assert torch.allclose(
+        output,
+        torch.tensor([[21.25, 29.0], [25.0, 50.0]]),
+    )
+
+
+def test_expert_map_skips_non_local_experts(monkeypatch):
+    _mock_expert_kernels(monkeypatch)
+    method = AscendModelSlimW8A8DynamicMoEMethod(_moe_config())
+    layer = _make_layer(method)
+    _load_known_weights(layer)
+    method.process_weights_after_loading(layer)
+    # global expert 0 -> local 1, expert 1 is remote, expert 2 -> local 0
+    layer.expert_map = torch.tensor([1, -1, 0])
+
+    output = method.apply(
+        layer,
+        torch.tensor([[2.0, 3.0]]),
+        topk_weights=torch.tensor([[0.5, 0.25, 0.25]]),
+        topk_ids=torch.tensor([[0, 1, 2]]),
+        shared_experts_input=None,
+    )
+
+    assert torch.allclose(output, torch.tensor([[14.5, 20.0]]))
+
+
+def test_nonzero_moe_weight_offset_is_rejected(monkeypatch):
+    monkeypatch.setattr(moe, "_npu_format_nz", lambda tensor: tensor)
+    method = AscendModelSlimW8A8DynamicMoEMethod(_moe_config())
+    layer = _make_layer(method)
+    layer.w13_weight_offset.data.zero_()
+    layer.w2_weight_offset.data.zero_()
+    layer.w2_weight_offset.data[0, 0, 0] = 1
+
+    with pytest.raises(ValueError, match="symmetric weights only"):
+        method.process_weights_after_loading(layer)

--- a/tests/unit_tests/test_platform.py
+++ b/tests/unit_tests/test_platform.py
@@ -1,0 +1,201 @@
+"""Focused tests for platform-level Ascend graph-mode policy."""
+
+import ast
+import sys
+from enum import Enum
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+PLATFORM_PATH = Path(__file__).parents[2] / "vllm_fl" / "platform.py"
+
+
+class CompilationMode(Enum):
+    NONE = 0
+    VLLM_COMPILE = 1
+
+
+class CUDAGraphMode(Enum):
+    NONE = 0
+    PIECEWISE = 1
+    FULL = 2
+    FULL_DECODE_ONLY = 3
+
+    def has_full_cudagraphs(self):
+        return self in (self.FULL, self.FULL_DECODE_ONLY)
+
+
+def _load_platform_policy(monkeypatch):
+    module = ast.parse(PLATFORM_PATH.read_text())
+    platform_class = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "PlatformFL"
+    )
+    method = next(
+        node
+        for node in platform_class.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "check_and_update_config"
+    )
+    method.decorator_list = []
+
+    vllm_config = ModuleType("vllm.config")
+    vllm_config.CompilationMode = CompilationMode
+    vllm_config.CUDAGraphMode = CUDAGraphMode
+    monkeypatch.setitem(sys.modules, "vllm", ModuleType("vllm"))
+    monkeypatch.setitem(sys.modules, "vllm.config", vllm_config)
+
+    patch_module = ModuleType("vllm_fl.dispatch.backends.vendor.ascend.patch")
+    patch_module.refresh_block_size = lambda config: None
+    for name in (
+        "vllm_fl",
+        "vllm_fl.dispatch",
+        "vllm_fl.dispatch.backends",
+        "vllm_fl.dispatch.backends.vendor",
+        "vllm_fl.dispatch.backends.vendor.ascend",
+    ):
+        package = ModuleType(name)
+        package.__path__ = []
+        monkeypatch.setitem(sys.modules, name, package)
+    monkeypatch.setitem(sys.modules, patch_module.__name__, patch_module)
+
+    namespace = {
+        "logger": SimpleNamespace(
+            info=lambda *args, **kwargs: None,
+            warning=lambda *args, **kwargs: None,
+        )
+    }
+    exec(
+        compile(
+            ast.Module([method], type_ignores=[]),
+            str(PLATFORM_PATH),
+            "exec",
+        ),
+        namespace,
+    )
+    return namespace["check_and_update_config"]
+
+
+def _graph_config(cudagraph_mode, *, enforce_eager=False):
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(worker_cls=None, data_parallel_size=1),
+        model_config=SimpleNamespace(
+            use_mla=False,
+            enforce_eager=enforce_eager,
+        ),
+        cache_config=None,
+        scheduler_config=None,
+        compilation_config=SimpleNamespace(
+            compile_sizes=None,
+            mode=CompilationMode.VLLM_COMPILE,
+            cudagraph_mode=cudagraph_mode,
+            backend="inductor",
+            use_inductor=True,
+            splitting_ops=["vllm.unified_attention"],
+            pass_config=SimpleNamespace(
+                fuse_norm_quant=True,
+                fuse_act_quant=True,
+                fuse_attn_quant=True,
+            ),
+            cudagraph_num_of_warmups=0,
+        ),
+        attention_config=None,
+    )
+
+
+def test_npu_full_decode_uses_eager_graph_policy(monkeypatch):
+    policy = _load_platform_policy(monkeypatch)
+    config = _graph_config(CUDAGraphMode.FULL_DECODE_ONLY)
+
+    policy(SimpleNamespace(device_type="npu", vendor_name="ascend"), config)
+
+    compilation = config.compilation_config
+    assert compilation.mode == CompilationMode.VLLM_COMPILE
+    assert compilation.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY
+    assert compilation.backend == "eager"
+    assert compilation.use_inductor is False
+    assert compilation.splitting_ops == []
+    assert compilation.pass_config.fuse_norm_quant is False
+    assert compilation.pass_config.fuse_act_quant is False
+    assert compilation.pass_config.fuse_attn_quant is False
+    assert compilation.cudagraph_num_of_warmups == 1
+
+
+@pytest.mark.parametrize(
+    ("cudagraph_mode", "enforce_eager"),
+    [
+        (CUDAGraphMode.NONE, False),
+        (CUDAGraphMode.FULL_DECODE_ONLY, True),
+        (CUDAGraphMode.FULL, False),
+    ],
+)
+def test_npu_non_supported_graph_policy_falls_back_to_none(
+    monkeypatch, cudagraph_mode, enforce_eager
+):
+    policy = _load_platform_policy(monkeypatch)
+    config = _graph_config(cudagraph_mode, enforce_eager=enforce_eager)
+
+    policy(SimpleNamespace(device_type="npu", vendor_name="ascend"), config)
+
+    assert config.compilation_config.mode == CompilationMode.NONE
+    assert config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+
+
+@pytest.mark.parametrize(
+    ("device_type", "expected"),
+    [("npu", "eager"), ("cuda", "inductor"), ("musa", "inductor")],
+)
+def test_simple_compile_backend_is_eager_only_on_npu(device_type, expected):
+    module = ast.parse(PLATFORM_PATH.read_text())
+    platform_class = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "PlatformFL"
+    )
+    assignment = next(
+        node
+        for node in platform_class.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "simple_compile_backend"
+    )
+
+    value = eval(
+        compile(ast.Expression(assignment.value), str(PLATFORM_PATH), "eval"),
+        {"device_type": device_type},
+    )
+    assert value == expected
+
+
+def test_non_ascend_graph_capture_context_is_preserved():
+    model_runner_path = (
+        Path(__file__).parents[2] / "vllm_fl" / "worker" / "model_runner.py"
+    )
+    module = ast.parse(model_runner_path.read_text())
+    graph_capture_if = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(child, ast.FunctionDef) and child.name == "graph_capture"
+            for child in node.body
+        )
+    )
+    condition = compile(
+        ast.Expression(graph_capture_if.test), str(model_runner_path), "eval"
+    )
+
+    def uses_local_capture(device_type, dist_backend="nccl"):
+        platform = SimpleNamespace(
+            device_type=device_type,
+            dist_backend=dist_backend,
+        )
+        return eval(condition, {"current_platform": platform})
+
+    assert uses_local_capture("npu", "hccl") is False
+    assert uses_local_capture("cuda", "nccl") is False
+    assert uses_local_capture("musa", "mccl") is True
+    assert uses_local_capture("cuda", "flagcx") is True

--- a/tests/unit_tests/test_platform.py
+++ b/tests/unit_tests/test_platform.py
@@ -199,3 +199,62 @@ def test_non_ascend_graph_capture_context_is_preserved():
     assert uses_local_capture("cuda", "nccl") is False
     assert uses_local_capture("musa", "mccl") is True
     assert uses_local_capture("cuda", "flagcx") is True
+
+
+def test_npu_pre_register_adds_ascend_quantization_choice(monkeypatch):
+    module = ast.parse(PLATFORM_PATH.read_text())
+    platform_class = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "PlatformFL"
+    )
+    method = next(
+        node
+        for node in platform_class.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "pre_register_and_update"
+    )
+    method.decorator_list = []
+
+    for name in (
+        "vllm_fl",
+        "vllm_fl.dispatch",
+        "vllm_fl.dispatch.backends",
+        "vllm_fl.dispatch.backends.vendor",
+        "vllm_fl.dispatch.backends.vendor.ascend",
+        "vllm_fl.quantization",
+    ):
+        package = ModuleType(name)
+        package.__path__ = []
+        monkeypatch.setitem(sys.modules, name, package)
+    modelslim = ModuleType("vllm_fl.quantization.modelslim")
+    modelslim.ASCEND_QUANTIZATION_METHOD = "ascend"
+    modelslim.AscendModelSlimConfig = type("AscendModelSlimConfig", (), {})
+    monkeypatch.setitem(sys.modules, modelslim.__name__, modelslim)
+
+    namespace = {}
+    exec(
+        compile(
+            ast.Module([method], type_ignores=[]),
+            str(PLATFORM_PATH),
+            "exec",
+        ),
+        namespace,
+    )
+    choices = ["compressed-tensors"]
+    parser = SimpleNamespace(
+        _option_string_actions={
+            "--quantization": SimpleNamespace(choices=choices),
+        }
+    )
+
+    namespace["pre_register_and_update"](
+        SimpleNamespace(device_name="npu"),
+        parser,
+    )
+    namespace["pre_register_and_update"](
+        SimpleNamespace(device_name="npu"),
+        parser,
+    )
+
+    assert choices == ["compressed-tensors", "ascend"]

--- a/vllm_fl/compilation/graph.py
+++ b/vllm_fl/compilation/graph.py
@@ -27,6 +27,11 @@ from vllm.forward_context import (
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
+from vllm_fl.compilation.graph_runtime import (
+    get_graph_class,
+    get_graph_runtime_backend,
+)
+
 logger = init_logger(__name__)
 
 
@@ -41,20 +46,11 @@ def weak_ref_tensors(tensor: Any) -> Any:
 
 # FL-specific: platform-agnostic graph class selection
 class Graph:
-    if current_platform.device_type == "cuda":
-        graph = torch.cuda.CUDAGraph
-    elif current_platform.device_type == "npu":
-        graph = torch.npu.NPUGraph
-    elif current_platform.device_type == "musa":
-        graph = torch.musa.MUSAGraph
-    elif current_platform.device_type == "ptpu":
-        graph = torch.ptpu.PTPUGraph
-    elif current_platform.device_type == "gcu":
-        graph = torch.gcu.GCUGraph
-    elif current_platform.device_type == "txda":
-        graph = None
-    else:
-        raise NotImplementedError("not support graph")
+    @staticmethod
+    def graph() -> Any:
+        # Resolve lazily so importing worker modules does not require an
+        # initialized accelerator runtime (for example in CPU-only unit tests).
+        return get_graph_class()()
 
 
 # Re-export CUDAGraphStat for compatibility
@@ -100,6 +96,7 @@ class GraphWrapper:
         self.vllm_config = vllm_config
         self.runtime_mode = runtime_mode
         self.compilation_config = vllm_config.compilation_config
+        self.graph_runtime = get_graph_runtime_backend()
 
         self.first_run_finished = False
         self.is_debugging_mode = envs.VLLM_LOGGING_LEVEL == "DEBUG"
@@ -151,6 +148,7 @@ class GraphWrapper:
             return self.runnable(*args, **kwargs)
 
         forward_context = get_forward_context()
+        self.graph_runtime.prepare_forward_context(forward_context)
         batch_descriptor = forward_context.batch_descriptor
         graph_runtime_mode = forward_context.cudagraph_runtime_mode
 
@@ -207,19 +205,25 @@ class GraphWrapper:
                 pass
 
             # FL-specific: use platform-agnostic graph capture
-            with current_platform.torch_device_fn.graph(
-                graph, pool=self.graph_pool
-            ):
-                # `output` is managed by pytorch's cudagraph pool
-                output = self.runnable(*args, **kwargs)
-                # Join offloader's copy stream after forward if available
-                try:
-                    from vllm.model_executor.offloader.base import get_offloader
-                    get_offloader().join_after_forward()
-                except (ImportError, RuntimeError):
-                    pass
-                if self.cudagraph_options.weak_ref_output:
-                    output = weak_ref_tensors(output)
+            self.graph_runtime.begin_capture(forward_context)
+            try:
+                with current_platform.torch_device_fn.graph(
+                    graph, pool=self.graph_pool
+                ):
+                    # `output` is managed by pytorch's cudagraph pool
+                    output = self.runnable(*args, **kwargs)
+                    # Join offloader's copy stream after forward if available
+                    try:
+                        from vllm.model_executor.offloader.base import get_offloader
+                        get_offloader().join_after_forward()
+                    except (ImportError, RuntimeError):
+                        pass
+                    if self.cudagraph_options.weak_ref_output:
+                        output = weak_ref_tensors(output)
+            finally:
+                self.graph_runtime.end_capture()
+
+            self.graph_runtime.after_capture()
 
             entry.output = weak_ref_tensors(output)
             entry.graph = graph
@@ -249,7 +253,6 @@ class GraphWrapper:
         except (ImportError, RuntimeError):
             pass
 
-        if current_platform.device_type == "npu":
-            current_platform.torch_device_fn.synchronize()
+        self.graph_runtime.before_replay()
         entry.graph.replay()
         return entry.output

--- a/vllm_fl/compilation/graph_runtime.py
+++ b/vllm_fl/compilation/graph_runtime.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device-specific lifecycle hooks for static graph execution."""
+
+from contextlib import contextmanager, nullcontext
+from typing import Any
+
+import torch
+
+from vllm.distributed.parallel_state import (
+    GraphCaptureContext,
+)
+from vllm.platforms import current_platform
+
+
+_GRAPH_CLASS_NAMES = {
+    "cuda": "CUDAGraph",
+    "npu": "NPUGraph",
+    "musa": "MUSAGraph",
+    "ptpu": "PTPUGraph",
+    "gcu": "GCUGraph",
+}
+
+
+@contextmanager
+def _ascend_graph_capture(device: torch.device):
+    """Capture an NPUGraph on a stream isolated from the default stream."""
+    capture_context = GraphCaptureContext(
+        current_platform.torch_device_fn.Stream(device=device)
+    )
+    stream = capture_context.stream
+    current_stream = current_platform.torch_device_fn.current_stream()
+    if current_stream != stream:
+        stream.wait_stream(current_stream)
+
+    with current_platform.torch_device_fn.stream(stream), nullcontext():
+        yield capture_context
+
+
+def get_graph_capture(default_capture: Any) -> Any:
+    """Override graph capture only for Ascend; preserve other vendors."""
+    if current_platform.device_type == "npu":
+        return _ascend_graph_capture
+    return default_capture
+
+
+def get_graph_class(device_type: str | None = None) -> Any:
+    """Resolve the torch graph class for the active accelerator."""
+    device_type = device_type or current_platform.device_type
+    if device_type == "txda":
+        return None
+    graph_class_name = _GRAPH_CLASS_NAMES.get(device_type)
+    if graph_class_name is None:
+        raise NotImplementedError(
+            f"Static graph is not supported on device type {device_type!r}"
+        )
+    try:
+        return getattr(getattr(torch, device_type), graph_class_name)
+    except AttributeError as exc:
+        raise NotImplementedError(
+            f"Torch does not provide {graph_class_name} for {device_type!r}"
+        ) from exc
+
+
+class GraphRuntimeBackend:
+    """No-op lifecycle hooks shared by graph-capable accelerators."""
+
+    def prepare_forward_context(self, forward_context: Any) -> None:
+        pass
+
+    def begin_capture(self, forward_context: Any) -> None:
+        pass
+
+    def end_capture(self) -> None:
+        pass
+
+    def after_capture(self) -> None:
+        pass
+
+    def before_replay(self) -> None:
+        pass
+
+
+class AscendGraphRuntimeBackend(GraphRuntimeBackend):
+    """Ascend synchronization around NPUGraph replay."""
+
+    def before_replay(self) -> None:
+        current_platform.torch_device_fn.synchronize()
+
+
+_GRAPH_RUNTIME_BACKENDS: dict[str, type[GraphRuntimeBackend]] = {
+    "npu": AscendGraphRuntimeBackend,
+}
+
+
+def get_graph_runtime_backend(
+    device_type: str | None = None,
+) -> GraphRuntimeBackend:
+    """Create lifecycle hooks for the active accelerator."""
+    device_type = device_type or current_platform.device_type
+    backend_cls = _GRAPH_RUNTIME_BACKENDS.get(device_type, GraphRuntimeBackend)
+    return backend_cls()

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/quantization/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/quantization/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ascend-specific quantization methods and kernels."""
+
+from .linear import AscendModelSlimLinearMethod
+from .moe import AscendModelSlimW8A8DynamicMoEMethod
+from .w8a8 import (
+    AscendW8A8DynamicLinearScheme,
+    AscendW8A8StaticLinearScheme,
+    get_w8a8_linear_scheme,
+)
+
+__all__ = [
+    "AscendModelSlimLinearMethod",
+    "AscendModelSlimW8A8DynamicMoEMethod",
+    "AscendW8A8DynamicLinearScheme",
+    "AscendW8A8StaticLinearScheme",
+    "get_w8a8_linear_scheme",
+]

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/quantization/linear.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/quantization/linear.py
@@ -1,0 +1,102 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""vLLM LinearMethod adapter for Ascend ModelSlim schemes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from vllm.distributed import get_tensor_model_parallel_rank
+from vllm.model_executor.layers.linear import LinearMethodBase, RowParallelLinear
+from vllm.model_executor.parameter import PerTensorScaleParameter
+from vllm.model_executor.utils import set_weight_attrs
+
+if TYPE_CHECKING:
+    from .w8a8 import AscendW8A8LinearScheme
+
+
+class AscendModelSlimLinearMethod(LinearMethodBase):
+    """Delegate vLLM's loading lifecycle to one Ascend W8A8 scheme."""
+
+    def __init__(self, scheme: AscendW8A8LinearScheme) -> None:
+        self.scheme = scheme
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del input_size, output_size
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        if weight_loader is None:
+            raise ValueError("ModelSlim Linear requires a vLLM weight_loader")
+
+        weight_specs = self.scheme.get_weight(
+            input_size_per_partition,
+            output_size_per_partition,
+            params_dtype,
+        )
+        for name, tensor in weight_specs.items():
+            parameter = torch.nn.Parameter(tensor, requires_grad=False)
+            set_weight_attrs(parameter, {"input_dim": 1, "output_dim": 0})
+            set_weight_attrs(parameter, extra_weight_attrs)
+            layer.register_parameter(name, parameter)
+
+        tensor_specs = self.scheme.get_pertensor_params(
+            params_dtype,
+            num_partitions=len(output_partition_sizes),
+        )
+        for name, tensor in tensor_specs.items():
+            parameter = PerTensorScaleParameter(
+                data=tensor,
+                weight_loader=weight_loader,
+            )
+            parameter.ignore_warning = True
+            layer.register_parameter(name, parameter)
+
+        channel_specs = self.scheme.get_perchannel_params(
+            output_size_per_partition,
+            params_dtype,
+        )
+        for name, tensor in channel_specs.items():
+            parameter = torch.nn.Parameter(tensor, requires_grad=False)
+            set_weight_attrs(parameter, {"output_dim": 0})
+            set_weight_attrs(parameter, extra_weight_attrs)
+            layer.register_parameter(name, parameter)
+
+        layer.ascend_quant_method = "ascend"
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.scheme.process_weights_after_loading(layer)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        tp_rank = (
+            get_tensor_model_parallel_rank()
+            if isinstance(layer, RowParallelLinear)
+            else 0
+        )
+        return self.scheme.apply(layer, x, bias=bias, tp_rank=tp_rank)

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/quantization/moe.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/quantization/moe.py
@@ -1,0 +1,265 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ascend ModelSlim Dynamic W8A8 MoE method.
+
+Routing and distributed output reduction stay in vLLM's ``MoERunner``. This
+module owns only the ModelSlim expert parameter layout and the Ascend expert
+compute path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoE,
+    FusedMoeWeightScaleSupported,
+)
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
+    FusedMoEMethodBase,
+)
+from vllm.model_executor.utils import set_weight_attrs
+
+from .w8a8 import _npu_dynamic_quant, _npu_format_nz, _npu_quant_matmul
+
+if TYPE_CHECKING:
+    from vllm.model_executor.layers.fused_moe.config import (
+        FusedMoEConfig,
+        FusedMoEQuantConfig,
+    )
+    from vllm.model_executor.layers.fused_moe.modular_kernel import (
+        FusedMoEPrepareAndFinalizeModular,
+    )
+
+
+def _npu_moe_activation(
+    activation: MoEActivation,
+    gate_up: torch.Tensor,
+) -> torch.Tensor:
+    import torch_npu
+
+    if activation == MoEActivation.SILU:
+        return torch_npu.npu_swiglu(gate_up)
+    if activation == MoEActivation.GELU:
+        return torch_npu.npu_gelu_mul(gate_up)
+    raise NotImplementedError(
+        "Ascend ModelSlim Dynamic W8A8 MoE supports only silu and gelu "
+        f"gated activations, got {activation.value!r}"
+    )
+
+
+def _require_zero_moe_weight_offsets(layer: torch.nn.Module) -> None:
+    for name in ("w13_weight_offset", "w2_weight_offset"):
+        offset = getattr(layer, name)
+        if torch.count_nonzero(offset.detach()).item() != 0:
+            raise ValueError(
+                f"ModelSlim MoE layer {getattr(layer, 'prefix', '<unknown>')!r} "
+                f"uses non-zero {name}, but the Ascend Dynamic W8A8 MoE "
+                "kernel supports symmetric weights only"
+            )
+
+
+class AscendModelSlimW8A8DynamicMoEMethod(FusedMoEMethodBase):
+    """Dynamic per-token activation and per-channel INT8 expert weights."""
+
+    def __init__(self, moe: FusedMoEConfig) -> None:
+        super().__init__(moe)
+        if not moe.is_act_and_mul:
+            raise NotImplementedError(
+                "Ascend ModelSlim Dynamic W8A8 MoE requires gated activation"
+            )
+        if moe.has_bias:
+            raise NotImplementedError(
+                "Ascend ModelSlim Dynamic W8A8 MoE does not support expert bias"
+            )
+        if moe.is_lora_enabled:
+            raise NotImplementedError(
+                "Ascend ModelSlim Dynamic W8A8 MoE does not support LoRA"
+            )
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        weight_specs = {
+            "w13_weight": torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                hidden_size,
+                dtype=torch.int8,
+            ),
+            "w2_weight": torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition,
+                dtype=torch.int8,
+            ),
+        }
+        for name, tensor in weight_specs.items():
+            parameter = torch.nn.Parameter(tensor, requires_grad=False)
+            set_weight_attrs(parameter, extra_weight_attrs)
+            layer.register_parameter(name, parameter)
+
+        channel_specs = {
+            "w13_weight_scale": torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                1,
+                dtype=params_dtype,
+            ),
+            "w13_weight_offset": torch.empty(
+                num_experts,
+                2 * intermediate_size_per_partition,
+                1,
+                dtype=params_dtype,
+            ),
+            "w2_weight_scale": torch.empty(
+                num_experts,
+                hidden_size,
+                1,
+                dtype=params_dtype,
+            ),
+            "w2_weight_offset": torch.empty(
+                num_experts,
+                hidden_size,
+                1,
+                dtype=params_dtype,
+            ),
+        }
+        channel_attrs = dict(extra_weight_attrs)
+        channel_attrs["quant_method"] = (
+            FusedMoeWeightScaleSupported.CHANNEL.value
+        )
+        for name, tensor in channel_specs.items():
+            parameter = torch.nn.Parameter(tensor, requires_grad=False)
+            set_weight_attrs(parameter, channel_attrs)
+            layer.register_parameter(name, parameter)
+
+    def process_weights_after_loading(self, layer: FusedMoE) -> None:
+        _require_zero_moe_weight_offsets(layer)
+        layer.w13_weight.data = _npu_format_nz(
+            layer.w13_weight.data.transpose(1, 2).contiguous()
+        )
+        layer.w2_weight.data = _npu_format_nz(
+            layer.w2_weight.data.transpose(1, 2).contiguous()
+        )
+        layer.w13_weight_scale.data = layer.w13_weight_scale.data.flatten(1)
+        layer.w13_weight_offset.data = layer.w13_weight_offset.data.flatten(1)
+        layer.w2_weight_scale.data = layer.w2_weight_scale.data.flatten(1)
+        layer.w2_weight_offset.data = layer.w2_weight_offset.data.flatten(1)
+
+    def get_fused_moe_quant_config(
+        self,
+        layer: torch.nn.Module,
+    ) -> FusedMoEQuantConfig | None:
+        del layer
+        return None
+
+    def maybe_make_prepare_finalize(
+        self,
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+        | None = None,
+    ) -> FusedMoEPrepareAndFinalizeModular | None:
+        del routing_tables
+        # This method uses vLLM's router and reduction, but owns expert compute.
+        return None
+
+    def _apply_expert(
+        self,
+        layer: FusedMoE,
+        expert_idx: int,
+        expert_input: torch.Tensor,
+    ) -> torch.Tensor:
+        quantized_input, input_scale = _npu_dynamic_quant(expert_input)
+        gate_up = _npu_quant_matmul(
+            quantized_input,
+            layer.w13_weight[expert_idx],
+            layer.w13_weight_scale[expert_idx],
+            pertoken_scale=input_scale.reshape(-1),
+            output_dtype=expert_input.dtype,
+        )
+        activated = _npu_moe_activation(layer.activation, gate_up)
+        quantized_hidden, hidden_scale = _npu_dynamic_quant(activated)
+        return _npu_quant_matmul(
+            quantized_hidden,
+            layer.w2_weight[expert_idx],
+            layer.w2_weight_scale[expert_idx],
+            pertoken_scale=hidden_scale.reshape(-1),
+            output_dtype=expert_input.dtype,
+        )
+
+    def apply(
+        self,
+        layer: FusedMoE,
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor:
+        del shared_experts_input
+        if x.ndim != 2:
+            raise ValueError(
+                "Ascend ModelSlim Dynamic W8A8 MoE expects 2D hidden states, "
+                f"got shape {tuple(x.shape)}"
+            )
+        if topk_weights.shape != topk_ids.shape:
+            raise ValueError(
+                "ModelSlim MoE topk_weights and topk_ids must have equal shapes"
+            )
+
+        if layer.expert_map is None:
+            local_topk_ids = topk_ids.long()
+        else:
+            local_topk_ids = layer.expert_map[topk_ids.long()]
+
+        output = x.new_zeros((x.shape[0], layer.w2_weight.shape[-1]))
+        num_local_experts = layer.w13_weight.shape[0]
+        for expert_idx in range(num_local_experts):
+            token_indices, topk_indices = torch.where(
+                local_topk_ids == expert_idx
+            )
+            if token_indices.numel() == 0:
+                continue
+
+            expert_input = x.index_select(0, token_indices)
+            routing_weight = topk_weights[
+                token_indices,
+                topk_indices,
+            ].unsqueeze(-1)
+            if layer.apply_router_weight_on_input:
+                expert_input = expert_input * routing_weight.to(x.dtype)
+
+            expert_output = self._apply_expert(
+                layer,
+                expert_idx,
+                expert_input,
+            )
+            if not layer.apply_router_weight_on_input:
+                expert_output = expert_output * routing_weight.to(
+                    expert_output.dtype
+                )
+            output.index_add_(0, token_indices, expert_output)
+
+        return output
+
+
+__all__ = ["AscendModelSlimW8A8DynamicMoEMethod"]

--- a/vllm_fl/dispatch/backends/vendor/ascend/impl/quantization/w8a8.py
+++ b/vllm_fl/dispatch/backends/vendor/ascend/impl/quantization/w8a8.py
@@ -1,0 +1,310 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ascend ModelSlim W8A8 static and dynamic Linear schemes."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import torch
+
+_ACL_FORMAT_FRACTAL_NZ = 29
+
+
+def _npu_format_nz(weight: torch.Tensor) -> torch.Tensor:
+    import torch_npu
+
+    return torch_npu.npu_format_cast(weight, _ACL_FORMAT_FRACTAL_NZ)
+
+
+def _npu_static_quant(
+    x: torch.Tensor,
+    scale_reciprocal: torch.Tensor,
+    offset: torch.Tensor,
+) -> torch.Tensor:
+    import torch_npu
+
+    return torch_npu.npu_quantize(
+        x,
+        scale_reciprocal,
+        offset,
+        torch.qint8,
+        -1,
+        False,
+    )
+
+
+def _npu_dynamic_quant(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    import torch_npu
+
+    return torch_npu.npu_dynamic_quant(x)
+
+
+def _npu_quant_matmul(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    **kwargs: Any,
+) -> torch.Tensor:
+    import torch_npu
+
+    return torch_npu.npu_quant_matmul(x, weight, scale, **kwargs)
+
+
+def _require_zero_weight_offset(layer: torch.nn.Module) -> None:
+    offset = getattr(layer, "weight_offset", None)
+    if offset is None:
+        return
+    if torch.count_nonzero(offset.detach()).item() != 0:
+        raise ValueError(
+            f"ModelSlim layer {getattr(layer, 'prefix', '<unknown>')!r} uses "
+            "non-zero weight_offset, but the Ascend W8A8 Linear kernel "
+            "supports symmetric weights only"
+        )
+
+
+class AscendW8A8LinearScheme(ABC):
+    @abstractmethod
+    def get_weight(
+        self,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> dict[str, torch.Tensor]: ...
+
+    def get_pertensor_params(
+        self,
+        params_dtype: torch.dtype,
+        *,
+        num_partitions: int,
+    ) -> dict[str, torch.Tensor]:
+        del params_dtype, num_partitions
+        return {}
+
+    @abstractmethod
+    def get_perchannel_params(
+        self,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> dict[str, torch.Tensor]: ...
+
+    @abstractmethod
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None: ...
+
+    @abstractmethod
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        tp_rank: int = 0,
+    ) -> torch.Tensor: ...
+
+
+class AscendW8A8StaticLinearScheme(AscendW8A8LinearScheme):
+    """Static per-tensor activation and per-channel INT8 weight Linear."""
+
+    def get_weight(
+        self,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> dict[str, torch.Tensor]:
+        del params_dtype
+        return {
+            "weight": torch.empty(output_size, input_size, dtype=torch.int8)
+        }
+
+    def get_pertensor_params(
+        self,
+        params_dtype: torch.dtype,
+        *,
+        num_partitions: int,
+    ) -> dict[str, torch.Tensor]:
+        return {
+            "input_scale": torch.empty(num_partitions, dtype=params_dtype),
+            "input_offset": torch.empty(num_partitions, dtype=torch.int8),
+        }
+
+    def get_perchannel_params(
+        self,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> dict[str, torch.Tensor]:
+        if params_dtype == torch.bfloat16:
+            deq_dtype = torch.float32
+        elif params_dtype == torch.float16:
+            deq_dtype = torch.int64
+        else:
+            raise ValueError(
+                f"Static ModelSlim W8A8 does not support dtype {params_dtype}"
+            )
+        return {
+            "quant_bias": torch.empty(output_size, dtype=torch.int32),
+            "deq_scale": torch.empty(output_size, dtype=deq_dtype),
+            "weight_scale": torch.empty(
+                output_size,
+                1,
+                dtype=params_dtype,
+            ),
+            "weight_offset": torch.empty(
+                output_size,
+                1,
+                dtype=params_dtype,
+            ),
+        }
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        input_scale = layer.input_scale.detach().flatten()
+        input_offset = layer.input_offset.detach().flatten()
+        if input_scale.numel() > 1 and not torch.allclose(
+            input_scale,
+            input_scale[0].expand_as(input_scale),
+        ):
+            raise ValueError(
+                f"Packed ModelSlim layer {getattr(layer, 'prefix', '<unknown>')!r} "
+                "has different static input scales across shards"
+            )
+        if input_offset.numel() > 1 and not torch.equal(
+            input_offset,
+            input_offset[0].expand_as(input_offset),
+        ):
+            raise ValueError(
+                f"Packed ModelSlim layer {getattr(layer, 'prefix', '<unknown>')!r} "
+                "has different static input offsets across shards"
+            )
+
+        input_size = layer.weight.shape[1]
+        scale = input_scale[:1].repeat(input_size)
+        offset = input_offset[:1].repeat(input_size).to(scale.dtype)
+        layer.aclnn_input_scale = torch.nn.Parameter(scale, requires_grad=False)
+        layer.aclnn_input_scale_reciprocal = torch.nn.Parameter(
+            scale.reciprocal(),
+            requires_grad=False,
+        )
+        layer.aclnn_input_offset = torch.nn.Parameter(
+            offset,
+            requires_grad=False,
+        )
+
+        _require_zero_weight_offset(layer)
+        layer.weight.data = _npu_format_nz(
+            layer.weight.data.transpose(0, 1).contiguous()
+        )
+        layer.weight_scale.data = layer.weight_scale.data.flatten()
+        layer.weight_offset.data = layer.weight_offset.data.flatten()
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        tp_rank: int = 0,
+    ) -> torch.Tensor:
+        del bias
+        if x.dtype != torch.int8:
+            x = _npu_static_quant(
+                x,
+                layer.aclnn_input_scale_reciprocal,
+                layer.aclnn_input_offset,
+            )
+        quant_bias = layer.quant_bias if tp_rank == 0 else None
+        return _npu_quant_matmul(
+            x,
+            layer.weight,
+            layer.deq_scale,
+            bias=quant_bias,
+            output_dtype=layer.params_dtype,
+        )
+
+
+class AscendW8A8DynamicLinearScheme(AscendW8A8LinearScheme):
+    """Dynamic per-token activation and per-channel INT8 weight Linear."""
+
+    def get_weight(
+        self,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> dict[str, torch.Tensor]:
+        del params_dtype
+        return {
+            "weight": torch.empty(output_size, input_size, dtype=torch.int8)
+        }
+
+    def get_perchannel_params(
+        self,
+        output_size: int,
+        params_dtype: torch.dtype,
+    ) -> dict[str, torch.Tensor]:
+        return {
+            "weight_scale": torch.empty(
+                output_size,
+                1,
+                dtype=params_dtype,
+            ),
+            "weight_offset": torch.empty(
+                output_size,
+                1,
+                dtype=params_dtype,
+            ),
+        }
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        _require_zero_weight_offset(layer)
+        layer.weight.data = _npu_format_nz(
+            layer.weight.data.transpose(0, 1).contiguous()
+        )
+        layer.weight_scale.data = layer.weight_scale.data.flatten()
+        layer.weight_scale_fp32 = layer.weight_scale.data.float()
+        layer.weight_offset.data = layer.weight_offset.data.flatten()
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+        tp_rank: int = 0,
+    ) -> torch.Tensor:
+        del tp_rank
+        output_shape = x.shape[:-1]
+        flattened_x = x.reshape(-1, x.shape[-1])
+        quantized_x, pertoken_scale = _npu_dynamic_quant(flattened_x)
+        output = _npu_quant_matmul(
+            quantized_x,
+            layer.weight,
+            layer.weight_scale,
+            pertoken_scale=pertoken_scale.reshape(-1),
+            bias=bias,
+            output_dtype=x.dtype,
+        )
+        return output.reshape(*output_shape, output.shape[-1])
+
+
+_LINEAR_SCHEMES: dict[str, type[AscendW8A8LinearScheme]] = {
+    "W8A8": AscendW8A8StaticLinearScheme,
+    "W8A8_DYNAMIC": AscendW8A8DynamicLinearScheme,
+}
+
+
+def get_w8a8_linear_scheme(quant_type: str) -> AscendW8A8LinearScheme:
+    try:
+        scheme_cls = _LINEAR_SCHEMES[quant_type]
+    except KeyError as exc:
+        raise NotImplementedError(
+            f"No Ascend ModelSlim Linear scheme is registered for {quant_type!r}"
+        ) from exc
+    return scheme_cls()

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -81,6 +81,9 @@ class PlatformFL(Platform):
     device_type = device_info.device_type
     dispatch_key = device_info.dispatch_key
     torch_device_fn = device_info.torch_device_fn
+    # NPU Inductor is not part of FL's Ascend graph path. Keep independently
+    # decorated helper functions on the eager backend.
+    simple_compile_backend: str = "eager" if device_type == "npu" else "inductor"
     ray_device_key: str = "GPU"
     dist_backend: str = (
         "flagcx"
@@ -241,17 +244,35 @@ class PlatformFL(Platform):
         if compilation_config.compile_sizes is None:
             compilation_config.compile_sizes = []
 
-        # Ascend NPU: torch_npu inductor codegen has issues with
-        # multi-device compilation (e.g. reduction scheduling on npu:1).
-        # Disable torch.compile and CUDAGraphs until torch_npu inductor
-        # is stable. check_and_update_config runs after VllmConfig.__init__
-        # processes enforce_eager, so we must set compilation_config directly.
         if cls.device_type == "npu":
             from vllm.config import CompilationMode
-            if compilation_config.mode != CompilationMode.NONE:
+
+            enforce_eager = bool(
+                model_config is not None
+                and getattr(model_config, "enforce_eager", False)
+            )
+            if enforce_eager or compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
+                compilation_config.mode = CompilationMode.NONE
+                compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+            elif compilation_config.cudagraph_mode == CUDAGraphMode.FULL_DECODE_ONLY:
+                compilation_config.mode = CompilationMode.VLLM_COMPILE
+                compilation_config.backend = "eager"
+                compilation_config.use_inductor = False
+                compilation_config.splitting_ops = []
+                # These post-passes are CUDA/Inductor-specific. The eager FX
+                # graph is used only to drive the existing NPUGraph wrapper.
+                compilation_config.pass_config.fuse_norm_quant = False
+                compilation_config.pass_config.fuse_act_quant = False
+                compilation_config.pass_config.fuse_attn_quant = False
+                compilation_config.cudagraph_num_of_warmups = 1
+                logger.info(
+                    "Enabling Ascend FULL_DECODE_ONLY with eager FX and NPUGraph."
+                )
+            else:
                 logger.warning(
-                    "Disabling torch.compile for Ascend NPU to avoid "
-                    "torch_npu inductor codegen issues."
+                    "Ascend FL currently supports only NONE or "
+                    "FULL_DECODE_ONLY graph mode; falling back to NONE from %s.",
+                    compilation_config.cudagraph_mode,
                 )
                 compilation_config.mode = CompilationMode.NONE
                 compilation_config.cudagraph_mode = CUDAGraphMode.NONE

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -483,6 +483,19 @@ class PlatformFL(Platform):
     def pre_register_and_update(cls, parser=None) -> None:
         if cls.device_name == "npu":
             import vllm_fl.dispatch.backends.vendor.ascend
+
+            # Register the ModelSlim config before VllmConfig validates the
+            # command-line quantization method.
+            from vllm_fl.quantization.modelslim import (
+                ASCEND_QUANTIZATION_METHOD,
+                AscendModelSlimConfig,  # noqa: F401
+            )
+
+            if parser is not None:
+                quant_action = parser._option_string_actions.get("--quantization")
+                choices = getattr(quant_action, "choices", None)
+                if choices and ASCEND_QUANTIZATION_METHOD not in choices:
+                    choices.append(ASCEND_QUANTIZATION_METHOD)
         elif cls.device_name == "gcu":
             import vllm_fl.dispatch.backends.vendor.gcu  # noqa: F401
 

--- a/vllm_fl/quantization/modelslim/__init__.py
+++ b/vllm_fl/quantization/modelslim/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ascend ModelSlim quantization support."""
+
+from .config import (
+    ASCEND_QUANTIZATION_METHOD,
+    MODELSLIM_CONFIG_FILENAME,
+    AscendModelSlimConfig,
+    register_modelslim_prefix_mapper,
+    resolve_linear_quant_type,
+)
+
+__all__ = [
+    "ASCEND_QUANTIZATION_METHOD",
+    "MODELSLIM_CONFIG_FILENAME",
+    "AscendModelSlimConfig",
+    "register_modelslim_prefix_mapper",
+    "resolve_linear_quant_type",
+]

--- a/vllm_fl/quantization/modelslim/config.py
+++ b/vllm_fl/quantization/modelslim/config.py
@@ -1,0 +1,328 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ModelSlim descriptor parsing and vLLM quantization registration.
+
+The implementation follows the ModelSlim contract used by vLLM-Ascend
+v0.20.2rc1, while keeping model-specific name mapping and NPU kernels outside
+the descriptor layer.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import torch
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization import register_quantization_config
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
+    from vllm.model_executor.models.utils import WeightsMapper
+
+ASCEND_QUANTIZATION_METHOD = "ascend"
+MODELSLIM_CONFIG_FILENAME = "quant_model_description.json"
+
+_SUPPORTED_LINEAR_QUANT_TYPES = frozenset({"FLOAT", "W8A8", "W8A8_DYNAMIC"})
+_PREFIX_MAPPERS: dict[str, Callable[[str], str]] = {}
+
+logger = init_logger(__name__)
+
+
+def register_modelslim_prefix_mapper(
+    model_type: str,
+    mapper: Callable[[str], str],
+    *,
+    replace: bool = False,
+) -> None:
+    """Register a model-owned descriptor-prefix adapter.
+
+    The generic quantization implementation does not contain model-name
+    branches. Models whose checkpoint names cannot be expressed by vLLM's
+    ``WeightsMapper`` can register one focused adapter during model setup.
+    """
+
+    if not model_type:
+        raise ValueError("model_type must be non-empty")
+    if model_type in _PREFIX_MAPPERS and not replace:
+        raise ValueError(f"ModelSlim prefix mapper already registered: {model_type}")
+    _PREFIX_MAPPERS[model_type] = mapper
+
+
+def _normalize_quant_description(config: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(config, Mapping):
+        raise TypeError("ModelSlim quantization config must be a mapping")
+
+    normalized = dict(config)
+    for key, value in tuple(config.items()):
+        if not isinstance(key, str):
+            raise TypeError("ModelSlim quantization config keys must be strings")
+        if "weight_packed" not in key:
+            continue
+        alias = key.replace("weight_packed", "weight")
+        previous = normalized.get(alias, value)
+        if previous != value:
+            raise ValueError(
+                f"Conflicting ModelSlim descriptor aliases: {key!r} and {alias!r}"
+            )
+        normalized[alias] = value
+    return normalized
+
+
+def _packed_shard_prefixes(
+    prefix: str,
+    packed_modules_mapping: Mapping[str, list[str]],
+) -> list[str]:
+    parent, separator, projection = prefix.rpartition(".")
+    shards = packed_modules_mapping.get(projection)
+    if not shards:
+        return [prefix]
+    base = f"{parent}{separator}" if separator else ""
+    return [f"{base}{shard}" for shard in shards]
+
+
+def resolve_linear_quant_type(
+    quant_description: Mapping[str, Any],
+    prefix: str,
+    packed_modules_mapping: Mapping[str, list[str]] | None = None,
+) -> str:
+    """Resolve one linear/MoE prefix to a single ModelSlim quant type."""
+
+    mapping = packed_modules_mapping or {}
+    shard_prefixes = _packed_shard_prefixes(prefix, mapping)
+    resolved: list[tuple[str, str]] = []
+    for shard_prefix in shard_prefixes:
+        key = f"{shard_prefix}.weight"
+        if key not in quant_description:
+            raise ValueError(
+                f"ModelSlim descriptor has no quantization entry for {key!r}"
+            )
+        quant_type = quant_description[key]
+        if not isinstance(quant_type, str):
+            raise TypeError(f"ModelSlim descriptor value for {key!r} must be a string")
+        resolved.append((key, quant_type.upper()))
+
+    quant_types = {quant_type for _, quant_type in resolved}
+    if len(quant_types) != 1:
+        details = ", ".join(f"{key}={value}" for key, value in resolved)
+        raise ValueError(
+            f"Packed layer {prefix!r} mixes ModelSlim quantization types: {details}"
+        )
+
+    quant_type = resolved[0][1]
+    if quant_type not in _SUPPORTED_LINEAR_QUANT_TYPES:
+        raise NotImplementedError(
+            f"ModelSlim quantization type {quant_type!r} is not supported for "
+            f"linear layer {prefix!r}"
+        )
+    return quant_type
+
+
+def _get_model_file(
+    model: str | Path,
+    filename: str,
+    revision: str | None = None,
+) -> Path | None:
+    model_path = Path(model)
+    if model_path.exists():
+        candidate = model_path / filename
+        return candidate if candidate.is_file() else None
+
+    try:
+        from vllm import envs
+
+        if envs.VLLM_USE_MODELSCOPE:
+            from modelscope.hub.file_download import model_file_download
+
+            return Path(
+                model_file_download(
+                    model_id=str(model),
+                    file_path=filename,
+                    revision=revision,
+                )
+            )
+
+        from huggingface_hub import hf_hub_download
+
+        return Path(
+            hf_hub_download(
+                repo_id=str(model),
+                filename=filename,
+                revision=revision,
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "Could not resolve ModelSlim descriptor %s from %s: %s",
+            filename,
+            model,
+            exc,
+        )
+        return None
+
+
+@register_quantization_config(ASCEND_QUANTIZATION_METHOD)
+class AscendModelSlimConfig(QuantizationConfig):
+    """Configuration adapter for ModelSlim ``quant_model_description.json``."""
+
+    def __init__(self, quant_config: Mapping[str, Any] | None = None) -> None:
+        super().__init__()
+        self.quant_description = _normalize_quant_description(quant_config or {})
+        self.model_type: str | None = None
+        self._applied_mapper_ids: set[int] = set()
+
+    def __repr__(self) -> str:
+        return f"AscendModelSlimConfig(entries={len(self.quant_description)})"
+
+    @classmethod
+    def get_name(cls) -> str:
+        return ASCEND_QUANTIZATION_METHOD
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        return [torch.bfloat16, torch.float16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 0
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        # Loading in maybe_update_config gives a precise error and also works
+        # with ModelScope/Hugging Face repositories.
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "AscendModelSlimConfig":
+        return cls(config)
+
+    def maybe_update_config(
+        self,
+        model_name: str,
+        hf_config: PretrainedConfig | None = None,
+        revision: str | None = None,
+    ) -> None:
+        if hf_config is not None:
+            self.model_type = getattr(hf_config, "model_type", None)
+        if self.quant_description:
+            return
+
+        config_path = _get_model_file(
+            model_name,
+            MODELSLIM_CONFIG_FILENAME,
+            revision=revision,
+        )
+        if config_path is None:
+            raise ValueError(
+                f"--quantization {ASCEND_QUANTIZATION_METHOD} requires "
+                f"{MODELSLIM_CONFIG_FILENAME!r} in model {model_name!r}"
+            )
+        try:
+            with config_path.open(encoding="utf-8") as descriptor_file:
+                descriptor = json.load(descriptor_file)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(
+                f"Failed to load ModelSlim descriptor {str(config_path)!r}: {exc}"
+            ) from exc
+        self.quant_description = _normalize_quant_description(descriptor)
+        if not self.quant_description:
+            raise ValueError(f"ModelSlim descriptor {str(config_path)!r} is empty")
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper: WeightsMapper) -> None:
+        mapper_id = id(hf_to_vllm_mapper)
+        if mapper_id in self._applied_mapper_ids:
+            return
+        mapped = hf_to_vllm_mapper.apply_dict(self.quant_description)
+        if len(mapped) != len(self.quant_description):
+            raise ValueError(
+                "vLLM weight mapping produced colliding ModelSlim descriptor keys"
+            )
+        self.quant_description = _normalize_quant_description(mapped)
+        self._applied_mapper_ids.add(mapper_id)
+
+    def _map_prefix(self, prefix: str) -> str:
+        if self.model_type is None:
+            return prefix
+        mapper = _PREFIX_MAPPERS.get(self.model_type)
+        return mapper(prefix) if mapper is not None else prefix
+
+    def _get_linear_quant_type(self, prefix: str) -> str:
+        return resolve_linear_quant_type(
+            self.quant_description,
+            self._map_prefix(prefix),
+            self.packed_modules_mapping,
+        )
+
+    def get_quant_method(
+        self,
+        layer: torch.nn.Module,
+        prefix: str,
+    ) -> QuantizeMethodBase | None:
+        from vllm.model_executor.layers.fused_moe import FusedMoE
+        from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+            UnquantizedFusedMoEMethod,
+        )
+        from vllm.model_executor.layers.linear import (
+            LinearBase,
+            UnquantizedLinearMethod,
+        )
+        from vllm.model_executor.layers.vocab_parallel_embedding import (
+            UnquantizedEmbeddingMethod,
+            VocabParallelEmbedding,
+        )
+
+        if isinstance(layer, VocabParallelEmbedding):
+            quant_type = self._get_linear_quant_type(prefix)
+            if quant_type == "FLOAT":
+                return UnquantizedEmbeddingMethod()
+            raise NotImplementedError(
+                f"ModelSlim quantized embedding is not supported: {prefix!r}"
+            )
+
+        if isinstance(layer, LinearBase):
+            quant_type = self._get_linear_quant_type(prefix)
+            if quant_type == "FLOAT":
+                return UnquantizedLinearMethod()
+
+            from vllm_fl.dispatch.backends.vendor.ascend.impl.quantization import (
+                AscendModelSlimLinearMethod,
+                get_w8a8_linear_scheme,
+            )
+
+            return AscendModelSlimLinearMethod(
+                get_w8a8_linear_scheme(quant_type)
+            )
+
+        if isinstance(layer, FusedMoE):
+            quant_type = self._get_linear_quant_type(prefix)
+            if quant_type == "FLOAT":
+                return UnquantizedFusedMoEMethod(layer.moe_config)
+            if quant_type == "W8A8_DYNAMIC":
+                from vllm_fl.dispatch.backends.vendor.ascend.impl.quantization import (
+                    AscendModelSlimW8A8DynamicMoEMethod,
+                )
+
+                return AscendModelSlimW8A8DynamicMoEMethod(layer.moe_config)
+            raise NotImplementedError(
+                f"ModelSlim {quant_type} MoE is not supported for {prefix!r}"
+            )
+
+        return None

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -114,39 +114,32 @@ def _accelerator_synchronize() -> None:
         torch.accelerator.synchronize()
 
 
-if current_platform.dist_backend == "flagcx" or current_platform.device_type == "musa":
+if (
+    current_platform.dist_backend == "flagcx"
+    or current_platform.device_type == "musa"
+):
     @contextmanager
     def graph_capture(device: torch.device):
-        """
-        `graph_capture` is a context manager which should surround the code that
-        is capturing the NPU graph. Its main purpose is to ensure that the
-        some operations will be run after the graph is captured, before the graph
-        is replayed. It returns a `GraphCaptureContext` object which contains the
-        necessary data for the graph capture. Currently, it only contains the
-        stream that the graph capture is running on. This stream is set to the
-        current NPU stream when the context manager is entered and reset to the
-        default stream when the context manager is exited. This is to ensure that
-        the graph capture is running on a separate stream from the default stream,
-        in order to explicitly distinguish the kernels to capture
-        from other kernels possibly launched on background in the default stream.
-        """
+        """Capture a graph on a stream isolated from the default stream."""
         graph_capture_context = GraphCaptureContext(
-            current_platform.torch_device_fn.Stream(device=device))
+            current_platform.torch_device_fn.Stream(device=device)
+        )
         stream = graph_capture_context.stream
 
-        # we use nullcontext now
-        maybe_ca_context = nullcontext()
-
-        # ensure all initialization operations complete before attempting to
-        # capture the graph on another stream
         curr_stream = current_platform.torch_device_fn.current_stream()
         if curr_stream != stream:
             stream.wait_stream(curr_stream)
 
-        with current_platform.torch_device_fn.stream(stream), maybe_ca_context:
+        with current_platform.torch_device_fn.stream(stream), nullcontext():
             yield graph_capture_context
 else:
     from vllm.distributed.parallel_state import graph_capture
+
+from vllm_fl.compilation.graph_runtime import get_graph_capture
+
+graph_capture = get_graph_capture(graph_capture)
+
+
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingType
 from vllm.sequence import IntermediateTensors


### PR DESCRIPTION
### PR Category

Vendor

### PR Type

New Features

### Description

为 FL 平台增加通用 ModelSlim W8A8 量化能力。解析
`quant_model_description.json` 中的 checkpoint 量化描述，接入 W8A8 Static/Dynamic
Linear 与 W8A8 Dynamic MoE 的权重加载和 NPU 执行路径，为采用相同 ModelSlim 权重契约
的量化模型提供统一的平台能力。

### Changes

- 注册 Ascend `ascend` quantization config，并接入 `--quantization` 参数校验。
- 支持从本地模型目录、Hugging Face 和 ModelScope 加载 ModelSlim 量化描述。
- 支持 packed module、`weight_packed` alias、vLLM `WeightsMapper` 和模型级 prefix mapper。
- 增加 W8A8 Static Linear 的 per-tensor activation 与 per-channel weight 量化路径。
- 增加 W8A8 Dynamic Linear 的 per-token activation 与 per-channel weight 量化路径。
- 增加 W8A8 Dynamic MoE 的 expert 权重布局、weight loader、expert map、routing 和 NPU expert compute。
- 增加 ModelSlim config、Linear、MoE、platform 注册及 wheel 打包测试。

### Testing

- 运行 platform 与完整 quantization 回归：77 tests passed。
- Python wheel 构建、安装和模块导入通过，安装环境中 Ascend quantization config 注册成功。

### Checklist

- [ ] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)