### PR TITLE
feat: add Hygon backend support for DeepSeek V4

### DIFF
--- a/tests/unit_tests/dispatch/test_policy.py
+++ b/tests/unit_tests/dispatch/test_policy.py
@@ -98,6 +98,30 @@ class TestSelectionPolicy:
         assert policy.get_per_op_order("rms_norm") == ["reference"]
         assert policy.get_per_op_order("nonexistent") is None
 
+    def test_native_op_inherits_base_op_order(self):
+        policy = SelectionPolicy.from_dict(
+            per_op_order={
+                "silu_and_mul": ["flagos", "vendor:hygon", "reference"]
+            },
+        )
+        assert policy.get_per_op_order("silu_and_mul_native") == [
+            "flagos",
+            "vendor:hygon",
+            "reference",
+        ]
+
+    def test_native_op_order_can_override_base_op_order(self):
+        policy = SelectionPolicy.from_dict(
+            per_op_order={
+                "silu_and_mul": ["flagos", "vendor:hygon", "reference"],
+                "silu_and_mul_native": ["vendor:hygon", "flagos"],
+            },
+        )
+        assert policy.get_per_op_order("silu_and_mul_native") == [
+            "vendor:hygon",
+            "flagos",
+        ]
+
     def test_fingerprint_uniqueness(self):
         policy1 = SelectionPolicy(prefer=PREFER_DEFAULT)
         policy2 = SelectionPolicy(prefer=PREFER_VENDOR)

--- a/tests/unit_tests/worker/test_model_runner.py
+++ b/tests/unit_tests/worker/test_model_runner.py
@@ -11,6 +11,7 @@ This module follows a layered testing strategy:
 Note: These tests require vllm >= 0.13.0 with full installation.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -36,6 +37,46 @@ def has_vllm_model_runner():
 pytestmark = pytest.mark.skipif(
     not has_vllm_model_runner(), reason="vllm_fl.worker.model_runner not available"
 )
+
+
+class TestHygonRopeH2DStaging:
+    def test_mrope_staging_preserves_active_columns(self):
+        from vllm_fl.worker.model_runner import ModelRunnerFL
+
+        num_tokens = 5
+        source = torch.arange(18, dtype=torch.int64).view(3, 6)
+        target = torch.zeros_like(source)
+        runner = SimpleNamespace(
+            _use_hygon_rope_h2d_staging=True,
+            mrope_positions=SimpleNamespace(cpu=source, gpu=target),
+            mrope_positions_h2d_cpu=torch.empty(15, dtype=torch.int64),
+            mrope_positions_h2d_gpu=torch.empty(15, dtype=torch.int64),
+        )
+
+        ModelRunnerFL._pack_mrope_positions_for_hygon_h2d(runner, num_tokens)
+        ModelRunnerFL._copy_mrope_positions_for_hygon_h2d(runner, num_tokens)
+
+        torch.testing.assert_close(target[:, :num_tokens], source[:, :num_tokens])
+
+    def test_xdrope_staging_preserves_active_columns(self):
+        from vllm_fl.worker.model_runner import ModelRunnerFL
+
+        num_tokens = 5
+        dim = 4
+        source = torch.arange(24, dtype=torch.int64).view(dim, 6)
+        target = torch.zeros_like(source)
+        runner = SimpleNamespace(
+            _use_hygon_rope_h2d_staging=True,
+            uses_xdrope_dim=dim,
+            xdrope_positions=SimpleNamespace(cpu=source, gpu=target),
+            xdrope_positions_h2d_cpu=torch.empty(dim * num_tokens, dtype=torch.int64),
+            xdrope_positions_h2d_gpu=torch.empty(dim * num_tokens, dtype=torch.int64),
+        )
+
+        ModelRunnerFL._pack_xdrope_positions_for_hygon_h2d(runner, num_tokens)
+        ModelRunnerFL._copy_xdrope_positions_for_hygon_h2d(runner, num_tokens)
+
+        torch.testing.assert_close(target[:, :num_tokens], source[:, :num_tokens])
 
 
 # =============================================================================

--- a/vllm_fl/dispatch/backends/flaggems/flaggems.py
+++ b/vllm_fl/dispatch/backends/flaggems/flaggems.py
@@ -55,8 +55,16 @@ class FlagGemsBackend(Backend):
             Output tensor of shape [..., d]
         """
         from .impl.activation import silu_and_mul_flaggems
-
         return silu_and_mul_flaggems(obj, x)
+
+    def silu_and_mul_native(
+        self,
+        output: torch.Tensor,
+        input: torch.Tensor,
+    ) -> None:
+        from .impl.native_ops import silu_and_mul_out_flaggems
+
+        silu_and_mul_out_flaggems(output, input)
 
     def gelu_and_mul(self, obj, x: torch.Tensor) -> torch.Tensor:
         """
@@ -188,6 +196,28 @@ class FlagGemsBackend(Backend):
             expert_map,
             pad_sorted_ids,
             ignore_invalid_experts,
+        )
+
+    def moe_align_block_size_native(
+        self,
+        topk_ids: torch.Tensor,
+        num_experts: int,
+        block_size: int,
+        sorted_token_ids: torch.Tensor,
+        expert_ids: torch.Tensor,
+        num_tokens_post_pad: torch.Tensor,
+        expert_map: torch.Tensor | None = None,
+    ) -> None:
+        from .impl.native_ops import moe_align_block_size_out_flaggems
+
+        moe_align_block_size_out_flaggems(
+            topk_ids,
+            num_experts,
+            block_size,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_pad,
+            expert_map,
         )
 
     def moe_sum(self, inp, out):

--- a/vllm_fl/dispatch/backends/flaggems/impl/native_ops.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/native_ops.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""FlagGems implementations for vLLM native out-parameter ABIs."""
+
+from __future__ import annotations
+
+import torch
+
+
+def silu_and_mul_out_flaggems(
+    output: torch.Tensor,
+    input: torch.Tensor,
+) -> None:
+    """Fill vLLM's preallocated output with the existing FlagGems kernel."""
+    from flag_gems.modules.activation import gems_silu_and_mul
+
+    hidden_size = input.shape[-1] // 2
+    # The current FlagGems API returns a tensor and has no documented out ABI.
+    # Keep the unavoidable final copy isolated to this native adapter.
+    output.copy_(
+        gems_silu_and_mul(
+            input[..., :hidden_size],
+            input[..., hidden_size:],
+        )
+    )
+
+
+def moe_align_block_size_out_flaggems(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_pad: torch.Tensor,
+    expert_map: torch.Tensor | None = None,
+) -> None:
+    """Call FlagGems' raw kernel with vLLM's preallocated outputs."""
+    if expert_map is not None:
+        raise NotImplementedError(
+            "FlagGems moe_align_block_size does not support expert_map"
+        )
+
+    from flag_gems import moe_align_block_size_triton
+
+    moe_align_block_size_triton(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_pad,
+    )
+
+
+__all__ = [
+    "moe_align_block_size_out_flaggems",
+    "silu_and_mul_out_flaggems",
+]

--- a/vllm_fl/dispatch/backends/flaggems/register_ops.py
+++ b/vllm_fl/dispatch/backends/flaggems/register_ops.py
@@ -49,6 +49,14 @@ def register_builtins(registry) -> None:
             priority=BackendPriority.DEFAULT,
         ),
         OpImpl(
+            op_name="silu_and_mul_native",
+            impl_id="default.flagos.native",
+            kind=BackendImplKind.DEFAULT,
+            fn=_bind_is_available(backend.silu_and_mul_native, is_avail),
+            vendor=None,
+            priority=BackendPriority.DEFAULT,
+        ),
+        OpImpl(
             op_name="gelu_and_mul",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
@@ -92,6 +100,14 @@ def register_builtins(registry) -> None:
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
+        OpImpl(
+            op_name="moe_align_block_size_native",
+            impl_id="default.flagos.native",
+            kind=BackendImplKind.DEFAULT,
+            fn=_bind_is_available(backend.moe_align_block_size_native, is_avail),
+            vendor=None,
+            priority=BackendPriority.DEFAULT,
+        ),
         # MoE sum
         OpImpl(
             op_name="moe_sum",
@@ -130,5 +146,9 @@ def register_builtins(registry) -> None:
         ),
     ]
 
-    filtered = [impl for impl in impls if use_flaggems_op(impl.op_name)]
+    filtered = [
+        impl
+        for impl in impls
+        if use_flaggems_op(impl.op_name.removesuffix("_native"))
+    ]
     registry.register_many(filtered)

--- a/vllm_fl/dispatch/backends/reference/impl/native_ops.py
+++ b/vllm_fl/dispatch/backends/reference/impl/native_ops.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""PyTorch reference implementations for vLLM native out ABIs."""
+
+from __future__ import annotations
+
+import torch
+
+
+def silu_and_mul_out_torch(
+    output: torch.Tensor,
+    input: torch.Tensor,
+) -> None:
+    """Write SiLU-and-mul directly into the supplied output tensor."""
+    hidden_size = input.shape[-1] // 2
+    gate = input[..., :hidden_size]
+    up = input[..., hidden_size:]
+    torch.sigmoid(gate, out=output)
+    output.mul_(gate)
+    output.mul_(up)
+
+
+__all__ = ["silu_and_mul_out_torch"]

--- a/vllm_fl/dispatch/backends/reference/reference.py
+++ b/vllm_fl/dispatch/backends/reference/reference.py
@@ -56,8 +56,16 @@ class ReferenceBackend(Backend):
             Output tensor of shape [..., d]
         """
         from .impl.activation import silu_and_mul_torch
-
         return silu_and_mul_torch(obj, x)
