### PR TITLE
feat(arm): enable Qwen3.8 W4A8 and DFlash2 on vLLM 0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
 | Moore Threads | Supported | - |
 | Hygon | Supported | - |
 | Sunrise | Supported | - |
+| ARM64 CPU (Apple M5 Pro, CIX P1) | Supported | - |
 
 ## Quick Start
 

--- a/tests/unit_tests/ops/test_cpu_int8_backends.py
+++ b/tests/unit_tests/ops/test_cpu_int8_backends.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+import unittest
+
+import torch
+
+
+class TestCpuInt8Backends(unittest.TestCase):
+    def test_torchpack_matches_dequantized_reference(self):
+        from vllm_fl.ops import cpu_int8_pack as op
+
+        torch.manual_seed(20260804)
+        n, k = 64, 128
+        weight = torch.randn(n, k, dtype=torch.bfloat16)
+        quantized, scale = op._quantize_int8(weight)
+        linear = op._make_cpu_linear(quantized, scale, n, k)
+        dequantized = quantized.float() * scale.float()[:, None]
+        for m in (1, 3, 7):
+            x = torch.randn(m, k, dtype=torch.bfloat16)
+            actual = linear(x, weight, None).float()
+            expected = x.float() @ dequantized.T
+            relative_error = torch.linalg.vector_norm(actual - expected) / (
+                torch.linalg.vector_norm(expected) + 1e-12
+            )
+            self.assertLess(float(relative_error), 0.02)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/ops/test_cpu_quant_linear.py
+++ b/tests/unit_tests/ops/test_cpu_quant_linear.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+import logging
+import unittest
+from unittest.mock import patch
+
+import torch
+
+
+class TestCpuQuantLinearInstaller(unittest.TestCase):
+    @staticmethod
+    def _bare_layer(cls):
+        layer = object.__new__(cls)
+        torch.nn.Module.__init__(layer)
+        layer.weight = torch.nn.Parameter(
+            torch.randn(64, 128, dtype=torch.bfloat16),
+            requires_grad=False,
+        )
+        layer.bias = None
+        return layer
+
+    def test_embedding_subclasses_are_not_prepared(self):
+        import vllm.model_executor.layers.utils as layer_utils
+        from vllm.model_executor.layers.vocab_parallel_embedding import (
+            ParallelLMHead,
+            VocabParallelEmbedding,
+        )
+        from vllm_fl.ops import cpu_quant_linear
+
+        class DerivedEmbedding(VocabParallelEmbedding):
+            pass
+
+        prepared = []
+        fallback = []
+
+        def prepare(weight):
+            prepared.append(weight)
+            return lambda x, stored_weight, bias: x
+
+        def original(layer, remove_weight):
+            fallback.append(layer)
+
+        with (
+            patch.object(layer_utils, "dispatch_cpu_unquantized_gemm", original),
+            patch.object(cpu_quant_linear, "_ACTIVE_BACKEND", None),
+        ):
+            cpu_quant_linear.install_cpu_quantized_linear(
+                backend="test-w8",
+                prepare_linear=prepare,
+                supports_shape=lambda n, k: True,
+                include_lm_head=False,
+                strict=True,
+                logger=logging.getLogger(__name__),
+            )
+            embedding = self._bare_layer(DerivedEmbedding)
+            lm_head = self._bare_layer(ParallelLMHead)
+            linear = torch.nn.Linear(128, 64, bias=False, dtype=torch.bfloat16)
+
+            layer_utils.dispatch_cpu_unquantized_gemm(embedding, False)
+            layer_utils.dispatch_cpu_unquantized_gemm(lm_head, False)
+            layer_utils.dispatch_cpu_unquantized_gemm(linear, False)
+
+        self.assertEqual(fallback, [embedding, lm_head])
+        self.assertEqual(prepared, [linear.weight])
+
+    def test_different_backends_cannot_stack_dispatch_patches(self):
+        import vllm.model_executor.layers.utils as layer_utils
+        from vllm_fl.ops import cpu_quant_linear
+
+        def original(layer, remove_weight):
+            return None
+
+        kwargs = {
+            "prepare_linear": lambda weight: None,
+            "supports_shape": lambda n, k: True,
+            "include_lm_head": False,
+            "strict": True,
+            "logger": logging.getLogger(__name__),
+        }
+        with (
+            patch.object(layer_utils, "dispatch_cpu_unquantized_gemm", original),
+            patch.object(cpu_quant_linear, "_ACTIVE_BACKEND", None),
+        ):
+            cpu_quant_linear.install_cpu_quantized_linear(backend="first", **kwargs)
+            with self.assertRaisesRegex(RuntimeError, "already active as first"):
+                cpu_quant_linear.install_cpu_quantized_linear(
+                    backend="second", **kwargs
+                )
+
+    def test_lm_head_is_prepared_only_when_enabled(self):
+        import vllm.model_executor.layers.utils as layer_utils
+        from vllm.model_executor.layers.vocab_parallel_embedding import (
+            ParallelLMHead,
+        )
+        from vllm_fl.ops import cpu_quant_linear
+
+        for include_lm_head in (False, True):
+            with self.subTest(include_lm_head=include_lm_head):
+                prepared = []
+                fallback = []
+
+                def prepare(weight):
+                    prepared.append(weight)
+                    return lambda x, stored_weight, bias: x
+
+                def original(layer, remove_weight):
+                    fallback.append(layer)
+
+                with (
+                    patch.object(
+                        layer_utils, "dispatch_cpu_unquantized_gemm", original
+                    ),
+                    patch.object(cpu_quant_linear, "_ACTIVE_BACKEND", None),
+                ):
+                    cpu_quant_linear.install_cpu_quantized_linear(
+                        backend="test-lm-head",
+                        prepare_linear=prepare,
+                        supports_shape=lambda n, k: True,
+                        include_lm_head=include_lm_head,
+                        strict=True,
+                        logger=logging.getLogger(__name__),
+                    )
+                    lm_head = self._bare_layer(ParallelLMHead)
+                    layer_utils.dispatch_cpu_unquantized_gemm(lm_head, False)
+
+                self.assertEqual(len(prepared), int(include_lm_head))
+                self.assertEqual(len(fallback), int(not include_lm_head))
+
+    def test_failed_backend_initialization_does_not_patch_dispatch(self):
+        import vllm.model_executor.layers.utils as layer_utils
+        from vllm_fl.ops import cpu_quant_linear
+
+        def original(layer, remove_weight):
+            return None
+
+        def fail_initialization():
+            raise RuntimeError("native initialization failed")
+
+        with (
+            patch.object(layer_utils, "dispatch_cpu_unquantized_gemm", original),
+            patch.object(cpu_quant_linear, "_ACTIVE_BACKEND", None),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "native initialization failed"):
+                cpu_quant_linear.install_cpu_quantized_linear(
+                    backend="broken",
+                    prepare_linear=lambda weight: None,
+                    supports_shape=lambda n, k: True,
+                    include_lm_head=False,
+                    strict=True,
+                    logger=logging.getLogger(__name__),
+                    initialize=fail_initialization,
+                )
+            self.assertIsNone(cpu_quant_linear._ACTIVE_BACKEND)
+            self.assertIs(layer_utils.dispatch_cpu_unquantized_gemm, original)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/ops/test_cpu_qwen_runtime.py
+++ b/tests/unit_tests/ops/test_cpu_qwen_runtime.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+import torch
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+from vllm.v1.kv_cache_interface import FullAttentionSpec, SlidingWindowSpec
+from vllm.v1.worker.utils import KVBlockZeroer
+
+from vllm_fl.ops import cpu_qwen_gdn, cpu_qwen_runtime, cpu_w8_greedy
+from vllm_fl.patches.arm_cpu_vllm_0240 import (
+    _cpu_attention_scheduler_rebuild_policy,
+    _install_cpu_hybrid_kv_zeroing,
+    _install_cpu_spec_decode_compat,
+    _zero_cpu_attention_blocks,
+)
+
+
+class TestCpuQwenRuntime(unittest.TestCase):
+    def test_apple_arm_split_kv_metadata_is_rebuilt_without_split(self):
+        scheduler = torch.zeros(96, dtype=torch.uint8)
+        header = scheduler[64:88].view(torch.int32)
+        header[0] = 3  # NEON ISA
+        header[3] = 1  # reduction_split_num
+
+        self.assertFalse(
+            _cpu_attention_scheduler_rebuild_policy(
+                scheduler,
+                expected_isa=3,
+                requested_split_kv=True,
+                apple_arm=True,
+            )
+        )
+
+        header[3] = 0
+        self.assertIsNone(
+            _cpu_attention_scheduler_rebuild_policy(
+                scheduler,
+                expected_isa=3,
+                requested_split_kv=True,
+                apple_arm=True,
+            )
+        )
+
+    def test_runtime_registration_does_not_set_machine_policy(self):
+        q4_module = types.ModuleType("flag_gems.runtime.backend._arm.q4")
+        q4_module.enable_vllm_q4_codegen = Mock()
+        integration_module = types.ModuleType("flag_gems.integrations.vllm")
+        integration_module.maybe_install_kernel_coverage = Mock()
+        compatibility = Mock()
+        gdn_bridge = Mock()
+        cached_greedy = Mock()
+
+        compatibility_module = types.ModuleType(
+            "vllm_fl.patches.arm_cpu_vllm_0240"
+        )
+        compatibility_module.install_arm_cpu_vllm_0240_compat = compatibility
+
+        policy_names = {
+            "FLAGGEMS_VENDOR",
+            "TRITON_CPU_BACKEND",
+            "TRITON_LOCAL_LIBOMP_PATH",
+            "FLAGGEMS_GDN_TRITON_THREADS",
+            "OMP_NUM_THREADS",
+        }
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.dict(
+                sys.modules,
+                {
+                    compatibility_module.__name__: compatibility_module,
+                    q4_module.__name__: q4_module,
+                    integration_module.__name__: integration_module,
+                },
+            ),
+            patch.object(
+                cpu_qwen_gdn,
+                "install_vllm_gdn_bridge",
+                gdn_bridge,
+            ),
+            patch.object(
+                cpu_w8_greedy,
+                "install_w8_cached_greedy",
+                cached_greedy,
+            ),
+            patch.object(cpu_qwen_runtime, "_ACTIVE", False),
+        ):
+            self.assertTrue(cpu_qwen_runtime.enable_qwen_runtime(verbose=False))
+            self.assertTrue(policy_names.isdisjoint(os.environ))
+
+        compatibility.assert_called_once_with()
+        gdn_bridge.assert_called_once_with()
+        cached_greedy.assert_called_once_with()
+        q4_module.enable_vllm_q4_codegen.assert_called_once_with(
+            verbose=False,
+            runtime="libtriton_jit",
+        )
+        integration_module.maybe_install_kernel_coverage.assert_called_once_with()
+
+    def test_gdn_bridge_delegates_to_flaggems(self):
+        integration = types.ModuleType("flag_gems.integrations.vllm")
+        integration.install_qwen_gdn = Mock()
+        with patch.dict(sys.modules, {integration.__name__: integration}):
+            cpu_qwen_gdn.install_vllm_gdn_bridge()
+        integration.install_qwen_gdn.assert_called_once_with()
+
+    def test_hybrid_cpu_kv_zeroing_delegates_to_vllm_zeroer(self):
+        runner = types.SimpleNamespace(_kv_block_zeroer=Mock())
+        _zero_cpu_attention_blocks(runner, [2, 7])
+        runner._kv_block_zeroer.zero_block_ids.assert_called_once_with([2, 7])
+
+    def test_hybrid_cpu_kv_zeroing_tolerates_uninitialized_zeroer(self):
+        _zero_cpu_attention_blocks(types.SimpleNamespace(), [2, 7])
+
+    def test_cpu_kv_zeroer_clears_requested_host_page(self):
+        _install_cpu_hybrid_kv_zeroing()
+        cache = torch.full((2, 3, 1, 4, 2), 7, dtype=torch.float16)
+        backend = Mock()
+        backend.get_kv_cache_block_dim.return_value = 1
+        group = types.SimpleNamespace(
+            kv_cache_spec=FullAttentionSpec(
+                block_size=4,
+                num_kv_heads=1,
+                head_size=2,
+                dtype=torch.float16,
+            ),
+            kv_cache_group_id=0,
+            backend=backend,
+            layer_names=["target.attn"],
+        )
+        zeroer = KVBlockZeroer(
+            torch.device("cpu"),
+            pin_memory=False,
+            attn_groups_iter=[group],
+            kernel_block_sizes=[4],
+            cache_dtype="auto",
+            runner_only_attn_layers=set(),
+            static_forward_context={
+                "target.attn": types.SimpleNamespace(kv_cache=cache)
+            },
+        )
+
+        zeroer.zero_block_ids([1])
+
+        torch.testing.assert_close(cache[:, 0], torch.full_like(cache[:, 0], 7))
+        torch.testing.assert_close(cache[:, 1], torch.zeros_like(cache[:, 1]))
+        torch.testing.assert_close(cache[:, 2], torch.full_like(cache[:, 2], 7))
+
+    def test_cpu_kv_zeroer_includes_sliding_window_attention(self):
+        _install_cpu_hybrid_kv_zeroing()
+        cache = torch.full((2, 3, 1, 4, 2), 7, dtype=torch.float16)
+        backend = Mock()
+        backend.get_kv_cache_block_dim.return_value = 1
+        group = types.SimpleNamespace(
+            kv_cache_spec=SlidingWindowSpec(
+                block_size=4,
+                num_kv_heads=1,
+                head_size=2,
+                dtype=torch.float16,
+                sliding_window=16,
+            ),
+            kv_cache_group_id=0,
+            backend=backend,
+            layer_names=["draft.attn"],
+        )
+        context = {
+            "draft.attn": types.SimpleNamespace(kv_cache=cache),
+        }
+        zeroer = KVBlockZeroer(
+            torch.device("cpu"),
+            pin_memory=False,
+            attn_groups_iter=[group],
+            kernel_block_sizes=[4],
+            cache_dtype="auto",
+            runner_only_attn_layers=set(),
+            static_forward_context=context,
+        )
+        zeroer.zero_block_ids([1])
+
+        torch.testing.assert_close(cache[:, 0], torch.full_like(cache[:, 0], 7))
+        torch.testing.assert_close(cache[:, 1], torch.zeros_like(cache[:, 1]))
+        torch.testing.assert_close(cache[:, 2], torch.full_like(cache[:, 2], 7))
+
+    def test_sliding_window_manager_reports_new_pages_for_zeroing(self):
+        spec = SlidingWindowSpec(
+            block_size=4,
+            num_kv_heads=1,
+            head_size=2,
+            dtype=torch.float16,
+            sliding_window=16,
+        )
+        pool = BlockPool(
+            num_gpu_blocks=8,
+            enable_caching=False,
+            hash_block_size=4,
+        )
+        manager = SlidingWindowManager(
+            spec,
+            block_pool=pool,
+            enable_caching=False,
+            kv_cache_group_id=0,
+            scheduler_block_size=4,
+            max_admission_blocks_per_request=8,
+        )
+
+        blocks = manager.allocate_new_blocks(
+            request_id="request",
+            num_tokens=4,
+            num_tokens_main_model=4,
+        )
+
+        self.assertEqual(
+            manager.take_new_block_ids(),
+            [block.block_id for block in blocks],
+        )
+
+    def test_cpu_spec_decode_compat_accepts_current_greedy_abi(self):
+        import vllm.utils.cpu_triton_utils as cpu_tl
+
+        kernel = cpu_tl.rejection_greedy_sample_kernel
+        random_kernel = cpu_tl.rejection_random_sample_kernel
+        original = kernel.func
+        original_random = random_kernel.func
+        legacy = Mock()
+        legacy._vllm_fl_spec_decode_abi = False
+        kernel.func = legacy
+        try:
+            _install_cpu_spec_decode_compat()
+            args = [object() for _ in range(7)]
+            kernel.func(
+                *args,
+                object(),
+                object(),
+                SYNTHETIC_MODE=False,
+            )
+            legacy.assert_called_once_with(*args)
+            with self.assertRaisesRegex(NotImplementedError, "synthetic"):
+                kernel.func(
+                    *args,
+                    None,
+                    None,
+                    SYNTHETIC_MODE=True,
+                )
+        finally:
+            kernel.func = original
+            random_kernel.func = original_random
+
+    def test_cached_greedy_accepts_only_safe_processor_state(self):
+        LogitBias = type("LogitBiasLogitsProcessor", (), {})
+        MinTokens = type("MinTokensLogitsProcessor", (), {})
+        ThinkingBudget = type("ThinkingTokenBudgetLogitsProcessor", (), {})
+        bias = LogitBias()
+        bias.biases = {}
+        min_tokens = MinTokens()
+        min_tokens.min_toks = {0: (128, [], {1, 2})}
+        thinking = ThinkingBudget()
+        thinking.is_enabled = False
+        processors = types.SimpleNamespace(
+            non_argmax_invariant=[bias, min_tokens, thinking]
+        )
+        metadata = types.SimpleNamespace(
+            logitsprocs=processors,
+            temperature=None,
+            all_random=False,
+            all_greedy=True,
+            max_num_logprobs=None,
+            logprob_token_ids={},
+            allowed_token_ids_mask=None,
+            bad_words_token_ids=[],
+            no_penalties=True,
+        )
+        logits = torch.zeros((1, 32), dtype=torch.bfloat16)
+        with patch.object(cpu_w8_greedy, "_ENABLED", True):
+            self.assertTrue(cpu_w8_greedy._eligible(logits, metadata))
+            self.assertEqual(
+                cpu_w8_greedy._masked_stop_tokens(metadata), {1, 2}
+            )
+            min_tokens.min_toks[1] = (129, [], {3})
+            self.assertEqual(
+                cpu_w8_greedy._all_masked_stop_tokens(metadata), {1, 2, 3}
+            )
+            bias.biases = {0: {5: 1.0}}
+            self.assertFalse(cpu_w8_greedy._eligible(logits, metadata))
+
+    def test_cached_greedy_recognizes_zero_temperature_mixed_batch(self):
+        metadata = types.SimpleNamespace(
+            logitsprocs=types.SimpleNamespace(non_argmax_invariant=[]),
+            temperature=torch.tensor([0.0]),
+            all_random=False,
+            all_greedy=False,
+            max_num_logprobs=None,
+            logprob_token_ids={},
+            allowed_token_ids_mask=None,
+            bad_words_token_ids=[],
+            no_penalties=True,
+        )
+        logits = torch.zeros((1, 32), dtype=torch.bfloat16)
+        with patch.object(cpu_w8_greedy, "_ENABLED", True):
+            self.assertTrue(cpu_w8_greedy._eligible(logits, metadata))
+            metadata.temperature.fill_(0.5)
+            self.assertFalse(cpu_w8_greedy._eligible(logits, metadata))
+
+    def test_cached_spec_greedy_requires_exact_mtp1_semantics(self):
+        sampling = types.SimpleNamespace(
+            logitsprocs=types.SimpleNamespace(non_argmax_invariant=[]),
+            temperature=torch.tensor([0.0]),
+            all_random=False,
+            all_greedy=True,
+            max_num_logprobs=None,
+            logprob_token_ids={},
+            allowed_token_ids_mask=None,
+            bad_words_token_ids=[],
+            no_penalties=True,
+        )
+        metadata = types.SimpleNamespace(
+            max_spec_len=1,
+            draft_token_ids=torch.tensor([7], dtype=torch.int32),
+            num_draft_tokens=[1],
+            target_logits_indices=torch.tensor([0]),
+            bonus_logits_indices=torch.tensor([1]),
+        )
+        logits = torch.zeros((2, 32), dtype=torch.bfloat16)
+        with patch.object(cpu_w8_greedy, "_ENABLED", True):
+            self.assertTrue(
+                cpu_w8_greedy._spec_eligible(logits, metadata, sampling)
+            )
+            metadata.max_spec_len = 2
+            self.assertFalse(
+                cpu_w8_greedy._spec_eligible(logits, metadata, sampling)
+            )
+            metadata.max_spec_len = 1
+            MinTokens = type("MinTokensLogitsProcessor", (), {})
+            sampling.logitsprocs.non_argmax_invariant = [MinTokens()]
+            self.assertTrue(
+                cpu_w8_greedy._spec_eligible(logits, metadata, sampling)
+            )
+            Unsupported = type("UnsupportedLogitsProcessor", (), {})
+            sampling.logitsprocs.non_argmax_invariant = [Unsupported()]
+            self.assertFalse(
+                cpu_w8_greedy._spec_eligible(logits, metadata, sampling)
+            )
+
+    def test_multi_spec_greedy_reduces_bf16_rows_without_fp32_copy(self):
+        sampling = types.SimpleNamespace(
+            logitsprocs=types.SimpleNamespace(non_argmax_invariant=[]),
+            temperature=torch.tensor([0.0]),
+            all_random=False,
+            all_greedy=True,
+            max_num_logprobs=None,
+            logprob_token_ids={},
+            allowed_token_ids_mask=None,
+            bad_words_token_ids=[],
+            no_penalties=True,
+        )
+        metadata = types.SimpleNamespace(
+            max_spec_len=3,
+            draft_token_ids=torch.tensor([2, 4, 1], dtype=torch.int32),
+            num_draft_tokens=[3],
+            target_logits_indices=torch.tensor([0, 1, 2]),
+            bonus_logits_indices=torch.tensor([3]),
+        )
+        logits = torch.full((4, 8), -4, dtype=torch.bfloat16)
+        logits[0, 2] = 5
+        logits[1, 4] = 5
+        logits[2, 6] = 5
+        logits[3, 7] = 5
+        with (
+            patch.dict(
+                os.environ,
+                {"VLLM_FL_FAST_GREEDY_SPEC_REJECTION": "1"},
+            ),
+            patch.object(cpu_w8_greedy, "_ENABLED", True),
+            patch.object(cpu_w8_greedy, "_SPEC_ENABLED", True),
+        ):
+            self.assertTrue(
+                cpu_w8_greedy._multi_spec_eligible(
+                    logits, metadata, sampling
+                )
+            )
+            sampled = cpu_w8_greedy._multi_spec_greedy_sample(
+                logits, metadata, sampling
+            )
+            self.assertEqual(sampled.tolist(), [[2, 4, 6, -1]])
+
+            metadata.draft_token_ids[2] = 6
+            sampled = cpu_w8_greedy._multi_spec_greedy_sample(
+                logits, metadata, sampling
+            )
+            self.assertEqual(sampled.tolist(), [[2, 4, 6, 7]])
+
+            MinTokens = type("MinTokensLogitsProcessor", (), {})
+            min_tokens = MinTokens()
+            min_tokens.min_toks = {0: (128, [], {7})}
+            sampling.logitsprocs.non_argmax_invariant = [min_tokens]
+            self.assertIsNone(
+                cpu_w8_greedy._multi_spec_greedy_sample(
+                    logits, metadata, sampling
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_arm_cpu_registration.py
+++ b/tests/unit_tests/test_arm_cpu_registration.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock, patch
+
+import vllm_fl
+
+
+def _fake_vllm_platforms(cpu_platform="vllm.platforms.cpu.CpuPlatform"):
+    module = ModuleType("vllm.platforms")
+    module.cpu_platform_plugin = Mock(return_value=cpu_platform)
+    module.current_platform = SimpleNamespace(device_type="cpu")
+    return module
+
+
+class TestArmCpuRegistration(unittest.TestCase):
+    def test_arm_cpu_target_uses_standard_flaggems_vendor_selection(self):
+        platforms = _fake_vllm_platforms()
+        with (
+            patch("platform.machine", return_value="aarch64"),
+            patch("flag_gems.vendor_name", "arm"),
+            patch.dict(sys.modules, {platforms.__name__: platforms}),
+        ):
+            self.assertTrue(vllm_fl._is_arm_cpu_target())
+
+    def test_arm_cpu_register_uses_native_backed_cpu_platform(self):
+        with (
+            patch.object(vllm_fl, "_is_arm_cpu_target", return_value=True),
+            patch.object(vllm_fl, "_patch_custom_ops") as custom_ops,
+            patch.object(vllm_fl, "_patch_flash_attn_import") as flash_attn,
+            patch.object(vllm_fl, "_patch_transformers_compat") as transformers,
+        ):
+            self.assertEqual(
+                vllm_fl.register(),
+                "vllm.platforms.cpu.CpuPlatform",
+            )
+            custom_ops.assert_not_called()
+            flash_attn.assert_not_called()
+            transformers.assert_not_called()
+
+    def test_arm_accelerator_vendor_does_not_select_cpu(self):
+        platforms = _fake_vllm_platforms()
+        with (
+            patch("platform.machine", return_value="aarch64"),
+            patch("flag_gems.vendor_name", "ascend"),
+            patch.dict(sys.modules, {platforms.__name__: platforms}),
+        ):
+            self.assertFalse(vllm_fl._is_arm_cpu_target())
+            platforms.cpu_platform_plugin.assert_not_called()
+
+    def test_arm_target_requires_vllm_cpu_backend(self):
+        platforms = _fake_vllm_platforms(cpu_platform=None)
+        with (
+            patch("platform.machine", return_value="aarch64"),
+            patch("flag_gems.vendor_name", "arm"),
+            patch.dict(sys.modules, {platforms.__name__: platforms}),
+        ):
+            self.assertFalse(vllm_fl._is_arm_cpu_target())
+
+    def test_non_arm_cpu_build_is_not_selected(self):
+        platforms = _fake_vllm_platforms()
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch.dict(sys.modules, {platforms.__name__: platforms}),
+        ):
+            self.assertFalse(vllm_fl._is_arm_cpu_target())
+            platforms.cpu_platform_plugin.assert_not_called()
+
+    def test_arm_registration_enables_quant_runtime_without_mode_flags(self):
+        integration_module = ModuleType("flag_gems.integrations.vllm")
+        integration_module.install_arm_cpu_runtime = Mock()
+        platforms = _fake_vllm_platforms()
+
+        with (
+            patch(
+                "vllm_fl.patches.qwen3_5_text.apply_qwen3_5_text_patches"
+            ) as qwen_compat,
+            patch.object(vllm_fl, "_is_arm_cpu_target", return_value=True),
+            patch("vllm_fl.patches.moe_sum.patch_vllm_moe_sum") as moe_sum,
+            patch.dict(
+                sys.modules,
+                {
+                    integration_module.__name__: integration_module,
+                    platforms.__name__: platforms,
+                },
+            ),
+        ):
+            vllm_fl.register_model()
+
+        qwen_compat.assert_called_once_with()
+        integration_module.install_arm_cpu_runtime.assert_called_once_with()
+        moe_sum.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_arm_cpu_registration.py
+++ b/tests/unit_tests/test_arm_cpu_registration.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2026 BAAI. All rights reserved.
 
+import os
+import subprocess
 import sys
+import textwrap
 import unittest
 from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock, patch
@@ -8,89 +11,99 @@ from unittest.mock import Mock, patch
 import vllm_fl
 
 
-def _fake_vllm_platforms(cpu_platform="vllm.platforms.cpu.CpuPlatform"):
-    module = ModuleType("vllm.platforms")
-    module.cpu_platform_plugin = Mock(return_value=cpu_platform)
-    module.current_platform = SimpleNamespace(device_type="cpu")
-    return module
-
-
 class TestArmCpuRegistration(unittest.TestCase):
-    def test_arm_cpu_target_uses_standard_flaggems_vendor_selection(self):
-        platforms = _fake_vllm_platforms()
-        with (
-            patch("platform.machine", return_value="aarch64"),
-            patch("flag_gems.vendor_name", "arm"),
-            patch.dict(sys.modules, {platforms.__name__: platforms}),
-        ):
-            self.assertTrue(vllm_fl._is_arm_cpu_target())
+    def test_import_does_not_eagerly_import_flaggems(self):
+        script = textwrap.dedent(
+            """
+            import builtins
 
-    def test_arm_cpu_register_uses_native_backed_cpu_platform(self):
+            original_import = builtins.__import__
+
+            def guarded_import(name, *args, **kwargs):
+                if name == "flag_gems" or name.startswith("flag_gems."):
+                    raise RuntimeError("vllm_fl imported FlagGems eagerly")
+                return original_import(name, *args, **kwargs)
+
+            builtins.__import__ = guarded_import
+            import vllm_fl
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_arm_cpu_build_is_selected(self):
         with (
-            patch.object(vllm_fl, "_is_arm_cpu_target", return_value=True),
+            patch.object(vllm_fl.platform, "machine", return_value="aarch64"),
+            patch.object(vllm_fl.metadata, "version", return_value="0.24.0+cpu"),
+        ):
+            self.assertTrue(vllm_fl._is_arm_cpu_build())
+
+    def test_plain_version_honors_explicit_cpu_target(self):
+        with (
+            patch.object(vllm_fl.platform, "machine", return_value="aarch64"),
+            patch.object(vllm_fl.metadata, "version", return_value="0.24.0"),
+            patch.dict(os.environ, {"VLLM_TARGET_DEVICE": "cpu"}),
+        ):
+            self.assertTrue(vllm_fl._is_arm_cpu_build())
+
+    def test_arm_accelerator_build_is_not_selected_as_cpu(self):
+        with (
+            patch.object(vllm_fl.platform, "machine", return_value="aarch64"),
+            patch.object(vllm_fl.metadata, "version", return_value="0.24.0"),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            self.assertFalse(vllm_fl._is_arm_cpu_build())
+
+    def test_non_arm_cpu_build_is_not_selected(self):
+        with (
+            patch.object(vllm_fl.platform, "machine", return_value="x86_64"),
+            patch.object(vllm_fl.metadata, "version", return_value="0.24.0+cpu"),
+        ):
+            self.assertFalse(vllm_fl._is_arm_cpu_build())
+
+    def test_arm_cpu_register_uses_native_backed_platform(self):
+        with (
+            patch.object(vllm_fl, "_is_arm_cpu_build", return_value=True),
             patch.object(vllm_fl, "_patch_custom_ops") as custom_ops,
             patch.object(vllm_fl, "_patch_flash_attn_import") as flash_attn,
             patch.object(vllm_fl, "_patch_transformers_compat") as transformers,
         ):
             self.assertEqual(
                 vllm_fl.register(),
-                "vllm.platforms.cpu.CpuPlatform",
+                "vllm_fl.platform_cpu.CpuPlatformFL",
             )
             custom_ops.assert_not_called()
             flash_attn.assert_not_called()
             transformers.assert_not_called()
 
-    def test_arm_accelerator_vendor_does_not_select_cpu(self):
-        platforms = _fake_vllm_platforms()
-        with (
-            patch("platform.machine", return_value="aarch64"),
-            patch("flag_gems.vendor_name", "ascend"),
-            patch.dict(sys.modules, {platforms.__name__: platforms}),
-        ):
-            self.assertFalse(vllm_fl._is_arm_cpu_target())
-            platforms.cpu_platform_plugin.assert_not_called()
-
-    def test_arm_target_requires_vllm_cpu_backend(self):
-        platforms = _fake_vllm_platforms(cpu_platform=None)
-        with (
-            patch("platform.machine", return_value="aarch64"),
-            patch("flag_gems.vendor_name", "arm"),
-            patch.dict(sys.modules, {platforms.__name__: platforms}),
-        ):
-            self.assertFalse(vllm_fl._is_arm_cpu_target())
-
-    def test_non_arm_cpu_build_is_not_selected(self):
-        platforms = _fake_vllm_platforms()
-        with (
-            patch("platform.machine", return_value="x86_64"),
-            patch.dict(sys.modules, {platforms.__name__: platforms}),
-        ):
-            self.assertFalse(vllm_fl._is_arm_cpu_target())
-            platforms.cpu_platform_plugin.assert_not_called()
-
-    def test_arm_registration_enables_quant_runtime_without_mode_flags(self):
-        integration_module = ModuleType("flag_gems.integrations.vllm")
-        integration_module.install_arm_cpu_runtime = Mock()
-        platforms = _fake_vllm_platforms()
+    def test_arm_registration_installs_cpu_compat_without_quant(self):
+        compat_module = ModuleType("vllm_fl.patches.arm_cpu_vllm_0240")
+        compat_module.install_arm_cpu_vllm_0240_compat = Mock()
 
         with (
             patch(
                 "vllm_fl.patches.qwen3_5_text.apply_qwen3_5_text_patches"
             ) as qwen_compat,
-            patch.object(vllm_fl, "_is_arm_cpu_target", return_value=True),
             patch("vllm_fl.patches.moe_sum.patch_vllm_moe_sum") as moe_sum,
+            patch.object(vllm_fl, "_is_arm_cpu_build", return_value=True),
+            patch(
+                "vllm.platforms.current_platform",
+                SimpleNamespace(device_type="cpu"),
+            ),
             patch.dict(
                 sys.modules,
-                {
-                    integration_module.__name__: integration_module,
-                    platforms.__name__: platforms,
-                },
+                {compat_module.__name__: compat_module},
             ),
+            patch.dict(os.environ, {}, clear=True),
         ):
             vllm_fl.register_model()
 
         qwen_compat.assert_called_once_with()
-        integration_module.install_arm_cpu_runtime.assert_called_once_with()
+        compat_module.install_arm_cpu_vllm_0240_compat.assert_called_once_with()
         moe_sum.assert_not_called()
 
 

--- a/tests/unit_tests/test_cpu_sampling_constraints.py
+++ b/tests/unit_tests/test_cpu_sampling_constraints.py
@@ -1,0 +1,190 @@
+from types import SimpleNamespace
+
+import torch
+
+from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p_pytorch
+from vllm.v1.sample.rejection_sampler import (
+    PLACEHOLDER_TOKEN_ID,
+    apply_sampling_constraints,
+    expand_batch_to_tokens,
+    rejection_sample,
+    sample_recovered_tokens,
+)
+
+from vllm_fl.patches.arm_cpu_vllm_0240 import (
+    _apply_top_k_top_p_small_k_cpu,
+    _install_cpu_spec_decode_compat,
+    _install_cpu_spec_decode_kernels,
+)
+
+
+def setup_module() -> None:
+    # Direct unit imports bypass platform-plugin initialization. Install the
+    # same official CPU wrappers used by the real vLLM 0.24 engine so these
+    # tests do not compile the generic GPU-oriented Triton control kernels.
+    _install_cpu_spec_decode_kernels()
+    _install_cpu_spec_decode_compat()
+
+
+def test_topk_vocab_size_disables_filter_with_top_p() -> None:
+    """vLLM 0.24 represents public top_k=0 as the vocabulary size."""
+    logits = torch.tensor([[0.1, 0.2, 0.3, 0.4]], dtype=torch.float32)
+    result = apply_top_k_top_p_pytorch(
+        logits.clone(),
+        k=torch.tensor([logits.shape[1]], dtype=torch.int32),
+        p=torch.tensor([1.0], dtype=torch.float32),
+    )
+
+    torch.testing.assert_close(result, logits)
+
+
+def test_small_topk_topp_matches_reference_masks_and_logits() -> None:
+    torch.manual_seed(20260822)
+    logits = torch.randn(4, 257, dtype=torch.float32)
+    top_k = torch.tensor([1, 5, 20, 127], dtype=torch.int32)
+    top_p = torch.tensor([0.8, 0.95, 1.0, 0.5], dtype=torch.float32)
+
+    expected = apply_top_k_top_p_pytorch(logits.clone(), top_k.clone(), top_p.clone())
+    actual = _apply_top_k_top_p_small_k_cpu(
+        logits.clone(), top_k.clone(), top_p.clone()
+    )
+
+    assert actual is not None
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_small_topk_topp_retains_all_topk_boundary_ties() -> None:
+    logits = torch.tensor([[4.0, 3.0, 2.0, 2.0, 1.0]], dtype=torch.float32)
+
+    actual = _apply_top_k_top_p_small_k_cpu(
+        logits,
+        torch.tensor([3], dtype=torch.int32),
+        torch.tensor([0.95], dtype=torch.float32),
+    )
+
+    expected = torch.tensor([[4.0, 3.0, 2.0, 2.0, -float("inf")]])
+    assert actual is not None
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_small_topk_topp_uses_triton_token_order_for_topp_ties() -> None:
+    logits = torch.tensor([[4.0, 4.0, 3.0, 2.0, 1.0]], dtype=torch.float32)
+
+    actual = _apply_top_k_top_p_small_k_cpu(
+        logits,
+        torch.tensor([4], dtype=torch.int32),
+        torch.tensor([0.3], dtype=torch.float32),
+    )
+
+    expected = torch.tensor(
+        [[4.0, -float("inf"), -float("inf"), -float("inf"), -float("inf")]]
+    )
+    assert actual is not None
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_small_topk_topp_keeps_fast_path_when_topp_does_not_split_tie() -> None:
+    logits = torch.tensor([[4.0, 4.0, 3.0, 2.0, 1.0]], dtype=torch.float32)
+
+    actual = _apply_top_k_top_p_small_k_cpu(
+        logits,
+        torch.tensor([4], dtype=torch.int32),
+        torch.tensor([0.5], dtype=torch.float32),
+    )
+
+    assert actual is not None
+    expected = apply_top_k_top_p_pytorch(
+        logits.clone(),
+        torch.tensor([4], dtype=torch.int32),
+        torch.tensor([0.5], dtype=torch.float32),
+    )
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_small_topk_topp_falls_back_for_nonpositive_k() -> None:
+    logits = torch.tensor([[4.0, 3.0, 2.0], [3.0, 2.0, 1.0]], dtype=torch.float32)
+
+    actual = _apply_top_k_top_p_small_k_cpu(
+        logits,
+        torch.tensor([2, 0], dtype=torch.int32),
+        torch.tensor([0.95, 0.95], dtype=torch.float32),
+    )
+
+    assert actual is None
+
+
+def test_cpu_expand_batch_to_tokens_is_initialized() -> None:
+    expanded = expand_batch_to_tokens(
+        torch.tensor([1.0, 0.5], dtype=torch.float32),
+        torch.tensor([3, 5], dtype=torch.int32),
+        num_tokens=5,
+    )
+
+    torch.testing.assert_close(expanded, torch.tensor([1.0, 1.0, 1.0, 0.5, 0.5]))
+
+
+def test_cpu_speculative_sampling_constraints_remain_finite() -> None:
+    logits = torch.arange(64, dtype=torch.float32).view(4, 16)
+    constrained = apply_sampling_constraints(
+        logits,
+        torch.tensor([4], dtype=torch.int32),
+        SimpleNamespace(
+            all_greedy=False,
+            temperature=torch.tensor([1.0]),
+            top_k=torch.tensor([5], dtype=torch.int32),
+            top_p=torch.tensor([0.95]),
+        ),
+    )
+
+    assert not torch.isnan(constrained).any()
+    assert torch.isfinite(constrained).any(dim=-1).all()
+
+
+def test_cpu_recovered_token_uses_positive_residual_mass() -> None:
+    vocab_size = 16
+    draft_probs = torch.zeros((1, vocab_size), dtype=torch.float32)
+    draft_probs[0, 1] = 1.0
+    target_probs = torch.zeros((1, vocab_size), dtype=torch.float32)
+    target_probs[0, 5] = 1.0
+
+    recovered = sample_recovered_tokens(
+        max_spec_len=1,
+        num_draft_tokens=[1],
+        cu_num_draft_tokens=torch.tensor([1], dtype=torch.int32),
+        draft_token_ids=torch.tensor([1], dtype=torch.int32),
+        draft_probs=draft_probs,
+        target_probs=target_probs,
+        sampling_metadata=SimpleNamespace(
+            generators={0: torch.Generator().manual_seed(7)}
+        ),
+        device=torch.device("cpu"),
+    )
+
+    torch.testing.assert_close(recovered, torch.tensor([5], dtype=torch.int32))
+
+
+def test_cpu_random_rejection_emits_recovered_token() -> None:
+    vocab_size = 16
+    draft_probs = torch.zeros((1, vocab_size), dtype=torch.float32)
+    draft_probs[0, 1] = 1.0
+    target_logits = torch.full((1, vocab_size), -100.0, dtype=torch.float32)
+    target_logits[0, 5] = 100.0
+
+    output = rejection_sample(
+        draft_token_ids=torch.tensor([1], dtype=torch.int32),
+        num_draft_tokens=[1],
+        max_spec_len=1,
+        cu_num_draft_tokens=torch.tensor([1], dtype=torch.int32),
+        draft_probs=draft_probs,
+        target_logits=target_logits,
+        bonus_token_ids=torch.tensor([[9]], dtype=torch.int32),
+        sampling_metadata=SimpleNamespace(
+            all_greedy=False,
+            all_random=True,
+            temperature=torch.tensor([1.0]),
+            generators={0: torch.Generator().manual_seed(11)},
+        ),
+    )
+
+    expected = torch.tensor([[5, PLACEHOLDER_TOKEN_ID]], dtype=torch.int32)
+    torch.testing.assert_close(output, expected)

--- a/tests/unit_tests/test_dflash2_vllm024.py
+++ b/tests/unit_tests/test_dflash2_vllm024.py
@@ -1,0 +1,570 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_fl.models.qwen3_dflash2 import (
+    _grouped_dynamic_conv_sliced,
+    dflash2_keyed_uniform,
+    grouped_dynamic_conv,
+    select_greedy_path,
+    select_stochastic_path,
+    validate_dflash2_block_size,
+)
+from vllm_fl.spec_decode.dflash2 import (
+    DFlash2Proposer,
+    compute_dflash2_anchor_positions,
+    dflash_target_rope_is_neox_style,
+)
+
+
+def test_dflash2_registers_before_registry_probe_returns(monkeypatch):
+    import vllm.model_executor.models as models
+    import vllm.platforms as platforms
+
+    import vllm_fl
+
+    registrations = []
+    monkeypatch.setattr(
+        models.ModelRegistry,
+        "register_model",
+        lambda architecture, model: registrations.append((architecture, model)),
+    )
+    monkeypatch.setattr(
+        platforms, "current_platform", SimpleNamespace(device_type="cpu")
+    )
+    monkeypatch.setattr(vllm_fl, "_is_arm_cpu_build", lambda: True)
+    monkeypatch.setattr("sys.argv", ["registry.py"])
+
+    vllm_fl.register_model()
+
+    dflash_registration = (
+        "DFlash2DraftModel",
+        "vllm_fl.models.qwen3_dflash2:DFlash2Qwen3ForCausalLM",
+    )
+    assert registrations.count(dflash_registration) == 1
+
+
+def test_arm_cpu_bf16_installs_dflash2_compat(monkeypatch):
+    import vllm.model_executor.models as models
+    import vllm.platforms as platforms
+
+    import vllm_fl
+
+    calls = []
+    compat = ModuleType("vllm_fl.patches.arm_cpu_vllm_0240")
+    compat.install_arm_cpu_vllm_0240_compat = lambda: calls.append(True)
+    monkeypatch.setitem(sys.modules, compat.__name__, compat)
+    monkeypatch.setattr(models.ModelRegistry, "register_model", lambda *args: None)
+    monkeypatch.setattr(
+        platforms,
+        "current_platform",
+        SimpleNamespace(device_type="cpu"),
+    )
+    monkeypatch.setattr(vllm_fl, "_is_arm_cpu_build", lambda: True)
+    monkeypatch.setattr("sys.argv", ["worker.py"])
+    monkeypatch.delenv("FL_CPU_INT8", raising=False)
+    monkeypatch.delenv("FL_CPU_INT4", raising=False)
+
+    vllm_fl.register_model()
+
+    assert calls == [True]
+
+
+class _FakeSelector:
+    def select_greedy(
+        self,
+        candidate_ids,
+        unary_logits,
+        hidden_states,
+        anchor_token_ids,
+    ):
+        del unary_logits, hidden_states, anchor_token_ids
+        return candidate_ids[..., 0]
+
+    def select_stochastic(
+        self,
+        candidate_ids,
+        unary_logits,
+        hidden_states,
+        anchor_token_ids,
+        temperatures,
+        seeds,
+        anchor_positions,
+    ):
+        del (
+            unary_logits,
+            hidden_states,
+            anchor_token_ids,
+            temperatures,
+            seeds,
+            anchor_positions,
+        )
+        probabilities = torch.zeros_like(candidate_ids, dtype=torch.float32)
+        probabilities[..., 1] = 1.0
+        return candidate_ids[..., 1], probabilities
+
+
+class _FakeDFlash2Model:
+    def __init__(self):
+        self.config = SimpleNamespace(vocab_size=11)
+        self.model = SimpleNamespace(candidate_selector=_FakeSelector())
+
+    def compute_candidates(self, hidden_states):
+        num_tokens = hidden_states.shape[0]
+        ids = torch.tensor([2, 5], dtype=torch.int64).expand(num_tokens, -1)
+        logits = torch.tensor([0.25, 0.75]).expand(num_tokens, -1)
+        return ids, logits
+
+
+def _make_proposer():
+    from vllm_fl.spec_decode.dflash2 import DFlash2Proposer
+
+    proposer = object.__new__(DFlash2Proposer)
+    proposer.model = _FakeDFlash2Model()
+    proposer.num_speculative_tokens = 2
+    proposer._anchor_token_ids = torch.tensor([7])
+    proposer._anchor_positions = torch.tensor([10])
+    proposer.runner = None
+    proposer._request_sampling_seeds = {}
+    return proposer
+
+
+def test_dflash2_vllm024_greedy_selector_path():
+    proposer = _make_proposer()
+    sampling = SimpleNamespace(all_greedy=True)
+
+    token_ids, draft_probs = proposer._sample_draft_tokens(torch.zeros(2, 3), sampling)
+
+    assert token_ids.tolist() == [2, 2]
+    assert draft_probs is None
+
+
+def test_dflash2_vllm024_stochastic_selector_probability_rows():
+    proposer = _make_proposer()
+    sampling = SimpleNamespace(
+        all_greedy=False,
+        temperature=torch.tensor([0.8]),
+        generators={},
+    )
+
+    token_ids, draft_probs = proposer._sample_draft_tokens(torch.zeros(2, 3), sampling)
+
+    assert token_ids.tolist() == [5, 5]
+    assert draft_probs.shape == (2, 11)
+    assert torch.equal(draft_probs[:, 5], torch.ones(2))
+    assert torch.count_nonzero(draft_probs).item() == 2
+
+
+def test_runtime_block_size_stays_within_checkpoint_contract() -> None:
+    draft_config = {"block_size": 8}
+
+    assert validate_dflash2_block_size(draft_config, 3) == 4
+    assert validate_dflash2_block_size(draft_config, 7) == 8
+    with pytest.raises(ValueError, match="checkpoint block size"):
+        validate_dflash2_block_size(draft_config, 8)
+
+
+def _reference_grouped_dynamic_conv(
+    hidden_states: torch.Tensor,
+    delta: torch.Tensor,
+    base: torch.Tensor,
+    block_size: int,
+    group_size: int,
+) -> torch.Tensor:
+    hidden_size = hidden_states.shape[-1]
+    num_groups = hidden_size // group_size
+    output = torch.empty_like(hidden_states)
+    for row in range(hidden_states.shape[0]):
+        block_position = row % block_size
+        for group in range(num_groups):
+            start = group * group_size
+            end = start + group_size
+            value = torch.zeros(group_size, dtype=hidden_states.dtype)
+            for tap in range(base.shape[0]):
+                if tap <= block_position:
+                    source = hidden_states[row - tap, start:end]
+                    coefficient = base[tap, start:end] + delta[row, tap, group]
+                    value += coefficient * source
+            output[row, start:end] = value
+    return output
+
+
+def _load_native_grouped_conv_or_skip() -> None:
+    if hasattr(torch.ops.triton_jit_cpu, "dflash2_grouped_conv"):
+        return
+    library = os.environ.get("FLAGGEMS_LIBTRITON_JIT_Q4_OP")
+    if library is None or not os.path.isfile(library):
+        pytest.skip("FlagGems ARM operator bundle is not built")
+    torch.ops.load_library(os.path.realpath(library))
+    if not hasattr(torch.ops.triton_jit_cpu, "dflash2_grouped_conv"):
+        pytest.skip("FlagGems ARM bundle lacks DFlash2 grouped convolution")
+
+
+def test_grouped_dynamic_conv_matches_scalar_reference(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_FL_DFLASH2_NATIVE_CONV", "0")
+    monkeypatch.setenv("VLLM_FL_DFLASH2_SLICED_CONV", "0")
+    torch.manual_seed(7)
+    block_size = 4
+    group_size = 2
+    hidden_states = torch.randn(3 * block_size, 8)
+    delta = torch.randn(3 * block_size, 3, 4)
+    base = torch.randn(3, 8)
+
+    actual = grouped_dynamic_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size,
+        group_size,
+    )
+    expected = _reference_grouped_dynamic_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size,
+        group_size,
+    )
+    torch.testing.assert_close(actual, expected)
+
+
+def test_grouped_dynamic_conv_does_not_cross_draft_blocks(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_FL_DFLASH2_NATIVE_CONV", "0")
+    monkeypatch.setenv("VLLM_FL_DFLASH2_SLICED_CONV", "0")
+    hidden_states = torch.tensor([[1.0], [2.0], [100.0], [200.0]])
+    delta = torch.zeros(4, 2, 1)
+    base = torch.ones(2, 1)
+
+    actual = grouped_dynamic_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size=2,
+        group_size=1,
+    )
+    torch.testing.assert_close(
+        actual[:, 0],
+        torch.tensor([1.0, 3.0, 100.0, 300.0]),
+    )
+
+
+def test_sliced_grouped_dynamic_conv_is_bf16_bit_exact(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_FL_DFLASH2_NATIVE_CONV", "0")
+    monkeypatch.setenv("VLLM_FL_DFLASH2_SLICED_CONV", "0")
+    torch.manual_seed(20260825)
+    hidden_states = torch.randn(24, 5120, dtype=torch.bfloat16)
+    delta = torch.randn(24, 2, 320, dtype=torch.bfloat16)
+    base = torch.randn(2, 5120, dtype=torch.bfloat16)
+
+    reference = grouped_dynamic_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size=8,
+        group_size=16,
+    )
+    direct_candidate = _grouped_dynamic_conv_sliced(
+        hidden_states,
+        delta,
+        base,
+        block_size=8,
+        group_size=16,
+    )
+    monkeypatch.setenv("VLLM_FL_DFLASH2_SLICED_CONV", "1")
+    routed_candidate = grouped_dynamic_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size=8,
+        group_size=16,
+    )
+
+    torch.testing.assert_close(direct_candidate, reference, atol=0, rtol=0)
+    torch.testing.assert_close(routed_candidate, reference, atol=0, rtol=0)
+
+
+def test_native_grouped_dynamic_conv_is_bf16_bit_exact(monkeypatch) -> None:
+    _load_native_grouped_conv_or_skip()
+    torch.manual_seed(20260826)
+    hidden_states = torch.randn(24, 5120, dtype=torch.bfloat16)
+    delta = torch.randn(24, 2, 320, dtype=torch.bfloat16)
+    base = torch.randn(2, 5120, dtype=torch.bfloat16)
+    monkeypatch.setenv("VLLM_FL_DFLASH2_NATIVE_CONV", "0")
+    monkeypatch.setenv("VLLM_FL_DFLASH2_SLICED_CONV", "0")
+    reference = grouped_dynamic_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size=8,
+        group_size=16,
+    )
+    candidate = torch.ops.triton_jit_cpu.dflash2_grouped_conv(
+        hidden_states,
+        delta,
+        base,
+        8,
+        16,
+    )
+    torch.testing.assert_close(candidate, reference, atol=0, rtol=0)
+    monkeypatch.setenv("VLLM_FL_DFLASH2_NATIVE_CONV", "1")
+    routed = grouped_dynamic_conv(
+        hidden_states,
+        delta,
+        base,
+        block_size=8,
+        group_size=16,
+    )
+    torch.testing.assert_close(routed, reference, atol=0, rtol=0)
+
+
+def test_native_grouped_dynamic_conv_accepts_side_strides(monkeypatch) -> None:
+    _load_native_grouped_conv_or_skip()
+    torch.manual_seed(20260827)
+    hidden_states = torch.randn(8, 5120, dtype=torch.bfloat16)
+    all_delta = torch.randn(8, 2, 2, 320, dtype=torch.bfloat16)
+    base = torch.randn(2, 5120, dtype=torch.bfloat16)
+    delta = all_delta[:, 1]
+    assert not delta.is_contiguous()
+    monkeypatch.setenv("VLLM_FL_DFLASH2_NATIVE_CONV", "0")
+    monkeypatch.setenv("VLLM_FL_DFLASH2_SLICED_CONV", "0")
+    reference = grouped_dynamic_conv(
+        hidden_states, delta, base, block_size=8, group_size=16
+    )
+    monkeypatch.setenv("VLLM_FL_DFLASH2_NATIVE_CONV", "1")
+    candidate = grouped_dynamic_conv(
+        hidden_states, delta, base, block_size=8, group_size=16
+    )
+    torch.testing.assert_close(candidate, reference, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("batched_selector", ["0", "1"])
+def test_select_greedy_path_matches_materialized_edge_scores(
+    monkeypatch, batched_selector
+) -> None:
+    monkeypatch.setenv("VLLM_FL_DFLASH2_BATCHED_GREEDY_SELECTOR", batched_selector)
+    torch.manual_seed(11)
+    batch_size, positions, top_k, rank, vocab_size = 2, 5, 4, 3, 23
+    candidate_ids = torch.stack(
+        [torch.randperm(vocab_size)[: positions * top_k] for _ in range(batch_size)]
+    ).reshape(batch_size, positions, top_k)
+    unary_logits = torch.randn(batch_size, positions, top_k)
+    hidden = torch.randn(batch_size, positions, rank)
+    anchors = torch.tensor([21, 22])
+    predecessor_codebook = torch.randn(vocab_size, rank)
+    successor_codebook = torch.randn(vocab_size, rank)
+
+    actual = select_greedy_path(
+        candidate_ids,
+        unary_logits,
+        hidden,
+        anchors,
+        predecessor_codebook,
+        successor_codebook,
+    )
+
+    predecessor = anchors
+    expected = []
+    for position in range(positions):
+        candidates = candidate_ids[:, position]
+        state = predecessor_codebook[predecessor] * hidden[:, position]
+        scores = unary_logits[:, position] + torch.bmm(
+            successor_codebook[candidates],
+            state.unsqueeze(-1),
+        ).squeeze(-1)
+        selected = scores.argmax(dim=-1)
+        predecessor = candidates.gather(1, selected[:, None]).squeeze(1)
+        expected.append(predecessor)
+    torch.testing.assert_close(actual, torch.stack(expected, dim=1))
+
+
+def test_batched_greedy_selector_matches_reference_bf16(monkeypatch) -> None:
+    torch.manual_seed(20260822)
+    batch_size, positions, top_k, rank, vocab_size = 2, 7, 16, 256, 521
+    candidate_ids = torch.randint(
+        vocab_size, (batch_size, positions, top_k), dtype=torch.int64
+    )
+    unary_logits = torch.randn(batch_size, positions, top_k)
+    hidden = torch.randn(batch_size, positions, rank, dtype=torch.bfloat16)
+    anchors = torch.randint(vocab_size, (batch_size,), dtype=torch.int64)
+    predecessor_codebook = torch.randn(vocab_size, rank, dtype=torch.bfloat16)
+    successor_codebook = torch.randn(vocab_size, rank, dtype=torch.bfloat16)
+    arguments = (
+        candidate_ids,
+        unary_logits,
+        hidden,
+        anchors,
+        predecessor_codebook,
+        successor_codebook,
+    )
+    monkeypatch.setenv("VLLM_FL_DFLASH2_BATCHED_GREEDY_SELECTOR", "0")
+    reference = select_greedy_path(*arguments)
+    monkeypatch.setenv("VLLM_FL_DFLASH2_BATCHED_GREEDY_SELECTOR", "1")
+    candidate = select_greedy_path(*arguments)
+    torch.testing.assert_close(candidate, reference, atol=0, rtol=0)
+
+
+def test_select_stochastic_path_returns_reproducible_normalized_q() -> None:
+    torch.manual_seed(13)
+    batch_size, positions, top_k, rank, vocab_size = 1, 3, 4, 2, 19
+    candidate_ids = torch.randperm(vocab_size)[: positions * top_k].reshape(
+        batch_size,
+        positions,
+        top_k,
+    )
+    unary_logits = torch.randn(batch_size, positions, top_k)
+    hidden = torch.randn(batch_size, positions, rank)
+    anchors = torch.tensor([18])
+    predecessor_codebook = torch.randn(vocab_size, rank)
+    successor_codebook = torch.randn(vocab_size, rank)
+
+    def run(seed: int):
+        return select_stochastic_path(
+            candidate_ids,
+            unary_logits,
+            hidden,
+            anchors,
+            predecessor_codebook,
+            successor_codebook,
+            torch.tensor([1.0]),
+            [seed],
+            torch.tensor([100]),
+        )
+
+    path, probabilities = run(29)
+    repeated_path, repeated_probabilities = run(29)
+    _, other_seed_probabilities = run(31)
+    torch.testing.assert_close(
+        probabilities.sum(dim=-1),
+        torch.ones(batch_size, positions),
+    )
+    torch.testing.assert_close(probabilities, repeated_probabilities)
+    # The first q row is seed-independent. Later rows legitimately change
+    # when another seed chooses a different predecessor token in the walk.
+    torch.testing.assert_close(probabilities[:, :1], other_seed_probabilities[:, :1])
+    torch.testing.assert_close(path, repeated_path)
+    assert torch.isin(path, candidate_ids.flatten()).all()
+
+
+def test_select_stochastic_path_is_candidate_order_invariant() -> None:
+    """The upstream sampler keys Gumbel noise by token id, not top-k slot."""
+    candidate_ids = torch.tensor([[[2, 5, 7, 11]]])
+    unary_logits = torch.zeros(1, 1, 4)
+    hidden = torch.zeros(1, 1, 2)
+    anchors = torch.tensor([13])
+    predecessor_codebook = torch.zeros(17, 2)
+    successor_codebook = torch.zeros(17, 2)
+
+    def run(ids: torch.Tensor, logits: torch.Tensor) -> torch.Tensor:
+        path, _ = select_stochastic_path(
+            ids,
+            logits,
+            hidden,
+            anchors,
+            predecessor_codebook,
+            successor_codebook,
+            torch.tensor([1.0]),
+            [29],
+            torch.tensor([100]),
+        )
+        return path
+
+    reference = run(candidate_ids, unary_logits)
+    permutation = torch.tensor([3, 2, 1, 0])
+    permuted = run(
+        candidate_ids.index_select(-1, permutation),
+        unary_logits.index_select(-1, permutation),
+    )
+    torch.testing.assert_close(permuted, reference)
+
+
+def test_dflash2_keyed_uniform_matches_upstream_triton_vector() -> None:
+    token_ids = torch.tensor(
+        [
+            2,
+            5,
+            7,
+            11,
+            17,
+            29,
+            31,
+            101,
+            127,
+            255,
+            1024,
+            4095,
+            65535,
+            131071,
+            248000,
+            248319,
+        ]
+    )
+    expected = torch.tensor(
+        [
+            0.46762946248054504,
+            0.38040393590927124,
+            0.9446861147880554,
+            0.3120281398296356,
+            0.05598408728837967,
+            0.3419990539550781,
+            0.1893262267112732,
+            0.6072098612785339,
+            0.29684576392173767,
+            0.4915401339530945,
+            0.352323442697525,
+            0.6909090876579285,
+            0.6584656834602356,
+            0.32988160848617554,
+            0.35414284467697144,
+            0.923816442489624,
+        ],
+        dtype=torch.float32,
+    )
+
+    actual = dflash2_keyed_uniform(29, 100, token_ids)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    assert not torch.equal(actual, dflash2_keyed_uniform(29, 101, token_ids))
+
+
+def test_dflash2_anchor_positions_skip_rejected_padding() -> None:
+    target_positions = torch.tensor(
+        [
+            [0, 1, 2, 3, 4, 0, 1, 2],
+            [0, 1, 2, 3, 4, 0, 1, 2],
+            [0, 1, 2, 3, 4, 0, 1, 2],
+        ]
+    )
+
+    actual = compute_dflash2_anchor_positions(
+        target_positions,
+        torch.tensor([0, 5, 8]),
+        torch.tensor([2, 1]),
+    )
+
+    torch.testing.assert_close(actual, torch.tensor([3, 2]))
+
+
+@pytest.mark.parametrize("style", [False, True])
+def test_dflash2_inherits_target_rope_layout(monkeypatch, style: bool) -> None:
+    target = torch.nn.Module()
+    target.rotary_emb = torch.nn.Module()
+    target.rotary_emb.is_neox_style = style
+    proposer = object.__new__(DFlash2Proposer)
+    proposer.draft_model_config = SimpleNamespace(hf_config=SimpleNamespace())
+    observed = []
+
+    def load_model(_self, _target_model):
+        observed.append(proposer.draft_model_config.hf_config.is_neox_style)
+
+    from vllm.v1.spec_decode.dflash import DFlashProposer
+
+    monkeypatch.setattr(DFlashProposer, "load_model", load_model)
+
+    proposer.load_model(target)
+
+    assert dflash_target_rope_is_neox_style(target) is style
+    assert observed == [style]

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -26,6 +26,22 @@ from . import version as version  # PyTorch-style: vllm_fl.version.git_version
 logger = logging.getLogger(__name__)
 
 
+def _is_arm_cpu_target() -> bool:
+    """Return whether FlagGems and vLLM both selected an ARM CPU target."""
+    import platform
+
+    if platform.machine().lower() not in {"aarch64", "arm64"}:
+        return False
+
+    import flag_gems
+
+    if flag_gems.vendor_name != "arm":
+        return False
+    from vllm.platforms import cpu_platform_plugin
+
+    return cpu_platform_plugin() is not None
+
+
 def __getattr__(name):
     if name == "distributed":
         import importlib
@@ -97,6 +113,12 @@ def _patch_custom_ops():
 
 def register():
     """Register the FL platform."""
+    # PlatformFL is accelerator-shaped. For the standard FlagGems ARM target,
+    # preserve vLLM's stock CPU platform and install kernels in register_model().
+    if _is_arm_cpu_target():
+        logger.info("[vllm_fl] FlagGems ARM target -> vLLM CPU platform")
+        return "vllm.platforms.cpu.CpuPlatform"
+
     _patch_custom_ops()
     _patch_flash_attn_import()
     _patch_transformers_compat()
@@ -144,6 +166,16 @@ def register_model():
     from vllm_fl.patches.qwen3_5_text import apply_qwen3_5_text_patches
 
     apply_qwen3_5_text_patches()
+
+    from vllm.platforms import current_platform
+    if current_platform.device_type == "cpu" and _is_arm_cpu_target():
+        # FlagGems owns the ARM CPU runtime and its compiler/runtime details.
+        # vLLM's quantization config still selects the checkpoint kernel.
+        from flag_gems.integrations.vllm import install_arm_cpu_runtime
+
+        install_arm_cpu_runtime()
+        return
+
     patch_vllm_moe_sum()
 
     _register_flagcx_connector()

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 
 import importlib
-import os
 import logging
+import os
+import platform
 import sys
+from importlib import metadata
 
 # torch.float4_e2m1fn_x2 exists only in CUDA builds of PyTorch 2.7+.
 # vllm.ir.tolerances references it at module level, so we inject a sentinel
@@ -26,20 +28,15 @@ from . import version as version  # PyTorch-style: vllm_fl.version.git_version
 logger = logging.getLogger(__name__)
 
 
-def _is_arm_cpu_target() -> bool:
-    """Return whether FlagGems and vLLM both selected an ARM CPU target."""
-    import platform
-
+def _is_arm_cpu_build() -> bool:
+    """Return whether vLLM is an AArch64 CPU build."""
     if platform.machine().lower() not in {"aarch64", "arm64"}:
         return False
-
-    import flag_gems
-
-    if flag_gems.vendor_name != "arm":
-        return False
-    from vllm.platforms import cpu_platform_plugin
-
-    return cpu_platform_plugin() is not None
+    target_is_cpu = os.environ.get("VLLM_TARGET_DEVICE", "").lower() == "cpu"
+    try:
+        return "cpu" in metadata.version("vllm").lower() or target_is_cpu
+    except metadata.PackageNotFoundError:
+        return target_is_cpu
 
 
 def __getattr__(name):
@@ -113,11 +110,9 @@ def _patch_custom_ops():
 
 def register():
     """Register the FL platform."""
-    # PlatformFL is accelerator-shaped. For the standard FlagGems ARM target,
-    # preserve vLLM's stock CPU platform and install kernels in register_model().
-    if _is_arm_cpu_target():
-        logger.info("[vllm_fl] FlagGems ARM target -> vLLM CPU platform")
-        return "vllm.platforms.cpu.CpuPlatform"
+    if _is_arm_cpu_build():
+        logger.info("[vllm_fl] ARM CPU -> native-backed FL CPU platform")
+        return "vllm_fl.platform_cpu.CpuPlatformFL"
 
     _patch_custom_ops()
     _patch_flash_attn_import()
@@ -160,6 +155,16 @@ def register_router():
 
 def register_model():
     """Register FL-specific models not yet upstream."""
+    from vllm.model_executor.models import ModelRegistry
+
+    # Register before the short-lived registry probe exits. The subprocess
+    # resolves architectures without loading the ARM runtime, but it still
+    # needs to know which module owns the DFlash2 checkpoint entry point.
+    ModelRegistry.register_model(
+        "DFlash2DraftModel",
+        "vllm_fl.models.qwen3_dflash2:DFlash2Qwen3ForCausalLM",
+    )
+
     # General plugins are loaded independently in spawned model-inspection and
     # worker processes, so all runtime compatibility hooks must be idempotent.
     from vllm_fl.patches.moe_sum import patch_vllm_moe_sum
@@ -168,12 +173,56 @@ def register_model():
     apply_qwen3_5_text_patches()
 
     from vllm.platforms import current_platform
-    if current_platform.device_type == "cpu" and _is_arm_cpu_target():
-        # FlagGems owns the ARM CPU runtime and its compiler/runtime details.
-        # vLLM's quantization config still selects the checkpoint kernel.
-        from flag_gems.integrations.vllm import install_arm_cpu_runtime
+    if current_platform.device_type == "cpu" and _is_arm_cpu_build():
+        # Registry inspection only needs model declarations. Loading the ARM
+        # runtime here would consume process locks before the engine starts.
+        if os.path.basename(sys.argv[0]) == "registry.py":
+            return
 
-        install_arm_cpu_runtime()
+        # Spec-decode and hybrid-cache compatibility apply to BF16 and every
+        # quant backend. FlagGems model kernels are selected independently.
+        from vllm_fl.patches.arm_cpu_vllm_0240 import (
+            install_arm_cpu_vllm_0240_compat,
+        )
+
+        install_arm_cpu_vllm_0240_compat()
+
+        int8_enabled = os.environ.get("FL_CPU_INT8", "0").lower()
+        if int8_enabled not in {"0", "1", "false", "true"}:
+            raise ValueError("FL_CPU_INT8 must be one of: 0, 1, false, true")
+        if int8_enabled in {"1", "true"}:
+            backend = os.environ.get(
+                "FL_CPU_INT8_BACKEND", "libtriton_jit"
+            ).lower()
+            if backend == "torchpack":
+                from vllm_fl.ops.cpu_int8_pack import enable_int8
+
+                enable_int8()
+                return
+            if backend != "libtriton_jit":
+                raise ValueError(
+                    "FL_CPU_INT8_BACKEND must be 'libtriton_jit' or "
+                    "'torchpack'"
+                )
+            from vllm_fl.ops.cpu_qwen_runtime import enable_qwen_runtime
+
+            enable_qwen_runtime()
+            return
+
+        int4_enabled = os.environ.get("FL_CPU_INT4", "0").lower()
+        if int4_enabled not in {"0", "1", "false", "true"}:
+            raise ValueError("FL_CPU_INT4 must be one of: 0, 1, false, true")
+        if int4_enabled in {"1", "true"}:
+            backend = os.environ.get(
+                "FL_CPU_INT4_BACKEND", "libtriton_jit"
+            ).lower()
+            if backend != "libtriton_jit":
+                raise ValueError("FL_CPU_INT4_BACKEND must be 'libtriton_jit'")
+            from vllm_fl.ops.cpu_qwen_runtime import enable_qwen_runtime
+
+            enable_qwen_runtime()
+        else:
+            logger.info("[vllm_fl] FL_CPU_INT4=0 -> bf16")
         return
 
     patch_vllm_moe_sum()

--- a/vllm_fl/models/qwen3_dflash2.py
+++ b/vllm_fl/models/qwen3_dflash2.py
@@ -1,0 +1,708 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash 2 draft model support for the ARM CPU vLLM-FL runtime.
+
+This is a vLLM 0.24-compatible adaptation of the upstream DFlash 2 model.
+The target model and its LM head remain owned by vLLM; the checkpoint only
+contains the five-layer drafter, dynamic convolutions, and path selector.
+"""
+
+import os
+from collections.abc import Callable
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+)
+from vllm.model_executor.models.qwen2 import Qwen2MLP as Qwen3MLP
+from vllm.model_executor.models.qwen3_dflash import (
+    DFlashQwen3DecoderLayer,
+    DFlashQwen3ForCausalLM,
+    DFlashQwen3Model,
+)
+from vllm.model_executor.models.utils import maybe_prefix
+from vllm.transformers_utils.config import set_default_rope_theta
+from vllm.v1.attention.backend import AttentionType
+
+_UINT32_MASK = (1 << 32) - 1
+_PHILOX_KEY_A = 0x9E3779B9
+_PHILOX_KEY_B = 0xBB67AE85
+_PHILOX_ROUND_A = 0xD2511F53
+_PHILOX_ROUND_B = 0xCD9E8D57
+_UINT32_TO_UNIFORM = 4.6566127342e-10
+
+
+def _philox4x32(seed: int, offset: int) -> tuple[int, int, int, int]:
+    """Return Triton's 10-round Philox4x32 output for one scalar offset."""
+    counter_0 = offset & _UINT32_MASK
+    counter_1 = (offset >> 32) & _UINT32_MASK
+    counter_2 = 0
+    counter_3 = 0
+    key_0 = seed & _UINT32_MASK
+    key_1 = (seed >> 32) & _UINT32_MASK
+    for _ in range(10):
+        old_counter_0 = counter_0
+        old_counter_2 = counter_2
+        product_0 = _PHILOX_ROUND_B * old_counter_2
+        product_1 = _PHILOX_ROUND_A * old_counter_0
+        counter_0 = ((product_0 >> 32) & _UINT32_MASK) ^ counter_1 ^ key_0
+        counter_1 = product_0 & _UINT32_MASK
+        counter_2 = ((product_1 >> 32) & _UINT32_MASK) ^ counter_3 ^ key_1
+        counter_3 = product_1 & _UINT32_MASK
+        key_0 = (key_0 + _PHILOX_KEY_A) & _UINT32_MASK
+        key_1 = (key_1 + _PHILOX_KEY_B) & _UINT32_MASK
+    return counter_0, counter_1, counter_2, counter_3
+
+
+def dflash2_keyed_uniform(
+    seed: int,
+    position: int,
+    token_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Reproduce upstream Triton's token/position-keyed uniform samples.
+
+    DFlash2 first hashes the request seed with the predecessor's absolute
+    position, then uses each candidate token id as a Philox counter.  Keeping
+    this CPU implementation bit-compatible makes sampling independent of the
+    order in which top-k candidates happen to be returned.
+    """
+    position_seed = _philox4x32(seed, position)[0]
+    words = [
+        _philox4x32(position_seed, int(token_id))[0]
+        for token_id in token_ids.detach().reshape(-1).tolist()
+    ]
+    # This is Triton's uint_to_uniform_float conversion.  It deliberately
+    # folds the sign bit instead of dividing the unsigned word by 2**32.
+    magnitudes = [word if word < (1 << 31) else _UINT32_MASK - word for word in words]
+    return (
+        torch.tensor(magnitudes, dtype=torch.float32, device=token_ids.device)
+        .mul_(_UINT32_TO_UNIFORM)
+        .reshape(token_ids.shape)
+    )
+
+
+def _keyed_gumbel_argmax(
+    scores: torch.Tensor,
+    candidate_ids: torch.Tensor,
+    seed: int,
+    position: int,
+    temperature: float,
+) -> torch.Tensor:
+    uniforms = dflash2_keyed_uniform(seed, position, candidate_ids).clamp_min_(
+        _UINT32_TO_UNIFORM
+    )
+    noise = -torch.log(-torch.log1p(-uniforms))
+    return (scores / temperature + noise).argmax()
+
+
+def validate_dflash2_block_size(
+    draft_config: dict,
+    num_speculative_tokens: int,
+) -> int:
+    """Return a checkpoint-compatible runtime block size.
+
+    DFlash counts the verified anchor in ``block_size`` whereas vLLM's
+    ``num_speculative_tokens`` does not.  The released implementation allows
+    shorter runtime blocks (and recommends them for quantized MLX kernels),
+    but running beyond the checkpoint's trained block is not a safe tuning.
+    """
+    runtime_block_size = 1 + int(num_speculative_tokens)
+    checkpoint_block_size = int(draft_config["block_size"])
+    if runtime_block_size < 2 or runtime_block_size > checkpoint_block_size:
+        raise ValueError(
+            "DFlash2 runtime block size must be in [2, checkpoint block size] "
+            f"but got {runtime_block_size} with checkpoint block size "
+            f"{checkpoint_block_size}"
+        )
+    return runtime_block_size
+
+
+def grouped_dynamic_conv(
+    hidden_states: torch.Tensor,
+    delta: torch.Tensor,
+    base: torch.Tensor,
+    block_size: int,
+    group_size: int,
+) -> torch.Tensor:
+    """Apply the DFlash 2 block-local dynamic depthwise convolution."""
+    if (
+        os.environ.get("VLLM_FL_DFLASH2_NATIVE_CONV", "0") == "1"
+        and hidden_states.device.type == "cpu"
+        and hidden_states.dtype == torch.bfloat16
+        and delta.dtype == torch.bfloat16
+        and base.dtype == torch.bfloat16
+        and hidden_states.is_contiguous()
+        and delta.stride(-1) == 1
+        and base.is_contiguous()
+        and hasattr(torch.ops.triton_jit_cpu, "dflash2_grouped_conv")
+    ):
+        return torch.ops.triton_jit_cpu.dflash2_grouped_conv(
+            hidden_states,
+            delta,
+            base,
+            block_size,
+            group_size,
+        )
+    if os.environ.get("VLLM_FL_DFLASH2_SLICED_CONV", "0") == "1":
+        return _grouped_dynamic_conv_sliced(
+            hidden_states, delta, base, block_size, group_size
+        )
+    taps = base.shape[0]
+    num_groups = hidden_states.shape[-1] // group_size
+    blocks = hidden_states.unflatten(-1, (num_groups, group_size))
+    coefficients = base.view(1, taps, num_groups, group_size) + delta.unsqueeze(-1)
+    output = coefficients[:, 0] * blocks
+    position = torch.arange(hidden_states.shape[0], device=hidden_states.device)
+    if block_size & (block_size - 1) == 0:
+        position = position & (block_size - 1)
+    else:
+        position = position % block_size
+    for tap in range(1, taps):
+        shifted = F.pad(blocks[:-tap], (0, 0, 0, 0, tap, 0))
+        output = output + (
+            coefficients[:, tap] * shifted * (position >= tap).view(-1, 1, 1)
+        )
+    return output.flatten(-2)
+
+
+def _grouped_dynamic_conv_sliced(
+    hidden_states: torch.Tensor,
+    delta: torch.Tensor,
+    base: torch.Tensor,
+    block_size: int,
+    group_size: int,
+) -> torch.Tensor:
+    """Apply the same convolution without padded shifts or position masks."""
+    taps = base.shape[0]
+    num_groups = hidden_states.shape[-1] // group_size
+    blocks = hidden_states.unflatten(-1, (num_groups, group_size))
+    coefficients = base.view(1, taps, num_groups, group_size) + delta.unsqueeze(-1)
+    output = coefficients[:, 0] * blocks
+    rows = hidden_states.shape[0]
+    for tap in range(1, taps):
+        for block_start in range(0, rows, block_size):
+            block_end = min(block_start + block_size, rows)
+            output_begin = block_start + tap
+            if output_begin >= block_end:
+                continue
+            output[output_begin:block_end].add_(
+                coefficients[output_begin:block_end, tap]
+                * blocks[block_start : block_end - tap]
+            )
+    return output.flatten(-2)
+
+
+def select_greedy_path(
+    candidate_ids: torch.Tensor,
+    unary_logits: torch.Tensor,
+    hidden: torch.Tensor,
+    anchor_token_ids: torch.Tensor,
+    predecessor_codebook: torch.Tensor,
+    successor_codebook: torch.Tensor,
+) -> torch.Tensor:
+    """Walk the greedy DFlash 2 path from already-projected hidden states."""
+    predecessor = anchor_token_ids.to(torch.long)
+    path = []
+    batch = torch.arange(candidate_ids.shape[0], device=candidate_ids.device)
+    use_batched_matvec = (
+        os.environ.get("VLLM_FL_DFLASH2_BATCHED_GREEDY_SELECTOR", "0") == "1"
+    )
+    successors = successor_codebook[candidate_ids] if use_batched_matvec else None
+    for position in range(candidate_ids.shape[1]):
+        candidates = candidate_ids[:, position]
+        predecessor_code = predecessor_codebook[predecessor]
+        state = predecessor_code * hidden[:, position]
+        if successors is not None:
+            interaction = torch.bmm(
+                successors[:, position], state.unsqueeze(-1)
+            ).squeeze(-1)
+        else:
+            interaction = torch.einsum(
+                "br,bkr->bk", state, successor_codebook[candidates]
+            )
+        scores = unary_logits[:, position] + interaction
+        selected = scores.argmax(dim=-1)
+        predecessor = candidates[batch, selected]
+        path.append(predecessor)
+    return torch.stack(path, dim=1)
+
+
+def select_stochastic_path(
+    candidate_ids: torch.Tensor,
+    unary_logits: torch.Tensor,
+    hidden: torch.Tensor,
+    anchor_token_ids: torch.Tensor,
+    predecessor_codebook: torch.Tensor,
+    successor_codebook: torch.Tensor,
+    temperatures: torch.Tensor,
+    seeds: list[int],
+    anchor_positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sample the upstream keyed-Gumbel path and retain its exact sparse q."""
+    predecessor = anchor_token_ids.to(torch.long)
+    path = []
+    probability_rows = []
+    batch = torch.arange(candidate_ids.shape[0], device=candidate_ids.device)
+    temperatures = temperatures[: candidate_ids.shape[0]].to(
+        device=unary_logits.device,
+        dtype=torch.float32,
+    )
+    anchor_positions = anchor_positions[: candidate_ids.shape[0]].to(
+        device=unary_logits.device,
+        dtype=torch.int64,
+    )
+    if len(seeds) < candidate_ids.shape[0]:
+        raise ValueError("DFlash2 requires one sampling seed per request")
+    for position in range(candidate_ids.shape[1]):
+        candidates = candidate_ids[:, position]
+        successor = successor_codebook[candidates]
+        predecessor_code = predecessor_codebook[predecessor]
+        scores = (
+            unary_logits[:, position].float()
+            + torch.einsum(
+                "br,bkr->bk",
+                predecessor_code * hidden[:, position],
+                successor,
+            ).float()
+        )
+        rows = []
+        selected_rows = []
+        for row_index in range(scores.shape[0]):
+            temperature = float(temperatures[row_index])
+            if temperature < 1.0e-5:
+                selected = scores[row_index].argmax()
+                probabilities = torch.zeros_like(scores[row_index])
+                probabilities[selected] = 1.0
+            else:
+                probabilities = torch.softmax(
+                    scores[row_index] / temperature,
+                    dim=-1,
+                    dtype=torch.float32,
+                )
+                selected = _keyed_gumbel_argmax(
+                    scores[row_index],
+                    candidates[row_index],
+                    seeds[row_index],
+                    int(anchor_positions[row_index]) + position,
+                    temperature,
+                )
+            rows.append(probabilities)
+            selected_rows.append(selected)
+        position_probabilities = torch.stack(rows)
+        selected = torch.stack(selected_rows)
+        predecessor = candidates[batch, selected]
+        path.append(predecessor)
+        probability_rows.append(position_probabilities)
+    return torch.stack(path, dim=1), torch.stack(probability_rows, dim=1)
+
+
+class DFlashGroupedConv(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        taps: int,
+        group_size: int,
+        block_size: int,
+        params_dtype: torch.dtype,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        if hidden_size % group_size:
+            raise ValueError(
+                f"conv_group_size={group_size} must divide hidden_size={hidden_size}"
+            )
+        self.block_size = block_size
+        self.group_size = group_size
+        self.num_groups = hidden_size // group_size
+        self.base_kernel = nn.Parameter(
+            torch.empty(2, taps, hidden_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        self.kernel_projection = ReplicatedLinear(
+            hidden_size,
+            2 * taps * self.num_groups,
+            bias=False,
+            params_dtype=params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "kernel_projection"),
+            return_bias=False,
+        )
+
+    def _convolve(
+        self, hidden_states: torch.Tensor, delta: torch.Tensor, side: int
+    ) -> torch.Tensor:
+        return grouped_dynamic_conv(
+            hidden_states,
+            delta,
+            self.base_kernel[side],
+            self.block_size,
+            self.group_size,
+        )
+
+    def prepare(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        taps = self.base_kernel.shape[1]
+        coefficients = self.kernel_projection(hidden_states).reshape(
+            hidden_states.shape[0], 2, taps, self.num_groups
+        )
+        return self._convolve(hidden_states, coefficients[:, 0], 0), coefficients[:, 1]
+
+    def finish(
+        self, hidden_states: torch.Tensor, coefficients: torch.Tensor
+    ) -> torch.Tensor:
+        return self._convolve(hidden_states, coefficients, 1)
+
+
+class DFlash2Qwen3Attention(nn.Module):
+    """Non-causal sliding-window attention used by the released Qwen drafter."""
+
+    def __init__(
+        self,
+        config,
+        prefix: str,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = config.num_attention_heads
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = config.num_key_value_heads
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = getattr(config, "head_dim", None) or (
+            config.hidden_size // self.total_num_heads
+        )
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.qkv_proj = QKVParallelLinear(
+            config.hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=getattr(config, "attention_bias", False),
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            config.hidden_size,
+            bias=getattr(config, "attention_bias", False),
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+        self.rotary_emb = get_rope(
+            self.head_dim,
+            max_position=config.max_position_embeddings,
+            is_neox_style=getattr(config, "is_neox_style", True),
+            rope_parameters=config.rope_parameters,
+        )
+        self.sliding_window = int(config.sliding_window)
+        self.attn = Attention(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            num_kv_heads=self.num_kv_heads,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            per_layer_sliding_window=self.sliding_window,
+            prefix=f"{prefix}.attn",
+            attn_type=AttentionType.DECODER,
+        )
+        # vLLM's CPU decoder backend constructs a one-sided sliding
+        # window even when CommonAttentionMetadata.causal is False. DFlash 2
+        # is non-causal within the parallel draft block, so queries must see
+        # both earlier and later query positions inside the configured window.
+        backend_window = getattr(self.attn.impl, "sliding_window", None)
+        if isinstance(backend_window, tuple) and len(backend_window) == 2:
+            symmetric_window = self.sliding_window - 1
+            self.attn.impl.sliding_window = (symmetric_window, symmetric_window)
+        self.causal = False
+        self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+    def forward(
+        self, positions: torch.Tensor, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q_shape, k_shape = q.shape, k.shape
+        q = self.q_norm(
+            q.view(*q_shape[:-1], q_shape[-1] // self.head_dim, self.head_dim)
+        ).view(q_shape)
+        k = self.k_norm(
+            k.view(*k_shape[:-1], k_shape[-1] // self.head_dim, self.head_dim)
+        ).view(k_shape)
+        q, k = self.rotary_emb(positions, q, k)
+        output, _ = self.o_proj(self.attn(q, k, v))
+        return output
+
+
+class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        config,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        self.hidden_size = config.hidden_size
+        set_default_rope_theta(config, default_theta=1000000)
+        self.self_attn = DFlash2Qwen3Attention(
+            config,
+            prefix=maybe_prefix(prefix, "self_attn"),
+            cache_config=cache_config,
+            quant_config=quant_config,
+        )
+        self.mlp = Qwen3MLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "mlp"),
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        draft_config = config.dflash_config
+        speculative_config = vllm_config.speculative_config
+        assert speculative_config is not None
+        runtime_block_size = validate_dflash2_block_size(
+            draft_config,
+            speculative_config.num_speculative_tokens,
+        )
+        conv_args = dict(
+            hidden_size=config.hidden_size,
+            taps=int(draft_config["conv_kernel_size"]),
+            group_size=int(draft_config["conv_group_size"]),
+            block_size=runtime_block_size,
+            params_dtype=vllm_config.model_config.dtype,
+        )
+        self.attention_conv = DFlashGroupedConv(
+            **conv_args, prefix=maybe_prefix(prefix, "attention_conv")
+        )
+        self.mlp_conv = DFlashGroupedConv(
+            **conv_args, prefix=maybe_prefix(prefix, "mlp_conv")
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        hidden_states, coefficients = self.attention_conv.prepare(hidden_states)
+        hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
+        hidden_states = self.attention_conv.finish(hidden_states, coefficients)
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states, coefficients = self.mlp_conv.prepare(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp_conv.finish(hidden_states, coefficients)
+        return hidden_states, residual
+
+
+class CandidateSelector(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        vocab_size: int,
+        rank: int,
+        top_k: int,
+        params_dtype: torch.dtype,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.top_k = top_k
+        # Keep direct Parameters rather than Embedding modules because the
+        # released checkpoint names omit the trailing ``.weight``.
+        self.predecessor_codebook = nn.Parameter(
+            torch.empty(vocab_size, rank, dtype=params_dtype), requires_grad=False
+        )
+        self.successor_codebook = nn.Parameter(
+            torch.empty(vocab_size, rank, dtype=params_dtype), requires_grad=False
+        )
+        self.hidden_projection = ReplicatedLinear(
+            hidden_size,
+            rank,
+            bias=False,
+            params_dtype=params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "hidden_projection"),
+            return_bias=False,
+        )
+
+    def select_greedy(
+        self,
+        candidate_ids: torch.Tensor,
+        unary_logits: torch.Tensor,
+        hidden_states: torch.Tensor,
+        anchor_token_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        """Walk the exact greedy DFlash 2 path without materializing KxK edges."""
+        hidden = self.hidden_projection(hidden_states)
+        return select_greedy_path(
+            candidate_ids,
+            unary_logits,
+            hidden,
+            anchor_token_ids,
+            self.predecessor_codebook,
+            self.successor_codebook,
+        )
+
+    def select_stochastic(
+        self,
+        candidate_ids: torch.Tensor,
+        unary_logits: torch.Tensor,
+        hidden_states: torch.Tensor,
+        anchor_token_ids: torch.Tensor,
+        temperatures: torch.Tensor,
+        seeds: list[int],
+        anchor_positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden = self.hidden_projection(hidden_states)
+        return select_stochastic_path(
+            candidate_ids,
+            unary_logits,
+            hidden,
+            anchor_token_ids,
+            self.predecessor_codebook,
+            self.successor_codebook,
+            temperatures,
+            seeds,
+            anchor_positions,
+        )
+
+
+class DFlash2Qwen3Model(DFlashQwen3Model):
+    """DFlash model body with DFlash 2 convolutions and selector."""
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int = 0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            vllm_config=vllm_config,
+            start_layer_id=start_layer_id,
+            prefix=prefix,
+        )
+        current_vllm_config = get_current_vllm_config()
+        static_context = current_vllm_config.compilation_config.static_forward_context
+        for layer in self.layers:
+            static_context.pop(layer.self_attn.attn.layer_name, None)
+        self.layers = nn.ModuleList(
+            [
+                DFlash2Qwen3DecoderLayer(
+                    current_vllm_config,
+                    prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
+                    config=self.config,
+                    cache_config=current_vllm_config.cache_config,
+                    quant_config=self.quant_config,
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+
+        draft_config = self.config.dflash_config
+        self.input_embedding_scale = float(
+            draft_config.get("input_embedding_scale", 1.0)
+        )
+        self.candidate_selector = CandidateSelector(
+            hidden_size=self.config.hidden_size,
+            vocab_size=self.config.vocab_size,
+            rank=int(draft_config["selector_rank"]),
+            top_k=int(draft_config["selector_top_k"]),
+            params_dtype=vllm_config.model_config.dtype,
+            prefix=maybe_prefix(prefix, "candidate_selector"),
+        )
+
+        # FlagGems must treat these BF16 drafter weights separately from the
+        # target model body; its online quantizer checks this marker.
+        for module in self.modules():
+            if hasattr(module, "weight"):
+                module._flag_gems_spec_draft = True
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return super().embed_input_ids(input_ids) * self.input_embedding_scale
+
+
+class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        nn.Module.__init__(self)
+        assert vllm_config.speculative_config is not None
+        self.config = vllm_config.speculative_config.draft_model_config.hf_config
+        if getattr(self.config, "draft_vocab_size", None) is None:
+            self.config.draft_vocab_size = getattr(self.config, "vocab_size", None)
+        target_layer_num = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config
+        )
+        self.model = DFlash2Qwen3Model(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "model"),
+            start_layer_id=target_layer_num,
+        )
+        logit_scale = getattr(self.config, "logit_scale", 1.0)
+        self.lm_head = ParallelLMHead(
+            self.config.draft_vocab_size,
+            self.config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        # DFlashQwen3ForCausalLM.compute_logits expects this processor.
+        from vllm.model_executor.layers.logits_processor import LogitsProcessor
+
+        self.logits_processor = LogitsProcessor(
+            self.config.draft_vocab_size, scale=logit_scale
+        )
+        target_vocab_size = vllm_config.model_config.get_vocab_size()
+        if self.config.draft_vocab_size != target_vocab_size:
+            self.draft_id_to_target_id = nn.Parameter(
+                torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
+                requires_grad=False,
+            )
+        else:
+            self.draft_id_to_target_id = None
+        draft_config = self.config.dflash_config
+        self.output_multiplier = float(draft_config.get("output_multiplier", 1.0))
+        softcap = float(draft_config.get("final_logit_softcapping") or 0.0)
+        self.final_logit_softcapping = softcap if softcap > 0 else None
+
+    def compute_candidates(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = self.compute_logits(hidden_states)
+        selector = self.model.candidate_selector
+        values, ids = torch.topk(logits, selector.top_k, dim=-1, sorted=False)
+        values = values.float() * self.output_multiplier
+        if self.final_logit_softcapping is not None:
+            cap = self.final_logit_softcapping
+            values = torch.tanh(values / cap) * cap
+        return ids.to(torch.int64), values
+
+
+EntryClass: Callable[..., nn.Module] = DFlash2Qwen3ForCausalLM

--- a/vllm_fl/ops/cpu_int8_pack.py
+++ b/vllm_fl/ops/cpu_int8_pack.py
@@ -1,0 +1,67 @@
+"""ARM CPU W8A16 Linear via torch-native fused int8-weight GEMM.
+
+Uses ``torch._weight_int8pack_mm`` (the gpt-fast / llama.cpp style CPU int8
+kernel): it streams the int8 weight and dequantizes on the fly inside the GEMM,
+never materializing a bf16 weight.  Decode is memory-bound, so halving the
+weight-read bandwidth gives a large speedup over torchao's dequant+bf16-mm path
+(which materializes bf16 and reads full bandwidth).
+
+Pure official torch op — no third-party kernel, no TLE, no flag_gems/triton.
+Weights are quantized online (per-row symmetric int8) when the model loads, so
+no torchao checkpoint is required; the original BF16 model is used directly.
+
+Installed by register_model() when ``FL_CPU_INT8=1`` and
+``FL_CPU_INT8_BACKEND=torchpack``, hooking vLLM's
+``dispatch_cpu_unquantized_gemm`` (same mechanism as the other quantized CPU
+backends).  Runs under CpuPlatformFL.
+"""
+import logging
+import os
+
+import torch
+
+from vllm_fl.ops.cpu_quant_linear import install_cpu_quantized_linear
+
+logger = logging.getLogger("vllm_fl.cpu_int8_pack")
+INCLUDE_LM_HEAD = os.environ.get("FL_INT8_LMHEAD", "0") == "1"
+STRICT = os.environ.get("FL_CPU_INT8_STRICT", "1") != "0"
+
+
+def _quantize_int8(weight):
+    """[N,K] bf16 weight -> (int8 [N,K] row-major, bf16 scale [N]), per-row symmetric."""
+    w = weight.detach().to(torch.float32)
+    scale = (w.abs().amax(dim=1) / 127.0).clamp(min=1e-8)
+    qw = (w / scale[:, None]).round().clamp(-128, 127).to(torch.int8).contiguous()
+    return qw, scale.to(torch.bfloat16).contiguous()
+
+
+def _make_cpu_linear(qweight, scale, N, K):
+    def cpu_linear(x, weight, bias):
+        shape = x.shape
+        xb = x.to(torch.bfloat16).reshape(-1, K).contiguous()
+        out = torch._weight_int8pack_mm(xb, qweight, scale)  # fused, [M,N] bf16
+        out = out.reshape(*shape[:-1], N)
+        return out + bias.to(out.dtype) if bias is not None else out
+
+    return cpu_linear
+
+
+def _prepare_linear(weight):
+    N, K = weight.shape
+    qweight, scale = _quantize_int8(weight.to(torch.bfloat16))
+    return _make_cpu_linear(qweight, scale, N, K)
+
+
+def enable_int8(verbose=True):
+    installed = install_cpu_quantized_linear(
+        backend="ARM W8A16 torchpack",
+        prepare_linear=_prepare_linear,
+        supports_shape=lambda n, k: k % 4 == 0,
+        include_lm_head=INCLUDE_LM_HEAD,
+        strict=STRICT,
+        logger=logger,
+    )
+    if installed and verbose:
+        logger.info(
+            "[vllm_fl] ARM int8 W8A16 enabled (torch _weight_int8pack_mm, fused)"
+        )

--- a/vllm_fl/ops/cpu_quant_linear.py
+++ b/vllm_fl/ops/cpu_quant_linear.py
@@ -1,0 +1,109 @@
+"""Shared lifecycle for ARM CPU quantized-linear backends."""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import platform
+from collections.abc import Callable
+from threading import Lock
+from typing import Any
+
+
+_INSTALL_LOCK = Lock()
+_ACTIVE_BACKEND: str | None = None
+
+
+def require_arm_quant_extensions(backend: str) -> None:
+    """Require the AArch64 extensions used by the packaged native kernels."""
+    if platform.machine().lower() not in {"aarch64", "arm64"}:
+        raise RuntimeError(f"{backend} requires AArch64")
+    cpuinfo = pathlib.Path("/proc/cpuinfo")
+    if not cpuinfo.is_file():
+        return
+    feature_sets = [
+        set(line.partition(":")[2].split())
+        for line in cpuinfo.read_text(encoding="utf-8").splitlines()
+        if line.lower().startswith("features")
+    ]
+    features = set.intersection(*feature_sets) if feature_sets else set()
+    required = {"asimddp", "i8mm", "bf16"}
+    missing = required - features
+    if missing:
+        raise RuntimeError(
+            f"{backend} requires dotprod, i8mm, and BF16 CPU extensions; "
+            f"missing: {', '.join(sorted(missing))}"
+        )
+
+
+def install_cpu_quantized_linear(
+    *,
+    backend: str,
+    prepare_linear: Callable[[Any], Callable[..., Any]],
+    supports_shape: Callable[[int, int], bool],
+    include_lm_head: bool,
+    strict: bool,
+    logger: logging.Logger,
+    initialize: Callable[[], None] | None = None,
+) -> bool:
+    """Install one process-wide CPU quantized-linear dispatch implementation.
+
+    Backend adapters own packing and compute. This module owns the shared layer
+    eligibility, fallback, weight-removal, and process-lifetime invariants.
+    """
+    import torch
+    import vllm.model_executor.layers.utils as layer_utils
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        ParallelLMHead,
+        VocabParallelEmbedding,
+    )
+
+    global _ACTIVE_BACKEND
+    with _INSTALL_LOCK:
+        if _ACTIVE_BACKEND == backend:
+            return False
+        if _ACTIVE_BACKEND is not None:
+            raise RuntimeError(
+                "ARM CPU quantized-linear backend is already active as "
+                f"{_ACTIVE_BACKEND}; cannot activate {backend} in the same process. "
+                "Select one backend and restart."
+            )
+
+        if initialize is not None:
+            initialize()
+        original_dispatch = layer_utils.dispatch_cpu_unquantized_gemm
+
+        def dispatch(layer, remove_weight):
+            weight = getattr(layer, "weight", None)
+            prefix = getattr(layer, "prefix", "") or ""
+            is_lm_head = isinstance(layer, ParallelLMHead)
+            is_input_embedding = (
+                isinstance(layer, VocabParallelEmbedding) and not is_lm_head
+            )
+            if (
+                weight is not None
+                and weight.ndim == 2
+                and supports_shape(int(weight.shape[0]), int(weight.shape[1]))
+                and not is_input_embedding
+                and (include_lm_head or not is_lm_head)
+            ):
+                try:
+                    layer.cpu_linear = prepare_linear(weight)
+                    if remove_weight:
+                        layer.weight = torch.nn.Parameter(
+                            torch.empty(0), requires_grad=False
+                        )
+                    return
+                except Exception as exc:
+                    message = (
+                        f"failed to prepare {backend} weight {prefix} "
+                        f"{tuple(weight.shape)}"
+                    )
+                    if strict:
+                        raise RuntimeError(message) from exc
+                    logger.warning("%s; falling back to BF16: %s", message, exc)
+            return original_dispatch(layer, remove_weight)
+
+        layer_utils.dispatch_cpu_unquantized_gemm = dispatch
+        _ACTIVE_BACKEND = backend
+        return True

--- a/vllm_fl/ops/cpu_qwen_gdn.py
+++ b/vllm_fl/ops/cpu_qwen_gdn.py
@@ -1,0 +1,65 @@
+"""Thin vLLM bridge to the FlagGems Qwen GDN integration."""
+
+from __future__ import annotations
+
+import sys
+
+
+def install_vllm_gdn_bridge() -> None:
+    """Install the version-adapted FlagGems GDN runtime lazily."""
+    # vLLM 0.24 split the generic GDN base from the Qwen implementation and
+    # moved the latter into the mamba.gdn package. The existing FlagGems
+    # integration patches the old module path and class name, so expose a
+    # narrow compatibility alias without changing either project globally.
+    from vllm.model_executor.layers.mamba.gdn import qwen_gdn_linear_attn as gdn
+
+    gdn.GatedDeltaNetAttention = gdn.QwenGatedDeltaNetAttention
+    sys.modules.setdefault(
+        "vllm.model_executor.layers.mamba.gdn_linear_attn", gdn
+    )
+
+    from flag_gems.integrations.vllm import install_qwen_gdn
+
+    install_qwen_gdn()
+
+    # ChunkGatedDeltaRule.forward_native in 0.24 can provide a preallocated
+    # output buffer.  The existing CPU implementation returns the same tensor
+    # instead, so bridge the new optional ABI and preserve both behaviours.
+    flag_gems_chunk_gated_delta_rule = gdn.fla_chunk_gated_delta_rule
+
+    def chunk_gated_delta_rule_024(*args, core_attn_out=None, **kwargs):
+        output, final_state = flag_gems_chunk_gated_delta_rule(*args, **kwargs)
+        if core_attn_out is not None:
+            output_flat = output.squeeze(0).reshape(-1)
+            target_flat = core_attn_out.reshape(-1)
+            target_flat[: output_flat.numel()].copy_(output_flat)
+        return output, final_state
+
+    gdn.fla_chunk_gated_delta_rule = chunk_gated_delta_rule_024
+
+    # vLLM 0.24 selects a new CPU-only GDN implementation in ``__init__``.
+    # That path bypasses the FlagGems functions installed above and explicitly
+    # rejects speculative metadata.  Keep using the generic Qwen GDN core on
+    # Apple ARM: despite the historical ``forward_cuda`` name, the patched
+    # implementation dispatches only CPU tensors to FlagGems/libtriton_jit.
+    # Install this after FlagGems so we retain its projection setup wrapper.
+    original_init = gdn.QwenGatedDeltaNetAttention.__init__
+
+    def install_arm_cpu_forward(self, *args, **kwargs) -> None:
+        original_init(self, *args, **kwargs)
+        self._forward_method = self.forward_cuda
+
+    gdn.QwenGatedDeltaNetAttention.__init__ = install_arm_cpu_forward
+
+    # vLLM 0.24 passes an additional token-count argument to this hook.
+    # FlagGems intentionally disables it because the accelerator JIT warmup
+    # is neither needed nor valid for the Apple CPU runtime.
+    def no_op_prefill_warmup(self, *args, **kwargs) -> None:
+        return None
+
+    gdn.QwenGatedDeltaNetAttention._warmup_prefill_kernels = (
+        no_op_prefill_warmup
+    )
+
+
+__all__ = ["install_vllm_gdn_bridge"]

--- a/vllm_fl/ops/cpu_qwen_runtime.py
+++ b/vllm_fl/ops/cpu_qwen_runtime.py
@@ -1,0 +1,53 @@
+"""Thin vLLM-to-FlagGems integration for ARM CPU Qwen models.
+
+Machine policy belongs to the launcher profile.  This module deliberately
+does not set Triton, OpenMP, scheduler, or kernel-selection environment
+variables; it only installs the version-locked vLLM compatibility hooks and
+registers the FlagGems runtime lazily in the model-loading process.
+"""
+
+from __future__ import annotations
+
+_ACTIVE = False
+
+
+def _print_runtime_banner() -> None:
+    print(
+        "[vllm_fl] ARM Qwen runtime active "
+        "(quant=FlagGems/libtriton_jit, gdn=FlagGems/native)",
+        flush=True,
+    )
+
+
+def enable_qwen_runtime(*, verbose: bool = True) -> bool:
+    """Install the stock-vLLM hooks and the FlagGems ARM runtime once."""
+    global _ACTIVE
+    if _ACTIVE:
+        return False
+
+    from vllm_fl.patches.arm_cpu_vllm_0240 import (
+        install_arm_cpu_vllm_0240_compat,
+    )
+
+    install_arm_cpu_vllm_0240_compat()
+    from vllm_fl.ops.cpu_qwen_gdn import install_vllm_gdn_bridge
+
+    install_vllm_gdn_bridge()
+    from flag_gems.runtime.backend._arm.q4 import enable_vllm_q4_codegen
+
+    enable_vllm_q4_codegen(verbose=verbose, runtime="libtriton_jit")
+    from vllm_fl.ops.cpu_w8_greedy import install_w8_cached_greedy
+
+    install_w8_cached_greedy()
+    from flag_gems.integrations.vllm import maybe_install_kernel_coverage
+
+    maybe_install_kernel_coverage()
+    _ACTIVE = True
+    if verbose:
+        _print_runtime_banner()
+    return True
+
+
+__all__ = [
+    "enable_qwen_runtime",
+]

--- a/vllm_fl/ops/cpu_w8_greedy.py
+++ b/vllm_fl/ops/cpu_w8_greedy.py
@@ -1,0 +1,359 @@
+"""Reuse W8 lm-head reductions for Batch=1 greedy and MTP-1 decode."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+
+_ENABLED = True
+_SPEC_ENABLED = True
+_PATCHED = False
+_HITS = 0
+_SPEC_HITS = 0
+
+
+def set_w8_cached_greedy_enabled(enabled: bool) -> bool:
+    """Set the in-process A/B route and return its previous value."""
+    global _ENABLED
+    previous = _ENABLED
+    _ENABLED = bool(enabled)
+    os.environ["FLAGGEMS_W8_CACHED_GREEDY"] = "1" if _ENABLED else "0"
+    return previous
+
+
+def set_w8_cached_spec_greedy_enabled(enabled: bool) -> bool:
+    """Set the in-process MTP rejection fast-path for controlled A/B tests."""
+    global _SPEC_ENABLED
+    previous = _SPEC_ENABLED
+    _SPEC_ENABLED = bool(enabled)
+    return previous
+
+
+def w8_cached_greedy_hits() -> int:
+    return _HITS
+
+
+def w8_cached_spec_greedy_hits() -> int:
+    return _SPEC_HITS
+
+
+def _eligible(logits, metadata) -> bool:
+    processors = metadata.logitsprocs
+    temperature = metadata.temperature
+    zero_temperature = (
+        temperature is not None
+        and temperature.numel() == 1
+        and float(temperature.reshape(-1)[0]) < 1.0e-5
+    )
+    processor_state_is_safe = True
+    for processor in processors.non_argmax_invariant:
+        name = type(processor).__name__
+        if name == "LogitBiasLogitsProcessor":
+            processor_state_is_safe &= not processor.biases
+        elif name == "MinTokensLogitsProcessor":
+            # This processor only masks stop-token IDs.  The fast path checks
+            # the cached winner against those IDs before accepting it.
+            pass
+        elif name == "ThinkingTokenBudgetLogitsProcessor":
+            processor_state_is_safe &= not processor.is_enabled
+        else:
+            processor_state_is_safe = False
+    return (
+        _ENABLED
+        and logits.device.type == "cpu"
+        and logits.dtype == torch.bfloat16
+        and logits.dim() == 2
+        and logits.shape[0] == 1
+        and logits.is_contiguous()
+        # vLLM 0.20.2 can classify a single zero-temperature request as a
+        # mixed batch (all_greedy=False).  The sampler nevertheless chooses
+        # its greedy result for that only row, so recognize the semantics
+        # directly instead of relying on the aggregate classification bit.
+        and not metadata.all_random
+        and (metadata.all_greedy or zero_temperature)
+        and metadata.max_num_logprobs is None
+        and not metadata.logprob_token_ids
+        and metadata.allowed_token_ids_mask is None
+        and not metadata.bad_words_token_ids
+        and metadata.no_penalties
+        and processor_state_is_safe
+    )
+
+
+def _masked_stop_tokens(metadata) -> set[int]:
+    blocked: set[int] = set()
+    for processor in metadata.logitsprocs.non_argmax_invariant:
+        if type(processor).__name__ != "MinTokensLogitsProcessor":
+            continue
+        state = processor.min_toks.get(0)
+        if state is not None:
+            blocked.update(int(token) for token in state[2])
+    return blocked
+
+
+def _all_masked_stop_tokens(metadata) -> set[int]:
+    """Conservatively union stop masks for every speculative logit row."""
+    blocked: set[int] = set()
+    for processor in metadata.logitsprocs.non_argmax_invariant:
+        if type(processor).__name__ != "MinTokensLogitsProcessor":
+            continue
+        for state in processor.min_toks.values():
+            blocked.update(int(token) for token in state[2])
+    return blocked
+
+
+def _spec_eligible(logits, metadata, sampling_metadata) -> bool:
+    """Recognize the exact Batch=1/MTP-1 greedy fast-path semantics."""
+    processors = sampling_metadata.logitsprocs
+    temperature = sampling_metadata.temperature
+    zero_temperature = (
+        temperature is not None
+        and temperature.numel() == 1
+        and float(temperature.reshape(-1)[0]) < 1.0e-5
+    )
+    processor_state_is_safe = True
+    for processor in processors.non_argmax_invariant:
+        name = type(processor).__name__
+        if name == "LogitBiasLogitsProcessor":
+            processor_state_is_safe &= not processor.biases
+        elif name == "MinTokensLogitsProcessor":
+            # The fast path checks both cached winners against the masked
+            # stop-token set before accepting the metadata.
+            pass
+        elif name == "ThinkingTokenBudgetLogitsProcessor":
+            processor_state_is_safe &= not processor.is_enabled
+        else:
+            processor_state_is_safe = False
+    target_indices = metadata.target_logits_indices
+    bonus_indices = metadata.bonus_logits_indices
+    return (
+        _ENABLED
+        and _SPEC_ENABLED
+        and logits.device.type == "cpu"
+        and logits.dtype == torch.bfloat16
+        and logits.dim() == 2
+        and logits.shape[0] == 2
+        and logits.is_contiguous()
+        and metadata.max_spec_len == 1
+        and metadata.draft_token_ids.numel() == 1
+        and metadata.num_draft_tokens == [1]
+        and target_indices.numel() == 1
+        and bonus_indices.numel() == 1
+        and int(target_indices[0]) == 0
+        and int(bonus_indices[0]) == 1
+        and not sampling_metadata.all_random
+        and (sampling_metadata.all_greedy or zero_temperature)
+        and sampling_metadata.max_num_logprobs is None
+        and not sampling_metadata.logprob_token_ids
+        and sampling_metadata.allowed_token_ids_mask is None
+        and not sampling_metadata.bad_words_token_ids
+        and sampling_metadata.no_penalties
+        and processor_state_is_safe
+    )
+
+
+def _multi_spec_eligible(logits, metadata, sampling_metadata) -> bool:
+    """Recognize clean Batch=1 greedy speculative verification.
+
+    vLLM's generic path gathers the bonus row, converts the target rows to
+    FP32, clones them, and only then takes argmax.  BF16-to-FP32 is lossless,
+    so a clean greedy request can reduce the original rows directly without
+    changing either the target winners or rejection semantics.
+    """
+    if os.getenv(
+        "VLLM_FL_FAST_GREEDY_SPEC_REJECTION", "0"
+    ).lower() not in {"1", "true", "yes", "on"}:
+        return False
+    processors = sampling_metadata.logitsprocs
+    temperature = sampling_metadata.temperature
+    zero_temperature = (
+        temperature is not None
+        and temperature.numel() == 1
+        and float(temperature.reshape(-1)[0]) < 1.0e-5
+    )
+    for processor in processors.non_argmax_invariant:
+        name = type(processor).__name__
+        if name == "LogitBiasLogitsProcessor":
+            if processor.biases:
+                return False
+        elif name == "MinTokensLogitsProcessor":
+            pass
+        elif name == "ThinkingTokenBudgetLogitsProcessor":
+            if processor.is_enabled:
+                return False
+        else:
+            return False
+    if (
+        not _ENABLED
+        or not _SPEC_ENABLED
+        or logits.device.type != "cpu"
+        or logits.dtype != torch.bfloat16
+        or logits.dim() != 2
+        or not logits.is_contiguous()
+        or len(metadata.num_draft_tokens) != 1
+        or metadata.max_spec_len <= 1
+        or metadata.num_draft_tokens != [metadata.max_spec_len]
+        or metadata.draft_token_ids.numel() != metadata.max_spec_len
+        or logits.shape[0] != metadata.max_spec_len + 1
+        or not sampling_metadata.all_greedy
+        or sampling_metadata.all_random
+        or not (sampling_metadata.all_greedy or zero_temperature)
+        or sampling_metadata.max_num_logprobs is not None
+        or sampling_metadata.logprob_token_ids
+        or sampling_metadata.allowed_token_ids_mask is not None
+        or sampling_metadata.bad_words_token_ids
+        or not sampling_metadata.no_penalties
+    ):
+        return False
+    target_indices = metadata.target_logits_indices
+    bonus_indices = metadata.bonus_logits_indices
+    expected = list(range(metadata.max_spec_len))
+    return (
+        target_indices.device.type == "cpu"
+        and bonus_indices.device.type == "cpu"
+        and target_indices.reshape(-1).tolist() == expected
+        and bonus_indices.reshape(-1).tolist() == [metadata.max_spec_len]
+    )
+
+
+def _multi_spec_greedy_sample(logits, metadata, sampling_metadata):
+    """Return exact greedy rejection output, or None for a masked winner."""
+    winners = logits.argmax(dim=-1)
+    blocked = _all_masked_stop_tokens(sampling_metadata)
+    if blocked and any(int(winner) in blocked for winner in winners):
+        return None
+    draft = metadata.draft_token_ids.reshape(-1)
+    width = metadata.max_spec_len
+    sampled = torch.full(
+        (1, width + 1), -1, dtype=torch.int32, device=logits.device
+    )
+    for position in range(width):
+        target_token = int(winners[position])
+        draft_token = int(draft[position])
+        sampled[0, position] = (
+            draft_token if draft_token == target_token else target_token
+        )
+        if draft_token != target_token:
+            return sampled
+    sampled[0, width] = int(winners[width])
+    return sampled
+
+
+def install_w8_cached_greedy() -> bool:
+    """Patch vLLM's sampler once; unsupported requests retain stock behavior."""
+    global _PATCHED
+    if _PATCHED:
+        return False
+    if not hasattr(torch.ops.triton_jit_cpu, "w8_cached_argmax"):
+        return False
+
+    from vllm.v1.outputs import SamplerOutput
+    from vllm.v1.sample.sampler import Sampler
+    from vllm.v1.sample.rejection_sampler import RejectionSampler
+
+    original_forward = Sampler.forward
+
+    def forward(
+        self,
+        logits,
+        sampling_metadata,
+        predict_bonus_token=False,
+        logprobs_mode_override=None,
+    ):
+        global _HITS
+        if _eligible(logits, sampling_metadata):
+            sampled = torch.ops.triton_jit_cpu.w8_cached_argmax(logits)
+            if int(sampled[0]) not in _masked_stop_tokens(sampling_metadata):
+                _HITS += 1
+                return SamplerOutput(
+                    sampled_token_ids=sampled.to(torch.int32).unsqueeze(-1),
+                    logprobs_tensors=None,
+                )
+        return original_forward(
+            self,
+            logits,
+            sampling_metadata,
+            predict_bonus_token,
+            logprobs_mode_override,
+        )
+
+    Sampler.forward = forward
+    Sampler._vllm_fl_w8_cached_greedy_original_forward = original_forward
+
+    original_spec_forward = RejectionSampler.forward
+
+    def spec_forward(
+        self,
+        metadata,
+        draft_probs,
+        logits,
+        sampling_metadata,
+    ):
+        global _SPEC_HITS
+        if (
+            not self.synthetic_mode
+            and not self.is_processed_logprobs_mode
+            and _spec_eligible(logits, metadata, sampling_metadata)
+        ):
+            winners = torch.ops.triton_jit_cpu.w8_cached_argmax(logits)
+            if winners.numel() == 2:
+                target = int(winners[0])
+                bonus = int(winners[1])
+                draft = int(metadata.draft_token_ids[0])
+                blocked = _all_masked_stop_tokens(sampling_metadata)
+                if target in blocked or bonus in blocked:
+                    return original_spec_forward(
+                        self,
+                        metadata,
+                        draft_probs,
+                        logits,
+                        sampling_metadata,
+                    )
+                sampled = torch.full(
+                    (1, 2), -1, dtype=torch.int32, device=logits.device
+                )
+                sampled[0, 0] = draft if draft == target else target
+                if draft == target:
+                    sampled[0, 1] = bonus
+                _SPEC_HITS += 1
+                return SamplerOutput(
+                    sampled_token_ids=sampled,
+                    logprobs_tensors=None,
+                )
+        if (
+            not self.synthetic_mode
+            and not self.is_processed_logprobs_mode
+            and _multi_spec_eligible(
+                logits, metadata, sampling_metadata
+            )
+        ):
+            sampled = _multi_spec_greedy_sample(
+                logits, metadata, sampling_metadata
+            )
+            if sampled is not None:
+                _SPEC_HITS += 1
+                return SamplerOutput(
+                    sampled_token_ids=sampled,
+                    logprobs_tensors=None,
+                )
+        return original_spec_forward(
+            self, metadata, draft_probs, logits, sampling_metadata
+        )
+
+    RejectionSampler.forward = spec_forward
+    RejectionSampler._vllm_fl_w8_cached_greedy_original_forward = (
+        original_spec_forward
+    )
+    _PATCHED = True
+    return True
+
+
+__all__ = [
+    "install_w8_cached_greedy",
+    "set_w8_cached_greedy_enabled",
+    "set_w8_cached_spec_greedy_enabled",
+    "w8_cached_greedy_hits",
+    "w8_cached_spec_greedy_hits",
+]

--- a/vllm_fl/patches/arm_cpu_vllm_0240.py
+++ b/vllm_fl/patches/arm_cpu_vllm_0240.py
@@ -1,0 +1,1013 @@
+"""ARM CPU compatibility layer for the stock vLLM 0.24.0 package.
+
+Keep model/runtime compatibility fixes in vllm-plugin-FL rather than carrying
+a permanently modified vLLM source tree. The integration intentionally fails
+closed on a different vLLM version because it patches private 0.24.0 APIs.
+"""
+
+from __future__ import annotations
+
+import gc
+import platform
+from importlib import metadata
+
+import torch
+
+_INSTALLED = False
+
+
+def _require_vllm_0240() -> None:
+    installed = metadata.version("vllm")
+    base = installed.split("+", 1)[0]
+    if base != "0.24.0":
+        raise RuntimeError(
+            "The FL ARM CPU compatibility layer requires vLLM 0.24.0; "
+            f"found {installed}"
+        )
+
+
+def _install_packed_w4a8() -> None:
+    from compressed_tensors.config import CompressionFormat
+
+    from vllm.logger import init_logger
+    from vllm.model_executor.kernels.linear import (
+        MPLinearLayerConfig,
+        choose_mp_linear_kernel,
+    )
+    from vllm.model_executor.layers.quantization.compressed_tensors import (
+        compressed_tensors as config_module,
+    )
+    from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+        compressed_tensors_w4a8_int as scheme_module,
+    )
+    from vllm.model_executor.parameter import (
+        BasevLLMParameter,
+        ChannelQuantScaleParameter,
+        GroupQuantScaleParameter,
+        PackedvLLMParameter,
+    )
+
+    scheme_cls = scheme_module.CompressedTensorsW4A8Int
+    config_cls = config_module.CompressedTensorsConfig
+    if getattr(scheme_cls, "_vllm_fl_packed_w4a8", False):
+        return
+
+    logger = init_logger(__name__)
+    original_init = scheme_cls.__init__
+    original_create_weights = scheme_cls.create_weights
+    original_get_scheme = config_cls._get_scheme_from_parts
+
+    def scheme_init(
+        self,
+        strategy: str,
+        num_bits: int,
+        group_size: int | None = None,
+        is_static_input_scheme: bool = False,
+        input_symmetric: bool = True,
+        packed: bool = False,
+    ) -> None:
+        original_init(
+            self,
+            strategy=strategy,
+            num_bits=num_bits,
+            group_size=group_size,
+            is_static_input_scheme=is_static_input_scheme,
+            input_symmetric=input_symmetric,
+        )
+        self._vllm_fl_checkpoint_packed = packed
+        self._vllm_fl_pack_factor = 32 // num_bits
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        output_size: int,
+        input_size: int,
+        output_partition_sizes: list[int],
+        input_size_per_partition: int,
+        params_dtype: torch.dtype,
+        weight_loader,
+        **kwargs,
+    ) -> None:
+        if not getattr(self, "_vllm_fl_checkpoint_packed", False):
+            return original_create_weights(
+                self,
+                layer,
+                output_size,
+                input_size,
+                output_partition_sizes,
+                input_size_per_partition,
+                params_dtype,
+                weight_loader,
+                **kwargs,
+            )
+
+        output_size_per_partition = sum(output_partition_sizes)
+        row_parallel = input_size != input_size_per_partition
+        effective_group_size = (
+            input_size_per_partition
+            if self.group_size == -1 and row_parallel
+            else input_size
+            if self.group_size == -1
+            else self.group_size
+        )
+        if input_size_per_partition % effective_group_size:
+            raise ValueError(
+                f"input partition {input_size_per_partition} is not divisible "
+                f"by W4 group size {effective_group_size}"
+            )
+
+        kernel_config = MPLinearLayerConfig(
+            full_weight_shape=(input_size, output_size),
+            partition_weight_shape=(
+                input_size_per_partition,
+                output_size_per_partition,
+            ),
+            weight_type=self.quant_type,
+            act_type=params_dtype,
+            group_size=effective_group_size,
+            zero_points=False,
+            has_g_idx=False,
+        )
+        kernel_type = choose_mp_linear_kernel(kernel_config)
+        if kernel_type.__name__ not in self._kernel_backends_being_used:
+            logger.info(
+                "Using %s for packed CompressedTensorsW4A8Int",
+                kernel_type.__name__,
+            )
+            self._kernel_backends_being_used.add(kernel_type.__name__)
+
+        weight = PackedvLLMParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self._vllm_fl_pack_factor,
+                dtype=torch.int32,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+            packed_factor=self._vllm_fl_pack_factor,
+            packed_dim=1,
+        )
+        layer.register_parameter("weight_packed", weight)
+
+        scale_args = {
+            "weight_loader": weight_loader,
+            "data": torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // effective_group_size,
+                dtype=params_dtype,
+            ),
+        }
+        if self.group_size == -1 and row_parallel:
+            weight_scale = ChannelQuantScaleParameter(output_dim=0, **scale_args)
+        else:
+            weight_scale = GroupQuantScaleParameter(
+                output_dim=0, input_dim=1, **scale_args
+            )
+        layer.register_parameter("weight_scale", weight_scale)
+        layer.register_parameter(
+            "weight_shape",
+            BasevLLMParameter(
+                data=torch.empty(2, dtype=torch.int64),
+                weight_loader=weight_loader,
+            ),
+        )
+        self.kernel = kernel_type(
+            kernel_config,
+            w_q_param_name="weight_packed",
+            w_s_param_name="weight_scale",
+            w_zp_param_name=None,
+            w_gidx_param_name=None,
+        )
+
+    def get_scheme_from_parts(
+        self,
+        weight_quant,
+        input_quant,
+        output_quant=None,
+        format: str | None = None,
+        layer_name: str | None = None,
+    ):
+        resolved_format = format if format is not None else self.quant_format
+        if (
+            resolved_format == CompressionFormat.pack_quantized.value
+            and self._is_dynamic_token_w4a8_int(weight_quant, input_quant)
+        ):
+            return scheme_cls(
+                num_bits=weight_quant.num_bits,
+                strategy=weight_quant.strategy,
+                group_size=weight_quant.group_size,
+                is_static_input_scheme=False,
+                input_symmetric=input_quant.symmetric,
+                packed=True,
+            )
+        return original_get_scheme(
+            self,
+            weight_quant,
+            input_quant,
+            output_quant=output_quant,
+            format=format,
+            layer_name=layer_name,
+        )
+
+    scheme_cls.__init__ = scheme_init
+    scheme_cls.create_weights = create_weights
+    config_cls._get_scheme_from_parts = get_scheme_from_parts
+    scheme_cls._vllm_fl_packed_w4a8 = True
+
+
+def _install_cpu_gemm_guard() -> None:
+    from vllm.model_executor.layers import utils as layer_utils
+
+    original = layer_utils.dispatch_cpu_unquantized_gemm
+    if getattr(original, "_vllm_fl_ndim_guard", False):
+        return
+
+    def guarded(layer: torch.nn.Module, remove_weight: bool) -> None:
+        weight = getattr(layer, "weight", None)
+        if isinstance(weight, torch.Tensor) and weight.ndim != 2:
+            return
+        return original(layer, remove_weight)
+
+    guarded._vllm_fl_ndim_guard = True
+    layer_utils.dispatch_cpu_unquantized_gemm = guarded
+
+
+def _install_text_only_vision_guard() -> None:
+    from contextvars import ContextVar
+
+    from vllm.model_executor.models import qwen3_5 as qwen
+
+    if getattr(qwen, "_vllm_fl_text_only_vision", False):
+        return
+
+    text_only_build = ContextVar("vllm_fl_qwen_text_only_build", default=False)
+    original_vision_init = qwen.Qwen3_VisionTransformer.__init__
+
+    def vision_init(self, *args, **kwargs) -> None:
+        if text_only_build.get():
+            kwargs["quant_config"] = None
+        original_vision_init(self, *args, **kwargs)
+
+    qwen.Qwen3_VisionTransformer.__init__ = vision_init
+
+    for model_cls in (
+        qwen.Qwen3_5ForConditionalGeneration,
+        qwen.Qwen3_5MoeForConditionalGeneration,
+    ):
+        original_model_init = model_cls.__init__
+
+        def model_init(
+            self,
+            *,
+            vllm_config,
+            prefix: str = "model",
+            _original=original_model_init,
+        ) -> None:
+            language_only = bool(
+                vllm_config.model_config.multimodal_config.language_model_only
+            )
+            token = text_only_build.set(language_only)
+            try:
+                _original(self, vllm_config=vllm_config, prefix=prefix)
+            finally:
+                text_only_build.reset(token)
+
+        model_cls.__init__ = model_init
+
+    qwen._vllm_fl_text_only_vision = True
+
+
+def _install_cpu_attention_block_constraint() -> None:
+    from vllm.v1.attention.backend import MultipleOf
+    from vllm.v1.attention.backends.cpu_attn import CPUAttentionBackend
+
+    if hasattr(CPUAttentionBackend, "get_supported_kernel_block_sizes"):
+        return
+
+    CPUAttentionBackend.get_supported_kernel_block_sizes = staticmethod(
+        lambda: [MultipleOf(32)]
+    )
+
+
+def _install_cpu_cleanup_guard() -> None:
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    original = GPUModelRunner._cleanup_profiling_kv_cache
+    if getattr(original, "_vllm_fl_cpu_guard", False):
+        return
+
+    def cleanup(self) -> None:
+        if self.device.type != "cpu":
+            return original(self)
+        if hasattr(self, "kv_caches") and self.kv_caches:
+            for index in range(len(self.kv_caches)):
+                self.kv_caches[index] = None
+            self.kv_caches.clear()
+        if hasattr(self, "cross_layers_kv_cache"):
+            self.cross_layers_kv_cache = None
+            self.cross_layers_attn_backend = None
+        if hasattr(self, "attn_groups"):
+            self.attn_groups.clear()
+        if hasattr(self, "kv_cache_config"):
+            delattr(self, "kv_cache_config")
+        self.cache_config.num_gpu_blocks = None
+        for layer in self.compilation_config.static_forward_context.values():
+            if hasattr(layer, "kv_cache"):
+                kv_cache = layer.kv_cache
+                layer.kv_cache = (
+                    torch.tensor([]) if isinstance(kv_cache, torch.Tensor) else []
+                )
+            if hasattr(layer, "impl"):
+                if hasattr(layer.impl, "_k_scale_cache"):
+                    layer.impl._k_scale_cache = None
+                if hasattr(layer.impl, "_v_scale_cache"):
+                    layer.impl._v_scale_cache = None
+        gc.collect()
+
+    cleanup._vllm_fl_cpu_guard = True
+    GPUModelRunner._cleanup_profiling_kv_cache = cleanup
+
+
+def _zero_cpu_attention_blocks(self, block_ids: list[int]) -> None:
+    """Clear recycled attention pages for vLLM's hybrid CPU cache.
+
+    vLLM 0.24.0 asks the runner to clear newly allocated pages whenever a
+    model has Mamba/GDN layers.  Its CPU runner discards that request, based
+    on the assumption that invalid attention positions are always masked.
+    With a hybrid page size larger than the CPU attention kernel block, stale
+    K/V data can still affect a recycled physical page.  The generic zeroer
+    already knows the hybrid page mapping and intentionally skips Mamba state;
+    GDN handles fresh state through ``has_initial_state`` during prefill.
+    """
+    zeroer = getattr(self, "_kv_block_zeroer", None)
+    if zeroer is not None:
+        zeroer.zero_block_ids(block_ids)
+
+
+def _install_cpu_hybrid_kv_zeroing() -> None:
+    from vllm.v1.core.single_type_kv_cache_manager import (
+        SingleTypeKVCacheManager,
+    )
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        SlidingWindowSpec,
+    )
+    from vllm.v1.worker.cpu_model_runner import CPUModelRunner
+    from vllm.v1.worker.utils import KVBlockZeroer
+
+    # Keep this compatibility in the plugin: a stock vLLM 0.24 zeroer only
+    # records FullAttentionSpec storage and launches a Triton pointer kernel,
+    # neither of which is correct for DFlash2's recycled host sliding-window
+    # cache.  Retain checked tensor slices and clear them directly on the CPU.
+    original_zeroer_init = KVBlockZeroer.__init__
+    if not getattr(original_zeroer_init, "_vllm_fl_cpu_tensor_slices", False):
+        original_zero_block_ids = KVBlockZeroer.zero_block_ids
+
+        def zeroer_init(
+            self,
+            device,
+            pin_memory,
+            attn_groups_iter,
+            kernel_block_sizes,
+            cache_dtype,
+            static_forward_context,
+            runner_only_attn_layers=None,
+        ) -> None:
+            groups = list(attn_groups_iter)
+            original_zeroer_init(
+                self,
+                device=device,
+                pin_memory=pin_memory,
+                attn_groups_iter=groups,
+                kernel_block_sizes=kernel_block_sizes,
+                cache_dtype=cache_dtype,
+                static_forward_context=static_forward_context,
+                runner_only_attn_layers=runner_only_attn_layers,
+            )
+            if device.type != "cpu":
+                return
+
+            excluded = runner_only_attn_layers or set()
+            seen_ptrs: set[int] = set()
+            slices: list[tuple[torch.Tensor, int, int]] = []
+            for group in groups:
+                spec = group.kv_cache_spec
+                if not isinstance(spec, (FullAttentionSpec, SlidingWindowSpec)):
+                    continue
+                group_id = group.kv_cache_group_id
+                if group_id >= len(kernel_block_sizes):
+                    continue
+                kernel_block_size = kernel_block_sizes[group_id]
+                if spec.block_size % kernel_block_size:
+                    raise ValueError(
+                        f"KV block size {spec.block_size} is not divisible by "
+                        f"kernel block size {kernel_block_size}"
+                    )
+                ratio = spec.block_size // kernel_block_size
+                block_dim = group.backend.get_kv_cache_block_dim(
+                    kernel_block_size,
+                    spec.num_kv_heads,
+                    spec.head_size,
+                    cache_dtype_str=cache_dtype,
+                )
+                for layer_name in group.layer_names:
+                    if layer_name in excluded:
+                        continue
+                    cache = static_forward_context[layer_name].kv_cache
+                    if not isinstance(cache, torch.Tensor):
+                        continue
+                    data_ptr = cache.data_ptr()
+                    if data_ptr in seen_ptrs:
+                        continue
+                    seen_ptrs.add(data_ptr)
+                    slices.append((cache, block_dim, ratio))
+            self._vllm_fl_cpu_slices = slices
+
+        def zero_block_ids(self, block_ids: list[int]) -> None:
+            slices = getattr(self, "_vllm_fl_cpu_slices", None)
+            if self.device.type != "cpu" or slices is None:
+                return original_zero_block_ids(self, block_ids)
+            for cache, block_dim, ratio in slices:
+                for block_id in dict.fromkeys(block_ids):
+                    start = block_id * ratio
+                    if block_id < 0 or start + ratio > cache.shape[block_dim]:
+                        raise IndexError(
+                            f"KV block {block_id} is outside cache shape "
+                            f"{tuple(cache.shape)} at block_dim={block_dim}"
+                        )
+                    cache.narrow(block_dim, start, ratio).zero_()
+
+        zeroer_init._vllm_fl_cpu_tensor_slices = True
+        zero_block_ids._vllm_fl_cpu_tensor_slices = True
+        KVBlockZeroer.__init__ = zeroer_init
+        KVBlockZeroer.zero_block_ids = zero_block_ids
+
+    # Stock vLLM 0.24 does not report pages allocated by SlidingWindowManager
+    # to the runner zeroer.  Wrap both allocation paths and add only IDs the
+    # underlying implementation did not already report, so this is safe with a
+    # source tree that has subsequently taken the same upstream fix.
+    original_allocate = SingleTypeKVCacheManager.allocate_new_blocks
+    if not getattr(original_allocate, "_vllm_fl_reports_sliding_pages", False):
+
+        def allocate_new_blocks(
+            self,
+            request_id: str,
+            num_tokens: int,
+            num_tokens_main_model: int,
+        ):
+            report_start = len(self.new_block_ids)
+            blocks = original_allocate(
+                self,
+                request_id,
+                num_tokens,
+                num_tokens_main_model,
+            )
+            if isinstance(self.kv_cache_spec, SlidingWindowSpec):
+                reported = set(self.new_block_ids[report_start:])
+                self.new_block_ids.extend(
+                    block.block_id for block in blocks if block.block_id not in reported
+                )
+            return blocks
+
+        allocate_new_blocks._vllm_fl_reports_sliding_pages = True
+        SingleTypeKVCacheManager.allocate_new_blocks = allocate_new_blocks
+
+    original_allocate_external = (
+        SingleTypeKVCacheManager.allocate_external_computed_blocks
+    )
+    if not getattr(
+        original_allocate_external,
+        "_vllm_fl_reports_sliding_pages",
+        False,
+    ):
+
+        def allocate_external_computed_blocks(
+            self,
+            request_id: str,
+            num_local_computed_tokens: int,
+            num_external_computed_tokens: int,
+        ) -> None:
+            block_start = len(self.req_to_blocks[request_id])
+            report_start = len(self.new_block_ids)
+            original_allocate_external(
+                self,
+                request_id,
+                num_local_computed_tokens,
+                num_external_computed_tokens,
+            )
+            if isinstance(self.kv_cache_spec, SlidingWindowSpec):
+                blocks = self.req_to_blocks[request_id][block_start:]
+                reported = set(self.new_block_ids[report_start:])
+                self.new_block_ids.extend(
+                    block.block_id for block in blocks if block.block_id not in reported
+                )
+
+        allocate_external_computed_blocks._vllm_fl_reports_sliding_pages = True
+        SingleTypeKVCacheManager.allocate_external_computed_blocks = (
+            allocate_external_computed_blocks
+        )
+
+    current = CPUModelRunner._zero_block_ids
+    if getattr(current, "_vllm_fl_hybrid_kv_zeroing", False):
+        return
+    _zero_cpu_attention_blocks._vllm_fl_hybrid_kv_zeroing = True
+    CPUModelRunner._zero_block_ids = _zero_cpu_attention_blocks
+
+
+def _cpu_attention_scheduler_rebuild_policy(
+    scheduler: object,
+    *,
+    expected_isa: int | None,
+    requested_split_kv: bool,
+    apple_arm: bool,
+) -> bool | None:
+    """Return the split-KV setting for a required metadata rebuild.
+
+    The vLLM 0.24 C++ metadata header starts at byte 64. Its first int32 is
+    the dispatch ISA and its fourth int32 is ``reduction_split_num``. On
+    Apple ARM, the split-KV reduction barrier can execute inside a serialized
+    nested OpenMP region: the only active thread then waits forever for the
+    logical worker count. Rebuilding without KV splitting preserves attention
+    semantics and avoids that barrier.
+
+    ``None`` means the existing scheduler is safe to reuse.
+    """
+    if expected_isa is None:
+        return None
+
+    scheduler_isa = None
+    reduction_split_num = 0
+    if (
+        isinstance(scheduler, torch.Tensor)
+        and scheduler.is_contiguous()
+        and scheduler.numel() * scheduler.element_size() >= 80
+    ):
+        header = scheduler.view(torch.uint8)[64:80].clone().view(torch.int32)
+        scheduler_isa = int(header[0])
+        reduction_split_num = int(header[3])
+
+    if apple_arm and reduction_split_num > 0:
+        return False
+    if scheduler_isa != expected_isa:
+        return False if apple_arm else requested_split_kv
+    return None
+
+
+def _install_cpu_attention_scheduler_isa_guard() -> None:
+    """Keep CPU attention scheduler metadata safe for the active runtime.
+
+    vLLM 0.24 can reuse metadata built for another attention subgroup in a
+    hybrid GDN/full-attention model.  The metadata embeds the C++ dispatch ISA;
+    on Apple ARM we observed VEC16 metadata paired with a NEON/BFMMLA-packed KV
+    cache. Apple ARM split-KV metadata is also rebuilt without splitting to
+    avoid the vLLM reduction barrier deadlock under the Triton-CPU runtime.
+    """
+    from vllm import _custom_ops as ops, envs
+    from vllm.v1.attention.backends.cpu_attn import CPUAttentionBackendImpl
+
+    original = CPUAttentionBackendImpl.forward
+    if getattr(original, "_vllm_fl_scheduler_isa_guard", False):
+        return
+
+    isa_codes = {
+        "amx": 0,
+        "vec": 1,
+        "vec16": 2,
+        "neon": 3,
+        "vxe": 4,
+        "rvv": 5,
+        "vsx": 6,
+    }
+
+    def forward(
+        self,
+        layer,
+        query,
+        key,
+        value,
+        kv_cache,
+        attn_metadata,
+        output,
+        output_scale=None,
+        output_block_scale=None,
+    ):
+        if attn_metadata is not None:
+            scheduler = getattr(attn_metadata, "scheduler_metadata", None)
+            expected_isa = isa_codes.get(self.isa)
+            requested_split_kv = envs.VLLM_CPU_ATTN_SPLIT_KV
+            rebuild_split_kv = _cpu_attention_scheduler_rebuild_policy(
+                scheduler,
+                expected_isa=expected_isa,
+                requested_split_kv=requested_split_kv,
+                apple_arm=(
+                    platform.system() == "Darwin"
+                    and platform.machine().lower() in {"aarch64", "arm64"}
+                ),
+            )
+            if rebuild_split_kv is not None:
+                attn_metadata.scheduler_metadata = ops.cpu_attn_get_scheduler_metadata(
+                    num_reqs=attn_metadata.query_start_loc.numel() - 1,
+                    num_heads=self.num_heads,
+                    num_kv_heads=self.num_kv_heads,
+                    head_dim=self.head_size,
+                    seq_lens=attn_metadata.seq_lens,
+                    dtype=query.dtype,
+                    query_start_loc=attn_metadata.query_start_loc,
+                    causal=attn_metadata.causal,
+                    sliding_window_size=self.sliding_window,
+                    isa=self.isa,
+                    enable_kv_split=rebuild_split_kv,
+                    dynamic_causal=attn_metadata.dynamic_causal,
+                )
+        return original(
+            self,
+            layer,
+            query,
+            key,
+            value,
+            kv_cache,
+            attn_metadata,
+            output,
+            output_scale,
+            output_block_scale,
+        )
+
+    forward._vllm_fl_scheduler_isa_guard = True
+    CPUAttentionBackendImpl.forward = forward
+
+
+def _install_cpu_spec_decode_kernels() -> None:
+    """Use vLLM's native CPU helpers for speculative control-plane ops.
+
+    vLLM 0.24 skips all of its C++ fallbacks when Triton-CPU is importable.
+    That is appropriate for model kernels, but it also sends small EAGLE/MTP
+    metadata and rejection-sampling operations through Triton.  In particular,
+    ``sample_recovered_tokens_kernel`` produces multi-megabyte LLVM IR on ARM
+    and can take minutes to compile.  Select only the official CPU wrappers
+    here; quantized model and GDN kernels remain on Triton-CPU/FlagGems.
+    """
+    import vllm.utils.cpu_triton_utils as cpu_tl
+    import vllm.v1.sample.rejection_sampler as rejection_sampler
+    import vllm.v1.spec_decode.llm_base_proposer as llm_base_proposer
+    import vllm.v1.spec_decode.utils as spec_utils
+    import vllm.v1.worker.block_table as block_table
+
+    recovered_kernel = cpu_tl.sample_recovered_tokens_kernel
+    recovered_impl = recovered_kernel.func
+    if not getattr(recovered_impl, "_vllm_fl_fp64_gumbel_abi", False):
+
+        def recovered_compat(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            draft_probs,
+            target_probs,
+            inv_q,
+            vocab_size,
+            block_size=None,
+            *,
+            NO_DRAFT_PROBS=False,
+            USE_FP64_GUMBEL=False,
+        ):
+            if USE_FP64_GUMBEL:
+                raise NotImplementedError(
+                    "FP64 Gumbel speculative sampling is unsupported by "
+                    "the vLLM 0.24 CPU C++ kernel"
+                )
+            return recovered_impl(
+                output_token_ids,
+                cu_num_draft_tokens,
+                draft_token_ids,
+                draft_probs,
+                target_probs,
+                inv_q,
+                vocab_size,
+                block_size,
+                NO_DRAFT_PROBS=NO_DRAFT_PROBS,
+            )
+
+        recovered_compat._vllm_fl_fp64_gumbel_abi = True
+        recovered_kernel.func = recovered_compat
+
+    # vLLM's 0.24 CPU C++ expand helper reads every input as int64. Sampling
+    # also uses this operation for floating-point temperature and top-p rows,
+    # so routing those tensors through the C++ helper truncates their values
+    # and leaves the floating-point output storage untouched. Expand the tiny
+    # per-request control vectors with PyTorch on the host instead.
+    expand_kernel = cpu_tl.expand_kernel
+    expand_impl = expand_kernel.func
+    if not getattr(expand_impl, "_vllm_fl_dtype_safe", False):
+
+        def expand_compat(
+            output,
+            input_val,
+            cu_num_tokens,
+            replace_from,
+            replace_to,
+            MAX_NUM_TOKENS=None,
+        ):
+            del MAX_NUM_TOKENS
+            values = input_val
+            if replace_from != replace_to:
+                values = torch.where(
+                    values == replace_from,
+                    values.new_tensor(replace_to),
+                    values,
+                )
+            starts = torch.cat((cu_num_tokens.new_zeros(1), cu_num_tokens[:-1]))
+            counts = (cu_num_tokens - starts).to(torch.int64)
+            expanded = torch.repeat_interleave(values, counts)
+            if expanded.numel() != output.numel():
+                raise ValueError(
+                    "expanded sampling metadata has "
+                    f"{expanded.numel()} tokens, expected {output.numel()}"
+                )
+            output.copy_(expanded)
+
+        expand_compat._vllm_fl_dtype_safe = True
+        expand_kernel.func = expand_compat
+
+    block_table._compute_slot_mapping_kernel = cpu_tl.compute_slot_mapping_kernel
+    llm_base_proposer.eagle_prepare_inputs_padded_kernel = (
+        cpu_tl.eagle_prepare_inputs_padded_kernel
+    )
+    llm_base_proposer.eagle_prepare_next_token_padded_kernel = (
+        cpu_tl.eagle_prepare_next_token_padded_kernel
+    )
+    llm_base_proposer.copy_and_expand_eagle_inputs_kernel = (
+        cpu_tl.copy_and_expand_eagle_inputs_kernel
+    )
+    spec_utils.eagle_step_slot_mapping_metadata_kernel = (
+        cpu_tl.eagle_step_slot_mapping_metadata_kernel
+    )
+    rejection_sampler.rejection_greedy_sample_kernel = (
+        cpu_tl.rejection_greedy_sample_kernel
+    )
+    rejection_sampler.rejection_random_sample_kernel = (
+        cpu_tl.rejection_random_sample_kernel
+    )
+    rejection_sampler.expand_kernel = expand_kernel
+    rejection_sampler.sample_recovered_tokens_kernel = recovered_kernel
+
+
+def _install_cpu_dflash2_proposer() -> None:
+    """Select the plugin DFlash2 proposer in vLLM's standalone CPU runner."""
+    from vllm.v1.worker.cpu_model_runner import CPUModelRunner
+
+    original_init = CPUModelRunner.__init__
+    if getattr(original_init, "_vllm_fl_dflash2_proposer", False):
+        return
+
+    def init_with_dflash2(self, vllm_config, device) -> None:
+        original_init(self, vllm_config, device)
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is None or not speculative_config.use_dflash():
+            return
+        draft_architectures = (
+            getattr(
+                speculative_config.draft_model_config.hf_config,
+                "architectures",
+                (),
+            )
+            or ()
+        )
+        if "DFlash2DraftModel" not in draft_architectures:
+            return
+
+        from vllm_fl.spec_decode.dflash2 import DFlash2Proposer
+
+        self.drafter = DFlash2Proposer(vllm_config, device, self)
+        self.use_aux_hidden_state_outputs = True
+
+    init_with_dflash2._vllm_fl_dflash2_proposer = True
+    CPUModelRunner.__init__ = init_with_dflash2
+
+
+def _apply_top_k_top_p_small_k_cpu(
+    logits: torch.Tensor,
+    top_k: torch.Tensor | None,
+    top_p: torch.Tensor | None,
+    *,
+    max_fast_k: int = 256,
+) -> torch.Tensor | None:
+    """Filter a small top-k before applying top-p on CPU.
+
+    vLLM's general Triton kernel scans the full vocabulary several times.  For
+    the common DFlash2 evaluation setting (top-k=20), reducing to K candidates
+    first is mathematically identical and substantially cheaper on CPU.
+    ``None`` asks the caller to use vLLM's general implementation.
+    """
+    if (
+        logits.device.type != "cpu"
+        or logits.ndim != 2
+        or top_k is None
+        or top_p is None
+        or top_k.numel() != logits.shape[0]
+        or top_p.numel() != logits.shape[0]
+    ):
+        return None
+    smallest_k = int(top_k.min())
+    largest_k = int(top_k.max())
+    if smallest_k <= 0 or largest_k > min(max_fast_k, logits.shape[1]):
+        return None
+
+    top_k_long = top_k.to(torch.long)
+    probe_k = min(largest_k + 1, logits.shape[1])
+    descending_logits, descending_ids = logits.topk(probe_k, dim=-1, sorted=True)
+    has_outside_candidate = top_k_long < logits.shape[1]
+    last_inside = descending_logits.gather(1, (top_k_long - 1).unsqueeze(1))
+    first_outside = descending_logits.gather(
+        1, top_k_long.clamp_max(probe_k - 1).unsqueeze(1)
+    )
+    # vLLM's Triton kernel has an explicit, deterministic rule for duplicates
+    # crossing the K boundary. torch.topk may choose another equal-logit token,
+    # which can change seeded output, so retain the general path for that rare
+    # case instead of silently changing sampling semantics.
+    unsafe_rows = has_outside_candidate & (
+        last_inside.squeeze(1) == first_outside.squeeze(1)
+    )
+
+    candidate_logits = descending_logits[:, :largest_k].flip(1)
+    candidate_ids = descending_ids[:, :largest_k].flip(1)
+
+    # With per-row K, the final K entries in ascending order are active.
+    ranks = torch.arange(largest_k, device=logits.device).unsqueeze(0)
+    first_active = largest_k - top_k_long
+    inactive = ranks < first_active.unsqueeze(1)
+    candidate_logits.masked_fill_(inactive, -float("inf"))
+
+    cumulative = candidate_logits.softmax(dim=-1)
+    cumulative.cumsum_(dim=-1)
+    top_p_mask = cumulative <= 1 - top_p.unsqueeze(1)
+    # Preserve at least the maximum-logit candidate, matching vLLM.
+    top_p_mask[:, -1] = False
+    if largest_k > 1:
+        # An equal-logit group is order-independent unless the top-p boundary
+        # splits that group. In that one case defer to vLLM's deterministic
+        # duplicate rule.
+        pair_ranks = torch.arange(largest_k - 1, device=logits.device).unsqueeze(0)
+        active_pair = pair_ranks >= first_active.unsqueeze(1)
+        split_equal_pair = (
+            (candidate_logits[:, 1:] == candidate_logits[:, :-1])
+            & (top_p_mask[:, 1:] != top_p_mask[:, :-1])
+            & active_pair
+        )
+        unsafe_rows |= split_equal_pair.any(dim=1)
+    candidate_logits.masked_fill_(top_p_mask, -float("inf"))
+
+    output = torch.full_like(logits, -float("inf")).scatter_(
+        1, candidate_ids, candidate_logits
+    )
+    if torch.any(unsafe_rows):
+        # Quantized logits can tie exactly. vLLM's combined Triton top-k/top-p
+        # kernel has a specialized token-ID rule for a boundary tie, including
+        # the p<1 case. Re-run only those rows through the original kernel;
+        # ordinary rows still avoid its full-vocabulary scan.
+        from vllm.v1.sample.ops.topk_topp_triton import apply_top_k_top_p_triton
+
+        output[unsafe_rows] = apply_top_k_top_p_triton(
+            logits[unsafe_rows].clone(),
+            top_k[unsafe_rows],
+            top_p[unsafe_rows],
+        )
+    return output
+
+
+def _install_cpu_small_top_k_top_p() -> None:
+    """Route small-K CPU sampling around the full-vocabulary Triton scan."""
+    import vllm.v1.sample.ops.topk_topp_sampler as sampler_ops
+
+    original = sampler_ops.apply_top_k_top_p
+    if getattr(original, "_vllm_fl_small_k_cpu", False):
+        return
+
+    def apply_top_k_top_p(logits, top_k, top_p):
+        optimized = _apply_top_k_top_p_small_k_cpu(logits, top_k, top_p)
+        if optimized is not None:
+            return optimized
+        return original(logits, top_k, top_p)
+
+    apply_top_k_top_p._vllm_fl_small_k_cpu = True
+    sampler_ops.apply_top_k_top_p = apply_top_k_top_p
+
+    # rejection_sampler imported the function directly, so update its binding
+    # as well as the sampler module's global used by TopKTopPSampler methods.
+    import vllm.v1.sample.rejection_sampler as rejection_sampler
+
+    rejection_sampler.apply_top_k_top_p = apply_top_k_top_p
+
+
+def _install_cpu_spec_decode_compat() -> None:
+    """Bridge a legacy CPU sampler to the current MTP call ABI.
+
+    The generic rejection sampler passes the optional synthetic-decoding
+    tensors used by the generic sampler. The legacy CPU implementation still
+    implements the ordinary greedy/random algorithm and has the older
+    signature.  Ignore those tensors for the ordinary path and fail closed if
+    synthetic rejection sampling is explicitly requested.
+    """
+    import vllm.utils.cpu_triton_utils as cpu_tl
+
+    greedy_kernel = cpu_tl.rejection_greedy_sample_kernel
+    greedy_impl = greedy_kernel.func
+    if getattr(greedy_impl, "_vllm_fl_spec_decode_abi", False):
+        return
+
+    random_kernel = cpu_tl.rejection_random_sample_kernel
+    random_impl = random_kernel.func
+
+    def greedy_compat(
+        output_token_ids,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        target_argmax,
+        bonus_token_ids,
+        is_greedy,
+        max_spec_len,
+        uniform_probs=None,
+        synthetic_conditional_rates=None,
+        *,
+        SYNTHETIC_MODE=False,
+    ):
+        del uniform_probs, synthetic_conditional_rates
+        if SYNTHETIC_MODE:
+            raise NotImplementedError(
+                "synthetic speculative rejection sampling is unsupported on "
+                "the legacy ARM CPU path"
+            )
+        return greedy_impl(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            target_argmax,
+            bonus_token_ids,
+            is_greedy,
+            max_spec_len,
+        )
+
+    def random_compat(
+        output_token_ids,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        draft_probs,
+        target_probs,
+        bonus_token_ids,
+        recovered_token_ids,
+        uniform_probs,
+        is_greedy,
+        max_spec_len,
+        vocab_size,
+        synthetic_conditional_rates=None,
+        *,
+        NO_DRAFT_PROBS=False,
+        SYNTHETIC_MODE=False,
+    ):
+        del synthetic_conditional_rates
+        if SYNTHETIC_MODE:
+            raise NotImplementedError(
+                "synthetic speculative rejection sampling is unsupported on "
+                "the legacy ARM CPU path"
+            )
+        return random_impl(
+            output_token_ids,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            draft_probs,
+            target_probs,
+            bonus_token_ids,
+            recovered_token_ids,
+            uniform_probs,
+            is_greedy,
+            max_spec_len,
+            vocab_size,
+            NO_DRAFT_PROBS=NO_DRAFT_PROBS,
+        )
+
+    greedy_compat._vllm_fl_spec_decode_abi = True
+    random_compat._vllm_fl_spec_decode_abi = True
+    greedy_kernel.func = greedy_compat
+    random_kernel.func = random_compat
+
+
+def install_arm_cpu_vllm_0240_compat() -> bool:
+    """Install all Python-only compatibility hooks exactly once."""
+    global _INSTALLED
+    if _INSTALLED:
+        return False
+    _require_vllm_0240()
+    _install_packed_w4a8()
+    _install_cpu_gemm_guard()
+    _install_text_only_vision_guard()
+    _install_cpu_attention_block_constraint()
+    _install_cpu_cleanup_guard()
+    _install_cpu_hybrid_kv_zeroing()
+    _install_cpu_attention_scheduler_isa_guard()
+    _install_cpu_spec_decode_kernels()
+    _install_cpu_small_top_k_top_p()
+    _install_cpu_dflash2_proposer()
+    _INSTALLED = True
+    return True
+
+
+__all__ = ["install_arm_cpu_vllm_0240_compat"]

--- a/vllm_fl/patches/dynamo_metrics.py
+++ b/vllm_fl/patches/dynamo_metrics.py
@@ -1,0 +1,22 @@
+"""Compatibility for Torch serializing FlagGems' logging-function set."""
+
+
+def patch_dynamo_metrics_serialization() -> None:
+    import torch._dynamo.utils as dynamo_utils
+
+    if getattr(dynamo_utils, "_fl_metrics_serialization_patched", False):
+        return
+    original = dynamo_utils._get_dynamo_config_for_logging
+
+    def get_dynamo_config_for_logging():
+        # FlagGems registers a set of logging functions in the Dynamo config;
+        # serializing it raises TypeError. The config is logging metadata only,
+        # so dropping it is harmless. Wrap unconditionally because the
+        # offending entry may be registered after this patch is installed.
+        try:
+            return original()
+        except TypeError:
+            return None
+
+    dynamo_utils._get_dynamo_config_for_logging = get_dynamo_config_for_logging
+    dynamo_utils._fl_metrics_serialization_patched = True

--- a/vllm_fl/platform_cpu.py
+++ b/vllm_fl/platform_cpu.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+"""ARM CPU platform for the FL quantized linear integrations.
+
+vllm-plugin-FL has no CPU vendor/backend (its PlatformFL/WorkerFL are
+GPU-shaped, adapted from vLLM v0.20.2 CUDA). On ARM CPU we register this
+subclass so the plugin provides a CPU backend while inheriting vLLM's native
+CpuPlatform (torch.compile, CPUWorker).
+
+Compilation mode, OpenMP policy, and affinity belong to the launcher profile.
+The native CPU platform requires its MP executor to configure OpenMP correctly. An explicit
+FL_CPU_UNIPROC=1 escape hatch keeps the measured in-process path available for controlled,
+single-worker deployments that configure thread affinity and allocator preload themselves.
+
+The selected W4A8 or W8 backend is installed via register_model(), which runs
+in whichever process loads the model.
+"""
+import os
+
+from vllm.logger import init_logger
+from vllm.platforms.cpu import CpuPlatform
+
+logger = init_logger(__name__)
+
+
+class CpuPlatformFL(CpuPlatform):
+    """Native vLLM CPU platform with compile enabled for ARM quantization."""
+
+    @classmethod
+    def check_and_update_config(cls, vllm_config) -> None:
+        from vllm_fl.patches.dynamo_metrics import (
+            patch_dynamo_metrics_serialization,
+        )
+
+        patch_dynamo_metrics_serialization()
+
+        pc = vllm_config.parallel_config
+        uniproc_requested = (
+            os.environ.get("FL_CPU_UNIPROC", "0") == "1"
+            and pc.world_size == 1
+        )
+
+        super().check_and_update_config(vllm_config)
+
+        # Opt-in only: vLLM's CPU platform normally requires MP to configure OMP.
+        if (
+            uniproc_requested
+            and pc.distributed_executor_backend == "mp"
+        ):
+            pc.distributed_executor_backend = "uni"
+            logger.warning(
+                "[vllm_fl] FL_CPU_UNIPROC=1: using unsupported-by-vLLM "
+                "in-process CPU executor; caller must configure OpenMP"
+            )
+
+        logger.info("[vllm_fl] FL ARM CPU platform active (native-backed)")
+
+    @classmethod
+    def update_block_size_for_backend(cls, vllm_config) -> None:
+        """Align hybrid attention pages without patching vLLM's CPU class."""
+        model_config = vllm_config.model_config
+        if not model_config or not model_config.is_hybrid:
+            return
+        backend_cls = cls._find_non_ssm_backend(vllm_config)
+        if backend_cls is not None:
+            cls._align_hybrid_block_size(vllm_config, backend_cls)

--- a/vllm_fl/spec_decode/__init__.py
+++ b/vllm_fl/spec_decode/__init__.py
@@ -1,0 +1,1 @@
+"""Speculative decoding extensions owned by vLLM-FL."""

--- a/vllm_fl/spec_decode/dflash2.py
+++ b/vllm_fl/spec_decode/dflash2.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash 2 proposer for the vLLM 0.24 CPU runner."""
+
+import secrets
+
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig
+from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.spec_decode.dflash import DFlashProposer
+
+
+def dflash_target_rope_is_neox_style(target_model: nn.Module) -> bool | None:
+    """Read the target's RoPE layout before constructing the draft model."""
+    language_model = (
+        target_model.get_language_model()
+        if hasattr(target_model, "get_language_model")
+        else target_model
+    )
+    for module in language_model.modules():
+        style = getattr(module, "is_neox_style", None)
+        if isinstance(style, bool):
+            return style
+    return None
+
+
+def compute_dflash2_anchor_positions(
+    target_positions: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    num_rejected_tokens: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Return the absolute positions used to key the first selector sample."""
+    position_row = (
+        target_positions[0] if target_positions.ndim > 1 else target_positions
+    )
+    context_ends = query_start_loc[1:].to(torch.int64)
+    if num_rejected_tokens is not None:
+        context_ends = context_ends - num_rejected_tokens.to(torch.int64)
+    last_context_indices = context_ends - 1
+    if torch.any(last_context_indices < 0):
+        raise ValueError("DFlash2 received an empty target context")
+    return position_row.index_select(0, last_context_indices).add(1)
+
+
+class DFlash2Proposer(DFlashProposer):
+    """Parallel DFlash proposer with the DFlash 2 candidate path selector."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        device: torch.device,
+        runner=None,
+    ) -> None:
+        super().__init__(vllm_config, device, runner)
+        self.runner = runner
+        self._anchor_token_ids: torch.Tensor | None = None
+        self._anchor_positions: torch.Tensor | None = None
+        self._request_sampling_seeds: dict[str, int] = {}
+
+    def load_model(self, target_model: nn.Module) -> None:
+        # DFlash checkpoints do not record the target's rotary layout.  A
+        # mismatch is silent but damages every draft attention layer.
+        style = dflash_target_rope_is_neox_style(target_model)
+        if style is not None:
+            self.draft_model_config.hf_config.is_neox_style = style
+        super().load_model(target_model)
+
+    def propose(self, *args, **kwargs) -> torch.Tensor | list[list[int]]:
+        next_token_ids = kwargs.get("next_token_ids")
+        if next_token_ids is None and len(args) > 4:
+            next_token_ids = args[4]
+        if next_token_ids is None:
+            raise ValueError("DFlash2 requires the verified anchor token IDs")
+
+        target_positions = kwargs.get("target_positions")
+        if target_positions is None and len(args) > 2:
+            target_positions = args[2]
+        common_attn_metadata = kwargs.get("common_attn_metadata")
+        if common_attn_metadata is None and len(args) > 6:
+            common_attn_metadata = args[6]
+        num_rejected_tokens = kwargs.get("num_rejected_tokens_gpu")
+        if num_rejected_tokens is None and len(args) > 9:
+            num_rejected_tokens = args[9]
+        if target_positions is None or common_attn_metadata is None:
+            raise ValueError("DFlash2 requires target positions and attention metadata")
+
+        # vLLM 0.24 already supplies CommonAttentionMetadata for the drafter's
+        # KV-cache group.  Do not swap only the block table as the 0.20 bridge
+        # did; doing so would separate it from its matching slot mapping.
+        self._anchor_token_ids = next_token_ids
+        # The first sampled draft follows next_token_ids, whose absolute
+        # position is one past the final target context token.
+        self._anchor_positions = compute_dflash2_anchor_positions(
+            target_positions,
+            common_attn_metadata.query_start_loc,
+            num_rejected_tokens,
+        )
+        try:
+            return super().propose(*args, **kwargs)
+        finally:
+            self._anchor_token_ids = None
+            self._anchor_positions = None
+
+    def _sampling_seeds(
+        self,
+        sampling_metadata: SamplingMetadata,
+        batch_size: int,
+    ) -> list[int]:
+        """Get stable per-request seeds, matching upstream sampling states."""
+        request_ids: list[str] = []
+        runner = getattr(self, "runner", None)
+        if runner is not None and hasattr(runner, "input_batch"):
+            request_ids = runner.input_batch.req_ids[:batch_size]
+
+        if request_ids:
+            active = set(request_ids)
+            cached_seeds = getattr(self, "_request_sampling_seeds", {})
+            self._request_sampling_seeds = {
+                req_id: seed
+                for req_id, seed in cached_seeds.items()
+                if req_id in active
+            }
+
+        seeds = []
+        for row_index in range(batch_size):
+            generator = sampling_metadata.generators.get(row_index)
+            if generator is not None:
+                seeds.append(generator.initial_seed())
+                continue
+            if row_index < len(request_ids):
+                request_id = request_ids[row_index]
+                cached_seeds = getattr(self, "_request_sampling_seeds", {})
+                seed = cached_seeds.get(request_id)
+                if seed is None:
+                    seed = secrets.randbits(63)
+                    cached_seeds[request_id] = seed
+                    self._request_sampling_seeds = cached_seeds
+                seeds.append(seed)
+            else:
+                seeds.append(secrets.randbits(63))
+        return seeds
+
+    def _sample_draft_tokens(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Select the trained DFlash2 path and return its exact proposal q."""
+        if self._anchor_token_ids is None:
+            raise RuntimeError("DFlash2 anchor tokens were not initialized")
+        if self._anchor_positions is None:
+            raise RuntimeError("DFlash2 anchor positions were not initialized")
+        batch_size = self._anchor_token_ids.shape[0]
+        steps = self.num_speculative_tokens
+        hidden = hidden_states.view(batch_size, steps, -1)
+        candidate_ids, unary_logits = self.model.compute_candidates(
+            hidden.flatten(0, 1)
+        )
+        candidate_ids = candidate_ids.view(batch_size, steps, -1)
+        unary_logits = unary_logits.view_as(candidate_ids)
+        if not sampling_metadata.all_greedy:
+            if sampling_metadata.temperature is None:
+                raise RuntimeError("random DFlash2 sampling requires temperatures")
+            path, sparse_probs = self.model.model.candidate_selector.select_stochastic(
+                candidate_ids,
+                unary_logits,
+                hidden,
+                self._anchor_token_ids,
+                sampling_metadata.temperature,
+                self._sampling_seeds(sampling_metadata, batch_size),
+                self._anchor_positions,
+            )
+            vocab_size = int(self.model.config.vocab_size)
+            draft_probs = torch.zeros(
+                (batch_size, steps, vocab_size),
+                dtype=torch.float32,
+                device=hidden_states.device,
+            )
+            draft_probs.scatter_(2, candidate_ids, sparse_probs)
+            return path.reshape(-1), draft_probs.flatten(0, 1)
+        path = self.model.model.candidate_selector.select_greedy(
+            candidate_ids,
+            unary_logits,
+            hidden,
+            self._anchor_token_ids,
+        )
+        return path.reshape(-1), None

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -4,15 +4,39 @@ import json
 import os
 from typing import Optional, Tuple
 
-import flag_gems
+# Importing FlagGems during plugin discovery performs accelerator device
+# probing. Keep it lazy so the ARM CPU platform can be selected first.
+flag_gems = None
+DeviceDetector = None
+backend = None
+_FLAG_GEMS_IMPORT_ATTEMPTED = False
 
-try:
-    # FlagGems<=5.0.2: DeviceDetector lives in device.
-    from flag_gems.runtime.backend.device import DeviceDetector
-except (ImportError, FileNotFoundError):
-    # FlagGems>5.0.2: DeviceDetector lives in device_finder.
-    from flag_gems.runtime.backend.device_finder import DeviceDetector
-from flag_gems.runtime import backend
+
+def _load_flag_gems() -> bool:
+    global flag_gems, DeviceDetector, backend, _FLAG_GEMS_IMPORT_ATTEMPTED
+    if _FLAG_GEMS_IMPORT_ATTEMPTED:
+        return flag_gems is not None
+    _FLAG_GEMS_IMPORT_ATTEMPTED = True
+
+    try:
+        import flag_gems as imported_flag_gems
+
+        try:
+            from flag_gems.runtime.backend.device import (
+                DeviceDetector as imported_device_detector,
+            )
+        except (ImportError, FileNotFoundError):
+            from flag_gems.runtime.backend.device_finder import (
+                DeviceDetector as imported_device_detector,
+            )
+        from flag_gems.runtime import backend as imported_backend
+    except ImportError:
+        return False
+
+    flag_gems = imported_flag_gems
+    DeviceDetector = imported_device_detector
+    backend = imported_backend
+    return True
 
 _OP_CONFIG: Optional[dict[str, str]] = None
 
@@ -236,6 +260,8 @@ _load_op_config_from_env()
 
 class DeviceInfo:
     def __init__(self):
+        if not _load_flag_gems():
+            raise ImportError("FlagGems is required for accelerator discovery")
         self.device = DeviceDetector()
         self.supported_device = ["nvidia", "ascend", "metax", "mthreads", "sunrise", "thead"]
         backend.set_torch_backend_device_fn(self.device.vendor_name)
@@ -272,6 +298,8 @@ def get_flaggems_all_ops() -> list[str]:
     """
     Get all FlagGems operator names from flag_gems._FULL_CONFIG.
     """
+    if not _load_flag_gems():
+        return []
     try:
         # _FULL_CONFIG is a tuple of (op_name, function, ...) tuples
         # Some entries have 2 elements, some have 3


### PR DESCRIPTION
## Summary

- register a native-backed ARM CPU platform while retaining vLLM's CPU worker and scheduler
- integrate Qwen3.8 packed W4A8 linear, GDN, hybrid-cache, and sampling compatibility with the FlagGems/libtriton_jit runtime
- register the official `DFlash2DraftModel` and implement block-wise DFlash2 proposal for vLLM 0.24
- support both no-spec Qwen3.8 inference and optional DFlash2 fixed `K=7/M=8` inference
- keep FlagGems device discovery lazy so plugin loading works before the CPU platform is selected
- preserve existing Qwen3.5 text registration and non-ARM plugin paths from current `main`

## Architecture

`vllm-plugin-FL` owns the vLLM-facing integration: platform selection, model registration, vLLM 0.24 compatibility, DFlash2 proposal/selection, hybrid KV/GDN state handling, and quantized-linear routing. FlagGems and libtriton_jit continue to own the ARM compute kernels.

The branch is rebased onto current `main` (`07063fd7`) and includes the ARM registration work previously published on `kevinzs2048:arm64-cpu-upstream`.

## Validation

- focused plugin suite: **52 passed, 2 skipped**
- Ruff lint: passed
- Ruff format check: passed
- Python compilation checks: passed
- real Qwen3.8-27B W4A8 no-spec smoke: target parameters on CPU, generation completed
- real Qwen3.8-27B W4A8 + official DFlash2 smoke: target and drafter parameters on CPU, `K=7/M=8`, generation completed

Test runtime:

- vLLM `0.24.0+cpu`
- PyTorch `2.11.0`
- Triton/flagtree-cpu `3.7.2`
- Transformers `5.15.1`
- compressed-tensors `0.17.0`
- Apple ARM64 CPU

## Scope

This PR contains source code and tests only. Model weights, machine-specific profiles, native binaries, and benchmark artifacts are not included.
