### PR TITLE
feat(flagcx connector): Prometheus KV-transfer metrics + port #315 from release/0.2

### DIFF
--- a/examples/disaggregated_serving_xpyd/router.py
+++ b/examples/disaggregated_serving_xpyd/router.py
@@ -12,7 +12,10 @@
 import argparse
 import asyncio
 import itertools
+import logging
 import os
+import threading
+import time
 import urllib.parse
 import uuid
 from contextlib import asynccontextmanager
@@ -22,6 +25,126 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 global_args = None
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [router] %(levelname)s %(message)s"
+)
+logger = logging.getLogger("flagcx.router")
+
+# Interval (seconds) between periodic router metric log lines. 0 disables it.
+STAT_LOG_INTERVAL = float(os.environ.get("FLAGCX_ROUTER_STAT_INTERVAL", "10"))
+
+
+class RouterStats:
+    """Per-interval router-side latency/throughput observations.
+
+    Mirrors the connector-side ``FlagCXKVConnectorStats`` shape: writers
+    append raw observations under a lock, and ``clone_and_reset`` hands the
+    logger a snapshot so each interval is reported exactly once. Timings are
+    seconds and reported in ms, matching the KV-transfer metric convention.
+
+    The three latencies bracket the P/D handoff:
+      prefill_latency  request sent to P -> P responded (KV ready to pull)
+      ttft             request sent to D -> first streamed byte from D
+      e2e_latency      request sent to D -> decode stream closed
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.reset()
+
+    def reset(self):
+        self.data: dict[str, list[float | int]] = {
+            "prefill_latency": [],
+            "ttft": [],
+            "e2e_latency": [],
+            "decode_bytes": [],
+            "num_failed_prefills": [],
+            "num_failed_decodes": [],
+        }
+
+    def record_prefill(self, duration_s: float):
+        with self._lock:
+            self.data["prefill_latency"].append(duration_s)
+
+    def record_failed_prefill(self):
+        with self._lock:
+            self.data["num_failed_prefills"].append(1)
+
+    def record_request(self, ttft_s: float, e2e_s: float, num_bytes: int):
+        with self._lock:
+            self.data["ttft"].append(ttft_s)
+            self.data["e2e_latency"].append(e2e_s)
+            self.data["decode_bytes"].append(num_bytes)
+
+    def record_failed_decode(self):
+        with self._lock:
+            self.data["num_failed_decodes"].append(1)
+
+    def clone_and_reset(self) -> dict[str, list[float | int]]:
+        with self._lock:
+            snapshot = {k: list(v) for k, v in self.data.items()}
+            self.reset()
+        return snapshot
+
+    @staticmethod
+    def is_empty(data: dict[str, list[float | int]]) -> bool:
+        return not any(data.values())
+
+    @staticmethod
+    def reduce(data: dict[str, list[float | int]]) -> dict[str, int | float]:
+        """Reduce one interval's observations to representative values."""
+        num_failed_prefills = len(data["num_failed_prefills"])
+        num_failed_decodes = len(data["num_failed_decodes"])
+        num_requests = len(data["e2e_latency"])
+
+        def _ms(values, pct=None):
+            if not values:
+                return 0
+            ordered = sorted(values)
+            if pct is None:
+                return round(sum(ordered) / len(ordered) * 1e3, 3)
+            # Nearest-rank percentile; avoids a numpy dependency in the proxy.
+            idx = min(len(ordered) - 1, int(round((pct / 100) * (len(ordered) - 1))))
+            return round(ordered[idx] * 1e3, 3)
+
+        total_mb = sum(data["decode_bytes"]) / 2**20
+        total_time_s = sum(data["e2e_latency"])
+        # Concurrent requests overlap, so this is per-request average
+        # throughput, not aggregate router egress.
+        throughput_mb_s = round(total_mb / total_time_s, 3) if total_time_s > 0 else 0.0
+
+        return {
+            "Num requests": num_requests,
+            "Avg prefill time (ms)": _ms(data["prefill_latency"]),
+            "P90 prefill time (ms)": _ms(data["prefill_latency"], 90),
+            "Avg TTFT (ms)": _ms(data["ttft"]),
+            "P90 TTFT (ms)": _ms(data["ttft"], 90),
+            "Avg E2E time (ms)": _ms(data["e2e_latency"]),
+            "P90 E2E time (ms)": _ms(data["e2e_latency"], 90),
+            "Avg MB per request": (
+                round(total_mb / num_requests, 4) if num_requests else 0
+            ),
+            "Throughput (MB/s)": throughput_mb_s,
+            "Num failed prefills": num_failed_prefills,
+            "Num failed decodes": num_failed_decodes,
+        }
+
+
+stats = RouterStats()
+
+
+async def _stat_logger_loop():
+    """Periodically log one line per interval, like KVConnectorLogging.log."""
+    while True:
+        await asyncio.sleep(STAT_LOG_INTERVAL)
+        snapshot = stats.clone_and_reset()
+        if RouterStats.is_empty(snapshot):
+            continue
+        metrics = RouterStats.reduce(snapshot)
+        logger.info(
+            "Router metrics: %s", ", ".join(f"{k}={v}" for k, v in metrics.items())
+        )
 
 
 async def wait_for_health(prefill_clients, decode_clients, ready):
@@ -91,6 +214,9 @@ async def lifespan(app):
             app.state.prefill_clients, app.state.decode_clients, app.state.ready
         )
     )