+
+    def silu_and_mul_native(
+        self,
+        output: torch.Tensor,
+        input: torch.Tensor,
+    ) -> None:
+        from .impl.native_ops import silu_and_mul_out_torch
+
+        silu_and_mul_out_torch(output, input)
 
     def gelu_and_mul(self, obj, x: torch.Tensor) -> torch.Tensor:
         """

--- a/vllm_fl/dispatch/backends/reference/register_ops.py
+++ b/vllm_fl/dispatch/backends/reference/register_ops.py
@@ -47,6 +47,14 @@ def register_builtins(registry) -> None:
             priority=BackendPriority.REFERENCE,
         ),
         OpImpl(
+            op_name="silu_and_mul_native",
+            impl_id="reference.torch.native",
+            kind=BackendImplKind.REFERENCE,
+            fn=_bind_is_available(backend.silu_and_mul_native, is_avail),
+            vendor=None,
+            priority=BackendPriority.REFERENCE,
+        ),
+        OpImpl(
             op_name="gelu_and_mul",
             impl_id="reference.torch",
             kind=BackendImplKind.REFERENCE,

--- a/vllm_fl/dispatch/backends/vendor/hygon/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon vendor backend for vLLM native fallback implementations."""
+
+from .hygon import HygonBackend
+
+__all__ = ["HygonBackend"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/hygon.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/hygon.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""
+Hygon backend implementation.
+
+Hygon devices in this environment are exposed through a ROCm/HIP-compatible
+runtime stack. Some Python layers may still use CUDA-style compatibility entry
+points such as ``torch.cuda`` on ROCm builds, but this backend should be treated
+as Hygon/ROCm rather than NVIDIA CUDA.
+
+The backend exposes vLLM native fallbacks for core operators and routes MoE
+GEMMs through Hygon-specific kernels when their validated constraints match.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Optional, Union
+
+import torch
+
+from vllm_fl.dispatch.backends.base import Backend
+
+
+class HygonBackend(Backend):
+    """Hygon backend for vendor-specific operator implementations."""
+
+    _available: Optional[bool] = None
+
+    @property
+    def name(self) -> str:
+        return "hygon"
+
+    @property
+    def vendor(self) -> Optional[str]:
+        return "hygon"
+
+    def is_available(self) -> bool:
+        """
+        Check whether the current runtime appears to be a Hygon environment.
+
+        Detection follows the same loose style as the other vendor backends:
+        prefer vLLM platform metadata when available, then fall back to the
+        environment hints already used by ``vllm_fl.utils``.
+        """
+        if HygonBackend._available is not None:
+            return HygonBackend._available
+
+        try:
+            from vllm.platforms import current_platform
+
+            vendor_name = getattr(current_platform, "vendor_name", None)
+            if isinstance(vendor_name, str) and vendor_name.lower() == "hygon":
+                HygonBackend._available = True
+                return True
+        except (ImportError, AttributeError):
+            # vLLM may be unavailable while package metadata is inspected.
+            # Continue with environment and management-tool detection.
+            pass
+
+        gems_vendor = os.environ.get("GEMS_VENDOR", "").strip().lower()
+        if gems_vendor == "hygon":
+            HygonBackend._available = True
+            return True
+
+        # Hygon deployments in this project expose both management tools.
+        if shutil.which("hy-smi") and shutil.which("rocm-smi"):
+            HygonBackend._available = True
+            return True
+
+        HygonBackend._available = False
+        return HygonBackend._available
+
+    # ==================== Operator Implementations ====================
+
+    def silu_and_mul(self, obj, x: torch.Tensor) -> torch.Tensor:
+        from .impl.native_ops.activation import silu_and_mul_hygon
+
+        return silu_and_mul_hygon(obj, x)
+
+    def silu_and_mul_native(
+        self,
+        output: torch.Tensor,
+        input: torch.Tensor,
+    ) -> None:
+        from .impl.native_ops.activation import silu_and_mul_hygon_out
+
+        silu_and_mul_hygon_out(output, input)
+
+    def gelu_and_mul(self, obj, x: torch.Tensor) -> torch.Tensor:
+        from .impl.native_ops.activation import gelu_and_mul_hygon
+
+        return gelu_and_mul_hygon(obj, x)
+
+    def rms_norm(
+        self,
+        obj,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        from .impl.custom_ops.normalization import rms_norm_hygon
+
+        return rms_norm_hygon(obj, x, residual)
+
+    def rotary_embedding(
+        self,
+        obj,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        rotary_interleaved: bool = False,
+        inplace: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        from .impl.custom_ops.rotary import rotary_embedding_hygon
+
+        return rotary_embedding_hygon(
+            obj,
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            rotary_interleaved=rotary_interleaved,
+            inplace=inplace,
+        )
+
+    def attention_backend(self, use_mla: bool = False, use_sparse: bool = False) -> str:
+        """
+        Get the vLLM native attention backend path for Hygon.
+
+        Hygon deployments use a HIP/ROCm-compatible stack, so the vendor
+        fallback should follow the adapted vLLM ROCm platform priorities rather
+        than CUDA FlashAttention paths.
+        """
+        from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        if use_mla:
+            if use_sparse:
+                return AttentionBackendEnum.ROCM_AITER_MLA_SPARSE.get_path()
+
+            from vllm._aiter_ops import rocm_aiter_ops
+
+            if rocm_aiter_ops.is_mla_enabled():
+                return AttentionBackendEnum.ROCM_AITER_MLA.get_path()
+            return AttentionBackendEnum.TRITON_MLA.get_path()
+
+        if use_sparse:
+            raise ValueError("use_sparse=True requires use_mla=True.")
+
+        return AttentionBackendEnum.ROCM_ATTN.get_path()
+
+    def moe_align_block_size(
+        self,
+        topk_ids: torch.Tensor,
+        block_size: int,
+        num_experts: int,
+        expert_map: Optional[torch.Tensor] = None,
+        pad_sorted_ids: bool = False,
+        ignore_invalid_experts: bool = False,
+    ):
+        from .impl.moe.fused_moe import moe_align_block_size_hygon
+
+        return moe_align_block_size_hygon(
+            topk_ids,
+            block_size,
+            num_experts,
+            expert_map,
+            pad_sorted_ids,
+            ignore_invalid_experts,
+        )
+
+    def moe_align_block_size_native(
+        self,
+        topk_ids: torch.Tensor,
+        num_experts: int,
+        block_size: int,
+        sorted_token_ids: torch.Tensor,
+        expert_ids: torch.Tensor,
+        num_tokens_post_pad: torch.Tensor,
+        expert_map: torch.Tensor | None = None,
+    ) -> None:
+        from .impl.native_ops.moe_align_block_size import (
+            moe_align_block_size_hygon_out,
+        )
+
+        moe_align_block_size_hygon_out(
+            topk_ids,
+            num_experts,
+            block_size,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_pad,
+            expert_map,
+        )
+
+    def moe_sum(self, inp, out):
+        from .impl.moe.fused_moe import moe_sum_hygon
+
+        moe_sum_hygon(inp, out)
+
+    def dynamic_scaled_int8_quant(self, result, input, scales, azp):
+        from .impl.native_ops.int8_quant import dynamic_scaled_int8_quant_hygon
+
+        dynamic_scaled_int8_quant_hygon(result, input, scales, azp)
+
+    def topk_softmax(
+        self,
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize=False,
+    ):
+        from .impl.moe.fused_moe import topk_softmax_hygon
+
+        return topk_softmax_hygon(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+        )
+
+    def topk_softplus_sqrt(
+        self,
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize=False,
+        routed_scaling_factor=1.0,
+        correction_bias=None,
+        input_ids=None,
+        tid2eid=None,
+    ):
+        from .impl.native_ops.topk_softplus_sqrt import topk_softplus_sqrt_hygon
+
+        topk_softplus_sqrt_hygon(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            routed_scaling_factor,
+            correction_bias,
+            input_ids,
+            tid2eid,
+        )
+
+    def invoke_fused_moe_triton_kernel(
+        self,
+        A,
+        B,
+        C,
+        A_scale,
+        B_scale,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        mul_routed_weight,
+        top_k,
+        config,
+        compute_type,
+        use_fp8_w8a8,
+        use_int8_w8a8,
+        use_int8_w8a16,
+        use_int4_w4a16,
+        per_channel_quant,
+        block_shape=None,
+        B_bias=None,
+    ):
+        from .impl.moe.fused_moe import invoke_fused_moe_triton_kernel_hygon
+
+        invoke_fused_moe_triton_kernel_hygon(
+            A,
+            B,
+            C,
+            A_scale,
+            B_scale,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight,
+            top_k,
+            config,
+            compute_type,
+            use_fp8_w8a8,
+            use_int8_w8a8,
+            use_int8_w8a16,
+            use_int4_w4a16,
+            per_channel_quant,
+            block_shape=block_shape,
+            B_bias=B_bias,
+        )
+
+    def grouped_topk(
+        self,
+        scores,
+        n_group,
+        topk_group,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        bias,
+        scoring_func=0,
+    ):
+        from .impl.moe.fused_moe import grouped_topk_hygon
+
+        return grouped_topk_hygon(
+            scores,
+            n_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+            bias,
+            scoring_func,
+        )

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon implementations grouped by their integration boundary.
+
+``native_ops`` supplies empty-install fallbacks for direct ``torch.ops._C``
+and ``torch.ops._moe_C`` call sites. ``custom_ops`` contains vLLM CustomOp
+implementations, while ``attention``, ``moe``, and ``other`` hold backend
+implementations for their respective domains.
+"""

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/attention/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/attention/__init__.py
@@ -1,0 +1,1 @@
+"""Hygon attention and sparse-indexer implementations."""

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/attention/bf16_indexer.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/attention/bf16_indexer.py
@@ -1,0 +1,665 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""BF16 Lightning Indexer kernels for Hygon gfx936.
+
+The implementations in this module are adapted from the validated
+``vllm_hcu`` DeepSeek-V4 path backed up with this project.  In particular,
+``bf16_paged_mqa_logits`` is the Triton kernel that the Hygon implementation
+documents as being adapted from FlagGems.  Keeping the implementation in the
+FL backend avoids a runtime dependency on the separate ``vllm_hcu`` plugin.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_LOGITS_BUFFER_ELEMENTS = 16384 * 16384
+_logits_buffers: dict[torch.device, torch.Tensor] = {}
+
+
+def use_bf16_indexer_cache() -> bool:
+    """Return whether the Hygon Lightning Indexer should use BF16 cache.
+
+    The FL-specific name is preferred.  The legacy HCU variable is accepted
+    so an existing Hygon deployment keeps the same startup configuration.
+    BF16 defaults to enabled on gfx936, matching the validated Hygon setup.
+    """
+    raw = os.getenv("VLLM_FL_HYGON_USE_BF16_INDEXER_CACHE")
+    if raw is None:
+        raw = os.getenv("VLLM_HCU_USE_BF16_INDEXER_CACHE", "1")
+    return raw.strip().lower() not in _FALSE_VALUES
+
+
+@triton.jit
+def _get_cos_sin(
+    cos_sin_cache_ptr,
+    cos_sin_cache_stride,
+    pos,
+    half_rot_dim: tl.constexpr,
+):
+    offsets = tl.arange(0, half_rot_dim)
+    cos = tl.load(cos_sin_cache_ptr + pos * cos_sin_cache_stride + offsets)
+    sin = tl.load(
+        cos_sin_cache_ptr + pos * cos_sin_cache_stride + offsets + half_rot_dim
+    )
+    return cos.to(tl.float32), sin.to(tl.float32)
+
+
+@triton.jit
+def _fused_indexer_q_rope_bf16_kernel(
+    positions_ptr,
+    index_q_ptr,
+    index_q_stride0,
+    index_q_stride1,
+    cos_sin_cache_ptr,
+    cos_sin_cache_stride,
+    half_rot_dim: tl.constexpr,
+    q_bf16_ptr,
+    q_bf16_stride0,
+    q_bf16_stride1,
+    head_dim: tl.constexpr,
+    weights_ptr,
+    weights_stride,
+    weights_softmax_scale,
+    weights_head_scale,
+    weights_out_ptr,
+    weights_out_stride,
+):
+    """Apply interleaved GPT-J RoPE and retain Q in BF16."""
+    rot_dim: tl.constexpr = 2 * half_rot_dim
+    nope_dim: tl.constexpr = head_dim - rot_dim
+    tl.static_assert(nope_dim >= 0)
+
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    position = tl.load(positions_ptr + token_idx)
+    cos, sin = _get_cos_sin(
+        cos_sin_cache_ptr,
+        cos_sin_cache_stride,
+        position,
+        half_rot_dim,
+    )
+
+    half_offsets = tl.arange(0, half_rot_dim)
+    q_base = index_q_ptr + token_idx * index_q_stride0 + head_idx * index_q_stride1
+    rot_base = q_base + nope_dim
+    even = tl.load(rot_base + half_offsets * 2).to(tl.float32)
+    odd = tl.load(rot_base + half_offsets * 2 + 1).to(tl.float32)
+    rotated_even = even * cos - odd * sin
+    rotated_odd = odd * cos + even * sin
+
+    out_base = q_bf16_ptr + token_idx * q_bf16_stride0 + head_idx * q_bf16_stride1
+    if nope_dim > 0:
+        nope_offsets = tl.arange(0, nope_dim)
+        nope = tl.load(q_base + nope_offsets)
+        tl.store(out_base + nope_offsets, nope.to(tl.bfloat16))
+    out_rot_base = out_base + nope_dim
+    tl.store(out_rot_base + half_offsets * 2, rotated_even.to(tl.bfloat16))
+    tl.store(out_rot_base + half_offsets * 2 + 1, rotated_odd.to(tl.bfloat16))
+
+    weight = tl.load(weights_ptr + token_idx * weights_stride + head_idx)
+    weight = weight.to(tl.float32)
+    weight *= weights_softmax_scale
+    weight *= weights_head_scale
+    tl.store(
+        weights_out_ptr + token_idx * weights_out_stride + head_idx,
+        weight,
+    )
+
+
+def fused_indexer_q_rope_bf16(
+    positions: torch.Tensor,
+    index_q: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    index_weights: torch.Tensor,
+    weights_softmax_scale: float,
+    weights_head_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Hygon reference ABI for BF16 Indexer Q and folded weights."""
+    assert positions.ndim == 1
+    assert index_q.ndim == 3
+    assert cos_sin_cache.ndim == 2
+
+    num_tokens, num_heads, head_dim = index_q.shape
+    q_bf16 = torch.empty_like(index_q, dtype=torch.bfloat16)
+    weights_out = torch.empty_like(index_weights, dtype=torch.float32)
+    _fused_indexer_q_rope_bf16_kernel[(num_tokens, num_heads)](
+        positions,
+        index_q,
+        index_q.stride(0),
+        index_q.stride(1),
+        cos_sin_cache,
+        cos_sin_cache.stride(0),
+        cos_sin_cache.shape[-1] // 2,
+        q_bf16,
+        q_bf16.stride(0),
+        q_bf16.stride(1),
+        head_dim,
+        index_weights,
+        index_weights.stride(0),
+        weights_softmax_scale,
+        weights_head_scale,
+        weights_out,
+        weights_out.stride(0),
+        num_warps=1,
+    )
+    return q_bf16, weights_out
+
+
+@triton.jit
+def _compress_norm_rope_store_bf16_kernel(
+    state_cache_ptr,
+    state_cache_stride0,
+    state_cache_stride1,
+    token_to_req_indices_ptr,
+    positions_ptr,
+    slot_mapping_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    rms_norm_weight_ptr,
+    rms_norm_eps,
+    cos_sin_cache_ptr,
+    cos_sin_stride,
+    k_cache_ptr,
+    kv_slot_mapping_ptr,
+    kv_cache_block_size,
+    head_dim: tl.constexpr,
+    triton_block_size: tl.constexpr,
+    state_width: tl.constexpr,
+    compress_ratio: tl.constexpr,
+    overlap: tl.constexpr,
+    rope_head_dim: tl.constexpr,
+    token_stride: tl.constexpr,
+    kv_block_stride: tl.constexpr,
+):
+    """compress -> RMSNorm -> RoPE -> direct BF16 Indexer cache store."""
+    token_idx = tl.program_id(0)
+    slot_id = tl.load(slot_mapping_ptr + token_idx)
+    if slot_id < 0:
+        return
+
+    position = tl.load(positions_ptr + token_idx)
+    if (position + 1) % compress_ratio != 0:
+        return
+
+    req_idx = tl.load(token_to_req_indices_ptr + token_idx)
+    start = position - (1 + overlap) * compress_ratio + 1
+    tokens = tl.arange(0, (1 + overlap) * compress_ratio)
+    state_positions = start + tokens
+    valid_positions = state_positions >= 0
+    block_indices = state_positions // block_size
+    block_numbers = tl.load(
+        block_table_ptr + req_idx * block_table_stride + block_indices,
+        mask=valid_positions,
+        other=0,
+    )
+    block_offsets = state_positions % block_size
+    head_offset = (tokens >= compress_ratio).to(tl.int32) * head_dim
+
+    offsets = tl.arange(0, triton_block_size)
+    valid_head = offsets < head_dim
+    row_base = (
+        state_cache_ptr
+        + block_numbers.to(tl.int64) * state_cache_stride0
+        + block_offsets * state_cache_stride1
+        + head_offset
+    )
+    mask = valid_positions[:, None] & valid_head[None, :]
+    score = tl.load(
+        row_base[:, None] + state_width + offsets[None, :],
+        mask=mask,
+        other=float("-inf"),
+    )
+    score = tl.softmax(score, dim=0)
+    kv = tl.load(
+        row_base[:, None] + offsets[None, :],
+        mask=mask,
+        other=0.0,
+    )
+    compressed_kv = tl.sum(kv * score, axis=0)
+
+    rms_weight = tl.load(
+        rms_norm_weight_ptr + offsets,
+        mask=valid_head,
+        other=0.0,
+    )
+    variance = tl.sum(compressed_kv * compressed_kv, axis=0) / head_dim
+    normed = compressed_kv * tl.rsqrt(variance + rms_norm_eps) * rms_weight
+
+    kv_slot = tl.load(kv_slot_mapping_ptr + token_idx)
+    if kv_slot < 0:
+        return
+    kv_block = kv_slot // kv_cache_block_size
+    kv_offset = kv_slot % kv_cache_block_size
+    out_ptr = (
+        k_cache_ptr + kv_block.to(tl.int64) * kv_block_stride + kv_offset * token_stride
+    )
+
+    nope_head_dim: tl.constexpr = head_dim - rope_head_dim
+    half_rope: tl.constexpr = rope_head_dim // 2
+    num_pairs: tl.constexpr = triton_block_size // 2
+    nope_pairs: tl.constexpr = nope_head_dim // 2
+    normed_pairs = tl.reshape(normed, (num_pairs, 2))
+    even, odd = tl.split(normed_pairs)
+    pair_idx = tl.arange(0, num_pairs)
+    rope_pair = pair_idx - nope_pairs
+    is_rope = rope_pair >= 0
+    cs_idx = tl.maximum(rope_pair, 0)
+    compressed_position = (position // compress_ratio) * compress_ratio
+    cs_base = cos_sin_cache_ptr + compressed_position * cos_sin_stride
+    cos = tl.load(cs_base + cs_idx, mask=is_rope, other=1.0)
+    sin = tl.load(cs_base + half_rope + cs_idx, mask=is_rope, other=0.0)
+    result = tl.interleave(even * cos - odd * sin, odd * cos + even * sin)
+    tl.store(out_ptr + offsets, result.to(tl.bfloat16), mask=valid_head)
+
+
+def compress_norm_rope_store_bf16(
+    *,
+    state_cache: torch.Tensor,
+    num_actual: int,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    state_width: int,
+    cos_sin_cache: torch.Tensor,
+    kv_cache: torch.Tensor,
+    k_cache_metadata: Any,
+    pdl_kwargs: dict,
+    head_dim: int,
+    rope_head_dim: int,
+    compress_ratio: int,
+    overlap: bool,
+    use_fp4_cache: bool,
+    rms_norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    quant_block: int,
+    token_stride: int,
+    scale_dim: int,
+) -> None:
+    """Launch the validated Hygon BF16 Indexer cache writer."""
+    del quant_block, scale_dim
+    if use_fp4_cache:
+        raise AssertionError("BF16 and MXFP4 Indexer caches are mutually exclusive")
+    if head_dim != 128 or kv_cache.dtype != torch.bfloat16:
+        raise AssertionError(
+            "Hygon BF16 Indexer writer requires head_dim=128 and BF16 cache"
+        )
+    _compress_norm_rope_store_bf16_kernel[(num_actual,)](
+        state_cache,
+        state_cache.stride(0),
+        state_cache.stride(1),
+        token_to_req_indices,
+        positions,
+        slot_mapping,
+        block_table,
+        block_table.stride(0),
+        block_size,
+        rms_norm_weight,
+        rms_norm_eps,
+        cos_sin_cache,
+        cos_sin_cache.stride(0),
+        kv_cache,
+        k_cache_metadata.slot_mapping,
+        kv_cache.shape[1],
+        head_dim=head_dim,
+        triton_block_size=triton.next_power_of_2(head_dim),
+        state_width=state_width,
+        compress_ratio=compress_ratio,
+        overlap=overlap,
+        rope_head_dim=rope_head_dim,
+        token_stride=token_stride,
+        kv_block_stride=kv_cache.stride(0),
+        num_warps=1,
+        **pdl_kwargs,
+    )
+
+
+@triton.jit
+def _gather_bf16_indexer_cache_kernel(
+    kv_cache_ptr,
+    output_ptr,
+    block_table_ptr,
+    cu_seq_lens_ptr,
+    block_size: tl.constexpr,
+    batch_size: tl.constexpr,
+    blocks_per_seq: tl.constexpr,
+    cache_stride: tl.constexpr,
+    head_dim: tl.constexpr,
+    num_tokens: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    if token_idx >= num_tokens:
+        return
+    head_offsets = tl.arange(0, head_dim)
+    batch_idx = tl.full((), -1, dtype=tl.int32)
+    for batch in tl.static_range(batch_size):
+        seq_start = tl.load(cu_seq_lens_ptr + batch)
+        seq_end = tl.load(cu_seq_lens_ptr + batch + 1)
+        in_batch = (token_idx >= seq_start) & (token_idx < seq_end)
+        batch_idx = tl.where(in_batch, batch, batch_idx)
+    if batch_idx < 0:
+        return
+
+    seq_start = tl.load(cu_seq_lens_ptr + batch_idx)
+    seq_offset = token_idx - seq_start
+    table_offset = seq_offset // block_size
+    if table_offset >= blocks_per_seq:
+        return
+    block_id = tl.load(block_table_ptr + batch_idx * blocks_per_seq + table_offset)
+    block_offset = seq_offset % block_size
+    src = (
+        kv_cache_ptr
+        + block_id.to(tl.int64) * cache_stride
+        + block_offset * head_dim
+        + head_offsets
+    )
+    dst = output_ptr + token_idx * head_dim + head_offsets
+    tl.store(dst, tl.load(src))
+
+
+def gather_bf16_indexer_cache(
+    kv_cache: torch.Tensor,
+    output: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+) -> None:
+    """Gather paged BF16 Indexer keys for prefill MQA."""
+    if kv_cache.dtype != torch.bfloat16 or output.dtype != torch.bfloat16:
+        raise AssertionError("BF16 Indexer gather requires BF16 input/output")
+    num_tokens, head_dim = output.shape
+    cache_2d = kv_cache.view(kv_cache.shape[0], -1)
+    _gather_bf16_indexer_cache_kernel[(num_tokens,)](
+        cache_2d,
+        output,
+        block_table,
+        cu_seq_lens,
+        kv_cache.shape[1],
+        block_table.shape[0],
+        block_table.shape[1],
+        cache_2d.stride(0),
+        head_dim,
+        num_tokens,
+    )
+
+
+@triton.jit
+def _bf16_paged_mqa_logits_kernel(
+    q_ptr,
+    kv_cache_ptr,
+    weights_ptr,
+    context_lens_ptr,
+    block_table_ptr,
+    logits_ptr,
+    next_n,
+    max_context_len,
+    block_table_stride,
+):
+    row = tl.program_id(0)
+    logical_block = tl.program_id(1)
+    context_len = tl.load(context_lens_ptr + row)
+    kv_position = logical_block * 64
+    if kv_position >= context_len:
+        return
+
+    heads = tl.arange(0, 64)
+    dims = tl.arange(0, 128)
+    positions = tl.arange(0, 64)
+    q_offsets = row * (64 * 128) + heads[:, None] * 128 + dims[None, :]
+    q = tl.load(q_ptr + q_offsets, eviction_policy="evict_last")
+    weights = tl.load(
+        weights_ptr + row * 64 + heads,
+        eviction_policy="evict_last",
+    )
+    batch_idx = row // next_n
+    physical_block = tl.load(
+        block_table_ptr + batch_idx * block_table_stride + logical_block
+    )
+    k_offsets = physical_block * (64 * 128) + positions[:, None] * 128 + dims[None, :]
+    k = tl.load(kv_cache_ptr + k_offsets, eviction_policy="evict_first")
+    scores = tl.maximum(tl.dot(k, tl.trans(q)), 0.0)
+    values = tl.sum(scores * weights[None, :], axis=1)
+    output_offsets = row * max_context_len + kv_position + positions
+    mask = positions < (context_len - kv_position)
+    tl.store(output_offsets + logits_ptr, values, mask=mask)
+
+
+def bf16_paged_mqa_logits(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    max_context_len: int,
+) -> torch.Tensor:
+    """BF16 decode MQA logits, adapted from the Hygon/FlagGems kernel."""
+    batch_size, next_n, heads, dims = q.shape
+    if heads != 64 or dims != 128:
+        raise AssertionError("BF16 Indexer MQA requires H=64 and D=128")
+    if (
+        kv_cache.ndim != 3
+        or kv_cache.dtype != torch.bfloat16
+        or kv_cache.shape[1:] != (64, 128)
+    ):
+        raise AssertionError(
+            "Hygon/FlagGems BF16 paged MQA requires cache pages shaped "
+            "[num_blocks, 64, 128]"
+        )
+    total_tokens = batch_size * next_n
+    logits = torch.empty(
+        (total_tokens, max_context_len),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    if total_tokens == 0 or max_context_len == 0:
+        return logits
+    _bf16_paged_mqa_logits_kernel[(total_tokens, (max_context_len + 63) // 64)](
+        q,
+        kv_cache,
+        weights,
+        context_lens,
+        block_table,
+        logits,
+        next_n,
+        max_context_len,
+        block_table.stride(0),
+        num_warps=8,
+        num_stages=1,
+    )
+    return logits
+
+
+def _get_logits_buffer(device: torch.device) -> torch.Tensor:
+    buffer = _logits_buffers.get(device)
+    if buffer is None or buffer.numel() < _LOGITS_BUFFER_ELEMENTS:
+        buffer = torch.empty(
+            _LOGITS_BUFFER_ELEMENTS,
+            dtype=torch.float32,
+            device=device,
+        )
+        _logits_buffers[device] = buffer
+    return buffer
+
+
+def _prefill_bf16_mqa_chunked(
+    chunk: Any,
+    q_bf16: torch.Tensor,
+    k_bf16: torch.Tensor,
+    weights: torch.Tensor,
+    topk_indices_buffer: torch.Tensor,
+    topk_tokens: int,
+) -> None:
+    """Hygon LightOp BF16 prefill MQA with bounded logits workspace."""
+    from .sparse_attn_indexer import (
+        _get_lightop_attention,
+        top_k_per_row_prefill_hygon_out,
+    )
+
+    attention = _get_lightop_attention()
+    if attention is None:
+        raise RuntimeError("Hygon BF16 Indexer prefill requires LightOp attention")
+
+    q_all = q_bf16[chunk.token_start : chunk.token_end]
+    weights_all = weights[chunk.token_start : chunk.token_end]
+    num_queries = q_all.shape[0]
+    num_keys = k_bf16.shape[0]
+    aligned_keys = ((num_keys + 127) // 128) * 128
+    logits_buffer = _get_logits_buffer(q_bf16.device)
+    max_queries = max(1, logits_buffer.numel() // max(1, aligned_keys))
+    max_queries = max(1, (max_queries // 128) * 128)
+
+    for query_start in range(0, num_queries, max_queries):
+        query_end = min(query_start + max_queries, num_queries)
+        query_count = query_end - query_start
+        aligned_queries = ((query_count + 127) // 128) * 128
+        logits_storage = logits_buffer[: aligned_queries * aligned_keys].view(
+            aligned_queries, aligned_keys
+        )
+        q_slice = q_all[query_start:query_end]
+        weights_slice = weights_all[query_start:query_end].to(torch.float32)
+        starts = chunk.cu_seqlen_ks[query_start:query_end]
+        ends = chunk.cu_seqlen_ke[query_start:query_end]
+        attention.mqa_logits(
+            q_slice,
+            k_bf16,
+            weights_slice,
+            starts,
+            ends,
+            None,
+            True,
+            logits_storage,
+        )
+        logits = logits_storage[:query_count, :num_keys]
+        output = topk_indices_buffer[
+            chunk.token_start + query_start : chunk.token_start + query_end,
+            :topk_tokens,
+        ]
+        top_k_per_row_prefill_hygon_out(
+            logits,
+            starts,
+            ends,
+            output,
+            query_count,
+            logits.stride(0),
+            logits.stride(1),
+            topk_tokens,
+        )
+
+
+def sparse_attn_indexer_bf16_hygon(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: Any,
+    kv_cache: torch.Tensor,
+    q_bf16: torch.Tensor,
+    weights: torch.Tensor,
+    topk_tokens: int,
+    head_dim: int,
+    max_model_len: int,
+    total_seq_lens: int,
+    topk_indices_buffer: torch.Tensor,
+) -> torch.Tensor:
+    """Execute the Hygon BF16 Lightning Indexer prefill/decode flow."""
+    from vllm.forward_context import get_forward_context
+    from vllm.utils.torch_utils import _resolve_layer_name
+    from vllm.v1.attention.backends.mla.indexer import DeepseekV32IndexerMetadata
+    from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
+
+    del total_seq_lens
+    attn_metadata = get_forward_context().attn_metadata
+    if not isinstance(attn_metadata, dict):
+        return topk_indices_buffer
+
+    layer_name = _resolve_layer_name(k_cache_prefix)
+    metadata = attn_metadata[layer_name]
+    if not isinstance(metadata, DeepseekV32IndexerMetadata):
+        raise AssertionError("Unexpected DeepSeek-V4 Indexer metadata type")
+    if kv_cache.dtype != torch.bfloat16 or q_bf16.dtype != torch.bfloat16:
+        raise AssertionError("BF16 Indexer path requires BF16 Q and K cache")
+
+    topk_indices_buffer[: hidden_states.shape[0]] = -1
+    if metadata.num_prefills > 0:
+        prefill = metadata.prefill
+        assert prefill is not None
+        for chunk in prefill.chunks:
+            gathered_k = torch.empty(
+                (chunk.total_seq_lens, head_dim),
+                dtype=torch.bfloat16,
+                device=q_bf16.device,
+            )
+            gather_bf16_indexer_cache(
+                kv_cache,
+                gathered_k,
+                chunk.block_table,
+                chunk.cu_seq_lens,
+            )
+            _prefill_bf16_mqa_chunked(
+                chunk,
+                q_bf16,
+                gathered_k,
+                weights,
+                topk_indices_buffer,
+                topk_tokens,
+            )
+
+    if metadata.num_decodes > 0:
+        from .sparse_attn_indexer import top_k_per_row_decode_hygon_out
+
+        decode = metadata.decode
+        assert decode is not None
+        num_decode_tokens = metadata.num_decode_tokens
+        decode_lens = decode.decode_lens
+        if decode.requires_padding:
+            padded_q = pack_seq_triton(q_bf16[:num_decode_tokens], decode_lens)
+        else:
+            padded_q = q_bf16[:num_decode_tokens].reshape(
+                decode_lens.shape[0], -1, *q_bf16.shape[1:]
+            )
+        batch_size, next_n = padded_q.shape[:2]
+        num_padded_tokens = batch_size * next_n
+        seq_lens = decode.seq_lens[:batch_size]
+        logits = bf16_paged_mqa_logits(
+            padded_q,
+            kv_cache,
+            weights[:num_padded_tokens],
+            seq_lens,
+            decode.block_table,
+            max_model_len,
+        )
+        topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
+        top_k_per_row_decode_hygon_out(
+            logits,
+            next_n,
+            seq_lens,
+            topk_indices,
+            logits.shape[0],
+            logits.stride(0),
+            logits.stride(1),
+            topk_tokens,
+        )
+        if decode.requires_padding:
+            topk_indices = unpack_seq_triton(
+                topk_indices.reshape(batch_size, -1, topk_tokens),
+                decode_lens,
+            )
+            topk_indices_buffer[: topk_indices.shape[0], : topk_indices.shape[-1]] = (
+                topk_indices
+            )
+
+    return topk_indices_buffer
+
+
+__all__ = [
+    "compress_norm_rope_store_bf16",
+    "fused_indexer_q_rope_bf16",
+    "sparse_attn_indexer_bf16_hygon",
+    "use_bf16_indexer_cache",
+]

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/attention/mla.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/attention/mla.py
@@ -1,0 +1,312 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon compatibility helpers for DeepSeek-V4 ROCm MLA."""
+
+import functools
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _VendorInt8Backend:
+    name: str
+    quantize: Callable[[torch.Tensor], tuple[torch.Tensor, torch.Tensor]]
+    gemm: Callable[..., Any]
+
+
+_vendor_int8_backend: _VendorInt8Backend | None = None
+_vendor_int8_backend_checked = False
+
+
+def _load_vendor_int8_backend() -> _VendorInt8Backend | None:
+    """Load the same LightOp/LMSlim W8A8 primitives used by vllm_hcu."""
+    global _vendor_int8_backend, _vendor_int8_backend_checked
+    if _vendor_int8_backend_checked:
+        return _vendor_int8_backend
+
+    _vendor_int8_backend_checked = True
+    gemm = None
+    gemm_source = None
+    try:
+        from lightop import gemm_ops
+
+        gemm = gemm_ops.hipblaslt_w8a8_gemm
+        gemm_source = "LightOp"
+    except Exception as lightop_error:
+        logger.debug("LightOp W8A8 GEMM is unavailable: %s", lightop_error)
+        try:
+            from lmslim import quant_ops
+
+            gemm = quant_ops.hipblaslt_w8a8_gemm
+            gemm_source = "LMSlim"
+        except Exception as lmslim_error:
+            logger.debug("LMSlim W8A8 GEMM is unavailable: %s", lmslim_error)
+
+    quantize = None
+    quant_source = None
+    try:
+        from lightop.quant import per_token_quant_int8
+
+        quantize = per_token_quant_int8
+        quant_source = "LightOp"
+    except Exception as lightop_error:
+        logger.debug("LightOp INT8 quantizer is unavailable: %s", lightop_error)
+        try:
+            from lmslim.layers.gemm.int8_utils import per_token_quant_int8
+
+            quantize = per_token_quant_int8
+            quant_source = "LMSlim"
+        except Exception as lmslim_error:
+            logger.debug("LMSlim INT8 quantizer is unavailable: %s", lmslim_error)
+
+    if gemm is None or quantize is None:
+        logger.warning(
+            "LightOp/LMSlim Hygon W8A8 backend is unavailable; DeepSeek-V4 "
+            "wo_a will use the BF16 dequantization fallback"
+        )
+        return None
+
+    sources = gemm_source if gemm_source == quant_source else f"{gemm_source}+{quant_source}"
+    _vendor_int8_backend = _VendorInt8Backend(sources, quantize, gemm)
+    logger.info("Using %s hipBLASLt W8A8 backend for DeepSeek-V4 wo_a", sources)
+    return _vendor_int8_backend
+
+
+def _logical_int8_weight_nk(
+    wo_a: torch.nn.Module,
+    out_features: int,
+    hidden_dim: int,
+) -> torch.Tensor:
+    """Return the logical ``[N, K]`` INT8 weight for either kernel layout."""
+    weight = wo_a.weight
+    expected_nk = (out_features, hidden_dim)
+    expected_kn = (hidden_dim, out_features)
+    if tuple(weight.shape) == expected_nk:
+        return weight
+    if tuple(weight.shape) == expected_kn:
+        cached = getattr(wo_a, "_dsv4_wo_a_int8_nk", None)
+        if cached is None:
+            cached = weight.t().contiguous()
+            wo_a._dsv4_wo_a_int8_nk = cached
+        return cached
+    raise ValueError(
+        "Unexpected INT8 wo_a weight shape: expected logical [N, K] "
+        f"{expected_nk} or Triton [K, N] {expected_kn}, got {tuple(weight.shape)}"
+    )
+
+
+def _logical_weight_scale_n1(
+    wo_a: torch.nn.Module,
+    out_features: int,
+) -> torch.Tensor:
+    """Normalize per-tensor/per-channel weight scales for group slicing."""
+    weight_scale = wo_a.weight_scale
+    if weight_scale.numel() == 1:
+        return weight_scale.reshape(1, 1)
+    if weight_scale.numel() == out_features:
+        return weight_scale.reshape(out_features, 1)
+    raise ValueError(
+        "INT8 wo_a requires a per-tensor or per-output-channel scale: "
+        f"expected 1 or {out_features} values, got {weight_scale.numel()}"
+    )
+
+
+def _apply_vendor_int8_linear(
+    input: torch.Tensor,
+    weight_nk: torch.Tensor,
+    weight_scale: torch.Tensor,
+    out_dtype: torch.dtype,
+    backend: _VendorInt8Backend,
+) -> torch.Tensor:
+    """Call the vllm_hcu-compatible hipBLASLt W8A8 linear primitive."""
+    input_q, input_scale = backend.quantize(input)
+    m, k = input_q.shape
+    n = weight_nk.shape[0]
+    if weight_nk.shape[1] != k:
+        raise ValueError(
+            "hipblaslt_w8a8_gemm expects weight [N, K], but got "
+            f"input K={k}, weight={tuple(weight_nk.shape)}"
+        )
+
+    gemm_result = backend.gemm(
+        input_q,
+        weight_nk,
+        input_scale,
+        weight_scale,
+        m,
+        n,
+        k,
+        "NT",
+        out_dtype,
+    )
+    if not isinstance(gemm_result, tuple) or len(gemm_result) < 2:
+        raise RuntimeError(
+            f"{backend.name} hipblaslt_w8a8_gemm returned an unexpected result"
+        )
+    return gemm_result[1]
+
+
+def _int8_wo_a_group_gemm(
+    o_ref: torch.Tensor,
+    wo_a: torch.nn.Module,
+    n_local_groups: int,
+    o_lora_rank: int,
+    backend: _VendorInt8Backend,
+) -> torch.Tensor:
+    """Run the block-diagonal ``wo_a`` projection as one INT8 GEMM per group."""
+    num_tokens = o_ref.shape[0]
+    hidden_dim = o_ref.shape[-1]
+    out_features = n_local_groups * o_lora_rank
+    weight_nk = _logical_int8_weight_nk(wo_a, out_features, hidden_dim)
+    weight_scale = _logical_weight_scale_n1(wo_a, out_features)
+
+    output = torch.empty(
+        (num_tokens, n_local_groups, o_lora_rank),
+        device=o_ref.device,
+        dtype=torch.bfloat16,
+    )
+    for group_idx in range(n_local_groups):
+        channel_slice = slice(
+            group_idx * o_lora_rank, (group_idx + 1) * o_lora_rank
+        )
+        group_scale = (
+            weight_scale
+            if weight_scale.shape[0] == 1
+            else weight_scale[channel_slice]
+        )
+        output[:, group_idx, :] = _apply_vendor_int8_linear(
+            o_ref[:, group_idx, :],
+            weight_nk[channel_slice],
+            group_scale,
+            torch.bfloat16,
+            backend,
+        )
+    return output
+
+
+def _dequantize_int8_wo_a(
+    wo_a: torch.nn.Module,
+    n_local_groups: int,
+    o_lora_rank: int,
+    hidden_dim: int,
+) -> torch.Tensor:
+    """BF16 fallback when neither LightOp nor LMSlim W8A8 GEMM is available."""
+    out_features = n_local_groups * o_lora_rank
+    weight_nk = _logical_int8_weight_nk(wo_a, out_features, hidden_dim)
+    weight_scale = _logical_weight_scale_n1(wo_a, out_features)
+    weight_bf16 = weight_nk.to(torch.float32) * weight_scale.to(torch.float32)
+    return weight_bf16.to(torch.bfloat16).reshape(
+        n_local_groups, o_lora_rank, hidden_dim
+    )
+
+
+def _patch_int8_wo_a_weight_layout() -> None:
+    """Keep BMM INT8 weights in the ``[N, K]`` layout required by hipBLASLt."""
+    from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+        compressed_tensors_w8a8_int8 as int8_scheme,
+    )
+
+    scheme_cls = int8_scheme.CompressedTensorsW8A8Int8
+    original = scheme_cls.process_weights_after_loading
+    if getattr(original, "_vllm_fl_hygon_wo_a_layout", False):
+        return
+
+    @functools.wraps(original)
+    def _process_weights_after_loading_hygon(self, layer: torch.nn.Module) -> None:
+        if (
+            getattr(layer, "is_bmm", False)
+            and layer.weight.dtype == torch.int8
+            and not self.is_static_input_scheme
+            and self.input_symmetric
+        ):
+            layer.weight.data = layer.weight.data.contiguous()
+            layer.weight_scale.data = layer.weight_scale.data.contiguous()
+            layer._vllm_fl_hygon_wo_a_nk = True
+            return
+        original(self, layer)
+
+    _process_weights_after_loading_hygon._vllm_fl_hygon_wo_a_layout = True
+    scheme_cls.process_weights_after_loading = _process_weights_after_loading_hygon
+
+
+def _patch_rocm_wo_a_bf16_fallback() -> None:
+    """Add INT8 awareness to upstream's cached BF16 fallback helper."""
+    import vllm.v1.attention.ops.rocm_aiter_mla_sparse as mla_sparse
+
+    original = mla_sparse._get_cached_wo_a_bf16
+    if getattr(original, "_vllm_fl_hygon_int8", False):
+        return
+
+    @functools.wraps(original)
+    def _get_cached_wo_a_bf16_hygon(
+        wo_a: torch.nn.Module,
+        n_local_groups: int,
+        o_lora_rank: int,
+        hidden_dim: int,
+    ) -> torch.Tensor:
+        cached = getattr(wo_a, "_dsv4_wo_a_bf16", None)
+        if cached is not None:
+            return cached
+        if wo_a.weight.dtype == torch.int8 and hasattr(wo_a, "weight_scale"):
+            cached = _dequantize_int8_wo_a(
+                wo_a, n_local_groups, o_lora_rank, hidden_dim
+            )
+            wo_a._dsv4_wo_a_bf16 = cached
+            return cached
+        return original(wo_a, n_local_groups, o_lora_rank, hidden_dim)
+
+    _get_cached_wo_a_bf16_hygon._vllm_fl_hygon_int8 = True
+    mla_sparse._get_cached_wo_a_bf16 = _get_cached_wo_a_bf16_hygon
+
+
+def _patch_rocm_wo_a_group_gemm() -> None:
+    """Route INT8 ``wo_a`` through the vllm_hcu group-GEMM design."""
+    import vllm.models.deepseek_v4.amd.rocm as amd_rocm
+    import vllm.v1.attention.ops.rocm_aiter_mla_sparse as mla_sparse
+
+    attention_cls = amd_rocm.DeepseekV4ROCMAiterMLAAttention
+    original = attention_cls._o_proj
+    if getattr(original, "_vllm_fl_hygon_int8_group_gemm", False):
+        return
+
+    @functools.wraps(original)
+    def _o_proj_hygon(self, o: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
+        if self.wo_a.weight.dtype != torch.int8:
+            return original(self, o, positions)
+
+        backend = _load_vendor_int8_backend()
+        if backend is None:
+            return original(self, o, positions)
+
+        o_ref = mla_sparse._fused_inverse_rope_gptj(
+            o,
+            positions,
+            self.rotary_emb.cos_sin_cache,
+            self.rope_head_dim,
+        )
+        o_ref = o_ref.reshape(o.shape[0], self.n_local_groups, -1)
+        z = _int8_wo_a_group_gemm(
+            o_ref,
+            self.wo_a,
+            self.n_local_groups,
+            self.o_lora_rank,
+            backend,
+        )
+        return self.wo_b(z.flatten(1))
+
+    _o_proj_hygon._vllm_fl_hygon_int8_group_gemm = True
+    attention_cls._o_proj = _o_proj_hygon
+
+
+def patch_rocm_wo_a_int8_group_gemm() -> None:
+    """Install Hygon's INT8 group GEMM with a correctness-first BF16 fallback."""
+    _patch_int8_wo_a_weight_layout()
+    _patch_rocm_wo_a_bf16_fallback()
+    _patch_rocm_wo_a_group_gemm()
+    logger.info("Patched DeepSeek-V4 ROCm wo_a INT8 group GEMM for Hygon")

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/attention/sparse_attn_indexer.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/attention/sparse_attn_indexer.py
@@ -1,0 +1,372 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon operator adapters for vLLM's native ROCm sparse indexer.
+
+The sparse-indexer control flow stays in
+``vllm.model_executor.layers.sparse_attn_indexer`` and cache
+quantization/gather reuses the Triton kernels already shipped in
+``vllm.v1.attention.ops.rocm_aiter_mla_sparse``.  This module only replaces the
+CUDA-extension leaves that are unavailable on Hygon with the LightOp APIs used
+by the Hygon vLLM implementation, retaining vLLM's PyTorch references as
+correctness fallbacks.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def _get_lightop_attention() -> Any | None:
+    """Resolve both the current and legacy LightOp attention APIs."""
+    try:
+        from lightop import attention
+
+        return attention
+    except (ImportError, AttributeError):
+        try:
+            from lightop import gemmopt, mqa_logits, op
+
+            return SimpleNamespace(
+                mqa_logits=mqa_logits,
+                paged_mqa_logits=gemmopt.paged_mqa_logits,
+                top_k_per_row_prefill=op.top_k_per_row_prefill,
+                top_k_per_row_decode=op.top_k_per_row_decode,
+            )
+        except (ImportError, AttributeError):
+            return None
+
+
+def fp8_mqa_logits_hygon(
+    q: torch.Tensor,
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+) -> torch.Tensor:
+    """Run the Hygon LightOp prefill MQA kernel."""
+    attention = _get_lightop_attention()
+    if attention is None:
+        from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+            fp8_mqa_logits_torch,
+        )
+
+        logger.warning(
+            "LightOp attention is unavailable; using vLLM's PyTorch FP8 "
+            "prefill MQA reference."
+        )
+        return fp8_mqa_logits_torch(q, kv, weights, cu_seqlen_ks, cu_seqlen_ke)
+
+    k_fp8, scale = kv
+    return attention.mqa_logits(
+        q,
+        k_fp8,
+        weights,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        scale,
+    )
+
+
+def fp8_paged_mqa_logits_hygon(
+    q_fp8: torch.Tensor,
+    kv_cache_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    schedule_metadata: torch.Tensor | None,
+    max_model_len: int,
+) -> torch.Tensor:
+    """Run the Hygon LightOp decode MQA kernel."""
+    del schedule_metadata  # LightOp does not consume DeepGEMM scheduling data.
+    attention = _get_lightop_attention()
+    if attention is None:
+        from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+            fp8_paged_mqa_logits_torch,
+        )
+
+        logger.warning(
+            "LightOp attention is unavailable; using vLLM's PyTorch FP8 "
+            "paged MQA reference."
+        )
+        return fp8_paged_mqa_logits_torch(
+            q_fp8,
+            kv_cache_fp8,
+            weights,
+            context_lens,
+            block_tables,
+            max_model_len,
+        )
+
+    return attention.paged_mqa_logits(
+        q_fp8,
+        kv_cache_fp8,
+        weights,
+        context_lens,
+        block_tables,
+        None,
+        max_model_len,
+        False,
+    )
+
+
+def _topk_indices_torch(
+    logits: torch.Tensor,
+    topk_tokens: int,
+    row_starts: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Reference top-k matching vLLM's sparse-indexer output contract."""
+    k = min(topk_tokens, logits.shape[-1])
+    values, indices = torch.topk(logits, k=k, dim=-1)
+    indices = indices.to(torch.int32)
+    indices = torch.where(
+        values == float("-inf"),
+        torch.full_like(indices, -1),
+        indices,
+    )
+    if row_starts is not None:
+        starts = row_starts.to(device=indices.device, dtype=torch.int32).view(-1, 1)
+        indices = torch.where(indices < 0, indices, indices - starts)
+    if k == topk_tokens:
+        return indices
+
+    padded = torch.full(
+        (logits.shape[0], topk_tokens),
+        -1,
+        dtype=torch.int32,
+        device=logits.device,
+    )
+    padded[:, :k] = indices
+    return padded
+
+
+def top_k_per_row_prefill_hygon_out(
+    logits: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    topk_indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    topk_tokens: int,
+) -> None:
+    """LightOp-compatible replacement for ``_C::top_k_per_row_prefill``."""
+    del stride0, stride1
+    attention = _get_lightop_attention()
+    if attention is None:
+        topk_indices.copy_(
+            _topk_indices_torch(logits, topk_tokens, row_starts)[:num_rows]
+        )
+        return
+
+    if logits.ndim != 2:
+        raise RuntimeError(f"Prefill top-k expects 2D logits, got {logits.shape}")
+    if logits.shape[0] != num_rows:
+        if logits.shape[1] == num_rows:
+            logits = logits.transpose(0, 1)
+        else:
+            raise RuntimeError(
+                "Prefill top-k logits/query row mismatch: "
+                f"logits={tuple(logits.shape)}, num_rows={num_rows}"
+            )
+
+    logits = logits.contiguous()
+    max_seq_len = logits.shape[1]
+    starts = (
+        row_starts.to(device=logits.device, dtype=torch.int32)
+        .reshape(-1)[:num_rows]
+        .clamp(0, max_seq_len)
+    )
+    ends = (
+        row_ends.to(device=logits.device, dtype=torch.int32)
+        .reshape(-1)[:num_rows]
+        .clamp(0, max_seq_len)
+    )
+    ends = torch.maximum(ends, starts)
+    output = (
+        topk_indices
+        if topk_indices.is_contiguous()
+        else torch.empty_like(topk_indices)
+    )
+    attention.top_k_per_row_prefill(
+        logits,
+        starts,
+        ends,
+        output,
+        num_rows,
+        logits.stride(0),
+        logits.stride(1),
+        topk_tokens,
+    )
+    if output is not topk_indices:
+        topk_indices.copy_(output)
+
+
+def _decode_row_ends(
+    seq_lens: torch.Tensor,
+    next_n: int,
+    num_rows: int,
+) -> torch.Tensor:
+    if seq_lens.ndim == 2:
+        return seq_lens.reshape(-1)[:num_rows].clamp(min=0)
+
+    flat = seq_lens.reshape(-1)
+    if next_n > 1 and flat.numel() * next_n == num_rows:
+        offsets = torch.arange(next_n, dtype=flat.dtype, device=flat.device)
+        return (flat.unsqueeze(1) - next_n + offsets + 1).reshape(-1).clamp(min=0)
+    return flat[:num_rows].clamp(min=0)
+
+
+def top_k_per_row_decode_hygon_out(
+    logits: torch.Tensor,
+    next_n: int,
+    seq_lens: torch.Tensor,
+    topk_indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    topk_tokens: int,
+) -> None:
+    """LightOp-compatible replacement for ``_C::top_k_per_row_decode``."""
+    del stride0, stride1
+    attention = _get_lightop_attention()
+    if attention is None:
+        row_ends = _decode_row_ends(seq_lens, next_n, num_rows)
+        masked = logits.clone()
+        columns = torch.arange(logits.shape[1], device=logits.device)
+        masked.masked_fill_(columns.unsqueeze(0) >= row_ends.unsqueeze(1), float("-inf"))
+        topk_indices.copy_(_topk_indices_torch(masked, topk_tokens))
+        return
+
+    row_ends = _decode_row_ends(seq_lens, next_n, num_rows)
+    attention.top_k_per_row_decode(
+        logits,
+        1,
+        row_ends.to(device=logits.device, dtype=torch.int32),
+        topk_indices,
+        num_rows,
+        logits.stride(0),
+        logits.stride(1),
+        topk_tokens,
+    )
+
+
+def fp8_fp4_mqa_logits_hygon(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    *,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    """Adapt vLLM's DeepGEMM ABI to the Hygon FP8 LightOp ABI."""
+    del clean_logits
+    q_values, q_scale = q
+    if q_scale is not None:
+        raise AssertionError("Hygon sparse indexer does not support FP4 Q")
+    return fp8_mqa_logits_hygon(
+        q_values, kv, weights, cu_seqlen_ks, cu_seqlen_ke
+    )
+
+
+def fp8_fp4_paged_mqa_logits_hygon(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    schedule_metadata: torch.Tensor | None,
+    *,
+    max_model_len: int,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    """Adapt vLLM's DeepGEMM paged ABI to the Hygon LightOp ABI."""
+    del clean_logits
+    q_values, q_scale = q
+    if q_scale is not None:
+        raise AssertionError("Hygon sparse indexer does not support FP4 Q")
+    return fp8_paged_mqa_logits_hygon(
+        q_values,
+        kv_cache,
+        weights,
+        context_lens,
+        block_tables,
+        schedule_metadata,
+        max_model_len,
+    )
+
+
+def indexer_k_quant_and_cache_hygon(
+    k: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    quant_block_size: int,
+    scale_fmt: str,
+) -> None:
+    """Use the Triton cache-insert kernel already shipped by vLLM 0.24.0."""
+    from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+        indexer_k_quant_and_cache_triton,
+    )
+
+    indexer_k_quant_and_cache_triton(
+        k, kv_cache, slot_mapping, quant_block_size, scale_fmt
+    )
+
+
+def cp_gather_indexer_k_quant_cache_hygon(
+    kv_cache: torch.Tensor,
+    dst_k: torch.Tensor,
+    dst_scale: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+) -> None:
+    """Use vLLM's Triton gather kernel with its required token-to-seq map."""
+    from vllm.v1.attention.ops.rocm_aiter_mla_sparse import (
+        cp_gather_indexer_k_quant_cache_triton,
+    )
+
+    seq_lengths = (cu_seq_lens[1:] - cu_seq_lens[:-1]).to(torch.int64)
+    seq_ids = torch.arange(
+        seq_lengths.numel(),
+        device=cu_seq_lens.device,
+        dtype=torch.int32,
+    )
+    token_to_seq = torch.repeat_interleave(
+        seq_ids,
+        seq_lengths,
+        output_size=dst_k.shape[0],
+    )
+    cp_gather_indexer_k_quant_cache_triton(
+        kv_cache,
+        dst_k,
+        dst_scale,
+        block_table,
+        cu_seq_lens,
+        token_to_seq,
+    )
+
+
+def install_sparse_indexer_hygon_ops(sparse_indexer: Any) -> None:
+    """Install FL-only Hygon leaves into vLLM's current indexer flow."""
+    sparse_indexer.fp8_fp4_mqa_logits = fp8_fp4_mqa_logits_hygon
+    sparse_indexer.fp8_fp4_paged_mqa_logits = fp8_fp4_paged_mqa_logits_hygon
+
+    # ``ops`` is vllm._custom_ops.  Its stock functions enter CUDA extension
+    # namespaces unavailable on Hygon, so replace only these four public Python
+    # entry points in the Hygon process.
+    sparse_indexer.ops.indexer_k_quant_and_cache = (
+        indexer_k_quant_and_cache_hygon
+    )
+    sparse_indexer.ops.cp_gather_indexer_k_quant_cache = (
+        cp_gather_indexer_k_quant_cache_hygon
+    )
+    sparse_indexer.ops.top_k_per_row_prefill = top_k_per_row_prefill_hygon_out
+    sparse_indexer.ops.top_k_per_row_decode = top_k_per_row_decode_hygon_out

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/custom_ops/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/custom_ops/__init__.py
@@ -1,0 +1,1 @@
+"""Hygon implementations used by vLLM CustomOp/OOT dispatch."""

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/custom_ops/normalization.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/custom_ops/normalization.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon normalization implementations backed by LightOp."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import torch
+
+
+def rms_norm_hygon(
+    obj,
+    x: torch.Tensor,
+    residual: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+    """RMS normalization using the LightOp APIs selected by vllm_hcu."""
+    try:
+        from lightop.norm import fused_add_rms_norm, rmsnorm_forward_autograd
+    except ImportError:
+        from lightop import fused_add_rms_norm
+        from lightop.op import rmsnorm_forward_autograd
+
+    weight = obj.weight
+    epsilon = obj.variance_epsilon
+
+    if residual is not None:
+        fused_add_rms_norm(x, residual, weight, epsilon)
+        return x, residual
+
+    return rmsnorm_forward_autograd(x, weight, epsilon, obj.training)

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/custom_ops/rotary.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/custom_ops/rotary.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon rotary embedding implementation backed by vLLM native ops."""
+
+from __future__ import annotations
+
+import torch
+
+
+def rotary_embedding_hygon(
+    obj,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    rotary_interleaved: bool = False,
+    inplace: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply rotary position embedding using vLLM custom ops."""
+    from vllm._custom_ops import rotary_embedding as vllm_rotary_embedding
+
+    if not inplace:
+        query = query.clone()
+        key = key.clone()
+
+    vllm_rotary_embedding(
+        position_ids,
+        query,
+        key,
+        cos,
+        sin,
+        rotary_interleaved,
+    )
+    return query, key

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/__init__.py
@@ -1,0 +1,18 @@
+"""Hygon modular MoE experts, kernels, and tuning helpers.
+
+Keep this initializer lightweight: native-op fallbacks also import individual
+MoE helpers and must not eagerly load vLLM's full modular-MoE stack.
+"""
+
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    if name == "HygonTritonExpertsFL":
+        from .triton_experts import HygonTritonExpertsFL
+
+        return HygonTritonExpertsFL
+    raise AttributeError(name)
+
+
+__all__ = ["HygonTritonExpertsFL"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/bf16_moe_fusions.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/bf16_moe_fusions.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon BF16 MoE fusion kernels."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+from vllm.triton_utils import tl, triton
+
+
+GEMM1_BLOCK_M = 128
+GEMM1_PHYSICAL_BLOCK_N = 128
+GEMM1_BLOCK_K = 128
+GEMM1_GROUP_M = 1
+GEMM1_NUM_WARPS = 4
+GEMM1_NUM_STAGES = 1
+
+REDUCE_PREFILL_TOKENS = 8192
+REDUCE_TOP_K = 8
+REDUCE_HIDDEN_SIZE = 2048
+REDUCE_BLOCK_N = 512
+REDUCE_ROWS_PER_PROGRAM = 1
+REDUCE_NUM_WARPS = 8
+REDUCE_NUM_STAGES = 1
+
+
+def supports_hygon_bf16_gemm1_silu(
+    activation: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    sorted_token_ids: torch.Tensor | None,
+    expert_ids: torch.Tensor | None,
+    config: Mapping[str, Any],
+    *,
+    top_k: int,
+    activation_name: str,
+    apply_router_weight_on_input: bool,
+    has_quantization: bool,
+    has_bias: bool,
+    has_expert_map: bool,
+    has_lora: bool,
+) -> bool:
+    """Return whether GEMM1 can use the generic BF16 fused SiLU path."""
+    if sorted_token_ids is None or expert_ids is None:
+        return False
+
+    if activation_name != "silu":
+        return False
+    if any(
+        (
+            apply_router_weight_on_input,
+            has_quantization,
+            has_bias,
+            has_expert_map,
+            has_lora,
+        )
+    ):
+        return False
+    if activation.dtype != torch.bfloat16:
+        return False
+    if weight.dtype != torch.bfloat16 or output.dtype != torch.bfloat16:
+        return False
+    if activation.ndim != 2 or weight.ndim != 3 or output.ndim != 2:
+        return False
+    num_tokens, hidden_size = activation.shape
+    num_experts, physical_intermediate_size, weight_hidden_size = weight.shape
+    if (
+        num_tokens <= 0
+        or hidden_size <= 0
+        or num_experts <= 0
+        or physical_intermediate_size <= 0
+        or top_k <= 0
+    ):
+        return False
+    if physical_intermediate_size % 2 != 0:
+        return False
+    intermediate_size = physical_intermediate_size // 2
+    if weight_hidden_size != hidden_size:
+        return False
+    if tuple(output.shape) != (
+        num_tokens * top_k,
+        intermediate_size,
+    ):
+        return False
+    if not activation.is_contiguous() or not output.is_contiguous():
+        return False
+    if weight.stride(-1) != 1:
+        return False
+    if not sorted_token_ids.is_contiguous() or not expert_ids.is_contiguous():
+        return False
+
+    expected_config = {
+        "BLOCK_SIZE_M": GEMM1_BLOCK_M,
+        "BLOCK_SIZE_N": GEMM1_PHYSICAL_BLOCK_N,
+        "BLOCK_SIZE_K": GEMM1_BLOCK_K,
+        "GROUP_SIZE_M": GEMM1_GROUP_M,
+        "num_warps": GEMM1_NUM_WARPS,
+        "num_stages": GEMM1_NUM_STAGES,
+    }
+    return all(config.get(key) == value for key, value in expected_config.items())
+
+
+@triton.jit
+def _hygon_bf16_gemm1_silu_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    num_valid_routes,
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    TOP_K_VALUE: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    PHYSICAL_BLOCK_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Compute gate/up columns together and apply SiLU before storing."""
+    pid = tl.program_id(axis=0)
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+    num_pid_m = tl.cdiv(num_tokens_post_padded, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, PHYSICAL_BLOCK_N)
+    if pid >= num_pid_m * num_pid_n:
+        return
+
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    if pid_m * BLOCK_SIZE_M >= num_tokens_post_padded:
+        return
+
+    route_offsets = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    route_ids = tl.load(sorted_token_ids_ptr + route_offsets).to(tl.int64)
+    route_mask = route_ids < num_valid_routes
+    expert_id = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+
+    k_offsets = tl.arange(0, BLOCK_SIZE_K)
+    physical_n_offsets = tl.arange(0, PHYSICAL_BLOCK_N).to(tl.int64)
+    output_block_n: tl.constexpr = PHYSICAL_BLOCK_N // 2
+
+    paired_output_offsets = pid_n * output_block_n + physical_n_offsets // 2
+    weight_n_offsets = paired_output_offsets + (physical_n_offsets % 2) * (N // 2)
+
+    a_ptrs = (
+        a_ptr
+        + (route_ids[:, None] // TOP_K_VALUE) * stride_am
+        + k_offsets[None, :] * stride_ak
+    )
+    b_ptrs = (
+        b_ptr
+        + expert_id * stride_be
+        + k_offsets[:, None] * stride_bk
+        + weight_n_offsets[None, :] * stride_bn
+    )
+
+    accumulator = tl.zeros(
+        (BLOCK_SIZE_M, PHYSICAL_BLOCK_N),
+        dtype=tl.float32,
+    )
+    output_column_mask = paired_output_offsets < N // 2
+    for k_block in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        k_mask = k_block * BLOCK_SIZE_K + k_offsets < K
+        a = tl.load(
+            a_ptrs,
+            mask=route_mask[:, None] & k_mask[None, :],
+            other=0.0,
+        )
+        b = tl.load(
+            b_ptrs,
+            mask=k_mask[:, None] & output_column_mask[None, :],
+            other=0.0,
+        )
+        accumulator = tl.dot(a, b, acc=accumulator)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    # Match the separate BF16 path, which rounds GEMM output before SiLU.
+    accumulator = accumulator.to(tl.bfloat16)
+    gate, up = (
+        accumulator.to(tl.float32).reshape(BLOCK_SIZE_M, output_block_n, 2).split()
+    )
+    gate = gate / (1.0 + tl.exp2(-(gate * 1.4426950408889634)))
+    result = (gate * up).to(tl.bfloat16)
+
+    output_offsets = pid_n * output_block_n + tl.arange(0, output_block_n)
+    c_ptrs = (
+        c_ptr + route_ids[:, None] * stride_cm + output_offsets[None, :] * stride_cn
+    )
+    output_mask = route_mask[:, None] & (output_offsets[None, :] < N // 2)
+    tl.store(c_ptrs, result, mask=output_mask)
+
+
+def invoke_hygon_bf16_gemm1_silu(
+    activation: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    *,
+    top_k: int,
+) -> None:
+    """Run the shape-generic Hygon BF16 GEMM1 + SiLU-and-Mul kernel."""
+    num_valid_routes = output.shape[0]
+    physical_n = weight.shape[1]
+    grid = (
+        triton.cdiv(sorted_token_ids.numel(), GEMM1_BLOCK_M)
+        * triton.cdiv(physical_n, GEMM1_PHYSICAL_BLOCK_N),
+    )
+    _hygon_bf16_gemm1_silu_kernel[grid](
+        activation,
+        weight,
+        output,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        num_valid_routes,
+        activation.stride(0),
+        activation.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        weight.stride(2),
+        output.stride(0),
+        output.stride(1),
+        N=physical_n,
+        K=activation.shape[1],
+        TOP_K_VALUE=top_k,
+        BLOCK_SIZE_M=GEMM1_BLOCK_M,
+        PHYSICAL_BLOCK_N=GEMM1_PHYSICAL_BLOCK_N,
+        BLOCK_SIZE_K=GEMM1_BLOCK_K,
+        GROUP_SIZE_M=GEMM1_GROUP_M,
+        num_warps=GEMM1_NUM_WARPS,
+        num_stages=GEMM1_NUM_STAGES,
+    )
+
+
+def supports_hygon_fixed_topk8_reduce(
+    input_tensor: torch.Tensor,
+    output: torch.Tensor,
+) -> bool:
+    """Return whether the validated prefill reduction can be used."""
+    if input_tensor.dtype != torch.bfloat16 or output.dtype != torch.bfloat16:
+        return False
+    if tuple(input_tensor.shape) != (
+        REDUCE_PREFILL_TOKENS,
+        REDUCE_TOP_K,
+        REDUCE_HIDDEN_SIZE,
+    ):
+        return False
+    if tuple(output.shape) != (
+        REDUCE_PREFILL_TOKENS,
+        REDUCE_HIDDEN_SIZE,
+    ):
+        return False
+    return input_tensor.is_contiguous() and output.is_contiguous()
+
+
+@triton.jit
+def _hygon_fixed_topk8_reduce_kernel(
+    input_ptr,
+    output_ptr,
+    num_tokens,
+    hidden_size,
+    input_stride_token,
+    input_stride_topk,
+    input_stride_hidden,
+    output_stride_token,
+    output_stride_hidden,
+    BLOCK_N: tl.constexpr,
+    ROWS_PER_PROGRAM: tl.constexpr,
+):
+    row_group = tl.program_id(0)
+    hidden_block = tl.program_id(1)
+
+    rows = row_group * ROWS_PER_PROGRAM + tl.arange(0, ROWS_PER_PROGRAM)
+    cols = hidden_block * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (rows[:, None] < num_tokens) & (cols[None, :] < hidden_size)
+    base = (
+        input_ptr
+        + rows[:, None] * input_stride_token
+        + cols[None, :] * input_stride_hidden
+    )
+
+    value0 = tl.load(base + 0 * input_stride_topk, mask=mask, other=0.0).to(tl.float32)
+    value1 = tl.load(base + 1 * input_stride_topk, mask=mask, other=0.0).to(tl.float32)
+    value2 = tl.load(base + 2 * input_stride_topk, mask=mask, other=0.0).to(tl.float32)
+    value3 = tl.load(base + 3 * input_stride_topk, mask=mask, other=0.0).to(tl.float32)
+    value4 = tl.load(base + 4 * input_stride_topk, mask=mask, other=0.0).to(tl.float32)
+    value5 = tl.load(base + 5 * input_stride_topk, mask=mask, other=0.0).to(tl.float32)
+    value6 = tl.load(base + 6 * input_stride_topk, mask=mask, other=0.0).to(tl.float32)
+    value7 = tl.load(base + 7 * input_stride_topk, mask=mask, other=0.0).to(tl.float32)
+
+    sum01 = value0 + value1
+    sum23 = value2 + value3
+    sum45 = value4 + value5
+    sum67 = value6 + value7
+    accumulator = (sum01 + sum23) + (sum45 + sum67)
+
+    output_offsets = (
+        rows[:, None] * output_stride_token + cols[None, :] * output_stride_hidden
+    )
+    tl.store(output_ptr + output_offsets, accumulator, mask=mask)
+
+
+def invoke_hygon_fixed_topk8_reduce(
+    input_tensor: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Run the validated fixed-topk=8 BF16 reduction."""
+    num_tokens, _, hidden_size = input_tensor.shape
+    grid = (
+        triton.cdiv(num_tokens, REDUCE_ROWS_PER_PROGRAM),
+        triton.cdiv(hidden_size, REDUCE_BLOCK_N),
+    )
+    _hygon_fixed_topk8_reduce_kernel[grid](
+        input_tensor,
+        output,
+        num_tokens,
+        hidden_size,
+        input_tensor.stride(0),
+        input_tensor.stride(1),
+        input_tensor.stride(2),
+        output.stride(0),
+        output.stride(1),
+        BLOCK_N=REDUCE_BLOCK_N,
+        ROWS_PER_PROGRAM=REDUCE_ROWS_PER_PROGRAM,
+        num_warps=REDUCE_NUM_WARPS,
+        num_stages=REDUCE_NUM_STAGES,
+    )
+
+
+def try_hygon_fixed_topk8_reduce(
+    input_tensor: torch.Tensor,
+    output: torch.Tensor,
+) -> bool:
+    """Run the fixed reduction when supported and report whether it was used."""
+    if not supports_hygon_fixed_topk8_reduce(input_tensor, output):
+        return False
+    invoke_hygon_fixed_topk8_reduce(input_tensor, output)
+    return True

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/bf16_moe_gemm2.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/bf16_moe_gemm2.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon-optimized BF16 MoE GEMM2 kernel for small decode batches."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from vllm.logger import init_logger
+from vllm.triton_utils import tl, triton
+
+
+logger = init_logger(__name__)
+MAX_SMALL_DECODE_TOKENS = 128
+_active_expert_log_count = 0
+
+
+@dataclass(frozen=True)
+class HygonBf16MoeGemm2Config:
+    block_m: int = 16
+    block_n: int = 128
+    block_k: int = 128
+    num_warps: int = 8
+    num_stages: int = 1
+    workers_per_cu: int = 4
+
+    @classmethod
+    def for_small_decode(
+        cls, route_config: Mapping[str, Any]
+    ) -> "HygonBf16MoeGemm2Config":
+        """Build the optimized GEMM2 launch config from the selected MoE tile."""
+        defaults = cls()
+        return cls(
+            block_m=int(route_config.get("BLOCK_SIZE_M", defaults.block_m)),
+            block_n=int(route_config.get("BLOCK_SIZE_N", defaults.block_n)),
+            block_k=int(route_config.get("BLOCK_SIZE_K", defaults.block_k)),
+            num_warps=int(route_config.get("num_warps", defaults.num_warps)),
+            num_stages=int(route_config.get("num_stages", defaults.num_stages)),
+            workers_per_cu=int(
+                route_config.get("workers_per_cu", defaults.workers_per_cu)
+            ),
+        )
+
+
+def supports_hygon_bf16_moe_gemm2(
+    activation: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    routed_weights: torch.Tensor | None,
+    sorted_token_ids: torch.Tensor | None,
+    top_k: int,
+    config: Mapping[str, Any],
+    use_fp8_w8a8: bool,
+    use_int8_w8a8: bool,
+    use_int8_w8a16: bool,
+    use_int4_w4a16: bool,
+    bias: torch.Tensor | None,
+) -> bool:
+    """Return whether this invocation matches the validated small-M GEMM2."""
+    if activation.dtype != torch.bfloat16:
+        return False
+    if weight.dtype != torch.bfloat16 or output.dtype != torch.bfloat16:
+        return False
+    if activation.ndim != 2 or weight.ndim != 3 or output.ndim != 3:
+        return False
+    if not 0 < output.shape[0] <= MAX_SMALL_DECODE_TOKENS:
+        return False
+    if output.shape[1] != 8 or top_k != 1:
+        return False
+    if tuple(weight.shape) != (256, 2048, 256):
+        return False
+    if tuple(activation.shape) != (output.shape[0] * 8, 256):
+        return False
+    if output.shape[2] != 2048:
+        return False
+    if routed_weights is None or routed_weights.numel() != activation.shape[0]:
+        return False
+    if sorted_token_ids is None:
+        return False
+    if any(
+        (
+            use_fp8_w8a8,
+            use_int8_w8a8,
+            use_int8_w8a16,
+            use_int4_w4a16,
+        )
+    ):
+        return False
+    if bias is not None:
+        return False
+    return "BLOCK_SIZE_M" in config
+
+
+def _maybe_log_active_experts(
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    block_m: int,
+) -> None:
+    """Log routed expert count for a small number of eager debug calls."""
+    global _active_expert_log_count
+
+    if os.getenv("VLLM_FL_DEBUG_MOE_ACTIVE_EXPERTS", "0") != "1":
+        return
+    if torch.cuda.is_current_stream_capturing():
+        return
+
+    limit = int(os.getenv("VLLM_FL_DEBUG_MOE_ACTIVE_EXPERTS_LIMIT", "20"))
+    if _active_expert_log_count >= limit:
+        return
+
+    padded_routes = int(num_tokens_post_padded.detach().cpu().item())
+    expert_block_count = triton.cdiv(padded_routes, block_m)
+    routed_expert_ids = expert_ids[:expert_block_count].detach().cpu().tolist()
+    active_experts = len(
+        {int(expert_id) for expert_id in routed_expert_ids if expert_id >= 0}
+    )
+    logger.info(
+        "Hygon BF16 MoE GEMM2 routing: active_experts=%d, "
+        "expert_blocks=%d, padded_routes=%d",
+        active_experts,
+        expert_block_count,
+        padded_routes,
+    )
+    _active_expert_log_count += 1
+
+
+@triton.jit
+def _hygon_bf16_moe_gemm2_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    routed_weight_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    route_count,
+    n_size: tl.constexpr,
+    k_size: tl.constexpr,
+    stride_am: tl.constexpr,
+    stride_ak: tl.constexpr,
+    stride_be: tl.constexpr,
+    stride_bn: tl.constexpr,
+    stride_bk: tl.constexpr,
+    stride_cm: tl.constexpr,
+    stride_cn: tl.constexpr,
+    mul_routed_weight: tl.constexpr,
+    block_m: tl.constexpr,
+    block_n: tl.constexpr,
+    block_k: tl.constexpr,
+):
+    worker_id = tl.program_id(0)
+    worker_count = tl.num_programs(0)
+    n_tiles = tl.cdiv(n_size, block_n)
+    padded_routes = tl.load(num_tokens_post_padded_ptr)
+    expert_blocks = tl.cdiv(padded_routes, block_m)
+    total_tiles = expert_blocks * n_tiles
+
+    tile_id = worker_id
+    while tile_id < total_tiles:
+        expert_block = tile_id // n_tiles
+        n_tile = tile_id - expert_block * n_tiles
+        expert_id = tl.load(expert_ids_ptr + expert_block)
+        valid_expert = expert_id >= 0
+
+        m_offsets = tl.arange(0, block_m)
+        n_offsets = n_tile * block_n + tl.arange(0, block_n)
+        route_ids = tl.load(sorted_token_ids_ptr + expert_block * block_m + m_offsets)
+        valid_rows = (route_ids < route_count) & valid_expert
+
+        accumulator = tl.zeros((block_m, block_n), dtype=tl.float32)
+        for k_start in range(0, k_size, block_k):
+            k_offsets = k_start + tl.arange(0, block_k)
+            a_addresses = (
+                a_ptr + route_ids[:, None] * stride_am + k_offsets[None, :] * stride_ak
+            )
+            b_addresses = (
+                b_ptr
+                + expert_id * stride_be
+                + k_offsets[:, None] * stride_bk
+                + n_offsets[None, :] * stride_bn
+            )
+            a = tl.load(
+                a_addresses,
+                mask=valid_rows[:, None] & (k_offsets[None, :] < k_size),
+                other=0.0,
+            )
+            b = tl.load(
+                b_addresses,
+                mask=(k_offsets[:, None] < k_size)
+                & (n_offsets[None, :] < n_size)
+                & valid_expert,
+                other=0.0,
+            )
+            accumulator = tl.dot(a, b, acc=accumulator, allow_tf32=False)
+
+        if mul_routed_weight:
+            routed_weight = tl.load(
+                routed_weight_ptr + route_ids,
+                mask=valid_rows,
+                other=0.0,
+            ).to(tl.float32)
+            accumulator *= routed_weight[:, None]
+
+        c_addresses = (
+            c_ptr + route_ids[:, None] * stride_cm + n_offsets[None, :] * stride_cn
+        )
+        tl.store(
+            c_addresses,
+            accumulator.to(tl.bfloat16),
+            mask=valid_rows[:, None] & (n_offsets[None, :] < n_size),
+        )
+        tile_id += worker_count
+
+
+def invoke_hygon_bf16_moe_gemm2(
+    activation: torch.Tensor,
+    weight: torch.Tensor,
+    output: torch.Tensor,
+    routed_weights: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    mul_routed_weight: bool,
+    config: HygonBf16MoeGemm2Config,
+) -> None:
+    """Run the persistent BF16 GEMM2 kernel on an existing route plan."""
+    if activation.shape[1] != weight.shape[2]:
+        raise ValueError("activation K and weight K must match")
+    if output.shape[-1] != weight.shape[1]:
+        raise ValueError("output N and weight N must match")
+    if output.numel() // output.shape[-1] != activation.shape[0]:
+        raise ValueError("output route count must match activation rows")
+    if activation.stride(-1) != 1 or weight.stride(-1) != 1:
+        raise ValueError("activation and weight K dimensions must be contiguous")
+    if output.stride(-1) != 1:
+        raise ValueError("output N dimension must be contiguous")
+    if not routed_weights.is_contiguous():
+        raise ValueError("routed_weights must be contiguous")
+    if not sorted_token_ids.is_contiguous() or not expert_ids.is_contiguous():
+        raise ValueError("the aligned route plan must be contiguous")
+
+    for name, value in (
+        ("block_m", config.block_m),
+        ("block_n", config.block_n),
+        ("block_k", config.block_k),
+    ):
+        if value <= 0 or value & (value - 1):
+            raise ValueError(f"{name} must be a positive power of two")
+
+    output_2d = output.view(-1, output.shape[-1])
+    device_props = torch.cuda.get_device_properties(activation.device)
+    cu_count = int(device_props.multi_processor_count)
+    n_tiles = triton.cdiv(weight.shape[1], config.block_n)
+    max_tiles = expert_ids.numel() * n_tiles
+    workers = min(max_tiles, cu_count * config.workers_per_cu)
+    workers = max(1, workers)
+
+    _maybe_log_active_experts(
+        expert_ids,
+        num_tokens_post_padded,
+        config.block_m,
+    )
+
+    _hygon_bf16_moe_gemm2_kernel[(workers,)](
+        activation,
+        weight,
+        output_2d,
+        routed_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        activation.shape[0],
+        n_size=weight.shape[1],
+        k_size=weight.shape[2],
+        stride_am=activation.stride(0),
+        stride_ak=activation.stride(1),
+        stride_be=weight.stride(0),
+        stride_bn=weight.stride(1),
+        stride_bk=weight.stride(2),
+        stride_cm=output_2d.stride(0),
+        stride_cn=output_2d.stride(1),
+        mul_routed_weight=mul_routed_weight,
+        block_m=config.block_m,
+        block_n=config.block_n,
+        block_k=config.block_k,
+        num_warps=config.num_warps,
+        num_stages=config.num_stages,
+    )

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/fused_experts.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/fused_experts.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon functional fused-MoE pipeline with per-stage GEMM configs."""
+
+from __future__ import annotations
+
+import functools
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.config import _get_config_dtype_str
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    _get_config_quant_dtype,
+    try_get_optimal_moe_config,
+)
+from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
+from vllm.triton_utils import tl
+
+from vllm_fl.dispatch import CachedOp
+
+from .bf16_moe_fusions import (
+    invoke_hygon_bf16_gemm1_silu,
+    supports_hygon_bf16_gemm1_silu,
+    try_hygon_fixed_topk8_reduce,
+)
+from .stage_config import (
+    requires_separate_expert_assignment,
+    resolve_moe_stage_configs,
+)
+
+logger = init_logger(__name__)
+
+_moe_align_block_size = CachedOp("moe_align_block_size")
+_invoke_fused_moe_triton_kernel = CachedOp("invoke_fused_moe_triton_kernel")
+_silu_and_mul = CachedOp("silu_and_mul")
+_gelu_and_mul = CachedOp("gelu_and_mul")
+_moe_sum = CachedOp("moe_sum")
+
+
+def fused_experts_impl(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    inplace: bool = False,
+    activation: str = "silu",
+    apply_router_weight_on_input: bool = False,
+    use_fp8_w8a8: bool = False,
+    use_int8_w8a8: bool = False,
+    use_int8_w8a16: bool = False,
+    use_int4_w4a16: bool = False,
+    per_channel_quant: bool = False,
+    global_num_experts: int = -1,
+    expert_map: Optional[torch.Tensor] = None,
+    w1_scale: Optional[torch.Tensor] = None,
+    w2_scale: Optional[torch.Tensor] = None,
+    w1_zp: Optional[torch.Tensor] = None,
+    w2_zp: Optional[torch.Tensor] = None,
+    a1_scale: Optional[torch.Tensor] = None,
+    a2_scale: Optional[torch.Tensor] = None,
+    block_shape: Optional[list[int]] = None,
+    w1_bias: Optional[torch.Tensor] = None,
+    w2_bias: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run functional fused MoE with independent GEMM1/GEMM2 configs."""
+    del w1_zp, w2_zp
+
+    if use_int4_w4a16:
+        assert hidden_states.size(1) // 2 == w1.size(2), "Hidden size mismatch"
+    else:
+        assert hidden_states.size(1) == w1.size(
+            2
+        ), f"Hidden size mismatch {hidden_states.size(1)} != {w1.size(2)}"
+
+    assert topk_weights.size() == topk_ids.size(), "topk shape mismatch"
+    assert hidden_states.is_contiguous(), "Hidden_states must be contiguous"
+    assert w1.stride(-1) == 1, "Stride of last dimension must be 1"
+    assert w2.stride(-1) == 1, "Stride of last dimension must be 1"
+    assert hidden_states.dtype in [torch.float32, torch.float16, torch.bfloat16]
+
+    num_tokens = hidden_states.size(0)
+    num_local_experts, intermediate_size, _ = w1.size()
+    hidden_size = w2.size(1)
+    if global_num_experts == -1:
+        global_num_experts = num_local_experts
+    top_k_num = topk_ids.size(1)
+
+    chunk_size = 65536
+    max_chunk_tokens = min(num_tokens, chunk_size)
+    config_dtype = _get_config_dtype_str(
+        use_fp8_w8a8=use_fp8_w8a8,
+        use_int8_w8a16=use_int8_w8a16,
+        use_int4_w4a16=use_int4_w4a16,
+        ocp_mx_scheme=None,
+        dtype=hidden_states.dtype,
+    )
+    quant_dtype = _get_config_quant_dtype(
+        use_fp8_w8a8=use_fp8_w8a8,
+        use_int8_w8a8=use_int8_w8a8,
+        ocp_mx_scheme=None,
+    )
+    get_config = functools.partial(
+        try_get_optimal_moe_config,
+        w1.size(),
+        w2.size(),
+        top_k_num,
+        config_dtype,
+        block_shape=block_shape,
+    )
+
+    raw_config = get_config(max_chunk_tokens)
+    gemm1_config, gemm2_config = resolve_moe_stage_configs(raw_config)
+    if "gemm1" in raw_config:
+        logger.info_once(
+            f"Using Hygon stage-specific MoE configs: "
+            f"GEMM1={gemm1_config}, GEMM2={gemm2_config}"
+        )
+
+    cache13 = torch.empty(
+        max_chunk_tokens * top_k_num * max(intermediate_size, hidden_size),
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
+    intermediate_cache1 = cache13[
+        : max_chunk_tokens * top_k_num * intermediate_size
+    ].view(max_chunk_tokens, top_k_num, intermediate_size)
+    intermediate_cache3 = cache13[: max_chunk_tokens * top_k_num * hidden_size].view(
+        max_chunk_tokens, top_k_num, hidden_size
+    )
+    intermediate_cache2 = torch.empty(
+        (max_chunk_tokens * top_k_num, intermediate_size // 2),
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
+
+    if hidden_states.dtype == torch.bfloat16:
+        compute_type = tl.bfloat16
+    elif hidden_states.dtype == torch.float16:
+        compute_type = tl.float16
+    elif hidden_states.dtype == torch.float32:
+        compute_type = tl.float32
+    else:
+        raise ValueError(f"Unsupported compute_type: {hidden_states.dtype}")
+
+    out_hidden_states = hidden_states if inplace else torch.empty_like(hidden_states)
+
+    for begin_chunk_idx in range(0, num_tokens, chunk_size):
+        end_chunk_idx = min(begin_chunk_idx + chunk_size, num_tokens)
+        curr_hidden_states = hidden_states[begin_chunk_idx:end_chunk_idx]
+        tokens_in_chunk = curr_hidden_states.size(0)
+
+        curr_cache1 = intermediate_cache1[:tokens_in_chunk]
+        curr_cache2 = intermediate_cache2[: tokens_in_chunk * top_k_num]
+        curr_cache3 = intermediate_cache3[:tokens_in_chunk]
+
+        if tokens_in_chunk != max_chunk_tokens:
+            raw_config = get_config(tokens_in_chunk)
+            gemm1_config, gemm2_config = resolve_moe_stage_configs(raw_config)
+            if "gemm1" in raw_config:
+                logger.info_once(
+                    f"Using Hygon stage-specific MoE configs: "
+                    f"GEMM1={gemm1_config}, GEMM2={gemm2_config}"
+                )
+
+        curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
+        curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
+        activation_name = (
+            activation.value if hasattr(activation, "value") else activation
+        )
+        qcurr_hidden_states, a1q_scale = moe_kernel_quantize_input(
+            A=curr_hidden_states,
+            A_scale=a1_scale,
+            quant_dtype=quant_dtype,
+            per_act_token_quant=per_channel_quant,
+            block_shape=block_shape,
+        )
+
+        sorted_token_ids, expert_ids, num_tokens_post_padded = _moe_align_block_size(
+            curr_topk_ids,
+            gemm1_config["BLOCK_SIZE_M"],
+            global_num_experts,
+            expert_map,
+            ignore_invalid_experts=True,
+        )
+        use_fused_gemm1_silu = supports_hygon_bf16_gemm1_silu(
+            qcurr_hidden_states,
+            w1,
+            curr_cache2,
+            sorted_token_ids,
+            expert_ids,
+            gemm1_config,
+            top_k=top_k_num,
+            activation_name=activation_name,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            has_quantization=any(
+                (
+                    use_fp8_w8a8,
+                    use_int8_w8a8,
+                    use_int8_w8a16,
+                    use_int4_w4a16,
+                    per_channel_quant,
+                    a1q_scale is not None,
+                    w1_scale is not None,
+                    block_shape is not None,
+                )
+            ),
+            has_bias=w1_bias is not None,
+            has_expert_map=expert_map is not None,
+            has_lora=False,
+        )
+        if use_fused_gemm1_silu:
+            invoke_hygon_bf16_gemm1_silu(
+                qcurr_hidden_states,
+                w1,
+                curr_cache2,
+                sorted_token_ids,
+                expert_ids,
+                num_tokens_post_padded,
+                top_k=top_k_num,
+            )
+        else:
+            _invoke_fused_moe_triton_kernel(
+                qcurr_hidden_states,
+                w1,
+                curr_cache1,
+                a1q_scale,
+                w1_scale,
+                curr_topk_weights,
+                sorted_token_ids,
+                expert_ids,
+                num_tokens_post_padded,
+                apply_router_weight_on_input,
+                top_k_num,
+                gemm1_config,
+                compute_type=compute_type,
+                use_fp8_w8a8=use_fp8_w8a8,
+                use_int8_w8a8=use_int8_w8a8,
+                use_int8_w8a16=use_int8_w8a16,
+                use_int4_w4a16=use_int4_w4a16,
+                per_channel_quant=per_channel_quant,
+                block_shape=block_shape,
+                B_bias=w1_bias,
+            )
+            if activation_name == "silu":
+                curr_cache2 = _silu_and_mul(
+                    None, curr_cache1.view(-1, intermediate_size)
+                )
+            elif activation_name == "gelu":
+                curr_cache2 = _gelu_and_mul(
+                    None, curr_cache1.view(-1, intermediate_size)
+                )
+            elif activation_name == "silu_no_mul":
+                curr_cache2 = F.silu(curr_cache1.view(-1, intermediate_size))
+            elif activation_name == "gelu_no_mul":
+                curr_cache2 = F.gelu(curr_cache1.view(-1, intermediate_size))
+            else:
+                raise ValueError(f"Unsupported FusedMoe activation: {activation_name}.")
+
+        qintermediate_cache2, a2q_scale = moe_kernel_quantize_input(
+            A=curr_cache2,
+            A_scale=a2_scale,
+            quant_dtype=quant_dtype,
+            per_act_token_quant=per_channel_quant,
+            block_shape=block_shape,
+        )
+
+        if requires_separate_expert_assignment(gemm1_config, gemm2_config):
+            (
+                gemm2_sorted_token_ids,
+                gemm2_expert_ids,
+                gemm2_num_tokens_post_padded,
+            ) = _moe_align_block_size(
+                curr_topk_ids,
+                gemm2_config["BLOCK_SIZE_M"],
+                global_num_experts,
+                expert_map,
+                ignore_invalid_experts=True,
+            )
+        else:
+            gemm2_sorted_token_ids = sorted_token_ids
+            gemm2_expert_ids = expert_ids
+            gemm2_num_tokens_post_padded = num_tokens_post_padded
+
+        _invoke_fused_moe_triton_kernel(
+            qintermediate_cache2,
+            w2,
+            curr_cache3,
+            a2q_scale,
+            w2_scale,
+            curr_topk_weights,
+            gemm2_sorted_token_ids,
+            gemm2_expert_ids,
+            gemm2_num_tokens_post_padded,
+            not apply_router_weight_on_input,
+            1,
+            gemm2_config,
+            compute_type=compute_type,
+            use_fp8_w8a8=use_fp8_w8a8,
+            use_int8_w8a8=use_int8_w8a8,
+            use_int8_w8a16=use_int8_w8a16,
+            use_int4_w4a16=use_int4_w4a16,
+            per_channel_quant=per_channel_quant,
+            block_shape=block_shape,
+            B_bias=w2_bias,
+        )
+        curr_output = out_hidden_states[begin_chunk_idx:end_chunk_idx]
+        if not try_hygon_fixed_topk8_reduce(curr_cache3, curr_output):
+            _moe_sum(curr_cache3, curr_output)
+
+    return out_hidden_states

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/fused_moe.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/fused_moe.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon MoE operator fallbacks backed by vLLM native ops."""
+
+from __future__ import annotations
+
+import torch
+from vllm.logger import init_logger
+from vllm.triton_utils import triton
+from vllm.utils.math_utils import round_up
+
+logger = init_logger(__name__)
+
+
+def moe_align_block_size_hygon(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    expert_map: torch.Tensor | None = None,
+    pad_sorted_ids: bool = False,
+    ignore_invalid_experts: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    from ..native_ops.moe_align_block_size import moe_align_block_size_hygon_out
+
+    max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
+    if pad_sorted_ids:
+        max_num_tokens_padded = round_up(max_num_tokens_padded, block_size)
+    if topk_ids.numel() < num_experts:
+        max_num_tokens_padded = min(
+            topk_ids.numel() * block_size, max_num_tokens_padded
+        )
+
+    sorted_ids = torch.empty(
+        (max_num_tokens_padded,), dtype=torch.int32, device=topk_ids.device
+    )
+    max_num_m_blocks = triton.cdiv(max_num_tokens_padded, block_size)
+    expert_ids = torch.empty(
+        (max_num_m_blocks,), dtype=torch.int32, device=topk_ids.device
+    )
+    num_tokens_post_pad = torch.empty((1,), dtype=torch.int32, device=topk_ids.device)
+
+    moe_align_block_size_hygon_out(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_ids,
+        expert_ids,
+        num_tokens_post_pad,
+        expert_map if ignore_invalid_experts else None,
+    )
+
+    if expert_map is not None and not ignore_invalid_experts:
+        expert_ids = expert_map[expert_ids]
+
+    return sorted_ids, expert_ids, num_tokens_post_pad
+
+
+def moe_sum_hygon(inp, out):
+    from ..native_ops.moe_sum import moe_sum_hygon_out
+
+    moe_sum_hygon_out(inp, out)
+
+
+def topk_softmax_hygon(
+    topk_weights,
+    topk_indices,
+    token_expert_indices,
+    gating_output,
+    renormalize=False,
+):
+    from vllm._custom_ops import topk_softmax
+
+    topk_softmax(
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+    )
+    return topk_weights, topk_indices
+
+
+def invoke_fused_moe_triton_kernel_hygon(
+    A,
+    B,
+    C,
+    A_scale,
+    B_scale,
+    topk_weights,
+    sorted_token_ids,
+    expert_ids,
+    num_tokens_post_padded,
+    mul_routed_weight,
+    top_k,
+    config,
+    compute_type,
+    use_fp8_w8a8,
+    use_int8_w8a8,
+    use_int8_w8a16,
+    use_int4_w4a16,
+    per_channel_quant,
+    block_shape=None,
+    B_bias=None,
+):
+    from .bf16_moe_gemm2 import (
+        HygonBf16MoeGemm2Config,
+        invoke_hygon_bf16_moe_gemm2,
+        supports_hygon_bf16_moe_gemm2,
+    )
+
+    if supports_hygon_bf16_moe_gemm2(
+        A,
+        B,
+        C,
+        topk_weights,
+        sorted_token_ids,
+        top_k,
+        config,
+        use_fp8_w8a8,
+        use_int8_w8a8,
+        use_int8_w8a16,
+        use_int4_w4a16,
+        B_bias,
+    ):
+        logger.info_once("Using Hygon BF16 optimized MoE GEMM2 for 1 <= M <= 128")
+        invoke_hygon_bf16_moe_gemm2(
+            A,
+            B,
+            C,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            mul_routed_weight=mul_routed_weight,
+            config=HygonBf16MoeGemm2Config.for_small_decode(config),
+        )
+        return
+
+    from vllm_fl.dispatch.backends.flaggems.impl.fused_moe import (
+        invoke_fused_moe_triton_kernel_flaggems,
+    )
+
+    flaggems_config = {
+        key: value for key, value in config.items() if key != "workers_per_cu"
+    }
+    invoke_fused_moe_triton_kernel_flaggems(
+        A,
+        B,
+        C,
+        A_scale,
+        B_scale,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        mul_routed_weight,
+        top_k,
+        flaggems_config,
+        compute_type,
+        use_fp8_w8a8,
+        use_int8_w8a8,
+        use_int8_w8a16,
+        use_int4_w4a16,
+        per_channel_quant,
+        block_shape=block_shape,
+        B_bias=B_bias,
+    )
+
+
+def grouped_topk_hygon(
+    scores,
+    n_group,
+    topk_group,
+    topk,
+    renormalize,
+    routed_scaling_factor,
+    bias,
+    scoring_func=0,
+):
+    from vllm._custom_ops import grouped_topk
+
+    return grouped_topk(
+        scores,
+        n_group,
+        topk_group,
+        topk,
+        renormalize,
+        routed_scaling_factor,
+        bias,
+        scoring_func,
+    )

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/stage_config.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/stage_config.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Resolve Hygon MoE configurations for the two GEMM stages."""
+
+from collections.abc import Mapping
+from typing import Any
+
+_REQUIRED_CONFIG_KEYS = (
+    "BLOCK_SIZE_M",
+    "BLOCK_SIZE_N",
+    "BLOCK_SIZE_K",
+    "GROUP_SIZE_M",
+    "num_warps",
+    "num_stages",
+)
+
+
+def _validate_stage_config(stage: str, config: Mapping[str, Any]) -> dict[str, Any]:
+    missing = [key for key in _REQUIRED_CONFIG_KEYS if key not in config]
+    if missing:
+        raise ValueError(
+            f"MoE {stage} config is missing required keys: {', '.join(missing)}"
+        )
+    return config if isinstance(config, dict) else dict(config)
+
+
+def resolve_moe_stage_configs(
+    config: Mapping[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Resolve a legacy flat config or separate GEMM1/GEMM2 configs."""
+    has_gemm1 = "gemm1" in config
+    has_gemm2 = "gemm2" in config
+
+    if not has_gemm1 and not has_gemm2:
+        flat_config = _validate_stage_config("shared", config)
+        return flat_config, flat_config
+
+    if not has_gemm1 or not has_gemm2:
+        missing_stage = "gemm1" if not has_gemm1 else "gemm2"
+        raise ValueError(
+            "Stage-specific MoE config must define both gemm1 and gemm2; "
+            f"missing {missing_stage}"
+        )
+
+    shared = config.get("shared", {})
+    gemm1 = config["gemm1"]
+    gemm2 = config["gemm2"]
+    if not isinstance(shared, Mapping):
+        raise TypeError("MoE shared config must be a mapping")
+    if not isinstance(gemm1, Mapping):
+        raise TypeError("MoE gemm1 config must be a mapping")
+    if not isinstance(gemm2, Mapping):
+        raise TypeError("MoE gemm2 config must be a mapping")
+
+    gemm1_config = {**shared, **gemm1}
+    gemm2_config = {**shared, **gemm2}
+    return (
+        _validate_stage_config("gemm1", gemm1_config),
+        _validate_stage_config("gemm2", gemm2_config),
+    )
+
+
+def requires_separate_expert_assignment(
+    gemm1_config: Mapping[str, Any],
+    gemm2_config: Mapping[str, Any],
+) -> bool:
+    """Return whether GEMM2 needs metadata aligned to a different M tile."""
+    return gemm1_config["BLOCK_SIZE_M"] != gemm2_config["BLOCK_SIZE_M"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/triton_experts.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/moe/triton_experts.py
@@ -1,0 +1,313 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon modular MoE experts with independent GEMM stage configs."""
+
+from __future__ import annotations
+
+import torch
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    try_get_optimal_moe_config,
+)
+from vllm.model_executor.layers.fused_moe.utils import (
+    _resize_cache,
+    moe_kernel_quantize_input,
+)
+from vllm.triton_utils import tl
+
+from vllm_fl.dispatch import CachedOp
+from vllm_fl.ops.fused_moe.activation import apply_moe_activation
+from vllm_fl.ops.fused_moe.fused_moe_utils import (
+    TritonExpertsFL,
+    _prepare_expert_assignment,
+)
+
+from .bf16_moe_fusions import (
+    invoke_hygon_bf16_gemm1_silu,
+    supports_hygon_bf16_gemm1_silu,
+    try_hygon_fixed_topk8_reduce,
+)
+from .stage_config import (
+    requires_separate_expert_assignment,
+    resolve_moe_stage_configs,
+)
+
+logger = init_logger(__name__)
+
+_invoke_fused_moe_triton_kernel = CachedOp("invoke_fused_moe_triton_kernel")
+_moe_sum = CachedOp("moe_sum")
+
+
+class HygonTritonExpertsFL(TritonExpertsFL):
+    """Hygon Triton experts using separate GEMM1 and GEMM2 route plans."""
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ) -> None:
+        del expert_tokens_meta
+
+        if self.quant_config.use_int4_w4a16:
+            assert hidden_states.size(-1) // 2 == w1.size(2), "Hidden size mismatch"
+        else:
+            assert hidden_states.size(-1) == w1.size(
+                2
+            ), f"Hidden size mismatch {hidden_states.size(-1)} != {w1.size(2)}"
+
+        assert hidden_states.is_contiguous(), "Hidden_states must be contiguous"
+        assert hidden_states.dim() == 2
+        assert w1.stride(-1) == 1, "Stride of last dimension must be 1"
+        assert w2.stride(-1) == 1, "Stride of last dimension must be 1"
+        assert hidden_states.dtype in [
+            torch.float32,
+            torch.float16,
+            torch.bfloat16,
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+        ]
+
+        num_local_experts, num_tokens, intermediate_size, hidden_size, top_k_num = (
+            self.moe_problem_size(hidden_states, w1, w2, topk_ids)
+        )
+        if global_num_experts == -1:
+            global_num_experts = num_local_experts
+
+        raw_config = try_get_optimal_moe_config(
+            w1.size(),
+            w2.size(),
+            top_k_num,
+            self.quant_config.config_name(hidden_states.dtype),
+            num_tokens,
+            block_shape=self.block_shape,
+        )
+        gemm1_config, gemm2_config = resolve_moe_stage_configs(raw_config)
+        if "gemm1" in raw_config:
+            logger.info_once(
+                f"Using Hygon stage-specific MoE configs: "
+                f"GEMM1={gemm1_config}, GEMM2={gemm2_config}"
+            )
+
+        if hidden_states.dtype == torch.bfloat16:
+            compute_type = tl.bfloat16
+        elif hidden_states.dtype == torch.float16:
+            compute_type = tl.float16
+        elif hidden_states.dtype == torch.float32:
+            compute_type = tl.float32
+        elif hidden_states.dtype in (
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+        ):
+            compute_type = tl.bfloat16
+        else:
+            raise ValueError(f"Unsupported compute_type: {hidden_states.dtype}")
+
+        intermediate_cache1 = _resize_cache(
+            workspace2,
+            (num_tokens, top_k_num, intermediate_size),
+        )
+        cache2_dim = self.adjust_N_for_activation(intermediate_size, activation)
+        intermediate_cache2 = _resize_cache(
+            workspace13,
+            (num_tokens * top_k_num, cache2_dim),
+        )
+        intermediate_cache3 = _resize_cache(
+            workspace2,
+            (num_tokens, top_k_num, hidden_size),
+        )
+
+        sorted_token_ids, expert_ids, num_tokens_post_padded = (
+            _prepare_expert_assignment(
+                topk_ids,
+                gemm1_config,
+                num_tokens,
+                top_k_num,
+                global_num_experts,
+                expert_map,
+                use_int8_w8a16=self.quant_config.use_int8_w8a16,
+                use_int4_w4a16=self.quant_config.use_int4_w4a16,
+                block_shape=self.block_shape,
+            )
+        )
+        sorted_token_ids_lora = None
+        expert_ids_lora = None
+        num_tokens_post_padded_lora = None
+        token_lora_mapping = None
+        lora_context = self._lora_context
+        activation_name = (
+            activation.value if hasattr(activation, "value") else str(activation)
+        )
+        use_fused_gemm1_silu = supports_hygon_bf16_gemm1_silu(
+            hidden_states,
+            w1,
+            intermediate_cache2,
+            sorted_token_ids,
+            expert_ids,
+            gemm1_config,
+            top_k=top_k_num,
+            activation_name=activation_name,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            has_quantization=any(
+                (
+                    self.quant_config.use_fp8_w8a8,
+                    self.quant_config.use_int8_w8a8,
+                    self.quant_config.use_int8_w8a16,
+                    self.quant_config.use_int4_w4a16,
+                    self.per_act_token_quant,
+                    self.quantization_emulation,
+                    a1q_scale is not None,
+                    self.w1_scale is not None,
+                    self.block_shape is not None,
+                )
+            ),
+            has_bias=self.w1_bias is not None,
+            has_expert_map=expert_map is not None,
+            has_lora=lora_context is not None,
+        )
+        if use_fused_gemm1_silu:
+            invoke_hygon_bf16_gemm1_silu(
+                hidden_states,
+                w1,
+                intermediate_cache2,
+                sorted_token_ids,
+                expert_ids,
+                num_tokens_post_padded,
+                top_k=top_k_num,
+            )
+        else:
+            _invoke_fused_moe_triton_kernel(
+                hidden_states,
+                w1,
+                intermediate_cache1,
+                a1q_scale,
+                self.w1_scale,
+                None,
+                sorted_token_ids,
+                expert_ids,
+                num_tokens_post_padded,
+                False,
+                top_k_num,
+                gemm1_config,
+                compute_type=compute_type,
+                use_fp8_w8a8=self.quant_config.use_fp8_w8a8,
+                use_int8_w8a8=self.quant_config.use_int8_w8a8,
+                use_int8_w8a16=self.quant_config.use_int8_w8a16,
+                use_int4_w4a16=self.quant_config.use_int4_w4a16,
+                per_channel_quant=self.per_act_token_quant,
+                block_shape=self.block_shape,
+                B_bias=self.w1_bias,
+            )
+
+            if lora_context is not None:
+                (
+                    sorted_token_ids_lora,
+                    expert_ids_lora,
+                    num_tokens_post_padded_lora,
+                    token_lora_mapping,
+                ) = self.apply_w13_lora(
+                    lora_context,
+                    y=intermediate_cache1,
+                    x=hidden_states,
+                    topk_ids=topk_ids,
+                    topk_weights=topk_weights,
+                    expert_map=expert_map,
+                    w1=w1,
+                    w2=w2,
+                    num_tokens=num_tokens,
+                    top_k_num=top_k_num,
+                )
+
+            apply_moe_activation(
+                activation,
+                intermediate_cache2,
+                intermediate_cache1.view(-1, intermediate_size),
+            )
+        qintermediate_cache2, a2q_scale = moe_kernel_quantize_input(
+            intermediate_cache2,
+            a2_scale,
+            self.quant_dtype,
+            self.per_act_token_quant,
+            self.block_shape,
+            quantization_emulation=self.quantization_emulation,
+        )
+
+        if requires_separate_expert_assignment(gemm1_config, gemm2_config):
+            (
+                gemm2_sorted_token_ids,
+                gemm2_expert_ids,
+                gemm2_num_tokens_post_padded,
+            ) = _prepare_expert_assignment(
+                topk_ids,
+                gemm2_config,
+                num_tokens,
+                top_k_num,
+                global_num_experts,
+                expert_map,
+                use_int8_w8a16=self.quant_config.use_int8_w8a16,
+                use_int4_w4a16=self.quant_config.use_int4_w4a16,
+                block_shape=self.block_shape,
+            )
+        else:
+            gemm2_sorted_token_ids = sorted_token_ids
+            gemm2_expert_ids = expert_ids
+            gemm2_num_tokens_post_padded = num_tokens_post_padded
+
+        _invoke_fused_moe_triton_kernel(
+            qintermediate_cache2,
+            w2,
+            intermediate_cache3,
+            a2q_scale,
+            self.w2_scale,
+            topk_weights,
+            gemm2_sorted_token_ids,
+            gemm2_expert_ids,
+            gemm2_num_tokens_post_padded,
+            not apply_router_weight_on_input,
+            1,
+            gemm2_config,
+            compute_type=compute_type,
+            use_fp8_w8a8=self.quant_config.use_fp8_w8a8,
+            use_int8_w8a8=self.quant_config.use_int8_w8a8,
+            use_int8_w8a16=self.quant_config.use_int8_w8a16,
+            use_int4_w4a16=self.quant_config.use_int4_w4a16,
+            per_channel_quant=self.per_act_token_quant,
+            block_shape=self.block_shape,
+            B_bias=self.w2_bias,
+        )
+
+        if lora_context is not None:
+            self.apply_w2_lora(
+                lora_context,
+                y=intermediate_cache3,
+                x=intermediate_cache2,
+                topk_weights=topk_weights,
+                sorted_token_ids_lora=sorted_token_ids_lora,
+                expert_ids_lora=expert_ids_lora,
+                num_tokens_post_padded_lora=num_tokens_post_padded_lora,
+                token_lora_mapping=token_lora_mapping,
+                num_tokens=num_tokens,
+                w1=w1,
+                w2=w2,
+                top_k_num=top_k_num,
+            )
+
+        if not try_hygon_fixed_topk8_reduce(intermediate_cache3, output):
+            self.moe_sum(intermediate_cache3, output)
+
+    def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:
+        _moe_sum(input, output)

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/__init__.py
@@ -1,0 +1,1 @@
+"""Hygon implementations of native vLLM operator ABIs."""

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/activation.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/activation.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon activation implementations for CUDA-compatible Hygon runtimes."""
+
+from __future__ import annotations
+
+import torch
+
+
+def silu_and_mul_hygon_out(output: torch.Tensor, x: torch.Tensor) -> None:
+    """Run Hygon LightOp using vLLM's native out-parameter ABI."""
+    try:
+        from lightop import activation as op
+    except ImportError:
+        import lightop.op as op
+
+    op.silu_and_mul_opt(output, x)
+
+
+def silu_and_mul_hygon(obj, x: torch.Tensor) -> torch.Tensor:
+    """SiLU activation followed by element-wise multiplication."""
+    d = x.shape[-1] // 2
+    out = torch.empty(*x.shape[:-1], d, dtype=x.dtype, device=x.device)
+    silu_and_mul_hygon_out(out, x)
+    return out
+
+
+def gelu_and_mul_hygon(obj, x: torch.Tensor) -> torch.Tensor:
+    """GELU activation followed by element-wise multiplication."""
+    approximate = getattr(obj, "approximate", "none") if obj is not None else "none"
+    d = x.shape[-1] // 2
+    out = torch.empty(*x.shape[:-1], d, dtype=x.dtype, device=x.device)
+    if approximate == "tanh":
+        torch.ops._C.gelu_tanh_and_mul(out, x)
+    else:
+        torch.ops._C.gelu_and_mul(out, x)
+    return out

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/int8_quant.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/int8_quant.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon Triton implementation of dynamic symmetric INT8 quantization."""
+
+import torch
+from triton.language.extra import libdevice
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _per_token_quant_int8_one_kernel_opt(
+    x_ptr,
+    xq_ptr,
+    scale_ptr,
+    stride_x,
+    stride_xq,
+    n_cols,
+    BLOCK: tl.constexpr,
+):
+    """Quantize one contiguous row per Triton program.
+
+    This is adapted from vllm_hcu's
+    ``_per_token_quant_int8_one_kernel_opt``.  The expert-token filtering was
+    removed because ``_C::dynamic_scaled_int8_quant`` operates on every row.
+    """
+    row_id = tl.program_id(0)
+    cols = tl.arange(0, BLOCK)
+    mask = cols < n_cols
+
+    x = tl.load(
+        x_ptr + row_id * stride_x + cols,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    absmax = tl.max(tl.abs(x))
+
+    # Match vLLM's native dynamic symmetric kernel for an all-zero row:
+    # scale=0 and inv_scale=0.  vllm_hcu clamps absmax to 1e-10, which is
+    # harmless for MoE math but does not exactly satisfy the _C op contract.
+    safe_absmax = tl.where(absmax == 0.0, 1.0, absmax)
+    inv_scale = tl.where(absmax == 0.0, 0.0, 127.0 / safe_absmax)
+    scale = absmax / 127.0
+    x_q = libdevice.nearbyint(x * inv_scale).to(tl.int8)
+
+    tl.store(xq_ptr + row_id * stride_xq + cols, x_q, mask=mask)
+    tl.store(scale_ptr + row_id, scale)
+
+
+def dynamic_scaled_int8_quant_hygon(
+    result: torch.Tensor,
+    input: torch.Tensor,
+    scales: torch.Tensor,
+    azp: torch.Tensor | None,
+) -> None:
+    """Implement vLLM's dynamic per-token symmetric INT8 ``_C`` op.
+
+    The current W8A8 compressed-tensors path always supplies ``azp=None``.
+    Dynamic asymmetric quantization is deliberately rejected until a referenced
+    Hygon implementation is available.
+    """
+    if azp is not None:
+        raise NotImplementedError(
+            "Hygon Triton implementation supports only dynamic symmetric "
+            "INT8 quantization (azp must be None)."
+        )
+    if input.ndim == 0 or input.shape[-1] == 0:
+        raise ValueError(
+            "dynamic_scaled_int8_quant requires a non-empty last dimension"
+        )
+    if input.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            "dynamic_scaled_int8_quant input must be float16, bfloat16, or "
+            f"float32, but got {input.dtype}"
+        )
+    if result.dtype is not torch.int8:
+        raise TypeError(
+            f"dynamic_scaled_int8_quant result must be int8, got {result.dtype}"
+        )
+    if scales.dtype is not torch.float32:
+        raise TypeError(
+            f"dynamic_scaled_int8_quant scales must be float32, got {scales.dtype}"
+        )
+    if result.shape != input.shape:
+        raise ValueError(
+            "dynamic_scaled_int8_quant result shape must match input shape: "
+            f"{result.shape} != {input.shape}"
+        )
+
+    hidden_size = input.shape[-1]
+    num_tokens = input.numel() // hidden_size
+    if scales.numel() != num_tokens:
+        raise ValueError(
+            "dynamic_scaled_int8_quant requires one scale per input row: "
+            f"expected {num_tokens}, got {scales.numel()}"
+        )
+    if not input.is_contiguous():
+        raise ValueError("dynamic_scaled_int8_quant input must be contiguous")
+    if not result.is_contiguous():
+        raise ValueError("dynamic_scaled_int8_quant result must be contiguous")
+    if not scales.is_contiguous():
+        raise ValueError("dynamic_scaled_int8_quant scales must be contiguous")
+    if result.device != input.device or scales.device != input.device:
+        raise ValueError("dynamic_scaled_int8_quant tensors must be on the same device")
+
+    if num_tokens == 0:
+        return
+
+    block = triton.next_power_of_2(hidden_size)
+    num_warps = min(max(block // 256, 1), 8)
+    _per_token_quant_int8_one_kernel_opt[(num_tokens,)](
+        input,
+        result,
+        scales,
+        stride_x=hidden_size,
+        stride_xq=hidden_size,
+        n_cols=hidden_size,
+        BLOCK=block,
+        num_warps=num_warps,
+        num_stages=1,
+    )

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/moe_align_block_size.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/moe_align_block_size.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon implementation of vLLM's raw ``moe_align_block_size`` op."""
+
+from __future__ import annotations
+
+import torch
+
+
+def moe_align_block_size_hygon_out(
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_pad: torch.Tensor,
+    expert_map: torch.Tensor | None = None,
+) -> None:
+    """Fill preallocated outputs with vllm_hcu's categorized LightOp API."""
+    from lightop.moe import moe_align_block_size_out
+
+    moe_align_block_size_out(
+        topk_ids,
+        num_experts,
+        block_size,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_pad,
+        expert_map,
+        is_ep=False,
+        is_fuse_fill=True,
+    )
+
+
+__all__ = ["moe_align_block_size_hygon_out"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/moe_sum.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/moe_sum.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon implementation of vLLM's raw ``moe_sum`` output ABI."""
+
+from __future__ import annotations
+
+import torch
+
+
+def moe_sum_hygon_out(input: torch.Tensor, output: torch.Tensor) -> None:
+    """Reduce expert outputs with the validated Hygon Triton kernel."""
+    from ..moe.bf16_moe_fusions import try_hygon_fixed_topk8_reduce
+
+    if try_hygon_fixed_topk8_reduce(input, output):
+        return
+
+    raise NotImplementedError(
+        "vendor:hygon moe_sum supports only the validated fixed-topk=8 "
+        "BF16 shape; select flagos or reference for other inputs"
+    )
+
+
+__all__ = ["moe_sum_hygon_out"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/topk_softplus_sqrt.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/native_ops/topk_softplus_sqrt.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon implementation of vLLM's ``topk_softplus_sqrt`` router op."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def topk_softplus_sqrt_hygon(
+    topk_weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    routed_scaling_factor: float = 1.0,
+    correction_bias: torch.Tensor | None = None,
+    input_ids: torch.Tensor | None = None,
+    tid2eid: torch.Tensor | None = None,
+) -> None:
+    """Apply the validated Hygon router semantics with PyTorch primitives.
+
+    Bias affects expert selection only; weights always come from the unbiased
+    ``sqrt(softplus(logit))`` scores.
+    """
+    scores = torch.sqrt(F.softplus(gating_output.float()))
+    scores_for_choice = (
+        scores + correction_bias.float()
+        if correction_bias is not None
+        else scores
+    )
+
+    if tid2eid is not None:
+        if input_ids is None:
+            raise ValueError("input_ids is required when tid2eid is provided")
+        selected_indices = tid2eid[input_ids.long()]
+    else:
+        selected_indices = torch.topk(
+            scores_for_choice,
+            k=topk_weights.shape[-1],
+            dim=-1,
+        ).indices
+
+    weights = scores.gather(1, selected_indices.long())
+    if renormalize:
+        weights = weights / weights.sum(dim=-1, keepdim=True).clamp(min=1e-20)
+
+    topk_weights.copy_(weights * routed_scaling_factor)
+    topk_indices.copy_(selected_indices)
+
+
+__all__ = ["topk_softplus_sqrt_hygon"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/other/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/other/__init__.py
@@ -1,0 +1,1 @@
+"""Other Hygon operator implementations not tied to one execution stack."""

--- a/vllm_fl/dispatch/backends/vendor/hygon/impl/other/mhc.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/impl/other/mhc.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon implementations for DeepSeek-V4 MHC.
+
+Hygon vLLM does not use vLLM's generic TileLang prenorm reduction on ROCm.
+That kernel assumes a 32-lane warp, while Hygon executes a 64-lane wavefront.
+Prefer the same wave64 AITER operators as Hygon vLLM, with vLLM's PyTorch MHC
+math as the fallback when those optional vendor operators are unavailable.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+import importlib
+import logging
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@cache
+def _get_aiter_mhc_ops() -> tuple[Any, Any] | None:
+    """Return the two Hygon vLLM AITER MHC leaves when installed."""
+    try:
+        aiter_tilelang = importlib.import_module("aiter.ops.tilelang")
+    except (ImportError, AttributeError):
+        logger.info("Hygon AITER MHC ops unavailable; using PyTorch fallback")
+        return None
+
+    pre = getattr(aiter_tilelang, "mhc_pre_big_fuse", None)
+    post = getattr(aiter_tilelang, "mhc_post_fwd", None)
+    if not callable(pre) or not callable(post):
+        logger.info("Installed AITER lacks Hygon MHC ops; using PyTorch fallback")
+        return None
+    logger.info("Using Hygon AITER MHC pre/post ops")
+    return pre, post
+
+
+def get_mhc_backend_name() -> str:
+    """Expose the selected backend for diagnostics and operator tests."""
+    return "aiter" if _get_aiter_mhc_ops() is not None else "torch"
+
+
+def _apply_optional_rms_norm(
+    layer_input: torch.Tensor,
+    norm_weight: torch.Tensor | None,
+    norm_eps: float,
+) -> torch.Tensor:
+    """Match the optional norm fused into vLLM's TileLang MHC pre output."""
+    if norm_weight is None:
+        return layer_input
+
+    layer_input_fp32 = layer_input.float()
+    normalized = layer_input_fp32 * torch.rsqrt(
+        layer_input_fp32.square().mean(dim=-1, keepdim=True) + norm_eps
+    )
+    return (normalized * norm_weight.float()).to(layer_input.dtype)
+
+
+def mhc_pre_hygon(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run Hygon vLLM's AITER MHC-pre op or its ROCm reference fallback."""
+    del n_splits
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+    residual_flat = residual.reshape(-1, hc_mult, hidden_size)
+
+    aiter_ops = _get_aiter_mhc_ops()
+    if aiter_ops is not None:
+        pre_op, _ = aiter_ops
+        post_mix, comb_mix, layer_input = pre_op(
+            residual=residual_flat,
+            fn=fn,
+            mhc_scale=hc_scale,
+            mhc_base=hc_base,
+            rms_eps=rms_eps,
+            mhc_pre_eps=hc_pre_eps,
+            mhc_sinkhorn_eps=hc_sinkhorn_eps,
+            mhc_post_mult_value=hc_post_mult_value,
+            sinkhorn_repeat=sinkhorn_repeat,
+        )
+        post_mix = post_mix.view(*outer_shape, hc_mult, 1)
+        comb_mix = comb_mix.view(*outer_shape, hc_mult, hc_mult)
+        layer_input = layer_input.view(*outer_shape, hidden_size)
+    else:
+        from vllm.model_executor.kernels import mhc as mhc_kernels
+
+        post_mix, comb_mix, layer_input = mhc_kernels.mhc_pre_torch(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+        )
+    layer_input = _apply_optional_rms_norm(layer_input, norm_weight, norm_eps)
+    return post_mix, comb_mix, layer_input
+
+
+def mhc_post_hygon(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    """Run Hygon vLLM's AITER MHC-post op or its ROCm reference fallback."""
+    aiter_ops = _get_aiter_mhc_ops()
+    if aiter_ops is not None:
+        _, post_op = aiter_ops
+        hc_mult = residual.shape[-2]
+        hidden_size = residual.shape[-1]
+        outer_shape = residual.shape[:-2]
+        result = post_op(
+            x.reshape(-1, hidden_size).contiguous(),
+            residual.reshape(-1, hc_mult, hidden_size),
+            post_layer_mix.reshape(-1, hc_mult).contiguous(),
+            comb_res_mix.reshape(-1, hc_mult, hc_mult).contiguous(),
+        )
+        return result.view(*outer_shape, hc_mult, hidden_size)
+
+    from vllm.model_executor.kernels import mhc as mhc_kernels
+
+    return mhc_kernels.mhc_post_torch(x, residual, post_layer_mix, comb_res_mix)
+
+
+def mhc_fused_post_pre_hygon(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+    tile_n: int = 1,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Decompose fused post+pre using the validated Hygon ROCm math."""
+    del tile_n
+    residual_cur = mhc_post_hygon(
+        x,
+        residual,
+        post_layer_mix,
+        comb_res_mix,
+    )
+    post_mix, comb_mix, layer_input = mhc_pre_hygon(
+        residual_cur,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        n_splits,
+        norm_weight,
+        norm_eps,
+    )
+    return residual_cur, post_mix, comb_mix, layer_input

--- a/vllm_fl/dispatch/backends/vendor/hygon/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/patch.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Orchestrate categorized Hygon vLLM compatibility patches."""
+
+import logging
+
+from .patches.custom_ops import patch_custom_op_dispatch
+from .patches.models.deepseek_v4 import (
+    _hygon_has_cutedsl,
+    _install_compressed_tensors_scale_fallback,
+    _scale_inv_alias,
+    patch_compressed_tensors_scale_fallback,
+    patch_deepseek_v4_bf16_indexer_cache,
+    patch_deepseek_v4_cutedsl_selection,
+    patch_deepseek_v4_qnorm_rope_kv_insert,
+    patch_mhc_ops,
+    patch_sparse_attn_indexer,
+)
+from .patches.moe import patch_int8_moe_quant_scheme
+from .patches.native_ops import (
+    patch_moe_sum,
+    patch_topk_softplus_sqrt,
+)
+
+
+logger = logging.getLogger(__name__)
+_patches_applied = False
+
+
+def apply_hygon_patches() -> None:
+    """Install all Hygon operator, backend, and model patches once."""
+    global _patches_applied
+    if _patches_applied:
+        return
+
+    # Keep kernel-heavy modules lazy, matching the previous entry-point
+    # behavior and allowing package metadata to be inspected without Triton.
+    from .impl.attention.mla import patch_rocm_wo_a_int8_group_gemm
+    from vllm_fl.ops.native_ops_registry import register_native_ops
+
+    register_native_ops()
+    patch_rocm_wo_a_int8_group_gemm()
+
+    patch_custom_op_dispatch()
+    # patch_topk_softplus_sqrt()  # Managed by FL dispatch.
+    # patch_moe_sum()  # Replaced by the YAML-controlled native-op bridge.
+    patch_mhc_ops()
+    patch_deepseek_v4_cutedsl_selection()
+    patch_deepseek_v4_bf16_indexer_cache()
+    patch_deepseek_v4_qnorm_rope_kv_insert()
+    patch_sparse_attn_indexer()
+    patch_int8_moe_quant_scheme()
+    patch_compressed_tensors_scale_fallback()
+
+    _patches_applied = True
+    logger.info("Applied Hygon vLLM compatibility patches")
+
+
+# Compatibility exports for existing tests and downstream imports. New code
+# should import the public ``patch_*`` names from the categorized modules.
+_patch_custom_op_dispatch = patch_custom_op_dispatch
+_patch_topk_softplus_sqrt = patch_topk_softplus_sqrt
+_patch_moe_sum = patch_moe_sum
+_patch_mhc_ops = patch_mhc_ops
+_patch_deepseek_v4_cutedsl_selection = patch_deepseek_v4_cutedsl_selection
+_patch_deepseek_v4_bf16_indexer_cache = patch_deepseek_v4_bf16_indexer_cache
+_patch_deepseek_v4_qnorm_rope_kv_insert = patch_deepseek_v4_qnorm_rope_kv_insert
+_patch_sparse_attn_indexer = patch_sparse_attn_indexer
+_patch_int8_moe_quant_scheme = patch_int8_moe_quant_scheme
+_patch_compressed_tensors_scale_fallback = patch_compressed_tensors_scale_fallback
+
+
+__all__ = ["apply_hygon_patches"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/patches/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/patches/__init__.py
@@ -1,0 +1,1 @@
+"""Categorized Hygon compatibility patches."""

--- a/vllm_fl/dispatch/backends/vendor/hygon/patches/custom_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/patches/custom_ops.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Patches for vLLM CustomOp dispatch on the Hygon OOT platform."""
+
+import functools
+import importlib
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def patch_custom_op_dispatch() -> None:
+    """Prefer explicit FL OOT implementations over ROCm on Hygon.
+
+    Hygon reports both OOT and ROCm because it reuses vLLM's HIP control flow.
+    Upstream checks ROCm first, so select ``forward_oot`` only for explicitly
+    registered OOT classes that actually override it. Unregistered or disabled
+    CustomOps keep their upstream HIP/native fallback.
+    """
+    custom_op_mod = importlib.import_module("vllm.model_executor.custom_op")
+    custom_op_cls = custom_op_mod.CustomOp
+    original = custom_op_cls.dispatch_forward
+    if getattr(original, "_vllm_fl_hygon_oot_first", False):
+        return
+
+    @functools.wraps(original)
+    def _dispatch_forward_hygon_oot_first(self, compile_native: bool):
+        selected = original(self, compile_native)
+        platform = custom_op_mod.current_platform
+        if (
+            str(getattr(platform, "vendor_name", "")).lower() != "hygon"
+            or not platform.is_out_of_tree()
+        ):
+            return selected
+
+        registration_name = getattr(type(self), "name", None)
+        oot_cls = custom_op_mod.op_registry_oot.get(registration_name)
+        if oot_cls is None or not isinstance(self, oot_cls):
+            return selected
+        if type(self).forward_oot is custom_op_cls.forward_oot:
+            return selected
+
+        selected_func = getattr(selected, "__func__", None)
+        hip_func = getattr(self.forward_hip, "__func__", None)
+        if selected_func is not hip_func:
+            return selected
+        return self.forward_oot
+
+    _dispatch_forward_hygon_oot_first._vllm_fl_hygon_oot_first = True
+    _dispatch_forward_hygon_oot_first._vllm_fl_original = original
+    custom_op_cls.dispatch_forward = _dispatch_forward_hygon_oot_first
+    logger.info("Patched Hygon CustomOp dispatch to prefer explicit FL OOT ops")
+
+
+# Backward-compatible private name used by existing tests and callers.
+_patch_custom_op_dispatch = patch_custom_op_dispatch
+
+__all__ = ["patch_custom_op_dispatch"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/patches/models/__init__.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/patches/models/__init__.py
@@ -1,0 +1,1 @@
+"""Model-specific Hygon patches."""

--- a/vllm_fl/dispatch/backends/vendor/hygon/patches/models/deepseek_v4.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/patches/models/deepseek_v4.py
@@ -1,0 +1,537 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""DeepSeek-V4-specific Hygon model and attention compatibility patches."""
+
+import functools
+import importlib
+import logging
+from types import MethodType
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _patch_mhc_ops() -> None:
+    """Use the Hygon vLLM ROCm MHC correctness path.
+
+    vLLM 0.24's generic TileLang prenorm and fused-post-pre reductions assume
+    a 32-lane warp. Hygon vLLM either uses wave64 AITER operators or the
+    PyTorch ROCm definition. FL does not depend on the separate HCU plugin;
+    the implementation module discovers AITER directly and retains the same
+    PyTorch fallback. Fused post+pre is composed from those validated leaves.
+    """
+    mhc_layers = importlib.import_module("vllm.model_executor.layers.mhc")
+    mhc_impl = importlib.import_module(
+        "vllm_fl.dispatch.backends.vendor.hygon.impl.other.mhc"
+    )
+
+    pre_cls = mhc_layers.MHCPreOp
+    original_pre = pre_cls.forward_hip
+    if not getattr(original_pre, "_vllm_fl_hygon", False):
+
+        @functools.wraps(original_pre)
+        def _mhc_pre_hygon(
+            self,
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            n_splits=1,
+            norm_weight=None,
+            norm_eps=0.0,
+        ):
+            return mhc_impl.mhc_pre_hygon(
+                residual,
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+                n_splits,
+                norm_weight,
+                norm_eps,
+            )
+
+        _mhc_pre_hygon._vllm_fl_hygon = True
+        pre_cls.forward_hip = _mhc_pre_hygon
+
+    post_cls = mhc_layers.MHCPostOp
+    original_post = post_cls.forward_hip
+    if not getattr(original_post, "_vllm_fl_hygon", False):
+
+        @functools.wraps(original_post)
+        def _mhc_post_hygon(
+            self,
+            x,
+            residual,
+            post_layer_mix,
+            comb_res_mix,
+        ):
+            return mhc_impl.mhc_post_hygon(
+                x,
+                residual,
+                post_layer_mix,
+                comb_res_mix,
+            )
+
+        _mhc_post_hygon._vllm_fl_hygon = True
+        post_cls.forward_hip = _mhc_post_hygon
+
+    fused_cls = mhc_layers.MHCFusedPostPreOp
+    original_fused = fused_cls.forward_hip
+    if not getattr(original_fused, "_vllm_fl_hygon", False):
+
+        @functools.wraps(original_fused)
+        def _mhc_fused_post_pre_hygon(
+            self,
+            x,
+            residual,
+            post_layer_mix,
+            comb_res_mix,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            n_splits=1,
+            tile_n=1,
+            norm_weight=None,
+            norm_eps=0.0,
+        ):
+            return mhc_impl.mhc_fused_post_pre_hygon(
+                x,
+                residual,
+                post_layer_mix,
+                comb_res_mix,
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+                n_splits,
+                tile_n,
+                norm_weight,
+                norm_eps,
+            )
+
+        _mhc_fused_post_pre_hygon._vllm_fl_hygon = True
+        fused_cls.forward_hip = _mhc_fused_post_pre_hygon
+
+    logger.info("Patched DeepSeek-V4 MHC with Hygon AITER/reference ops")
+
+
+def _hygon_has_cutedsl() -> bool:
+    """CuTeDSL kernels in DeepSeek-V4 are NVIDIA-specific."""
+    return False
+
+
+def _patch_deepseek_v4_cutedsl_selection() -> None:
+    """Keep Hygon DeepSeek-V4 indexer/cache operations on Triton kernels.
+
+    Upstream imports ``has_cutedsl`` into these modules and uses package
+    presence alone to select NVIDIA CuTeDSL kernels.  A Hygon environment may
+    contain the ``cutlass`` Python package while lacking
+    ``vllm.vllm_flash_attn.cute``.  vllm_hcu uses the Triton FP8 indexer and
+    cache kernels instead, so override only the two module-local probes.
+    """
+    module_names = (
+        "vllm.models.deepseek_v4.common.ops.fused_indexer_q",
+        "vllm.models.deepseek_v4.common.ops.cache_utils",
+    )
+    for module_name in module_names:
+        module = importlib.import_module(module_name)
+        module.has_cutedsl = _hygon_has_cutedsl
+
+    logger.info("Disabled NVIDIA CuTeDSL DeepSeek-V4 ops on Hygon")
+
+
+def _patch_deepseek_v4_bf16_indexer_cache() -> None:
+    """Add the validated Hygon BF16 Lightning Indexer branch.
+
+    The main MLA/SWA cache remains controlled by ``--kv-cache-dtype``.  This
+    patch changes only the separate Lightning Indexer Q/K cache from
+    FP8+scale to BF16, then switches the compressor writer and Q RoPE output
+    to their BF16 ABIs.  The corresponding prefill/decode MQA flow is selected
+    later in :func:`_patch_sparse_attn_indexer` by inspecting the cache dtype.
+    """
+    import torch
+
+    bf16_impl = importlib.import_module(
+        "vllm_fl.dispatch.backends.vendor.hygon.impl.attention.bf16_indexer"
+    )
+    if not bf16_impl.use_bf16_indexer_cache():
+        logger.info("Hygon BF16 Lightning Indexer cache is disabled by environment")
+        return
+
+    attention_module = importlib.import_module("vllm.models.deepseek_v4.attention")
+    compressor_module = importlib.import_module("vllm.models.deepseek_v4.compressor")
+    common_q_module = importlib.import_module(
+        "vllm.models.deepseek_v4.common.ops.fused_indexer_q"
+    )
+
+    indexer_cls = attention_module.DeepseekV4Indexer
+    original_init = indexer_cls.__init__
+    if not getattr(original_init, "_vllm_fl_hygon_bf16_indexer", False):
+
+        @functools.wraps(original_init)
+        def _init_bf16_indexer(self, *args, **kwargs) -> None:
+            original_init(self, *args, **kwargs)
+            if self.use_fp4_kv:
+                raise AssertionError(
+                    "Hygon BF16 and MXFP4 Indexer caches are mutually exclusive"
+                )
+
+            # Cache allocation happens after model construction from this
+            # layer's KVCacheSpec, so changing the spec fields here is early
+            # enough and preserves the object references held by compressor
+            # and SparseAttnIndexer.
+            self.use_bf16_cache = True
+            self.k_cache.head_dim = self.head_dim
+            self.k_cache.dtype = torch.bfloat16
+            self.compressor.use_bf16_cache = True
+            self.indexer_op.use_bf16_cache = True
+
+        _init_bf16_indexer._vllm_fl_hygon_bf16_indexer = True
+        indexer_cls.__init__ = _init_bf16_indexer
+
+    original_q = attention_module.fused_indexer_q_rope_quant
+    if not getattr(original_q, "_vllm_fl_hygon_bf16_indexer", False):
+
+        @functools.wraps(original_q)
+        def _fused_indexer_q_rope_bf16(
+            positions,
+            index_q,
+            cos_sin_cache,
+            index_weights,
+            weights_softmax_scale,
+            weights_head_scale,
+            use_fp4=False,
+        ):
+            if use_fp4:
+                return original_q(
+                    positions,
+                    index_q,
+                    cos_sin_cache,
+                    index_weights,
+                    weights_softmax_scale,
+                    weights_head_scale,
+                    use_fp4=True,
+                )
+            return bf16_impl.fused_indexer_q_rope_bf16(
+                positions,
+                index_q,
+                cos_sin_cache,
+                index_weights,
+                weights_softmax_scale,
+                weights_head_scale,
+            )
+
+        _fused_indexer_q_rope_bf16._vllm_fl_hygon_bf16_indexer = True
+        attention_module.fused_indexer_q_rope_quant = _fused_indexer_q_rope_bf16
+        common_q_module.fused_indexer_q_rope_quant = _fused_indexer_q_rope_bf16
+
+    original_store = compressor_module.compress_norm_rope_store_triton
+    if not getattr(original_store, "_vllm_fl_hygon_bf16_indexer", False):
+
+        @functools.wraps(original_store)
+        def _compress_norm_rope_store_hygon(**kwargs) -> None:
+            kv_cache = kwargs["kv_cache"]
+            if kv_cache.dtype == torch.bfloat16:
+                bf16_impl.compress_norm_rope_store_bf16(**kwargs)
+                return
+            original_store(**kwargs)
+
+        _compress_norm_rope_store_hygon._vllm_fl_hygon_bf16_indexer = True
+        compressor_module.compress_norm_rope_store_triton = (
+            _compress_norm_rope_store_hygon
+        )
+
+    logger.info("Patched DeepSeek-V4 Lightning Indexer to use Hygon BF16 cache")
+
+
+def _patch_deepseek_v4_qnorm_rope_kv_insert() -> None:
+    """Use Hygon LightOp's 8-argument fused Q/KV insert ABI.
+
+    vLLM 0.24.0 added ``q_head_padded`` to its CUDA op and changed the result
+    from an in-place mutation to a returned padded Q tensor.  Hygon's ROCm
+    backend does not pad Q heads, while the validated LightOp kernel retains
+    the older 8-argument in-place ABI.  Call that kernel directly and return Q.
+    """
+    import torch
+
+    rocm_module = importlib.import_module("vllm.models.deepseek_v4.amd.rocm")
+    attention_cls = rocm_module.DeepseekV4ROCMAiterMLAAttention
+    original = attention_cls._fused_qnorm_rope_kv_insert
+    if getattr(original, "_vllm_fl_hygon", False):
+        return
+
+    @functools.wraps(original)
+    def _fused_qnorm_rope_kv_insert_hygon(
+        self,
+        q,
+        kv,
+        positions,
+        attn_metadata,
+    ):
+        if not isinstance(attn_metadata, dict):
+            return original(self, q, kv, positions, attn_metadata)
+
+        swa_kv_cache = self.swa_cache_layer.kv_cache
+        if swa_kv_cache.dtype != torch.uint8:
+            return original(self, q, kv, positions, attn_metadata)
+
+        swa_metadata = attn_metadata.get(self.swa_cache_layer.prefix)
+        if swa_metadata is None:
+            raise AssertionError("DeepSeek-V4 SWA metadata is missing")
+        if self.padded_heads != self.n_local_heads:
+            raise AssertionError(
+                "Hygon LightOp Q/KV insert requires unpadded ROCm Q heads"
+            )
+
+        try:
+            from lightop import op as lightop_op
+        except (ImportError, AttributeError) as exc:
+            raise RuntimeError(
+                "Hygon DeepSeek-V4 requires LightOp's "
+                "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert"
+            ) from exc
+
+        kernel = getattr(
+            lightop_op,
+            "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert",
+            None,
+        )
+        if kernel is None:
+            raise RuntimeError(
+                "The installed LightOp lacks "
+                "lightop.op.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert"
+            )
+
+        swa_kv_cache_2d = swa_kv_cache.view(swa_kv_cache.shape[0], -1)
+        kernel(
+            q,
+            kv,
+            swa_kv_cache_2d,
+            swa_metadata.slot_mapping,
+            positions.to(torch.int64),
+            self.rotary_emb.cos_sin_cache,
+            self.eps,
+            swa_metadata.block_size,
+        )
+        return q
+
+    _fused_qnorm_rope_kv_insert_hygon._vllm_fl_hygon = True
+    attention_cls._fused_qnorm_rope_kv_insert = _fused_qnorm_rope_kv_insert_hygon
+    logger.info("Patched DeepSeek-V4 fused Q/KV insert with Hygon LightOp")
+
+
+def _patch_sparse_attn_indexer() -> None:
+    """Route Hygon to vLLM's native ROCm indexer with FL operator leaves.
+
+    Keep the current metadata/workspace flow in this module.  Reuse the cache
+    quantization/gather Triton kernels already shipped in
+    ``vllm.v1.attention.ops.rocm_aiter_mla_sparse``, and replace only the
+    unavailable DeepGEMM/CUDA-extension leaves with FL's LightOp adapters.
+    This mirrors the Hygon selection rule without taking a runtime dependency
+    on the separate vllm_hcu plugin.
+    """
+    import torch
+
+    sparse_indexer = importlib.import_module(
+        "vllm.model_executor.layers.sparse_attn_indexer"
+    )
+    indexer_cls = sparse_indexer.SparseAttnIndexer
+    original = indexer_cls.forward_hip
+    if getattr(original, "_vllm_fl_hygon", False):
+        return
+
+    sparse_impl = importlib.import_module(
+        "vllm_fl.dispatch.backends.vendor.hygon.impl.attention.sparse_attn_indexer"
+    )
+    bf16_impl = importlib.import_module(
+        "vllm_fl.dispatch.backends.vendor.hygon.impl.attention.bf16_indexer"
+    )
+    sparse_impl.install_sparse_indexer_hygon_ops(sparse_indexer)
+
+    from vllm.utils.torch_utils import _encode_layer_name
+
+    @functools.wraps(original)
+    def _forward_hip_hygon(self, hidden_states, q_quant, k, weights):
+        if (
+            getattr(self, "use_bf16_cache", False)
+            or self.k_cache.kv_cache.dtype == torch.bfloat16
+        ):
+            if isinstance(q_quant, tuple) or q_quant.dtype != torch.bfloat16:
+                raise AssertionError(
+                    "Hygon BF16 Indexer cache requires a BF16 query tensor"
+                )
+            return bf16_impl.sparse_attn_indexer_bf16_hygon(
+                hidden_states,
+                _encode_layer_name(self.k_cache.prefix),
+                self.k_cache.kv_cache,
+                q_quant,
+                weights,
+                self.topk_tokens,
+                self.head_dim,
+                self.max_model_len,
+                self.max_total_seq_len,
+                self.topk_indices_buffer,
+            )
+
+        use_native_rocm = (
+            self.skip_k_cache_insert or not sparse_indexer.rocm_aiter_ops.is_enabled()
+        )
+        if not use_native_rocm:
+            return original(self, hidden_states, q_quant, k, weights)
+
+        if self.use_fp4_cache:
+            raise AssertionError("Hygon sparse indexer does not support FP4 cache")
+        if isinstance(q_quant, tuple):
+            raise AssertionError("Hygon sparse indexer expects FP8 q_quant")
+
+        return sparse_indexer.sparse_attn_indexer(
+            hidden_states,
+            _encode_layer_name(self.k_cache.prefix),
+            self.k_cache.kv_cache,
+            q_quant,
+            None,
+            k,
+            weights,
+            self.quant_block_size,
+            self.scale_fmt,
+            self.topk_tokens,
+            self.head_dim,
+            self.max_model_len,
+            self.max_total_seq_len,
+            self.topk_indices_buffer,
+            self.skip_k_cache_insert,
+            False,
+        )
+
+    _forward_hip_hygon._vllm_fl_hygon = True
+    indexer_cls.forward_hip = _forward_hip_hygon
+    logger.info("Patched DeepSeek-V4 sparse indexer with FL-only Hygon ops")
+
+
+def _scale_inv_alias(param_name: str) -> str | None:
+    """Return the FP8-style alias for an INT8 scale parameter name."""
+    if param_name.endswith(".weight_scale"):
+        return f"{param_name[: -len('.weight_scale')]}.weight_scale_inv"
+    if param_name.endswith("_weight_scale"):
+        return f"{param_name[: -len('_weight_scale')]}_weight_scale_inv"
+    return None
+
+
+def _install_compressed_tensors_scale_fallback(model_cls: type) -> None:
+    """Install a target-aware compressed-tensors scale-name fallback.
+
+    The upstream DeepSeek-V4 AMD mapper emits the FP8 name
+    ``weight_scale_inv`` for checkpoint keys ending in ``.scale``. W8A8 INT8
+    modules instead register ``weight_scale``. Keep the upstream name as the
+    first choice, and expose an ``*_inv`` alias only when the corresponding
+    non-inverse parameter exists and the inverse parameter does not.
+
+    Injecting aliases into the local ``params_dict`` built by upstream
+    ``load_weights`` avoids copying that version-sensitive method while still
+    covering stacked attention parameters, fused MoE expert parameters, and
+    ordinary parameters. The aliases exist only for the duration of loading.
+    """
+    original_load_weights = model_cls.load_weights
+    if getattr(original_load_weights, "_vllm_fl_hygon_scale_fallback", False):
+        return
+
+    original_init = model_cls.__init__
+
+    @functools.wraps(original_init)
+    def _init_hygon_scale_fallback(self, *args, **kwargs) -> None:
+        vllm_config = kwargs.get("vllm_config")
+        if vllm_config is None and args:
+            vllm_config = args[0]
+        original_init(self, *args, **kwargs)
+        self._vllm_fl_hygon_quant_config = getattr(vllm_config, "quant_config", None)
+
+    @functools.wraps(original_load_weights)
+    def _load_weights_hygon_scale_fallback(self, weights):
+        quant_config = getattr(self, "_vllm_fl_hygon_quant_config", None)
+        if quant_config is None or quant_config.get_name() != "compressed-tensors":
+            return original_load_weights(self, weights)
+
+        original_named_parameters = self.named_parameters
+        alias_to_actual: dict[str, str] = {}
+
+        def _named_parameters_with_scale_aliases(_self, *args, **kwargs):
+            parameters = list(original_named_parameters(*args, **kwargs))
+            existing_names = {name for name, _ in parameters}
+            yield from parameters
+
+            for actual_name, parameter in parameters:
+                alias = _scale_inv_alias(actual_name)
+                if alias is None or alias in existing_names:
+                    continue
+                alias_to_actual[alias] = actual_name
+                yield alias, parameter
+
+        had_instance_override = "named_parameters" in vars(self)
+        previous_override: Any = vars(self).get("named_parameters")
+        object.__setattr__(
+            self,
+            "named_parameters",
+            MethodType(_named_parameters_with_scale_aliases, self),
+        )
+        try:
+            loaded_params = original_load_weights(self, weights)
+        finally:
+            if had_instance_override:
+                object.__setattr__(self, "named_parameters", previous_override)
+            else:
+                object.__delattr__(self, "named_parameters")
+
+        if loaded_params is None:
+            return None
+        return {alias_to_actual.get(name, name) for name in loaded_params}
+
+    _load_weights_hygon_scale_fallback._vllm_fl_hygon_scale_fallback = True
+    model_cls.__init__ = _init_hygon_scale_fallback
+    model_cls.load_weights = _load_weights_hygon_scale_fallback
+
+
+def _patch_compressed_tensors_scale_fallback() -> None:
+    """Patch DeepSeek-V4 AMD loading without changing its global mapper."""
+    import vllm.models.deepseek_v4.amd.model as amd_model
+
+    _install_compressed_tensors_scale_fallback(amd_model.DeepseekV4Model)
+    logger.info("Patched DeepSeek-V4 compressed-tensors scale fallback for Hygon")
+
+
+# Public names are used by the central Hygon patch orchestrator. Keep the
+# private aliases above so existing downstream imports remain compatible.
+patch_mhc_ops = _patch_mhc_ops
+patch_deepseek_v4_cutedsl_selection = _patch_deepseek_v4_cutedsl_selection
+patch_deepseek_v4_bf16_indexer_cache = _patch_deepseek_v4_bf16_indexer_cache
+patch_deepseek_v4_qnorm_rope_kv_insert = _patch_deepseek_v4_qnorm_rope_kv_insert
+patch_sparse_attn_indexer = _patch_sparse_attn_indexer
+patch_compressed_tensors_scale_fallback = _patch_compressed_tensors_scale_fallback
+
+
+__all__ = [
+    "patch_compressed_tensors_scale_fallback",
+    "patch_deepseek_v4_bf16_indexer_cache",
+    "patch_deepseek_v4_cutedsl_selection",
+    "patch_deepseek_v4_qnorm_rope_kv_insert",
+    "patch_mhc_ops",
+    "patch_sparse_attn_indexer",
+]

--- a/vllm_fl/dispatch/backends/vendor/hygon/patches/moe.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/patches/moe.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Compatibility patches for vLLM's MoE backend selection."""
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def patch_int8_moe_quant_scheme() -> None:
+    """Allow compressed-tensors W8A8 INT8 MoE on Hygon ROCm."""
+    import vllm.model_executor.layers.fused_moe.experts.triton_moe as triton_moe
+    from vllm.model_executor.layers.quantization.utils.quant_utils import (
+        kInt8DynamicTokenSym,
+        kInt8StaticChannelSym,
+    )
+    from vllm.platforms import current_platform
+
+    original = triton_moe.TritonExperts._supports_quant_scheme
+
+    def _supports_quant_scheme_hygon(weight_key, activation_key) -> bool:
+        if original(weight_key, activation_key):
+            return True
+        return bool(
+            (weight_key, activation_key)
+            == (kInt8StaticChannelSym, kInt8DynamicTokenSym)
+            and str(getattr(current_platform, "vendor_name", "")).lower() == "hygon"
+            and current_platform.has_device_capability((7, 5))
+        )
+
+    triton_moe.TritonExperts._supports_quant_scheme = staticmethod(
+        _supports_quant_scheme_hygon
+    )
+    logger.info("Patched TritonExperts int8 MoE quant scheme for Hygon ROCm")
+
+
+_patch_int8_moe_quant_scheme = patch_int8_moe_quant_scheme
+
+__all__ = ["patch_int8_moe_quant_scheme"]

--- a/vllm_fl/dispatch/backends/vendor/hygon/patches/native_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/patches/native_ops.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Patches for missing ``_C``/``_moe_C`` native operator entry points."""
+
+import functools
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def patch_topk_softplus_sqrt() -> None:
+    """Replace unavailable ``_moe_C`` sqrt-softplus routing on Hygon."""
+    import vllm._custom_ops as custom_ops
+
+    original = custom_ops.topk_hash_softplus_sqrt
+    if getattr(original, "_vllm_fl_hygon", False):
+        return
+
+    from ..impl.native_ops.topk_softplus_sqrt import topk_softplus_sqrt_hygon
+
+    @functools.wraps(original)
+    def _topk_hash_softplus_sqrt_hygon(
+        topk_weights,
+        topk_indices,
+        token_expert_indices,
+        gating_output,
+        renormalize=False,
+        routed_scaling_factor=1.0,
+        e_score_correction_bias=None,
+        input_tokens=None,
+        hash_indices_table=None,
+    ) -> None:
+        topk_softplus_sqrt_hygon(
+            topk_weights,
+            topk_indices,
+            token_expert_indices,
+            gating_output,
+            renormalize,
+            routed_scaling_factor,
+            e_score_correction_bias,
+            input_tokens,
+            hash_indices_table,
+        )
+
+    _topk_hash_softplus_sqrt_hygon._vllm_fl_hygon = True
+    custom_ops.topk_hash_softplus_sqrt = _topk_hash_softplus_sqrt_hygon
+    logger.info("Patched topk_softplus_sqrt dispatch for Hygon")
+
+
+def patch_moe_sum() -> None:
+    """Replace unavailable ``_moe_C::moe_sum`` on Hygon."""
+    import vllm._custom_ops as custom_ops
+
+    original = custom_ops.moe_sum
+    if getattr(original, "_vllm_fl_hygon", False):
+        return
+
+    from ..impl.native_ops.moe_sum import moe_sum_hygon_out
+
+    @functools.wraps(original)
+    def _moe_sum_hygon(input, output) -> None:
+        moe_sum_hygon_out(input, output)
+
+    _moe_sum_hygon._vllm_fl_hygon = True
+    custom_ops.moe_sum = _moe_sum_hygon
+    logger.info("Patched moe_sum dispatch for Hygon")
+
+
+_patch_topk_softplus_sqrt = patch_topk_softplus_sqrt
+_patch_moe_sum = patch_moe_sum
+
+__all__ = [
+    "patch_moe_sum",
+    "patch_topk_softplus_sqrt",
+]

--- a/vllm_fl/dispatch/backends/vendor/hygon/register_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/hygon/register_ops.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Hygon backend operator registrations."""
+
+from __future__ import annotations
+
+import functools
+
+from vllm_fl.dispatch.types import OpImpl, BackendImplKind, BackendPriority
+
+
+def _bind_is_available(fn, is_available_fn):
+    """Wrap a function and bind _is_available for OpImpl.is_available()."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    wrapper._is_available = is_available_fn
+    return wrapper
+
+
+def register_builtins(registry) -> None:
+    """
+    Register Hygon vendor operator implementations.
+
+    Args:
+        registry: Registry to register into.
+    """
+    from .hygon import HygonBackend
+
+    backend = HygonBackend()
+    is_avail = backend.is_available
+
+    impls: list[OpImpl] = [
+        OpImpl(
+            op_name="silu_and_mul",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.silu_and_mul, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="silu_and_mul_native",
+            impl_id="vendor.hygon.native",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.silu_and_mul_native, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="gelu_and_mul",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.gelu_and_mul, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="rms_norm",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.rms_norm, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="rotary_embedding",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.rotary_embedding, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="attention_backend",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.attention_backend, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="moe_align_block_size",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.moe_align_block_size, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="moe_align_block_size_native",
+            impl_id="vendor.hygon.native",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.moe_align_block_size_native, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="moe_sum",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.moe_sum, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="dynamic_scaled_int8_quant",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.dynamic_scaled_int8_quant, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="topk_softmax",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.topk_softmax, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="topk_softplus_sqrt",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.topk_softplus_sqrt, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="invoke_fused_moe_triton_kernel",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.invoke_fused_moe_triton_kernel, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+        OpImpl(
+            op_name="grouped_topk",
+            impl_id="vendor.hygon",
+            kind=BackendImplKind.VENDOR,
+            fn=_bind_is_available(backend.grouped_topk, is_avail),
+            vendor="hygon",
+            priority=BackendPriority.VENDOR,
+        ),
+    ]
+
+    registry.register_many(impls)
+
+
+__all__ = [
+    "BackendImplKind",
+    "BackendPriority",
+    "OpImpl",
+    "_bind_is_available",
+    "register_builtins",
+]

--- a/vllm_fl/dispatch/config/hygon.yaml
+++ b/vllm_fl/dispatch/config/hygon.yaml
@@ -1,5 +1,5 @@
 # vLLM-FL Dispatch Configuration for hygon GPU
-# Auto-loaded when running on hygon hardware
+# Auto-loaded when running on hygons hardware
 
 # Preferred default backend type: flagos, vendor, reference
 prefer: flagos
@@ -26,8 +26,8 @@ strict: false
 #   - reference   : PyTorch reference implementation
 #   - vendor      : Any available vendor backend (auto-detected)
 #   - vendor:hygon : hygon-specific vendor backend
+
 op_backends:
-  # All operators: prioritize FlagGems (Triton), fallback to vendor, then reference
   attention_backend:
     - flagos
     - vendor:hygon
@@ -35,24 +35,133 @@ op_backends:
 
   rms_norm:
     - flagos
+    #- flagos
     - vendor:hygon
+    #- flagos
     - reference
 
   silu_and_mul:
     - flagos
+    #- flagos
     - vendor:hygon
+    #- flagos
+    - reference
+
+  gelu_and_mul:
+    - flagos
+    #- flagos
+    - vendor:hygon
+    #- flagos
     - reference
 
   rotary_embedding:
     - flagos
+    #- flagos
+    - vendor:hygon
+    #- flagos
+    - reference
+
+  moe_align_block_size:
+    - flagos
     - vendor:hygon
     - reference
 
-# FlagOS operator blacklist
-# Blacklist only ops that are known to have issues
+  moe_sum:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  dynamic_scaled_int8_quant:
+    - vendor:hygon
+    - flagos
+    - reference
+
+  topk_softmax:
+    - flagos
+    - vendor:hygon
+    - reference
+
+  # FlagGems' similarly named kernel was unstable in DeepSeek-V4 inference.
+  # Keep the validated Hygon PyTorch implementation as the explicit route.
+  topk_softplus_sqrt:
+    - vendor:hygon
+    - flagos
+    - reference
+
+  invoke_fused_moe_triton_kernel:
+    - vendor:hygon
+    - flagos
+  #  - vendor:hygon
+    - reference
+
+  grouped_topk:
+    - flagos
+    - vendor:hygon
+    - reference
+
+
 flagos_blacklist:
   - cat
+  - cat_out
 
+  - mm
+  - mm_out
+  - bmm
+  - bmm_out
+  - addmm
+  - addmm_out
+  - addmm_dtype
+  - addmm_dtype_out
+  - group_mm
+
+  - sum
+  - sum_out
+  - sum_dim
+  - sum_dim_out
+
+  - to_copy
+  - copy_
+
+  - zeros
+  - zeros_like
+  - zero
+  - zero_
+  - zero_out
+
+  - fill_scalar
+  - fill_tensor
+  - fill_scalar_
+  - fill_tensor_
+
+  - index
+  - index_select
+  - index_put
+  - index_put_
+  - _index_put_impl_
+
+  - gather
+  - scatter
+  - scatter_
+  - scatter_add_
+  - scatter_reduce
+  - scatter_reduce_
+  - scatter_reduce_out
+  - slice_scatter
+
+  # Graph-out prepare_inputs dynamic-shape small ops confirmed by hipprof:
+  # hipModuleGetFunction -> hipModuleLaunchKernel resolves to
+  # _index_jit_function, _to_copy_func_kernel_rank_1,
+  # _copy_kernel_kernel_rank_{1,2}, add_func_kernel_rank_1,
+  # and sub_func_tensor_scalar_kernel_rank_1. The add/sub kernels are
+  # shared by both functional and inplace FlagGems wrappers.
+  # Existing entries above already cover index/to_copy/copy_.
+  - add
+  - add_
+  - sub
+  - sub_
+  - exponential_
+  #- mul
+  #- mul_
 # OOT (Out-of-Tree) operator blacklist
 # These operators will NOT be registered as OOT replacements.
 # oot_blacklist:

--- a/vllm_fl/dispatch/manager.py
+++ b/vllm_fl/dispatch/manager.py
@@ -327,7 +327,7 @@ class OpManager:
             return cached
 
         candidates = self._compute_candidates(op_name, policy)
-        order = policy.per_op_order_dict.get(op_name) or self._default_order(policy)
+        order = policy.get_per_op_order(op_name) or self._default_order(policy)
 
         chosen: Optional[OpImpl] = None
         for token in order:
@@ -438,7 +438,7 @@ class OpManager:
             return cached
 
         candidates = self._compute_candidates(op_name, policy)
-        order = policy.per_op_order_dict.get(op_name) or self._default_order(policy)
+        order = policy.get_per_op_order(op_name) or self._default_order(policy)
 
         sorted_candidates: list[OpImpl] = []
         for token in order:

--- a/vllm_fl/dispatch/policy.py
+++ b/vllm_fl/dispatch/policy.py
@@ -86,10 +86,16 @@ class SelectionPolicy:
         return {k: list(v) for k, v in self.per_op_order}
 
     def get_per_op_order(self, op_name: str) -> Optional[List[str]]:
-        """Get order for a specific operator."""
+        """Get an exact order, then let internal native variants inherit it."""
         for name, order in self.per_op_order:
             if name == op_name:
                 return list(order)
+
+        if op_name.endswith("_native"):
+            base_name = op_name.removesuffix("_native")
+            for name, order in self.per_op_order:
+                if name == base_name:
+                    return list(order)
         return None
 
     def get_default_order(self) -> List[str]:

--- a/vllm_fl/ops/_C_ops_schemas.py
+++ b/vllm_fl/ops/_C_ops_schemas.py
@@ -24,7 +24,7 @@ SCHEMAS: list[str] = [
     'rms_norm(Tensor! result, Tensor input, Tensor weight, float epsilon) -> ()',
     'fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, float epsilon) -> ()',
     'fused_qk_norm_rope(Tensor! qkv, int num_heads_q, int num_heads_k, int num_heads_v, int head_dim, float eps, Tensor q_weight, Tensor k_weight, Tensor cos_sin_cache, bool is_neox, Tensor position_ids, int forced_token_heads_per_warp=-1) -> ()',
-    'fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(Tensor! q, Tensor kv, Tensor! k_cache, Tensor slot_mapping, Tensor position_ids, Tensor cos_sin_cache, float eps, int cache_block_size) -> ()',
+    'fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(Tensor q_in, Tensor kv, Tensor! k_cache, Tensor slot_mapping, Tensor position_ids, Tensor cos_sin_cache, int q_head_padded, float eps, int cache_block_size) -> Tensor',
     'apply_repetition_penalties_(Tensor! logits, Tensor prompt_mask, Tensor output_mask, Tensor repetition_penalties) -> ()',
     'top_k_per_row_prefill(Tensor logits, Tensor rowStarts, Tensor rowEnds, Tensor! indices, int numRows, int stride0, int stride1, int topK) -> ()',
     'top_k_per_row_decode(Tensor logits, int next_n, Tensor seq_lens, Tensor! indices, int numRows, int stride0, int stride1, int topK) -> ()',

--- a/vllm_fl/ops/custom_ops.py
+++ b/vllm_fl/ops/custom_ops.py
@@ -133,6 +133,9 @@ def register_oot_ops(whitelist: Optional[List[str]] = None) -> None:
     if "fused_moe" not in (blacklist or []):
         _patch_fused_moe_factory()
 
+    if str(getattr(current_platform, "vendor_name", "")).lower() == "hygon":
+        from vllm_fl.dispatch.backends.vendor.hygon.patch import apply_hygon_patches
+        apply_hygon_patches()
 
 def _patch_fused_moe_factory() -> None:
     """Replace the FusedMoE factory function with FusedMoEFL in all relevant

--- a/vllm_fl/ops/fused_moe/__init__.py
+++ b/vllm_fl/ops/fused_moe/__init__.py
@@ -1,5 +1,15 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 
-from vllm_fl.ops.fused_moe.layer import FusedMoEFL, UnquantizedFusedMoEMethodFL
+from vllm_fl.ops.fused_moe.layer import (
+    CompressedTensorsW8A8Int8MoEMethodFL,
+    FusedMoEFL,
+    RoutedExpertsFL,
+    UnquantizedFusedMoEMethodFL,
+)
 
-__all__ = ["FusedMoEFL", "UnquantizedFusedMoEMethodFL"]
+__all__ = [
+    "CompressedTensorsW8A8Int8MoEMethodFL",
+    "FusedMoEFL",
+    "RoutedExpertsFL",
+    "UnquantizedFusedMoEMethodFL",
+]

--- a/vllm_fl/ops/fused_moe/fused_moe_utils.py
+++ b/vllm_fl/ops/fused_moe/fused_moe_utils.py
@@ -89,6 +89,13 @@ def select_unquantized_moe_backend_oot(moe_config: FusedMoEConfig,
     if current_platform.is_tpu():
         return UnquantizedMoeBackend.TPU, None
 
+    if str(getattr(current_platform, "vendor_name", "")).lower() == "hygon":
+        from vllm_fl.dispatch.backends.vendor.hygon.impl.moe.triton_experts import (
+            HygonTritonExpertsFL,
+        )
+
+        return UnquantizedMoeBackend.TRITON, HygonTritonExpertsFL
+
     if current_platform.is_out_of_tree() and use_flaggems():
         return UnquantizedMoeBackend.TRITON, TritonExpertsFL
 

--- a/vllm_fl/ops/fused_moe/layer.py
+++ b/vllm_fl/ops/fused_moe/layer.py
@@ -8,13 +8,20 @@ import vllm.model_executor.layers.fused_moe as _fused_moe_pkg
 # infinitely.  Capturing it here breaks the cycle.
 _OrigFusedMoE = _fused_moe_pkg.FusedMoE
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
+from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
     UnquantizedFusedMoEMethod,
 )
+from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w8a8_int8 import (  # noqa: E501
+    CompressedTensorsW8A8Int8MoEMethod,
+)
 
 from vllm_fl.ops.fused_moe.router import replace_router_with_fl
-from .fused_moe_utils import select_unquantized_moe_backend_oot
+from .fused_moe_utils import (
+    TritonExpertsFL,
+    select_unquantized_moe_backend_oot,
+)
 
 
 class UnquantizedFusedMoEMethodFL(UnquantizedFusedMoEMethod):
@@ -36,27 +43,81 @@ class UnquantizedFusedMoEMethodFL(UnquantizedFusedMoEMethod):
         return self.moe_kernel.is_monolithic
 
 
+class CompressedTensorsW8A8Int8MoEMethodFL(
+    CompressedTensorsW8A8Int8MoEMethod
+):
+    """FL W8A8 INT8 method preserving the upstream weight/scale lifecycle."""
+
+    def __init__(self, weight_quant, input_quant, moe, layer_name=None):
+        # Keep the official validation and INT8 backend oracle. In particular,
+        # create_weights(), process_weights_after_loading(), quant config
+        # construction, and apply() remain owned by the upstream method.
+        super().__init__(weight_quant, input_quant, moe, layer_name)
+
+        from vllm.platforms import current_platform
+
+        if str(getattr(current_platform, "vendor_name", "")).lower() == "hygon":
+            from vllm_fl.dispatch.backends.vendor.hygon.impl.moe.triton_experts import (
+                HygonTritonExpertsFL,
+            )
+
+            self.experts_cls = HygonTritonExpertsFL
+        elif current_platform.is_out_of_tree():
+            from vllm_fl.utils import use_flaggems
+
+            if use_flaggems():
+                self.experts_cls = TritonExpertsFL
+
+        # For non-OOT platforms, or when FlagGems is disabled, retain the
+        # experts class selected by the official INT8 backend oracle.
+
+
+class RoutedExpertsFL(RoutedExperts):
+    """Select FL MoE methods before RoutedExperts creates any weights."""
+
+    def _get_quant_method(self, prefix, quant_config, moe_config):
+        quant_method = super()._get_quant_method(prefix, quant_config, moe_config)
+
+        if isinstance(quant_method, CompressedTensorsW8A8Int8MoEMethod):
+            return CompressedTensorsW8A8Int8MoEMethodFL(
+                quant_method.weight_quant,
+                quant_method.input_quant,
+                moe_config,
+                layer_name=prefix,
+            )
+
+        if isinstance(quant_method, UnquantizedFusedMoEMethod):
+            return UnquantizedFusedMoEMethodFL(moe_config)
+
+        # Quantization schemes without a validated FL method retain the exact
+        # method selected by the upstream quantization config.
+        return quant_method
+
+
 def FusedMoEFL(*args, **kwargs) -> MoERunner:
     """
     OOT factory replacement for FusedMoE (vllm >= 0.24.0).
 
     In vllm 0.24.0, FusedMoE changed from a class to a factory function that
     returns a MoERunner instance.  FusedMoEFL mirrors this pattern: it
-    delegates to the standard FusedMoE() factory and then replaces the router
-    and quant_method on the returned MoERunner with FL-customised versions.
+    delegates to the standard FusedMoE() factory after injecting an FL
+    RoutedExperts class, then replaces the router implementation.
 
     Registration: op_registry_oot maps FusedMoE -> FusedMoEFL so that all
     MoE layers in a model use flaggems operators transparently.
     """
-    # 1. Build the standard MoERunner via the upstream factory.
+    # 1. Inject the FL RoutedExperts class before the upstream factory creates
+    #    the quant method and its weights. The factory has no direct
+    #    ``quant_method`` argument; ``routed_experts_cls`` is its supported
+    #    construction-time extension point.
+    if kwargs.get("routed_experts_cls") is None:
+        kwargs["routed_experts_cls"] = RoutedExpertsFL
+
+    # 2. Build the standard MoERunner via the upstream factory.
     #    Use _OrigFusedMoE (captured at import time, before monkey-patching)
     #    to avoid infinite recursion when custom_ops.py has already replaced
     #    _fused_moe_pkg.FusedMoE with FusedMoEFL.
     runner: MoERunner = _OrigFusedMoE(*args, **kwargs)
-
-    # 2. Replace quant_method with FL version.
-    fl_quant_method = UnquantizedFusedMoEMethodFL(runner.moe_config)
-    runner._replace_quant_method(fl_quant_method)
 
     # 3. Replace router _compute_routing with FL version via monkey-patch.
     #    replace_router_with_fl() patches the class method so the router
@@ -68,4 +129,9 @@ def FusedMoEFL(*args, **kwargs) -> MoERunner:
     return runner
 
 
-__all__ = ["FusedMoEFL", "UnquantizedFusedMoEMethodFL"]
+__all__ = [
+    "CompressedTensorsW8A8Int8MoEMethodFL",
+    "FusedMoEFL",
+    "RoutedExpertsFL",
+    "UnquantizedFusedMoEMethodFL",
+]

--- a/vllm_fl/ops/fused_moe/router.py
+++ b/vllm_fl/ops/fused_moe/router.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 # FL router subclasses that route ops through call_op dispatch.
 
-import torch
 from functools import partial
+
+import torch
 
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
@@ -16,12 +17,73 @@ from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
 )
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
     FusedTopKBiasRouter,
-    fused_topk_bias
+    fused_topk_bias,
 )
 from vllm_fl.dispatch import CachedOp
 
 _topk_softmax = CachedOp("topk_softmax")
 _grouped_topk = CachedOp("grouped_topk")
+_topk_softplus_sqrt = CachedOp("topk_softplus_sqrt")
+
+
+def _fl_topk_softplus_sqrt(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    routed_scaling_factor: float,
+    e_score_correction_bias: torch.Tensor | None,
+    input_tokens: torch.Tensor | None,
+    hash_indices_table: torch.Tensor | None,
+    indices_type: torch.dtype | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Route DeepSeek-V4 sqrt-softplus top-k through FL dispatch."""
+    assert hidden_states.size(0) == gating_output.size(0), (
+        "Number of tokens mismatch"
+    )
+
+    if indices_type is not None:
+        if input_tokens is not None and input_tokens.dtype != indices_type:
+            input_tokens = input_tokens.to(dtype=indices_type)
+        if (
+            hash_indices_table is not None
+            and hash_indices_table.dtype != indices_type
+        ):
+            hash_indices_table = hash_indices_table.to(dtype=indices_type)
+
+    num_tokens = hidden_states.size(0)
+    topk_weights = torch.empty(
+        num_tokens,
+        topk,
+        dtype=torch.float32,
+        device=hidden_states.device,
+    )
+    topk_ids = torch.empty(
+        num_tokens,
+        topk,
+        dtype=torch.int32 if indices_type is None else indices_type,
+        device=hidden_states.device,
+    )
+    token_expert_indices = torch.empty(
+        num_tokens,
+        topk,
+        dtype=torch.int32,
+        device=hidden_states.device,
+    )
+
+    _topk_softplus_sqrt(
+        topk_weights,
+        topk_ids,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+        routed_scaling_factor,
+        e_score_correction_bias,
+        input_tokens,
+        hash_indices_table,
+    )
+    return topk_weights, topk_ids
+
 
 def fused_topk(
     hidden_states: torch.Tensor,
@@ -228,7 +290,7 @@ class GroupedTopKRouterFL(GroupedTopKRouter):
 
 
 class FusedTopKBiasRouterFL(FusedTopKBiasRouter):
-    """FL router that routes topk_softmax (with bias) through call_op."""
+    """FL bias router with dispatch support for sqrt-softplus routing."""
 
     def _compute_routing(
         self,
@@ -238,22 +300,40 @@ class FusedTopKBiasRouterFL(FusedTopKBiasRouter):
         *,
         input_ids: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        correction_bias = (
+            self.e_score_correction_bias.data
+            if self.e_score_correction_bias is not None
+            else None
+        )
+
+        if self.scoring_func == "sqrtsoftplus":
+            return _fl_topk_softplus_sqrt(
+                hidden_states=hidden_states,
+                gating_output=router_logits,
+                topk=self.top_k,
+                renormalize=self.renormalize,
+                routed_scaling_factor=self.routed_scaling_factor,
+                e_score_correction_bias=correction_bias,
+                input_tokens=input_ids,
+                hash_indices_table=self._hash_indices_table,
+                indices_type=indices_type,
+            )
+
         topk_weights, topk_ids = fused_topk_bias(
             hidden_states=hidden_states,
             gating_output=router_logits,
-            e_score_correction_bias=self.e_score_correction_bias.data
-            if self.e_score_correction_bias is not None
-            else None,
+            e_score_correction_bias=correction_bias,
             topk=self.top_k,
             renormalize=self.renormalize,
             scoring_func=self.scoring_func,
             indices_type=indices_type,
+            input_tokens=input_ids,
+            hash_indices_table=self._hash_indices_table,
+            routed_scaling_factor=self.routed_scaling_factor,
         )
 
-        if self.routed_scaling_factor != 1.0:
-            topk_weights *= self.routed_scaling_factor
-
         return topk_weights, topk_ids
+
 
 def replace_router_with_fl() -> None:
     """Monkey-patch upstream router classes to their FL subclasses (in-place)."""

--- a/vllm_fl/ops/native_ops_registry.py
+++ b/vllm_fl/ops/native_ops_registry.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Route missing vLLM native kernels through the FL YAML dispatcher.
+
+Only native operator names in ``namespace::op`` form are supported.  The
+operator name after ``::`` is also used as the FL/YAML dispatch name.
+
+This registry only installs a bridge when an operator schema already exists
+and the requested device dispatch key has no implementation.  Schema fallback
+remains the responsibility of ``_C_ops_registry.py`` and
+``_C_ops_schemas.py``.  Existing implementations are retained and cannot be
+overridden through this mechanism.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+import torch
+
+
+_NATIVE_OPS = [
+    "_moe_C::moe_sum",
+    "_moe_C::moe_align_block_size",
+    "_moe_C::topk_softplus_sqrt",
+    "_C::silu_and_mul",
+    "_C::dynamic_scaled_int8_quant",
+]
+
+NATIVE_OP_SCHEMAS = {
+    "_moe_C::moe_sum": "moe_sum(Tensor input, Tensor! output) -> ()",
+    "_moe_C::moe_align_block_size": (
+        "moe_align_block_size(Tensor topk_ids, int num_experts, "
+        "int block_size, Tensor! sorted_token_ids, Tensor! experts_ids, "
+        "Tensor! num_tokens_post_pad, Tensor? maybe_expert_map) -> ()"
+    ),
+    "_moe_C::topk_softplus_sqrt": (
+        "topk_softplus_sqrt(Tensor! topk_weights, Tensor! topk_indices, "
+        "Tensor! token_expert_indices, Tensor gating_output, bool renormalize, "
+        "float routed_scaling_factor, Tensor? bias, Tensor? input_ids, "
+        "Tensor? tid2eid) -> ()"
+    ),
+    "_C::dynamic_scaled_int8_quant": (
+        "dynamic_scaled_int8_quant(Tensor! result, Tensor input, "
+        "Tensor! scale, Tensor!? azp) -> ()"
+    ),
+    "_C::silu_and_mul": "silu_and_mul(Tensor! result, Tensor input) -> ()",
+}
+
+# Native operators are mapped to the FL dispatch name after ``::`` by default.
+# For example, ``_moe_C::moe_sum`` automatically dispatches to ``moe_sum`` and
+# therefore does not need an entry below.  Add an override only when the native
+# ABI differs from the existing logical FL operator, such as an out-parameter
+# interface versus a tensor-returning interface.  The dedicated ``*_native``
+# name keeps the two Python call signatures separate, while dispatch policy
+# lets it inherit the backend order configured for the logical base operator.
+_NATIVE_OP_DISPATCH_NAMES = {
+    "_C::silu_and_mul": "silu_and_mul_native",
+    "_moe_C::moe_align_block_size": "moe_align_block_size_native",
+}
+
+
+# Reuse the configured FL dispatch logger hierarchy.  Keeping this module under
+# ``vllm_fl.ops`` would leave its early INFO messages to the root logger, which
+# is not configured yet when native bridges are installed during startup.
+logger = logging.getLogger("vllm_fl.dispatch.native_ops_registry")
+
+# torch.library registrations disappear when their Library object is released.
+_SCHEMA_LIBRARIES: dict[str, torch.library.Library] = {}
+_LIBRARIES: dict[tuple[str, str], torch.library.Library] = {}
+_REGISTERED: set[tuple[str, str]] = set()
+
+
+def _split_name(name: str) -> tuple[str, str]:
+    if name.count("::") != 1:
+        raise ValueError(
+            f"Native op name must have the form 'namespace::op', got {name!r}"
+        )
+
+    namespace, op = name.split("::")
+    if not namespace or not op:
+        raise ValueError(f"Invalid native op name: {name!r}")
+    return namespace, op
+
+
+def _schema_exists(name: str) -> bool:
+    try:
+        torch._C._dispatch_find_schema_or_throw(name, "")
+    except RuntimeError:
+        return False
+    return True
+
+
+def _has_kernel(name: str, dispatch_key: str) -> bool:
+    try:
+        return torch._C._dispatch_has_kernel_for_dispatch_key(name, dispatch_key)
+    except RuntimeError:
+        return False
+
+
+def _ensure_schema(name: str, namespace: str) -> None:
+    if _schema_exists(name):
+        return
+
+    schema = NATIVE_OP_SCHEMAS.get(name)
+    if schema is None:
+        raise RuntimeError(f"No bundled schema is available for native op {name}")
+
+    if namespace not in _SCHEMA_LIBRARIES:
+        _SCHEMA_LIBRARIES[namespace] = torch.library.Library(namespace, "FRAGMENT")
+    _SCHEMA_LIBRARIES[namespace].define(schema)
+    logger.info("Registered fallback schema for native op %s", name)
+
+
+def _get_library(namespace: str, dispatch_key: str) -> torch.library.Library:
+    key = (namespace, dispatch_key)
+    if key not in _LIBRARIES:
+        _LIBRARIES[key] = torch.library.Library(namespace, "IMPL", dispatch_key)
+    return _LIBRARIES[key]
+
+
+def _make_bridge(op: str):
+    def bridge(*args, **kwargs):
+        # Lazy import avoids a cycle during platform/schema initialization.
+        from vllm_fl.dispatch import call_op
+
+        return call_op(op, *args, **kwargs)
+
+    return bridge
+
+
+def register_native_op(name: str, dispatch_key: str = "CUDA") -> bool:
+    """Install one missing-kernel bridge; return whether it was installed."""
+    namespace, op = _split_name(name)
+    identity = (name, dispatch_key)
+    if identity in _REGISTERED:
+        return False
+
+    _ensure_schema(name, namespace)
+
+    if _has_kernel(name, dispatch_key):
+        logger.info(
+            "Keeping existing %s implementation for %s; native bridges only "
+            "handle missing kernels",
+            dispatch_key,
+            name,
+        )
+        return False
+
+    dispatch_name = _NATIVE_OP_DISPATCH_NAMES.get(name, op)
+    _get_library(namespace, dispatch_key).impl(op, _make_bridge(dispatch_name))
+    _REGISTERED.add(identity)
+    logger.info(
+        "Native op %s is now managed by FL dispatch as '%s'",
+        name,
+        dispatch_name,
+    )
+    return True
+
+
+def register_native_ops(
+    names: Iterable[str] | None = None,
+    dispatch_key: str = "CUDA",
+) -> tuple[str, ...]:
+    """Register the supplied names, or every entry in ``_NATIVE_OPS``."""
+    selected = tuple(names) if names is not None else tuple(_NATIVE_OPS)
+    return tuple(name for name in selected if register_native_op(name, dispatch_key))
+
+
+__all__ = [
+    "register_native_op",
+    "register_native_ops",
+]

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -76,12 +76,17 @@ class PlatformFL(Platform):
         if self.device_type == "musa":
             return True
         if self.vendor_name == "hygon":
-            return False
+            return True
         return self.device_type == "cuda"
 
     def is_cuda(self) -> bool:
         """Stateless version of [torch.cuda.is_available][]."""
         return self.device_type == "cuda" and self.vendor_name == "nvidia"
+        
+    def is_rocm(self) -> bool:
+        if self.vendor_name == "hygon":
+            return True
+        return False
 
     def is_musa(self) -> bool:
         if hasattr(torch, 'musa') and torch.musa.is_available():

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -501,6 +501,9 @@ class ModelRunnerFL(
         parallel_config = self.parallel_config
         self.device = device
         self.pin_memory = is_pin_memory_available()
+        self._use_hygon_rope_h2d_staging = (
+            str(getattr(current_platform, "vendor_name", "")).lower() == "hygon"
+        )
         self.dtype = self.model_config.dtype
 
         self.kv_cache_dtype = kv_cache_dtype_str_to_dtype(
@@ -824,6 +827,10 @@ class ModelRunnerFL(
             self.max_num_reqs, dtype=torch.int32
         )
 
+        # Hygon uses flat contiguous staging buffers because the active columns
+        # of the compile-stable RoPE buffers are intentionally non-contiguous.
+        self.mrope_positions_h2d_cpu: torch.Tensor | None = None
+        self.mrope_positions_h2d_gpu: torch.Tensor | None = None
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
             # NOTE: `mrope_positions` is implemented with one additional dummy
@@ -839,13 +846,39 @@ class ModelRunnerFL(
             self.mrope_positions = self._make_buffer(
                 (3, self.max_num_tokens + 1), dtype=torch.int64
             )
+            if self._use_hygon_rope_h2d_staging:
+                self.mrope_positions_h2d_cpu = torch.empty(
+                    3 * self.max_num_tokens,
+                    dtype=torch.int64,
+                    device="cpu",
+                    pin_memory=self.pin_memory,
+                )
+                self.mrope_positions_h2d_gpu = torch.empty(
+                    3 * self.max_num_tokens,
+                    dtype=torch.int64,
+                    device=self.device,
+                )
 
         # Only relevant for models using XD-RoPE (e.g, HunYuan-VL)
+        self.xdrope_positions_h2d_cpu: torch.Tensor | None = None
+        self.xdrope_positions_h2d_gpu: torch.Tensor | None = None
         if self.uses_xdrope_dim > 0:
             # Similar to mrope but use assigned dimension number for RoPE, 4 as default.
             self.xdrope_positions = self._make_buffer(
                 (self.uses_xdrope_dim, self.max_num_tokens + 1), dtype=torch.int64
             )
+            if self._use_hygon_rope_h2d_staging:
+                self.xdrope_positions_h2d_cpu = torch.empty(
+                    self.uses_xdrope_dim * self.max_num_tokens,
+                    dtype=torch.int64,
+                    device="cpu",
+                    pin_memory=self.pin_memory,
+                )
+                self.xdrope_positions_h2d_gpu = torch.empty(
+                    self.uses_xdrope_dim * self.max_num_tokens,
+                    dtype=torch.int64,
+                    device=self.device,
+                )
 
         # None in the first PP rank. The rest are set after load_model.
         self.intermediate_tensors: IntermediateTensors | None = None
@@ -1990,11 +2023,19 @@ class ModelRunnerFL(
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
             self._calc_mrope_positions(scheduler_output)
+            if self._use_hygon_rope_h2d_staging:
+                self._pack_mrope_positions_for_hygon_h2d(
+                    total_num_scheduled_tokens
+                )
 
         # Calculate XD-RoPE positions.
         # Only relevant for models using XD-RoPE (e.g, HunYuan-VL)
         if self.uses_xdrope_dim > 0:
             self._calc_xdrope_positions(scheduler_output)
+            if self._use_hygon_rope_h2d_staging:
+                self._pack_xdrope_positions_for_hygon_h2d(
+                    total_num_scheduled_tokens
+                )
 
         # Get token indices.
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
@@ -2202,16 +2243,26 @@ class ModelRunnerFL(
 
         if self.uses_mrope:
             # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
-            self.mrope_positions.gpu[:, :total_num_scheduled_tokens].copy_(
-                self.mrope_positions.cpu[:, :total_num_scheduled_tokens],
-                non_blocking=True,
-            )
+            if self._use_hygon_rope_h2d_staging:
+                self._copy_mrope_positions_for_hygon_h2d(
+                    total_num_scheduled_tokens
+                )
+            else:
+                self.mrope_positions.gpu[:, :total_num_scheduled_tokens].copy_(
+                    self.mrope_positions.cpu[:, :total_num_scheduled_tokens],
+                    non_blocking=True,
+                )
         elif self.uses_xdrope_dim > 0:
             # Only relevant for models using XD-RoPE (e.g, HunYuan-VL)
-            self.xdrope_positions.gpu[:, :total_num_scheduled_tokens].copy_(
-                self.xdrope_positions.cpu[:, :total_num_scheduled_tokens],
-                non_blocking=True,
-            )
+            if self._use_hygon_rope_h2d_staging:
+                self._copy_xdrope_positions_for_hygon_h2d(
+                    total_num_scheduled_tokens
+                )
+            else:
+                self.xdrope_positions.gpu[:, :total_num_scheduled_tokens].copy_(
+                    self.xdrope_positions.cpu[:, :total_num_scheduled_tokens],
+                    non_blocking=True,
+                )
         if self.use_async_spec_decode and (self.uses_mrope or self.uses_xdrope_dim > 0):
             drift = self.num_computed_tokens[req_indices_gpu].to(
                 torch.int64
@@ -2710,6 +2761,52 @@ class ModelRunnerFL(
             dcp_world_size=self.dcp_world_size,
         )
         return common_prefix_len if use_cascade else 0
+
+    def _pack_mrope_positions_for_hygon_h2d(self, num_tokens: int) -> None:
+        assert self.mrope_positions_h2d_cpu is not None
+        packed = self.mrope_positions_h2d_cpu[: 3 * num_tokens].view(
+            3, num_tokens
+        )
+        packed.copy_(self.mrope_positions.cpu[:, :num_tokens])
+
+    def _copy_mrope_positions_for_hygon_h2d(self, num_tokens: int) -> None:
+        assert self._use_hygon_rope_h2d_staging
+        assert self.mrope_positions_h2d_cpu is not None
+        assert self.mrope_positions_h2d_gpu is not None
+        num_elements = 3 * num_tokens
+        packed_gpu = self.mrope_positions_h2d_gpu[:num_elements]
+        packed_gpu.copy_(
+            self.mrope_positions_h2d_cpu[:num_elements],
+            non_blocking=True,
+        )
+        self.mrope_positions.gpu[:, :num_tokens].copy_(
+            packed_gpu.view(3, num_tokens),
+            non_blocking=True,
+        )
+
+    def _pack_xdrope_positions_for_hygon_h2d(self, num_tokens: int) -> None:
+        assert self.xdrope_positions_h2d_cpu is not None
+        dim = self.uses_xdrope_dim
+        packed = self.xdrope_positions_h2d_cpu[: dim * num_tokens].view(
+            dim, num_tokens
+        )
+        packed.copy_(self.xdrope_positions.cpu[:, :num_tokens])
+
+    def _copy_xdrope_positions_for_hygon_h2d(self, num_tokens: int) -> None:
+        assert self._use_hygon_rope_h2d_staging
+        assert self.xdrope_positions_h2d_cpu is not None
+        assert self.xdrope_positions_h2d_gpu is not None
+        dim = self.uses_xdrope_dim
+        num_elements = dim * num_tokens
+        packed_gpu = self.xdrope_positions_h2d_gpu[:num_elements]
+        packed_gpu.copy_(
+            self.xdrope_positions_h2d_cpu[:num_elements],
+            non_blocking=True,
+        )
+        self.xdrope_positions.gpu[:, :num_tokens].copy_(
+            packed_gpu.view(dim, num_tokens),
+            non_blocking=True,
+        )
 
     def _calc_mrope_positions(self, scheduler_output: "SchedulerOutput"):
         mrope_pos_ptr = 0
@@ -3267,11 +3364,27 @@ class ModelRunnerFL(
 
         if should_sync_mrope_positions:
             self._calc_mrope_positions(scheduler_output)
-            self.mrope_positions.copy_to_gpu(total_num_scheduled_tokens)
+            if self._use_hygon_rope_h2d_staging:
+                self._pack_mrope_positions_for_hygon_h2d(
+                    total_num_scheduled_tokens
+                )
+                self._copy_mrope_positions_for_hygon_h2d(
+                    total_num_scheduled_tokens
+                )
+            else:
+                self.mrope_positions.copy_to_gpu(total_num_scheduled_tokens)
 
         if should_sync_xdrope_positions:
             self._calc_xdrope_positions(scheduler_output)
-            self.xdrope_positions.copy_to_gpu(total_num_scheduled_tokens)
+            if self._use_hygon_rope_h2d_staging:
+                self._pack_xdrope_positions_for_hygon_h2d(
+                    total_num_scheduled_tokens
+                )
+                self._copy_xdrope_positions_for_hygon_h2d(
+                    total_num_scheduled_tokens
+                )
+            else:
+                self.xdrope_positions.copy_to_gpu(total_num_scheduled_tokens)
 
         return mm_embeds, is_mm_embed
 


### PR DESCRIPTION
### PR Type

New Features

### Description

This PR adds Hygon backend support for DeepSeek-V4 on vLLM 0.24.0, including environments where vLLM is installed without compiled native `_C` / `_moe_C` kernels.

The main goals are:

1. Introduce a generic FL dispatch bridge for missing vLLM native operators.
2. Correctly expose Hygon as a CUDA-like, ROCm-compatible OOT platform.
3. Complete the FL FusedMoE integration for unquantized and W8A8 INT8 MoE.
4. Add a structured Hygon vendor backend for attention, MoE, native operators, CustomOps, and model-specific patches.
5. Extend the FlagGems backend with native out-parameter ABI implementations required by the new native-op registry.

Existing native kernels are preserved. The new registry installs an FL bridge only when the requested dispatch kernel is missing.

### Related Issues

Related to DeepSeek-V4 enablement on Hygon with vLLM 0.24.0.

### Changes

#### 1. Generic native operator registration and FL dispatch

Added `vllm_fl/ops/native_ops_registry.py` to handle direct vLLM native calls that cannot be intercepted by the existing `CustomOp.register_oot` mechanism.

This is required for call chains such as:

```text
vLLM Python code
    -> torch.ops._C.xxx / torch.ops._moe_C.xxx
    -> missing CUDA/HIP kernel in an empty vLLM installation
    -> NotImplementedError
```

The registry currently manages:

```text
_moe_C::moe_sum
_moe_C::moe_align_block_size
_moe_C::topk_softplus_sqrt
_C::silu_and_mul
_C::dynamic_scaled_int8_quant
```

Key behavior:

- Registers missing schemas through `torch.library` when required.
- Installs a dispatch bridge only when the native implementation is absent.
- Keeps existing vLLM CUDA/HIP implementations unchanged when they are available.
- Routes native calls into the normal FL `call_op()` dispatcher.
- Uses the operator name after `::` as the default FL dispatch name.

For example:

```text
_moe_C::moe_sum
    -> call_op("moe_sum", ...)
```

Operators whose native ABI differs from the existing logical FL ABI use dedicated internal names:

```text
_C::silu_and_mul
    -> silu_and_mul_native

_moe_C::moe_align_block_size
    -> moe_align_block_size_native
```

The dispatch policy allows `*_native` operators to inherit the YAML configuration of their logical base operators. Vendors therefore only need one configuration entry:

```yaml
silu_and_mul:
  - flagos
  - vendor:hygon
  - reference
```

This order controls both `silu_and_mul` and `silu_and_mul_native`. An explicit `silu_and_mul_native` entry can still override the inherited order when necessary.

This mechanism is vendor-neutral. Other OOT vendors can provide their own implementations and select them through YAML without adding operator-specific monkey patches.

#### 2. Hygon platform properties and CustomOp dispatch

Updated the Hygon platform properties so that it reports:

```text
is_cuda_alike() = True
is_rocm() = True
is_out_of_tree() = True
```

This reflects the actual Hygon runtime model:

- It uses CUDA-compatible PyTorch device semantics.
- It reuses vLLM ROCm/HIP control flow.
- It remains an FL out-of-tree platform and can use OOT operator registration.

vLLM normally checks `is_rocm()` before `is_out_of_tree()` in `CustomOp.dispatch_forward()`. Without additional handling, a Hygon CustomOp would select `forward_hip` before reaching an FL `forward_oot` implementation.

The Hygon CustomOp dispatch patch now:

- Prefers `forward_oot` only when an explicit Hygon/FL OOT implementation is registered.
- Keeps `forward_hip` for unregistered, disabled, or unsupported CustomOps.
- Does not change dispatch behavior for AMD ROCm or other platforms.

This provides the following Hygon behavior:

```text
Explicit FL OOT CustomOp
    -> forward_oot

No explicit FL OOT implementation
    -> forward_hip / upstream native path
```

#### 3. FusedMoE integration improvements

Improved `vllm_fl/ops/fused_moe` for the vLLM 0.24.0 factory-based FusedMoE architecture.

Main changes include:

- Added `RoutedExpertsFL` to select the FL quantization method before vLLM creates MoE weights.
- Injected `RoutedExpertsFL` through the official `routed_experts_cls` construction-time extension point.
- Preserved the upstream quantization method lifecycle instead of replacing the quantization method after weight creation.
- Added `CompressedTensorsW8A8Int8MoEMethodFL`.
- Kept the upstream `CompressedTensorsW8A8Int8MoEMethod` validation, weight creation, scale processing, quantization configuration, and apply lifecycle.
- Selected `HygonTritonExpertsFL` for Hygon W8A8 INT8 MoE.
- Retained `UnquantizedFusedMoEMethodFL` for BF16/unquantized MoE.
- Added Hygon-specific unquantized MoE backend selection.
- Added `FusedTopKBiasRouterFL` support for DeepSeek-V4 `sqrtsoftplus` routing.
- Routed `topk_softplus_sqrt` through FL dispatch.
- Preserved correction-bias selection semantics, hash-based routing, renormalization, and routed scaling.

Quantization schemes without a validated FL method continue to use the original method selected by upstream vLLM.

#### 4. Structured Hygon vendor backend

Added a dedicated Hygon backend under:

```text
vllm_fl/dispatch/backends/vendor/hygon/
```

The implementation is organized by responsibility:

```text
hygon/
├── impl/
│   ├── attention/
│   ├── custom_ops/
│   ├── moe/
│   ├── native_ops/
│   └── other/
├── patches/
│   └── models/
├── hygon.py
├── patch.py
└── register_ops.py
```

Added Hygon implementations and adaptations for:

- LightOp SiLU-and-multiply.
- LightOp RMSNorm.
- LightOp MoE block alignment.
- Hygon Triton dynamic symmetric INT8 quantization.
- Hygon BF16 MoE GEMM and reduction kernels.
- Hygon TritonExperts integration.
- DeepSeek-V4 BF16 Indexer cache.
- Sparse MLA attention and Indexer paths.
- DeepSeek-V4 MHC pre/post operations.
- DeepSeek-V4 model-specific compatibility patches.
- W8A8 INT8 scale-name compatibility.
- Hygon-specific M-RoPE/XD-RoPE H2D staging.

Cross-backend selection remains in `hygon.yaml`. Hygon implementations no longer contain internal FlagGems/reference fallback chains where a vendor implementation exists.

#### 5. FlagGems native ABI implementations

Extended the FlagGems backend to support the native out-parameter interfaces introduced by `native_ops_registry.py`.

Added:

```text
silu_and_mul_native
moe_align_block_size_native
```

The implementations are located in:

```text
vllm_fl/dispatch/backends/flaggems/impl/native_ops.py
```

They adapt existing FlagGems kernels to vLLM native ABIs:

```text
silu_and_mul_native(
    output,
    input,
) -> None

moe_align_block_size_native(
    topk_ids,
    num_experts,
    block_size,
    sorted_token_ids,
    expert_ids,
    num_tokens_post_pad,
    expert_map,
) -> None
```

The original high-level FlagGems implementations remain unchanged.

FlagGems registration strips the internal `_native` suffix when checking operator enablement, so one YAML entry controls both the logical and native ABI variants.

A PyTorch native out-ABI implementation was also added for `silu_and_mul_native` in the reference backend.

