### PR TITLE
fix(worker): unwrap kv_cache_config list + set config context on vLLM 0.20

### DIFF
--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -608,22 +608,32 @@ class WorkerFL(WorkerBase):
 
     def initialize_from_config(self, kv_cache_config: KVCacheConfig) -> None:
         """Allocate GPU KV cache with the specified kv_cache_config."""
+        # vllm 0.20 passes a per-rank kv_cache_config list from the executor;
+        # stock worker_base unwraps it before dispatch, and this override must
+        # too. Each multi-engine core gets its own single-item list (TP=1), so
+        # unwrap by engine-local index rather than global rank.
+        if isinstance(kv_cache_config, list):
+            kv_cache_config = kv_cache_config[0] if len(kv_cache_config) == 1 \
+                else kv_cache_config[self.rank]
         # Init kv cache connector here, because it requires
         # `kv_cache_config`.
         # NOTE(Kuntai): This need to be done before `initialize_kv_cache`,
         # because `initialize_kv_cache` will inject kv cache groups not
         # related to kv cache connector (e.g. kv cache sharing layers).
-        ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
+        # The stock worker_base dispatch also runs under this context; some
+        # downstream calls (e.g. kv cache reshape) read the current config.
+        with set_current_vllm_config(self.vllm_config):
+            ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
 
-        ### TODO(lms):
-        # if self.vllm_config.model_config.enable_sleep_mode:
-        #     from vllm.device_allocator.cumem import CuMemAllocator
+            ### TODO(lms):
+            # if self.vllm_config.model_config.enable_sleep_mode:
+            #     from vllm.device_allocator.cumem import CuMemAllocator
 
-        #     allocator = CuMemAllocator.get_instance()
-        #     context = allocator.use_memory_pool(tag="kv_cache")
-        # else:
-        #     context = nullcontext()
-        self.model_runner.initialize_kv_cache(kv_cache_config)
+            #     allocator = CuMemAllocator.get_instance()
+            #     context = allocator.use_memory_pool(tag="kv_cache")
+            # else:
+            #     context = nullcontext()
+            self.model_runner.initialize_kv_cache(kv_cache_config)
 
     def compile_or_warm_up_model(self) -> CompilationTimes:
         warmup_sizes = []


### PR DESCRIPTION
Fixes #502

Fixes #419

`WorkerFL.initialize_from_config` overrides the stock worker dispatch and
missed two vLLM 0.20 behaviors:

- the executor now passes a per-rank `kv_cache_config` **list**; stock
  `worker_base` unwraps it before dispatch, this override did not
  (`IndexError: list index out of range`). Multi-engine (TP=1 per engine)
  gets a single-item list, so unwrap by engine-local `self.rank` rather
  than global rank.
- stock dispatch runs under `set_current_vllm_config`; the override
  lacked the context, breaking downstream `get_current_vllm_config()`
  calls during kv-cache reshape.

The `isinstance` guard keeps pre-0.20 behavior unchanged.

E2E on hygon 25: verl-FL GRPO passes on both flagtree and triton paths
with vLLM 0.20.2+flagos.

This PR was written in part with the assistance of generative AI.