+    stat_logger_task = (
+        asyncio.create_task(_stat_logger_loop()) if STAT_LOG_INTERVAL > 0 else None
+    )
     app.state.prefill_iterator = itertools.cycle(range(len(app.state.prefill_clients)))
     app.state.decode_iterator = itertools.cycle(range(len(app.state.decode_clients)))
     print(
@@ -99,6 +225,8 @@ async def lifespan(app):
 
     yield
 
+    if stat_logger_task is not None:
+        stat_logger_task.cancel()
     for c in app.state.prefill_clients:
         await c["client"].aclose()
     for c in app.state.decode_clients:
@@ -124,14 +252,30 @@ async def send_to_prefill(prefill_client, endpoint, req_data, request_id):
     api_key = os.environ.get("OPENAI_API_KEY", "")
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
+    start_time = time.perf_counter()
     try:
         response = await prefill_client["client"].post(
             endpoint, json=data, headers=headers
         )
         response.raise_for_status()
         await response.aclose()
+        duration = time.perf_counter() - start_time
+        stats.record_prefill(duration)
+        logger.debug(
+            "Prefill %s on %s done, took %.3fs",
+            request_id,
+            prefill_client["url"],
+            duration,
+        )
     except Exception as exc:
-        print(f"Prefill request {request_id} error: {exc}")
+        stats.record_failed_prefill()
+        logger.error(
+            "Prefill request %s on %s failed after %.3fs: %s",
+            request_id,
+            prefill_client["url"],
+            time.perf_counter() - start_time,
+            exc,
+        )
 
 
 async def stream_from_decode(
@@ -149,12 +293,41 @@ async def stream_from_decode(
     api_key = os.environ.get("OPENAI_API_KEY", "")
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
-    async with decode_client["client"].stream(
-        "POST", endpoint, json=data, headers=headers
-    ) as response:
-        response.raise_for_status()
-        async for chunk in response.aiter_bytes():
-            yield chunk
+    start_time = time.perf_counter()
+    first_byte_time = None
+    num_bytes = 0
+    try:
+        async with decode_client["client"].stream(
+            "POST", endpoint, json=data, headers=headers
+        ) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_bytes():
+                if first_byte_time is None:
+                    first_byte_time = time.perf_counter()
+                num_bytes += len(chunk)
+                yield chunk
+    except Exception as exc:
+        stats.record_failed_decode()
+        logger.error(
+            "Decode request %s on %s failed after %.3fs: %s",
+            request_id,
+            decode_client["url"],
+            time.perf_counter() - start_time,
+            exc,
+        )
+        raise
+    end_time = time.perf_counter()
+    # No byte ever arrived (empty stream): attribute the whole wait to TTFT.
+    ttft = (first_byte_time or end_time) - start_time
+    stats.record_request(ttft_s=ttft, e2e_s=end_time - start_time, num_bytes=num_bytes)
+    logger.debug(
+        "Decode %s on %s done: ttft=%.3fs e2e=%.3fs bytes=%d",
+        request_id,
+        decode_client["url"],
+        ttft,
+        end_time - start_time,
+        num_bytes,
+    )
 
 
 async def _handle_completions(api, request):

--- a/examples/disaggregated_serving_xpyd/router.py
+++ b/examples/disaggregated_serving_xpyd/router.py
@@ -110,7 +110,11 @@ app = FastAPI(lifespan=lifespan)
 
 async def send_to_prefill(prefill_client, endpoint, req_data, request_id):
     data = req_data.copy()
-    data["kv_transfer_params"] = {"do_remote_decode": True, "do_remote_prefill": False}
+    data["kv_transfer_params"] = {
+        "do_remote_decode": True,
+        "do_remote_prefill": False,
+        "transfer_id": f"fgx-{request_id}",
+    }
     data["stream"] = False
     data["max_tokens"] = 1
     if "max_completion_tokens" in data:
@@ -139,6 +143,7 @@ async def stream_from_decode(
         "do_remote_decode": False,
         "remote_host": prefill_client["remote_host"],
         "remote_port": prefill_client["side_channel_port"],
+        "transfer_id": f"fgx-{request_id}",
     }
     headers = {"X-Request-Id": request_id}
     api_key = os.environ.get("OPENAI_API_KEY", "")

--- a/vllm_fl/distributed/device_communicators/flagcx.py
+++ b/vllm_fl/distributed/device_communicators/flagcx.py
@@ -96,9 +96,17 @@ class PyFlagcxCommunicator:
         self.available = True
         self.disabled = False
 
+        self._legacy_unique_id_api = (
+            hasattr(self.flagcx, "handler")
+            and not hasattr(self.flagcx, "devHandle")
+        )
+
         if self.rank == 0:
             # get the unique id from NCCL
-            self.unique_id = self.flagcx.flagcxGetUniqueId().contents
+            if self._legacy_unique_id_api:
+                self.unique_id = self.flagcx.flagcxGetUniqueId().contents
+            else:
+                self.unique_id = self.flagcx.flagcxGetUniqueId()
         else:
             # construct an empty unique id
             self.unique_id = flagcxUniqueId()
@@ -131,8 +139,12 @@ class PyFlagcxCommunicator:
             device_ctx = torch.cuda.device(self.device)
 
         with device_ctx:
-            self.comm = self.flagcx.flagcxCommInitRank(
-                self.world_size, ctypes.byref(self.unique_id), self.rank)
+            if self._legacy_unique_id_api:
+                self.comm = self.flagcx.flagcxCommInitRank(
+                    self.world_size, ctypes.pointer(self.unique_id), self.rank)
+            else:
+                self.comm = self.flagcx.flagcxCommInitRank(
+                    self.world_size, self.unique_id, self.rank)
 
             stream = current_stream()
             # A small all_reduce for warmup.

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -74,6 +74,7 @@ except ImportError as e:
 
 EngineId = str
 ReqId = str
+TransferId = str
 
 TRANS_DONE = b"trans_done"
 TRANS_ERROR = b"trans_error"
@@ -109,8 +110,7 @@ class FlagCXAgentMetadata(
     remote_port: int
     remote_tp_size: int
     remote_tp_rank: int
-    # req_id -> per KV-cache-group block ids on the Decode (receiver) side.
-    req_blocks: dict[ReqId, list[list[int]]]
+    req_blocks: dict[ReqId, tuple[TransferId, list[list[int]]]]
     kv_caches_base_addr: list[int]
     block_lens: list[int]
     kv_block_lens: list[int]
@@ -124,11 +124,14 @@ class RecvReqMeta:
     local_block_ids: list[list[int]]
     remote_host: str
     remote_port: int
+    transfer_id: TransferId
     remote_tp_size: int = 0
 
 
 @dataclass
 class SendBlockMeta:
+    p_req_id: ReqId
+    transfer_id: TransferId
     local_block_ids: list[list[int]]
     ready: threading.Event
     expire_time: float = float("inf")
@@ -138,7 +141,7 @@ class SendBlockMeta:
 
 @dataclass
 class SendReqMeta:
-    reqs: dict[ReqId, SendBlockMeta]
+    reqs: dict[TransferId, SendBlockMeta]
     lock: threading.Lock
 
 
@@ -158,7 +161,9 @@ class FlagCXConnectorMetadata(KVConnectorMetadata):
     def __init__(self):
         self.reqs_to_recv: dict[ReqId, RecvReqMeta] = {}
         # Per-request, per KV-cache-group block ids.
-        self.reqs_to_send: dict[ReqId, list[list[int]]] = {}
+        self.reqs_to_send: dict[
+            ReqId, tuple[TransferId, list[list[int]]]
+        ] = {}
 
     def add_new_req(
         self,
@@ -167,15 +172,17 @@ class FlagCXConnectorMetadata(KVConnectorMetadata):
         kv_transfer_params: dict[str, Any],
         load_remote_cache: bool = True,
     ):
+        transfer_id = kv_transfer_params["transfer_id"]
         if load_remote_cache:
             self.reqs_to_recv[request_id] = RecvReqMeta(
                 local_block_ids=local_block_ids,
                 remote_host=kv_transfer_params["remote_host"],
                 remote_port=kv_transfer_params["remote_port"],
+                transfer_id=transfer_id,
                 remote_tp_size=kv_transfer_params.get("remote_tp_size", 0),
             )
         else:
-            self.reqs_to_send[request_id] = local_block_ids
+            self.reqs_to_send[request_id] = (transfer_id, local_block_ids)
 
 
 class FlagCXConnector(KVConnectorBase_V1, SupportsHMA):
@@ -334,7 +341,9 @@ class FlagCXConnectorScheduler:
         ]
 
         self._reqs_need_recv: dict[ReqId, tuple[Request, list[list[int]]]] = {}
-        self._reqs_need_send: dict[ReqId, list[list[int]]] = {}
+        self._reqs_need_send: dict[
+            ReqId, tuple["Request", list[list[int]]]
+        ] = {}
 
     def get_sw_clipped_blocks(
         self,
@@ -415,7 +424,9 @@ class FlagCXConnectorScheduler:
 
         if params.get("do_remote_prefill"):
             assert self.kv_role != "kv_producer"
-            if all(p in params for p in ("remote_host", "remote_port")):
+            if all(
+                p in params for p in ("remote_host", "remote_port", "transfer_id")
+            ):
                 unhashed_block_ids = (
                     blocks.get_unhashed_block_ids_all_groups()
                     if num_external_tokens > 0
@@ -431,7 +442,10 @@ class FlagCXConnectorScheduler:
             params["do_remote_prefill"] = False
 
         elif params.get("do_remote_decode"):
-            self._reqs_need_send[request.request_id] = []
+            if not params.get("transfer_id"):
+                logger.warning("Missing transfer_id in KVTransferParams: %s", params)
+            else:
+                self._reqs_need_send[request.request_id] = (request, [])
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
@@ -449,11 +463,12 @@ class FlagCXConnectorScheduler:
             self._reqs_need_recv.clear()
 
         if self.kv_role != "kv_consumer":
-            for req_id, block_ids in self._reqs_need_send.items():
+            for req_id, (req, block_ids) in self._reqs_need_send.items():
+                assert req.kv_transfer_params is not None
                 meta.add_new_req(
                     request_id=req_id,
                     local_block_ids=block_ids,
-                    kv_transfer_params={},
+                    kv_transfer_params=req.kv_transfer_params,
                     load_remote_cache=False,
                 )
             self._reqs_need_send.clear()
@@ -464,7 +479,7 @@ class FlagCXConnectorScheduler:
         self, request: "Request", block_ids: tuple[list[int], ...]
     ) -> tuple[bool, dict[str, Any] | None]:
         params = request.kv_transfer_params
-        if not params:
+        if not params or not params.get("transfer_id"):
             return False, None
 
         if params.get("do_remote_prefill"):
@@ -483,8 +498,9 @@ class FlagCXConnectorScheduler:
         delay_free_blocks = any(len(group) > 0 for group in block_ids)
 
         if delay_free_blocks:
-            self._reqs_need_send[request.request_id] = self.get_sw_clipped_blocks(
-                block_ids
+            self._reqs_need_send[request.request_id] = (
+                request,
+                self.get_sw_clipped_blocks(block_ids),
             )
 
         return delay_free_blocks, dict(
@@ -493,6 +509,7 @@ class FlagCXConnectorScheduler:
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             remote_tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
+            transfer_id=params["transfer_id"],
         )
 
 
@@ -920,19 +937,30 @@ class FlagCXConnectorWorker:
 
         ready_reqs: list[tuple[ReqId, SendBlockMeta]] = []
         with self.reqs_need_send.lock:
-            for req_id in meta.req_blocks:
-                send_meta = self.reqs_need_send.reqs.get(req_id)
+            for d_req_id, (transfer_id, _) in meta.req_blocks.items():
+                send_meta = self.reqs_need_send.reqs.get(transfer_id)
                 if send_meta is None:
-                    logger.warning("Request %s not found in reqs_need_send", req_id)
-                    return
+                    send_meta = SendBlockMeta(
+                        p_req_id="",
+                        transfer_id=transfer_id,
+                        local_block_ids=[],
+                        ready=threading.Event(),
+                    )
+                    self.reqs_need_send.reqs[transfer_id] = send_meta
                 # Mark it as not expired. We will send it now.
                 send_meta.expire_time = float("inf")
                 send_meta.need_send = need
-                ready_reqs.append((req_id, send_meta))
+                ready_reqs.append((d_req_id, send_meta))
 
         # Wait until the scheduler has committed each request's blocks.
-        for _, send_meta in ready_reqs:
-            send_meta.ready.wait()
+        deadline = time.perf_counter() + self._abort_request_timeout
+        for d_req_id, send_meta in ready_reqs:
+            remaining = deadline - time.perf_counter()
+            if remaining <= 0 or not send_meta.ready.wait(timeout=remaining):
+                raise RuntimeError(
+                    "Timed out waiting for prefill blocks of transfer "
+                    f"{send_meta.transfer_id} (decode request {d_req_id})."
+                )
 
         remote_session = f"{meta.remote_hostname}:{meta.remote_port}"
         conn = self._get_conn(remote_session)
@@ -980,11 +1008,15 @@ class FlagCXConnectorWorker:
 
         finished: list[ReqId] = []
         with self.reqs_need_send.lock:
-            for req_id, send_meta in ready_reqs:
+            for _, send_meta in ready_reqs:
                 send_meta.sent += 1
                 if send_meta.sent >= max(send_meta.need_send, 1):
-                    self.reqs_need_send.reqs.pop(req_id, None)
-                    finished.append(req_id)
+                    self.reqs_need_send.reqs.pop(send_meta.transfer_id, None)
+                    if not send_meta.p_req_id:
+                        raise RuntimeError(
+                            f"Missing Prefill request ID for {send_meta.transfer_id}."
+                        )
+                    finished.append(send_meta.p_req_id)
         if finished:
             with self.finished_sending_reqs.lock:
                 self.finished_sending_reqs.set.update(finished)
@@ -1011,7 +1043,7 @@ class FlagCXConnectorWorker:
         group_specs = self.kv_cache_config.kv_cache_groups
 
         for d_req_id, send_meta in ready_reqs:
-            remote_block_ids_per_group = agent_meta.req_blocks[d_req_id]
+            _, remote_block_ids_per_group = agent_meta.req_blocks[d_req_id]
             if not remote_block_ids_per_group or all(
                 len(g) == 0 for g in remote_block_ids_per_group
             ):
@@ -1129,7 +1161,7 @@ class FlagCXConnectorWorker:
     async def _receive_kv(
         self,
         path: str,
-        req_blocks: dict[ReqId, list[list[int]]],
+        req_blocks: dict[ReqId, tuple[TransferId, list[list[int]]]],
     ):
         req_ids = list(req_blocks.keys())
 
@@ -1152,7 +1184,9 @@ class FlagCXConnectorWorker:
         sock: zmq.asyncio.Socket = make_zmq_socket(
             self.async_zmq_ctx, path, zmq.REQ, bind=False, linger=0
         )
-        sock.setsockopt(zmq.RCVTIMEO, 60000)
+        sock.setsockopt(
+            zmq.RCVTIMEO, (self._abort_request_timeout + 60) * 1000
+        )
 
         try:
             await sock.send(encoded_data)
@@ -1193,13 +1227,21 @@ class FlagCXConnectorWorker:
 
         if self.kv_role != "kv_consumer":
             with self.reqs_need_send.lock:
-                for req_id, block_ids in metadata.reqs_to_send.items():
-                    send_meta = self.reqs_need_send.reqs.get(req_id)
+                for p_req_id, (
+                    transfer_id,
+                    block_ids,
+                ) in metadata.reqs_to_send.items():
+                    send_meta = self.reqs_need_send.reqs.get(transfer_id)
                     if send_meta is None:
                         send_meta = SendBlockMeta(
-                            local_block_ids=[], ready=threading.Event()
+                            p_req_id=p_req_id,
+                            transfer_id=transfer_id,
+                            local_block_ids=[],
+                            ready=threading.Event(),
                         )
-                        self.reqs_need_send.reqs[req_id] = send_meta
+                        self.reqs_need_send.reqs[transfer_id] = send_meta
+                    else:
+                        send_meta.p_req_id = p_req_id
                     # Non-empty means request_finished() has committed the
                     # per-group block ids; arm the send.
                     if block_ids:
@@ -1223,7 +1265,9 @@ class FlagCXConnectorWorker:
         loop; populates ``_pull_pending`` and launches the per-peer pulls
         without an intervening await, so it is atomic w.r.t. other coroutines.
         """
-        kv_pulls: dict[str, dict[ReqId, list[list[int]]]] = defaultdict(dict)
+        kv_pulls: dict[
+            str, dict[ReqId, tuple[TransferId, list[list[int]]]]
+        ] = defaultdict(dict)
         for req_id, meta in reqs_to_recv.items():
             remote_tp_size = meta.remote_tp_size or self.tp_size
             target_p_ranks = self.kv_topo.handshake_target_ranks(remote_tp_size)
@@ -1232,7 +1276,10 @@ class FlagCXConnectorWorker:
                 path = make_zmq_path(
                     "tcp", meta.remote_host, meta.remote_port + p_rank
                 )
-                kv_pulls[path][req_id] = meta.local_block_ids
+                kv_pulls[path][req_id] = (
+                    meta.transfer_id,
+                    meta.local_block_ids,
+                )
         for path, req_blocks in kv_pulls.items():
             asyncio.ensure_future(self._receive_kv(path, req_blocks))
 
@@ -1261,15 +1308,17 @@ class FlagCXConnectorWorker:
         now = time.perf_counter()
         with self.reqs_need_send.lock:
             expired = [
-                rid
-                for rid, sm in self.reqs_need_send.reqs.items()
+                transfer_id
+                for transfer_id, sm in self.reqs_need_send.reqs.items()
                 if sm.expire_time < now
             ]
-            for rid in expired:
-                logger.warning("Request %s send timed out, freeing blocks", rid)
-                del self.reqs_need_send.reqs[rid]
-            if expired:
-                finished_sending.update(expired)
+            for transfer_id in expired:
+                send_meta = self.reqs_need_send.reqs.pop(transfer_id)
+                logger.warning(
+                    "Transfer %s send timed out, freeing blocks", transfer_id
+                )
+                if send_meta.p_req_id:
+                    finished_sending.add(send_meta.p_req_id)
 
         return finished_sending or None, finished_recving or None
 

--- a/vllm_fl/distributed/kv_transfer/flagcx_connector.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_connector.py
@@ -28,6 +28,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tensor_model_parallel_rank,
@@ -52,6 +58,11 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.request import RequestStatus
 from vllm.v1.worker.block_table import BlockTable
 from vllm.v1.worker.utils import select_common_block_size
+
+from vllm_fl.distributed.kv_transfer.flagcx_stats import (
+    FlagCXKVConnectorStats,
+    FlagCXPromMetrics,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -300,6 +311,43 @@ class FlagCXConnector(KVConnectorBase_V1, SupportsHMA):
 
     def wait_for_save(self):
         pass
+
+    def get_kv_connector_stats(self) -> "KVConnectorStats | None":
+        """Return worker-local transfer stats since the last call.
+
+        Note the P/D asymmetry: FlagCX is P-push (P issues the one-sided
+        flagcxP2pBatchWriteSync), so P records successful transfer latency,
+        bytes and descriptor counts, while D only records failures (ZMQ /
+        side-channel errors). NIXL-style dashboards will therefore find
+        successful-transfer metrics on the P worker, not D.
+        """
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_kv_connector_stats()
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> "KVConnectorStats | None":
+        return FlagCXKVConnectorStats(data=data or {})
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> KVConnectorPromMetrics:
+        """Register the FlagCX Prometheus metrics.
+
+        Without this the base class returns None and the stats above only
+        reach the periodic CLI log line; the counters registered here are
+        what make rate()/increase() queries possible.
+        """
+        return FlagCXPromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )
 
 
 class FlagCXConnectorScheduler:
@@ -595,6 +643,8 @@ class FlagCXConnectorWorker:
                 daemon=True,
             )
             self._receiver_t.start()
+
+        self.xfer_stats = FlagCXKVConnectorStats()
 
         self.finished_sending_reqs = FinishedSendReqSet(set(), threading.Lock())
         self.finished_recving_reqs = FinishedReceiveReqSet(set(), asyncio.Lock())
@@ -1004,7 +1054,19 @@ class FlagCXConnectorWorker:
         )
 
         if sizes:
-            self.flagcx.flagcxP2pBatchWriteSync(conn, src_vas, dst_vas, sizes)
+            write_start = time.perf_counter()
+            try:
+                self.flagcx.flagcxP2pBatchWriteSync(conn, src_vas, dst_vas, sizes)
+            except Exception:
+                # Only the one-sided write itself counts as a failed transfer;
+                # earlier setup errors are reported by the sender worker.
+                self.xfer_stats.record_failed_transfer()
+                raise
+            self.xfer_stats.record_transfer(
+                duration_s=time.perf_counter() - write_start,
+                total_bytes=sum(sizes),
+                num_descs=len(sizes),
+            )
 
         finished: list[ReqId] = []
         with self.reqs_need_send.lock:
@@ -1197,12 +1259,14 @@ class FlagCXConnectorWorker:
                     "see logs in prefiller.",
                     req_ids,
                 )
+                self.xfer_stats.record_failed_recv()
                 return
 
         except zmq.ContextTerminated:
             logger.debug("ZMQ context terminated, exiting FlagCX receiver thread.")
         except Exception as e:
             logger.error("FlagCXAgentMetadata transfer failed for %s: %s", req_ids, e)
+            self.xfer_stats.record_failed_recv()
             return
         finally:
             sock.close()
@@ -1315,12 +1379,22 @@ class FlagCXConnectorWorker:
             for transfer_id in expired:
                 send_meta = self.reqs_need_send.reqs.pop(transfer_id)
                 logger.warning(
-                    "Transfer %s send timed out, freeing blocks", transfer_id
+                    "Transfer %s send timed out after %d seconds, freeing blocks",
+                    transfer_id,
+                    self._abort_request_timeout,
                 )
+                self.xfer_stats.record_kv_expired_req()
                 if send_meta.p_req_id:
                     finished_sending.add(send_meta.p_req_id)
 
         return finished_sending or None, finished_recving or None
+
+    def get_kv_connector_stats(self) -> "KVConnectorStats | None":
+        """Return transfer stats collected since the last call, or None
+        if nothing has been recorded in this interval."""
+        if self.xfer_stats.is_empty():
+            return None
+        return self.xfer_stats.clone_and_reset()
 
     def __del__(self):
         self.shutdown()

--- a/vllm_fl/distributed/kv_transfer/flagcx_stats.py
+++ b/vllm_fl/distributed/kv_transfer/flagcx_stats.py
@@ -1,0 +1,351 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+"""Stats and Prometheus metrics for the FlagCX connector."""
+
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+from vllm.v1.metrics.utils import create_metric_per_engine
+
+
+@dataclass
+class FlagCXKVConnectorStats(KVConnectorStats):
+    """Container for FlagCX KV transfer performance metrics.
+
+    `_lock` serializes record_* against clone_and_reset so each row's
+    appends are atomic and column lengths stay aligned. Writers run on
+    the sender pool / receiver loop; the reader runs on the main worker
+    thread.
+    """
+
+    def __post_init__(self):
+        self._lock = threading.Lock()
+        if not self.data:
+            self.reset()
+
+    # threading.Lock is not picklable; strip it from the wire form and
+    # rebuild a fresh per-process lock on the receiver side.
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+
+    def reset(self):
+        self.data: dict[str, list[float | int]] = {
+            "transfer_duration": [],
+            "bytes_transferred": [],
+            "num_descriptors": [],
+            "num_failed_transfers": [],
+            "num_failed_recvs": [],
+            "num_kv_expired_reqs": [],
+        }
+
+    def record_transfer(self, duration_s: float, total_bytes: int, num_descs: int):
+        with self._lock:
+            self.data["transfer_duration"].append(duration_s)
+            self.data["bytes_transferred"].append(total_bytes)
+            self.data["num_descriptors"].append(num_descs)
+
+    # Failure counters store a list of 1s so a future Prom counter can iterate
+    # with .inc(list_item), mirroring NIXL's NixlPromMetrics.observe.
+    def record_failed_transfer(self):
+        with self._lock:
+            self.data["num_failed_transfers"].append(1)
+
+    def record_failed_recv(self):
+        with self._lock:
+            self.data["num_failed_recvs"].append(1)
+
+    def record_kv_expired_req(self):
+        with self._lock:
+            self.data["num_kv_expired_reqs"].append(1)
+
+    def clone_and_reset(self) -> "FlagCXKVConnectorStats":
+        # Copy lists under the lock for length alignment; return a fresh
+        # instance so the snapshot has its own _lock.
+        with self._lock:
+            snapshot_data: dict[str, list[float | int]] = {
+                k: list(v) for k, v in self.data.items()
+            }
+            self.reset()
+        return FlagCXKVConnectorStats(data=snapshot_data)
+
+    def is_empty(self) -> bool:
+        return (
+            self.num_successful_transfers == 0
+            and len(self.data["num_failed_transfers"]) == 0
+            and len(self.data["num_failed_recvs"]) == 0
+            and len(self.data["num_kv_expired_reqs"]) == 0
+        )
+
+    def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        if not other.is_empty():
+            for k, v in other.data.items():
+                accumulator = self.data[k]
+                assert isinstance(accumulator, list)
+                accumulator.extend(v)
+        return self
+
+    def reduce(self) -> dict[str, int | float]:
+        num_failed_transfers = len(self.data["num_failed_transfers"])
+        num_failed_recvs = len(self.data["num_failed_recvs"])
+        num_kv_expired_reqs = len(self.data["num_kv_expired_reqs"])
+
+        if self.num_successful_transfers == 0:
+            return {
+                "Num successful transfers": 0,
+                "Avg xfer time (ms)": 0,
+                "P90 xfer time (ms)": 0,
+                "Avg MB per transfer": 0,
+                "Throughput (MB/s)": 0,
+                "Avg number of descriptors": 0,
+                "Num failed transfers": num_failed_transfers,
+                "Num failed recvs": num_failed_recvs,
+                "Num KV expired reqs": num_kv_expired_reqs,
+            }
+
+        xfer_time = np.asarray(self.data["transfer_duration"])
+        mb = np.asarray(self.data["bytes_transferred"]) / 2**20
+        descs = np.asarray(self.data["num_descriptors"], dtype=np.uint32)
+        n = len(descs)
+        assert n == self.num_successful_transfers
+
+        total_mb = mb.sum()
+        avg_mb = total_mb / n
+        total_time_seconds = xfer_time.sum()
+        throughput_mb_s = (
+            total_mb / total_time_seconds if total_time_seconds > 0 else 0.0
+        )
+
+        return {
+            "Num successful transfers": n,
+            "Avg xfer time (ms)": round(xfer_time.mean() * 1e3, 3),
+            "P90 xfer time (ms)": round(np.percentile(xfer_time, 90).item() * 1e3, 3),
+            "Avg MB per transfer": round(avg_mb, 3),
+            "Throughput (MB/s)": round(throughput_mb_s, 3),
+            "Avg number of descriptors": round(descs.mean(), 1),
+            "Num failed transfers": num_failed_transfers,
+            "Num failed recvs": num_failed_recvs,
+            "Num KV expired reqs": num_kv_expired_reqs,
+        }
+
+    @property
+    def num_successful_transfers(self) -> int:
+        return len(self.data["transfer_duration"])
+
+
+class FlagCXPromMetrics(KVConnectorPromMetrics):
+    """Prometheus metrics for FlagCX KV transfers.
+
+    Counters (monotonic, so ``rate()``/``increase()`` work in PromQL) carry
+    the volume series; histograms carry the per-transfer distributions:
+
+      vllm:flagcx_total_bytes_transferred -> rate() = KV transfer bytes/s
+      vllm:flagcx_total_xfer_time_seconds -> ratio with the above gives
+                                             effective bytes/s while the link
+                                             was actually busy
+      vllm:flagcx_transfers               -> rate() = transfers/s
+      vllm:flagcx_total_descriptors       -> descriptors/s
+      vllm:flagcx_num_failed_transfers    -> P-side write failures
+      vllm:flagcx_num_failed_recvs        -> D-side side-channel failures
+      vllm:flagcx_num_kv_expired_reqs     -> P-side unsent, expired requests
+      vllm:flagcx_xfer_time_seconds       -> per-transfer latency histogram
+      vllm:flagcx_bytes_transferred       -> per-transfer size histogram
+      vllm:flagcx_num_descriptors         -> per-transfer descriptor count
+
+    Counter names deliberately avoid a ``_total`` suffix: prometheus_client
+    strips it and appends its own, so ``vllm:flagcx_xfer_time_seconds_total``
+    would register as ``vllm:flagcx_xfer_time_seconds`` and collide with the
+    histogram of the same name. The scraped counters still end in ``_total``.
+
+    Same P/D asymmetry as the stats container: FlagCX is P-push, so the
+    success series only advance on the P engine, while
+    ``num_failed_recvs`` only advances on D.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ):
+        super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
+
+        # ---- Counters: the series to use with rate()/increase(). ----
+        # (metric name, documentation, stats data key)
+        counter_specs: list[tuple[str, str, str]] = [
+            (
+                "vllm:flagcx_total_bytes_transferred",
+                "Total bytes transferred by FlagCX KV Cache transfers.",
+                "bytes_transferred",
+            ),
+            (
+                "vllm:flagcx_total_xfer_time_seconds",
+                "Total time spent inside FlagCX KV Cache transfers. Divide "
+                "vllm:flagcx_total_bytes_transferred_total by this to get "
+                "effective link throughput.",
+                "transfer_duration",
+            ),
+            (
+                "vllm:flagcx_transfers",
+                "Number of successful FlagCX KV Cache transfers.",
+                "num_transfers",
+            ),
+            (
+                "vllm:flagcx_total_descriptors",
+                "Total number of descriptors written by FlagCX KV Cache transfers.",
+                "num_descriptors",
+            ),
+            (
+                "vllm:flagcx_num_failed_transfers",
+                "Number of failed FlagCX KV Cache transfers. "
+                "NOTE: This metric is tracked on the P instance.",
+                "num_failed_transfers",
+            ),
+            (
+                "vllm:flagcx_num_failed_recvs",
+                "Number of failed FlagCX KV Cache receives (side-channel or "
+                "transfer errors reported to D). "
+                "NOTE: This metric is tracked on the D instance.",
+                "num_failed_recvs",
+            ),
+            (
+                "vllm:flagcx_num_kv_expired_reqs",
+                "Number of requests that had their KV expire before being sent. "
+                "NOTE: This metric is tracked on the P instance.",
+                "num_kv_expired_reqs",
+            ),
+        ]
+        self._counters: list[tuple[dict[int, PromMetric], str]] = []
+        for name, documentation, data_key in counter_specs:
+            counter = self._counter_cls(
+                name=name,
+                documentation=documentation,
+                labelnames=labelnames,
+            )
+            self._counters.append(
+                (
+                    create_metric_per_engine(counter, self.per_engine_labelvalues),
+                    data_key,
+                )
+            )
+
+        # ---- Histograms: per-transfer distributions. ----
+        histogram_xfer_time = self._histogram_cls(
+            name="vllm:flagcx_xfer_time_seconds",
+            documentation="Histogram of transfer duration for FlagCX KV Cache "
+            "transfers.",
+            buckets=[
+                0.005,
+                0.01,
+                0.025,
+                0.05,
+                0.075,
+                0.1,
+                0.2,
+                0.3,
+                0.5,
+                0.75,
+                1.0,
+                5.0,
+            ],
+            labelnames=labelnames,
+        )
+        # Uniform 2KB to 16GB range, matching NixlPromMetrics.
+        histogram_bytes_transferred = self._histogram_cls(
+            name="vllm:flagcx_bytes_transferred",
+            documentation="Histogram of bytes transferred per FlagCX KV Cache "
+            "transfer.",
+            buckets=[2 ** (10 + i) for i in range(1, 25, 2)],
+            labelnames=labelnames,
+        )
+        histogram_num_descriptors = self._histogram_cls(
+            name="vllm:flagcx_num_descriptors",
+            documentation="Histogram of number of descriptors per FlagCX KV Cache "
+            "transfer.",
+            buckets=[
+                10,
+                20,
+                30,
+                50,
+                75,
+                100,
+                200,
+                400,
+                1000,
+                2000,
+                4000,
+                10000,
+                20000,
+                50000,
+            ],
+            labelnames=labelnames,
+        )
+        self._histograms: list[tuple[dict[int, PromMetric], str]] = [
+            (
+                create_metric_per_engine(
+                    histogram_xfer_time, self.per_engine_labelvalues
+                ),
+                "transfer_duration",
+            ),
+            (
+                create_metric_per_engine(
+                    histogram_bytes_transferred, self.per_engine_labelvalues
+                ),
+                "bytes_transferred",
+            ),
+            (
+                create_metric_per_engine(
+                    histogram_num_descriptors, self.per_engine_labelvalues
+                ),
+                "num_descriptors",
+            ),
+        ]
+
+    def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
+        # `num_transfers` is not stored in the stats container: one successful
+        # transfer is one `transfer_duration` observation, so the counter is
+        # advanced by that column's length.
+        num_transfers = len(transfer_stats_data.get("transfer_duration", ()))
+        for counter_obj, data_key in self._counters:
+            counter = counter_obj.get(engine_idx)
+            if counter is None:
+                continue
+            if data_key == "num_transfers":
+                counter.inc(num_transfers)
+                continue
+            for value in transfer_stats_data.get(data_key, ()):
+                counter.inc(value)
+        for histogram_obj, data_key in self._histograms:
+            histogram = histogram_obj.get(engine_idx)
+            if histogram is None:
+                continue
+            for value in transfer_stats_data.get(data_key, ()):
+                histogram.observe(value)


### PR DESCRIPTION
### PR Category
Core

### PR Type
Bug Fixes

### Description
Ports two connector changes from `release/0.2` onto `main` (vLLM 0.24).

1. **P/D request matching (cherry-pick of #315).** In disaggregated serving, P and
D assign different `request_id`s to the same logical request, so the connector's
`request_id`-keyed bookkeeping never matches and KV transfers silently fail with
`Request %s not found in reqs_need_send`. #315 fixed this on `release/0.2` but
landed after `main` diverged, so `main` never got it.

2. **KV-transfer observability.** The connector records no metrics today. This
adds a stats container and Prometheus registration so transfer latency,
throughput and failure counts reach both the periodic log line and a scrape.
FlagCX is P-push, so successful-transfer metrics land on the P worker; D only
records failures.

### Related Issues
Ports #315 to the `main` line.

### Changes
- `flagcx_connector.py`: added `TransferId`, threaded `transfer_id` through the
  metadata structs and rekeyed `reqs_need_send` by it, while still reporting
  completion/timeout under the Prefill `request_id` (`p_req_id`) that the
  scheduler needs to free blocks.
- `flagcx_connector.py`: missing `transfer_id` now warns and skips instead of
  mis-matching; unbounded/hardcoded 60s waits replaced with bounded waits driven
  by `_abort_request_timeout`.
- `flagcx_connector.py`: implemented the `get_kv_connector_stats` /
  `build_kv_connector_stats` / `build_prom_metrics` hooks and instrumented the
  one-sided write, the D-side receive failures, and KV expiry.
- `flagcx_stats.py` (new): `FlagCXKVConnectorStats` + `FlagCXPromMetrics` — 7
  counters and 3 histograms under `vllm:flagcx_*`.
- `router.py`: inject `transfer_id = f"fgx-{request_id}"` on both legs; added
  `RouterStats` (prefill latency, TTFT, E2E, decode bytes, failures) logged once
  per `FLAGCX_ROUTER_STAT_INTERVAL` (default 10s, 0 disables); `print()` error
  paths replaced with `logging`.
- `flagcx.py`: fixed ctypes usage for `flagcxGetUniqueId()` /
  `flagcxCommInitRank()`, gated so both FlagCX v0.9.0 and v0.13.0 work.

### Testing
- #315's connector diff applied to `main` with zero conflicts; the metrics commit
  cherry-picked cleanly. Resulting `flagcx_connector.py` and `flagcx_stats.py`
  are byte-identical to their `release/0.2` counterparts.
- `python -m py_compile` passes on all four files.
- **Not yet verified on vLLM 0.24**: the metrics code targets the 0.20.2 base
  classes (`KVConnectorPromMetrics`, `PromMetric`, `PromMetricT`,
  `create_metric_per_engine`, and the `build_prom_metrics` signature). Needs a
  1P2D run on 0.24 to confirm the imports and signatures still hold.

### Checklist
- [x] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)