### PR TITLE
[Kunlunxin] Fix inference problem with CUDAGraph enabled

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
@@ -736,6 +736,12 @@ class KunlunxinAttentionBackendImpl(AttentionImpl[KunlunxinMetadata]):
         query = query.view(-1, self.num_heads, self.head_size)
         if output is None:
             output = torch.empty_like(query)
+        if (
+            attn_metadata is not None
+            and getattr(attn_metadata, "num_actual_tokens", None) is not None
+            and attn_metadata.num_actual_tokens < output.shape[0]
+        ):
+            output[attn_metadata.num_actual_tokens:].zero_()
         if attn_metadata is None:
             # Profiling run.
 

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/patch.py
@@ -390,7 +390,7 @@ def patch_decode_attention():
             if max_window_size > 0:
                 window_left = max_window_size
                 window_right = 0
-
+            alpha = scale * (float(decode_query.shape[2]) ** 0.5)
             xtorch_ops.prefill_attention(
                 decode_query,
                 key_cache,
@@ -398,7 +398,7 @@ def patch_decode_attention():
                 decode_output,
                 is_causal=True,
                 is_prefix_cache=True,
-                alpha=scale,
+                alpha=alpha,
                 context_qlen_lod_cpu=query_start_loc_host,
                 context_qlen_lod_xpu=query_start_loc,
                 context_kvlen_lod_cpu=kv_prefix_start_loc_host,


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->

### PR Category

Vendor

### PR Type

Bug Fixes

### Description

Fix uninitialized padding output in Kunlunxin attention backend.

### Related Issues

<!-- N/A -->

### Changes

* Zero out the padding region of attention output.

### Testing

* Tested inference on Kunlunxin hardware.
* Fixed abnormal output during inference.