### PR TITLE
Arm: integrate Qwen packed W4A8 and GDN on CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In theory, vllm-plugin-FL can support all models available in vLLM, as long as n
 | Moore Threads | Supported | - |
 | Hygon | Supported | - |
 | Sunrise | Supported | - |
+| ARM64 CPU | Supported | - |
 
 ## Quick Start
 

--- a/tests/unit_tests/patches/test_arm_cpu_gdn.py
+++ b/tests/unit_tests/patches/test_arm_cpu_gdn.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+import torch
+
+from vllm_fl.patches.arm_cpu_gdn import (
+    apply_arm_cpu_gdn_state_indices_patch,
+)
+
+
+class _Builder:
+    def __init__(self, state_indices):
+        self.state_indices = state_indices
+
+    def build(self):
+        return SimpleNamespace(
+            non_spec_state_indices_tensor=self.state_indices,
+        )
+
+
+def test_patch_materializes_singleton_cpu_state_index_stride():
+    state_indices = torch.arange(8, dtype=torch.int32).reshape(1, 8)[:, 0]
+    assert state_indices.is_contiguous()
+    assert state_indices.stride() == (8,)
+
+    class Builder(_Builder):
+        pass
+
+    assert apply_arm_cpu_gdn_state_indices_patch(Builder) is True
+    metadata = Builder(state_indices).build()
+
+    assert metadata.non_spec_state_indices_tensor.tolist() == [0]
+    assert metadata.non_spec_state_indices_tensor.dtype == torch.int32
+    assert metadata.non_spec_state_indices_tensor.stride() == (1,)
+    assert metadata.non_spec_state_indices_tensor.data_ptr() != state_indices.data_ptr()
+
+
+def test_patch_is_idempotent_and_avoids_unnecessary_copy():
+    state_indices = torch.tensor([3, 5], dtype=torch.int32)
+
+    class Builder(_Builder):
+        pass
+
+    original = Builder.build
+    assert apply_arm_cpu_gdn_state_indices_patch(Builder) is True
+    patched = Builder.build
+    assert apply_arm_cpu_gdn_state_indices_patch(Builder) is False
+    assert Builder.build is patched
+    assert patched._vllm_fl_original is original
+
+    metadata = Builder(state_indices).build()
+    assert metadata.non_spec_state_indices_tensor is state_indices
+
+
+def test_patch_preserves_missing_state_indices():
+    class Builder(_Builder):
+        pass
+
+    assert apply_arm_cpu_gdn_state_indices_patch(Builder) is True
+    metadata = Builder(None).build()
+    assert metadata.non_spec_state_indices_tensor is None

--- a/tests/unit_tests/quantization/test_arm_cpu_w4a8.py
+++ b/tests/unit_tests/quantization/test_arm_cpu_w4a8.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+import platform
+import unittest
+from unittest.mock import patch
+
+import flag_gems
+import torch
+from compressed_tensors.config import CompressionFormat
+from compressed_tensors.quantization import QuantizationArgs
+
+from vllm_fl.quantization.arm_cpu_w4a8 import install_arm_cpu_packed_w4a8
+
+_IS_ARM_CPU_RUNTIME = (
+    platform.machine().lower() in {"aarch64", "arm64"}
+    and flag_gems.vendor_name == "arm"
+)
+
+
+@unittest.skipUnless(
+    _IS_ARM_CPU_RUNTIME,
+    "requires an ARM64 host with the FlagGems ARM CPU backend",
+)
+class TestArmCpuPackedW4A8(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from vllm.model_executor.kernels.linear.mixed_precision.dynamic_4bit import (
+            Dynamic4bitLinearKernel,
+        )
+        from vllm.model_executor.layers.quantization.compressed_tensors import (
+            compressed_tensors as config_module,
+        )
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+            compressed_tensors_w4a8_int as scheme_module,
+        )
+
+        cls.scheme_cls = scheme_module.CompressedTensorsW4A8Int
+        cls.config_cls = config_module.CompressedTensorsConfig
+        cls.kernel_cls = Dynamic4bitLinearKernel
+        cls.originals = {
+            "scheme_init": cls.scheme_cls.__init__,
+            "scheme_create_weights": cls.scheme_cls.create_weights,
+            "config_get_scheme": cls.config_cls._get_scheme_from_parts,
+            "kernel_process": cls.kernel_cls.process_weights_after_loading,
+            "kernel_apply": cls.kernel_cls.apply_weights,
+        }
+        cls.first_install = install_arm_cpu_packed_w4a8()
+
+    @classmethod
+    def tearDownClass(cls):
+        if not cls.first_install:
+            return
+
+        from vllm_fl.quantization import arm_cpu_w4a8 as adapter
+
+        cls.scheme_cls.__init__ = cls.originals["scheme_init"]
+        cls.scheme_cls.create_weights = cls.originals["scheme_create_weights"]
+        cls.config_cls._get_scheme_from_parts = cls.originals["config_get_scheme"]
+        cls.kernel_cls.process_weights_after_loading = cls.originals["kernel_process"]
+        cls.kernel_cls.apply_weights = cls.originals["kernel_apply"]
+        for owner, attribute in (
+            (cls.scheme_cls, "_vllm_fl_arm_packed_w4a8"),
+            (cls.scheme_cls, "_vllm_fl_arm_original_init"),
+            (cls.scheme_cls, "_vllm_fl_arm_original_create_weights"),
+            (cls.config_cls, "_vllm_fl_arm_original_get_scheme"),
+            (cls.kernel_cls, "_vllm_fl_arm_w4a8"),
+            (cls.kernel_cls, "_vllm_fl_arm_original_process"),
+            (cls.kernel_cls, "_vllm_fl_arm_original_apply"),
+        ):
+            if attribute in owner.__dict__:
+                delattr(owner, attribute)
+        adapter._INSTALLED = False
+
+    def test_installer_is_idempotent(self):
+        self.assertFalse(install_arm_cpu_packed_w4a8())
+
+    def test_packed_checkpoint_scheme_preserves_metadata(self):
+        from vllm.model_executor.layers.quantization.compressed_tensors import (
+            compressed_tensors as config_module,
+        )
+
+        config = object.__new__(config_module.CompressedTensorsConfig)
+        config.quant_format = CompressionFormat.pack_quantized.value
+        weight_quant = QuantizationArgs(
+            num_bits=4,
+            type="int",
+            symmetric=True,
+            group_size=128,
+            strategy="group",
+            dynamic=False,
+        )
+        input_quant = QuantizationArgs(
+            num_bits=8,
+            type="int",
+            symmetric=True,
+            strategy="token",
+            dynamic=True,
+        )
+
+        scheme = config._get_scheme_from_parts(
+            weight_quant,
+            input_quant,
+            format=CompressionFormat.pack_quantized.value,
+            layer_name="model.layers.0.linear_attn.in_proj_qkvz",
+        )
+        layer = torch.nn.Module()
+        with (
+            patch(
+                "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            patch(
+                "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+                return_value=1,
+            ),
+        ):
+            scheme.create_weights(
+                layer,
+                output_size=48,
+                input_size=5120,
+                output_partition_sizes=[48],
+                input_size_per_partition=5120,
+                params_dtype=torch.bfloat16,
+                weight_loader=lambda *args, **kwargs: None,
+            )
+
+        self.assertEqual(layer.weight_packed.shape, (48, 640))
+        self.assertEqual(layer.weight_packed.dtype, torch.int32)
+        self.assertEqual(layer.weight_scale.shape, (48, 40))
+        self.assertEqual(layer.weight_scale.dtype, torch.bfloat16)
+        self.assertEqual(layer.weight_shape.shape, (2,))
+        self.assertEqual(layer.weight_shape.dtype, torch.int64)
+        self.assertEqual(scheme.kernel.config.group_size, 128)
+        self.assertFalse(scheme.kernel.config.zero_points)
+        self.assertTrue(scheme.kernel._vllm_fl_arm_packed_checkpoint)
+
+        layer.weight_packed.data.zero_()
+        layer.weight_scale.data.fill_(0.01)
+        layer.weight_shape.data.copy_(torch.tensor([48, 5120]))
+        scheme.kernel.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.weight_packed.dtype, torch.uint8)
+        self.assertEqual(scheme.kernel._vllm_fl_arm_w4a8_shape, (48, 5120))
+        output = scheme.kernel.apply_weights(
+            layer,
+            torch.zeros((1, 5120), dtype=torch.bfloat16),
+        )
+        self.assertEqual(output.shape, (1, 48))
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertEqual(torch.count_nonzero(output).item(), 0)
+
+    def test_unpacked_checkpoint_keeps_stock_kernel_path(self):
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+            compressed_tensors_w4a8_int as scheme_module,
+        )
+
+        scheme = scheme_module.CompressedTensorsW4A8Int(
+            strategy="group",
+            num_bits=4,
+            group_size=128,
+            is_static_input_scheme=False,
+            input_symmetric=True,
+        )
+        layer = torch.nn.Module()
+        layer.bias = None
+        with (
+            patch(
+                "vllm.model_executor.parameter.get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            patch(
+                "vllm.model_executor.parameter.get_tensor_model_parallel_world_size",
+                return_value=1,
+            ),
+        ):
+            scheme.create_weights(
+                layer,
+                output_size=48,
+                input_size=5120,
+                output_partition_sizes=[48],
+                input_size_per_partition=5120,
+                params_dtype=torch.bfloat16,
+                weight_loader=lambda *args, **kwargs: None,
+            )
+
+        self.assertNotIn(
+            "_vllm_fl_arm_packed_checkpoint",
+            vars(scheme.kernel),
+        )
+        layer.weight_packed.data.zero_()
+        layer.weight_scale.data.fill_(0.01)
+        scheme.kernel.process_weights_after_loading(layer)
+        self.assertNotIn("_vllm_fl_arm_w4a8_shape", vars(scheme.kernel))
+
+    def test_packed_checkpoint_rejects_invalid_group_partition(self):
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+            compressed_tensors_w4a8_int as scheme_module,
+        )
+
+        scheme = scheme_module.CompressedTensorsW4A8Int(
+            strategy="group",
+            num_bits=4,
+            group_size=128,
+            is_static_input_scheme=False,
+            input_symmetric=True,
+            packed=True,
+        )
+        with self.assertRaisesRegex(ValueError, "not divisible"):
+            scheme.create_weights(
+                torch.nn.Module(),
+                output_size=48,
+                input_size=130,
+                output_partition_sizes=[48],
+                input_size_per_partition=130,
+                params_dtype=torch.bfloat16,
+                weight_loader=lambda *args, **kwargs: None,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/quantization/test_arm_cpu_w4a8.py
+++ b/tests/unit_tests/quantization/test_arm_cpu_w4a8.py
@@ -51,8 +51,6 @@ class TestArmCpuPackedW4A8(unittest.TestCase):
         if not cls.first_install:
             return
 
-        from vllm_fl.quantization import arm_cpu_w4a8 as adapter
-
         cls.scheme_cls.__init__ = cls.originals["scheme_init"]
         cls.scheme_cls.create_weights = cls.originals["scheme_create_weights"]
         cls.config_cls._get_scheme_from_parts = cls.originals["config_get_scheme"]
@@ -69,7 +67,6 @@ class TestArmCpuPackedW4A8(unittest.TestCase):
         ):
             if attribute in owner.__dict__:
                 delattr(owner, attribute)
-        adapter._INSTALLED = False
 
     def test_installer_is_idempotent(self):
         self.assertFalse(install_arm_cpu_packed_w4a8())

--- a/tests/unit_tests/test_arm_cpu_registration.py
+++ b/tests/unit_tests/test_arm_cpu_registration.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+import os
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock, patch
+
+import vllm_fl
+
+
+def _fake_vllm_platforms(cpu_platform="vllm.platforms.cpu.CpuPlatform"):
+    module = ModuleType("vllm.platforms")
+    module.cpu_platform_plugin = Mock(return_value=cpu_platform)
+    module.current_platform = SimpleNamespace(device_type="cpu")
+    return module
+
+
+class TestArmCpuRegistration(unittest.TestCase):
+    def test_arm_host_uses_vllm_cpu_platform(self):
+        platforms = _fake_vllm_platforms()
+        with (
+            patch("platform.machine", return_value="aarch64"),
+            patch.dict(sys.modules, {platforms.__name__: platforms}),
+        ):
+            self.assertEqual(
+                vllm_fl._arm_cpu_platform(),
+                "vllm.platforms.cpu.CpuPlatform",
+            )
+
+    def test_arm_cpu_register_uses_vllm_cpu_platform(self):
+        with (
+            patch.object(
+                vllm_fl,
+                "_arm_cpu_platform",
+                return_value="vllm.platforms.cpu.CpuPlatform",
+            ),
+            patch.object(vllm_fl, "_patch_custom_ops") as custom_ops,
+            patch.object(vllm_fl, "_patch_flash_attn_import") as flash_attn,
+            patch.object(vllm_fl, "_patch_transformers_compat") as transformers,
+        ):
+            self.assertEqual(
+                vllm_fl.register(),
+                "vllm.platforms.cpu.CpuPlatform",
+            )
+            custom_ops.assert_not_called()
+            flash_attn.assert_not_called()
+            transformers.assert_not_called()
+
+    def test_arm_target_requires_vllm_cpu_backend(self):
+        platforms = _fake_vllm_platforms(cpu_platform=None)
+        with (
+            patch("platform.machine", return_value="aarch64"),
+            patch.dict(sys.modules, {platforms.__name__: platforms}),
+        ):
+            self.assertIsNone(vllm_fl._arm_cpu_platform())
+
+    def test_arm64_gpu_build_preserves_existing_platform_registration(self):
+        platforms = _fake_vllm_platforms(cpu_platform=None)
+        with (
+            patch("platform.machine", return_value="aarch64"),
+            patch.dict(sys.modules, {platforms.__name__: platforms}),
+            patch.object(vllm_fl, "_patch_custom_ops") as custom_ops,
+            patch.object(vllm_fl, "_patch_flash_attn_import") as flash_attn,
+            patch.object(vllm_fl, "_patch_transformers_compat") as transformers,
+            patch.object(vllm_fl, "_get_op_config") as get_op_config,
+            patch(
+                "vllm_fl.patches.glm_moe_dsa.apply_platform_patches"
+            ) as platform_patches,
+            patch.dict(os.environ, {"VLLM_WORKER_MULTIPROC_METHOD": "spawn"}),
+        ):
+            self.assertEqual(vllm_fl.register(), "vllm_fl.platform.PlatformFL")
+
+        custom_ops.assert_called_once_with()
+        flash_attn.assert_called_once_with()
+        transformers.assert_called_once_with()
+        platform_patches.assert_called_once_with()
+        get_op_config.assert_called_once_with()
+
+    def test_arm64_gpu_model_registration_does_not_import_arm_cpu_hooks(self):
+        platforms = _fake_vllm_platforms(cpu_platform=None)
+        platforms.current_platform.device_type = "cuda"
+        adapter_module = ModuleType("vllm_fl.quantization.arm_cpu_w4a8")
+        adapter_module.install_arm_cpu_packed_w4a8 = Mock()
+        gdn_module = ModuleType("vllm_fl.patches.arm_cpu_gdn")
+        gdn_module.apply_arm_cpu_gdn_state_indices_patch = Mock()
+
+        with (
+            patch("platform.machine", return_value="aarch64"),
+            patch(
+                "vllm_fl.patches.qwen3_5_text.apply_qwen3_5_text_patches"
+            ) as qwen_compat,
+            patch("vllm_fl.patches.moe_sum.patch_vllm_moe_sum") as moe_sum,
+            patch.object(vllm_fl, "_arm_cpu_platform") as arm_cpu_platform,
+            patch.object(vllm_fl, "_register_flagcx_connector") as flagcx,
+            patch.object(vllm_fl, "register_quant_linear") as quant_linear,
+            patch.object(vllm_fl, "register_router") as router,
+            patch.dict(
+                sys.modules,
+                {
+                    adapter_module.__name__: adapter_module,
+                    gdn_module.__name__: gdn_module,
+                    platforms.__name__: platforms,
+                },
+            ),
+        ):
+            vllm_fl.register_model()
+
+        qwen_compat.assert_called_once_with()
+        arm_cpu_platform.assert_not_called()
+        gdn_module.apply_arm_cpu_gdn_state_indices_patch.assert_not_called()
+        adapter_module.install_arm_cpu_packed_w4a8.assert_not_called()
+        moe_sum.assert_called_once_with()
+        flagcx.assert_called_once_with()
+        quant_linear.assert_called_once_with()
+        router.assert_called_once_with()
+
+    def test_non_arm_cpu_build_is_not_selected(self):
+        platforms = _fake_vllm_platforms()
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch.dict(sys.modules, {platforms.__name__: platforms}),
+        ):
+            self.assertIsNone(vllm_fl._arm_cpu_platform())
+            platforms.cpu_platform_plugin.assert_not_called()
+
+    def test_arm_registration_enables_quant_runtime_without_mode_flags(self):
+        adapter_module = ModuleType("vllm_fl.quantization.arm_cpu_w4a8")
+        adapter_module.install_arm_cpu_packed_w4a8 = Mock()
+        platforms = _fake_vllm_platforms()
+
+        with (
+            patch(
+                "vllm_fl.patches.arm_cpu_gdn.apply_arm_cpu_gdn_state_indices_patch"
+            ) as gdn_compat,
+            patch(
+                "vllm_fl.patches.qwen3_5_text.apply_qwen3_5_text_patches"
+            ) as qwen_compat,
+            patch.object(vllm_fl, "_arm_cpu_platform", return_value=True),
+            patch("flag_gems.vendor_name", "arm"),
+            patch("vllm_fl.patches.moe_sum.patch_vllm_moe_sum") as moe_sum,
+            patch.dict(
+                sys.modules,
+                {
+                    adapter_module.__name__: adapter_module,
+                    platforms.__name__: platforms,
+                },
+            ),
+        ):
+            vllm_fl.register_model()
+
+        qwen_compat.assert_called_once_with()
+        gdn_compat.assert_called_once_with()
+        adapter_module.install_arm_cpu_packed_w4a8.assert_called_once_with()
+        moe_sum.assert_not_called()
+
+    def test_missing_flaggems_disables_packed_w4a8_integration(self):
+        platforms = _fake_vllm_platforms()
+
+        with (
+            self.assertLogs("vllm_fl", level="WARNING") as logs,
+            patch(
+                "vllm_fl.patches.arm_cpu_gdn.apply_arm_cpu_gdn_state_indices_patch"
+            ) as gdn_compat,
+            patch(
+                "vllm_fl.patches.qwen3_5_text.apply_qwen3_5_text_patches"
+            ) as qwen_compat,
+            patch.object(vllm_fl, "_arm_cpu_platform", return_value=True),
+            patch("vllm_fl.patches.moe_sum.patch_vllm_moe_sum") as moe_sum,
+            patch.dict(
+                sys.modules,
+                {
+                    "flag_gems": None,
+                    platforms.__name__: platforms,
+                },
+            ),
+        ):
+            vllm_fl.register_model()
+
+        qwen_compat.assert_called_once_with()
+        gdn_compat.assert_called_once_with()
+        moe_sum.assert_not_called()
+        self.assertIn("FlagGems is not installed", logs.output[0])
+
+    def test_non_arm_flaggems_vendor_is_reported(self):
+        platforms = _fake_vllm_platforms()
+
+        with (
+            self.assertLogs("vllm_fl", level="WARNING") as logs,
+            patch(
+                "vllm_fl.patches.arm_cpu_gdn.apply_arm_cpu_gdn_state_indices_patch"
+            ) as gdn_compat,
+            patch("vllm_fl.patches.qwen3_5_text.apply_qwen3_5_text_patches"),
+            patch.object(vllm_fl, "_arm_cpu_platform", return_value=True),
+            patch("flag_gems.vendor_name", "cuda"),
+            patch("vllm_fl.patches.moe_sum.patch_vllm_moe_sum") as moe_sum,
+            patch.dict(sys.modules, {platforms.__name__: platforms}),
+        ):
+            vllm_fl.register_model()
+
+        gdn_compat.assert_called_once_with()
+        moe_sum.assert_not_called()
+        self.assertIn("selected vendor 'cuda'", logs.output[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2025 BAAI. All rights reserved.
 
 import importlib
-import os
 import logging
+import os
 import sys
 
 # torch.float4_e2m1fn_x2 exists only in CUDA builds of PyTorch 2.7+.
@@ -18,12 +18,21 @@ else:
         _torch.float4_e2m1fn_x2 = _torch.uint8
 del _torch
 
+from . import version as version  # PyTorch-style: vllm_fl.version.git_version
 from vllm_fl.utils import get_op_config as _get_op_config
 
-from . import version as version  # PyTorch-style: vllm_fl.version.git_version
-
-
 logger = logging.getLogger(__name__)
+
+
+def _arm_cpu_platform() -> str | None:
+    """Return vLLM's CPU platform on AArch64 hosts, if available."""
+    import platform
+
+    if platform.machine().lower() not in {"aarch64", "arm64"}:
+        return None
+    from vllm.platforms import cpu_platform_plugin
+
+    return cpu_platform_plugin()
 
 
 def __getattr__(name):
@@ -97,6 +106,13 @@ def _patch_custom_ops():
 
 def register():
     """Register the FL platform."""
+    # PlatformFL is accelerator-shaped. For the standard FlagGems ARM target,
+    # preserve vLLM's stock CPU platform and install kernels in register_model().
+    arm_cpu_platform = _arm_cpu_platform()
+    if arm_cpu_platform is not None:
+        logger.info("[vllm_fl] ARM64 CPU target -> vLLM CPU platform")
+        return arm_cpu_platform
+
     _patch_custom_ops()
     _patch_flash_attn_import()
     _patch_transformers_compat()
@@ -144,6 +160,42 @@ def register_model():
     from vllm_fl.patches.qwen3_5_text import apply_qwen3_5_text_patches
 
     apply_qwen3_5_text_patches()
+
+    from vllm.platforms import current_platform
+    if current_platform.device_type == "cpu" and _arm_cpu_platform() is not None:
+        from vllm_fl.patches.arm_cpu_gdn import (
+            apply_arm_cpu_gdn_state_indices_patch,
+        )
+
+        apply_arm_cpu_gdn_state_indices_patch()
+
+        # FlagGems owns the generic Triton operator. This plugin owns vLLM's
+        # checkpoint metadata and kernel-lifecycle integration.
+        try:
+            import flag_gems
+        except ModuleNotFoundError as error:
+            if error.name != "flag_gems":
+                raise
+            logger.warning(
+                "[vllm_fl] FlagGems is not installed; ARM packed W4A8 "
+                "integration is disabled and other vLLM paths are unchanged"
+            )
+            return
+        if flag_gems.vendor_name != "arm":
+            logger.warning(
+                "[vllm_fl] FlagGems selected vendor %r, not 'arm'; ARM CPU "
+                "runtime integration was not installed",
+                flag_gems.vendor_name,
+            )
+            return
+
+        from vllm_fl.quantization.arm_cpu_w4a8 import (
+            install_arm_cpu_packed_w4a8,
+        )
+
+        install_arm_cpu_packed_w4a8()
+        return
+
     patch_vllm_moe_sum()
 
     _register_flagcx_connector()
@@ -155,6 +207,7 @@ def register_model():
     # Register GLM-5 (GlmMoeDsa) — config not yet upstream
     try:
         from vllm.transformers_utils.config import _CONFIG_REGISTRY
+
         from vllm_fl.configs.glm_moe_dsa import GlmMoeDsaConfig
         _CONFIG_REGISTRY["glm_moe_dsa"] = GlmMoeDsaConfig
 

--- a/vllm_fl/patches/arm_cpu_gdn.py
+++ b/vllm_fl/patches/arm_cpu_gdn.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Runtime compatibility for vLLM 0.24's CPU GDN metadata."""
+
+import logging
+from functools import wraps
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_PATCH_MARKER = "_vllm_fl_arm_cpu_gdn_state_indices_patch"
+
+
+def apply_arm_cpu_gdn_state_indices_patch(builder_cls=None) -> bool:
+    """Materialize dense CPU state indices returned by the GDN builder.
+
+    A singleton ``block_table[:, 0]`` view can report ``is_contiguous()`` while
+    retaining a stride larger than one. vLLM's native CPU GDN kernel requires
+    the last dimension to have stride one. The wrapper is a no-op for tensors
+    that already satisfy that contract and is safe to install repeatedly.
+    """
+    if builder_cls is None:
+        from vllm.v1.attention.backends.gdn_attn import (
+            GDNAttentionMetadataBuilder,
+        )
+
+        builder_cls = GDNAttentionMetadataBuilder
+
+    original = builder_cls.build
+    if getattr(original, _PATCH_MARKER, False):
+        return False
+
+    @wraps(original)
+    def build_with_dense_cpu_state_indices(self, *args, **kwargs):
+        metadata = original(self, *args, **kwargs)
+        state_indices = metadata.non_spec_state_indices_tensor
+        if (
+            state_indices is not None
+            and state_indices.device.type == "cpu"
+            and state_indices.ndim > 0
+            and state_indices.stride(-1) != 1
+        ):
+            metadata.non_spec_state_indices_tensor = state_indices.clone(
+                memory_format=torch.contiguous_format
+            )
+        return metadata
+
+    setattr(build_with_dense_cpu_state_indices, _PATCH_MARKER, True)
+    build_with_dense_cpu_state_indices._vllm_fl_original = original
+    builder_cls.build = build_with_dense_cpu_state_indices
+    logger.info("Installed ARM CPU GDN state-index compatibility for vLLM 0.24")
+    return True
+
+
+__all__ = ["apply_arm_cpu_gdn_state_indices_patch"]

--- a/vllm_fl/quantization/arm_cpu_w4a8.py
+++ b/vllm_fl/quantization/arm_cpu_w4a8.py
@@ -9,16 +9,11 @@ import threading
 import torch
 
 _INSTALL_LOCK = threading.Lock()
-_INSTALLED = False
 
 
 def install_arm_cpu_packed_w4a8() -> bool:
     """Teach vLLM 0.24 to retain packed W4 G128 checkpoint parameters."""
-    global _INSTALLED
     with _INSTALL_LOCK:
-        if _INSTALLED:
-            return False
-
         from compressed_tensors.compressors.pack_quantized.helpers import (
             unpack_from_int32,
         )
@@ -54,7 +49,6 @@ def install_arm_cpu_packed_w4a8() -> bool:
         if scheme_installed != kernel_installed:
             raise RuntimeError("incomplete ARM W4A8 runtime installation detected")
         if scheme_installed:
-            _INSTALLED = True
             return False
 
         original_init = scheme_cls.__init__
@@ -95,7 +89,7 @@ def install_arm_cpu_packed_w4a8() -> bool:
             **kwargs,
         ) -> None:
             if not getattr(self, "_vllm_fl_checkpoint_packed", False):
-                return original_create_weights(
+                original_create_weights(
                     self,
                     layer,
                     output_size,
@@ -106,6 +100,7 @@ def install_arm_cpu_packed_w4a8() -> bool:
                     weight_loader,
                     **kwargs,
                 )
+                return
 
             output_size_per_partition = sum(output_partition_sizes)
             row_parallel = input_size != input_size_per_partition
@@ -185,6 +180,7 @@ def install_arm_cpu_packed_w4a8() -> bool:
             # checkpoint path.  Stock vLLM W4A8 kernels must keep their
             # original loading and execution behavior.
             self.kernel._vllm_fl_arm_packed_checkpoint = True
+            return
 
         def get_scheme_from_parts(
             self,
@@ -218,11 +214,13 @@ def install_arm_cpu_packed_w4a8() -> bool:
 
         def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
             if not getattr(self, "_vllm_fl_arm_packed_checkpoint", False):
-                return original_process(self, layer)
+                original_process(self, layer)
+                return
 
             config = self.config
             if config.group_size != 128 or config.zero_points:
-                return original_process(self, layer)
+                original_process(self, layer)
+                return
 
             quantized = getattr(layer, self.w_q_name)
             scales = getattr(layer, self.w_s_name)
@@ -293,6 +291,7 @@ def install_arm_cpu_packed_w4a8() -> bool:
             if packed_checkpoint:
                 layer.weight_shape = None
             self._vllm_fl_arm_w4a8_shape = (n, k)
+            return
 
         def apply_weights(
             self,
@@ -337,5 +336,4 @@ def install_arm_cpu_packed_w4a8() -> bool:
         Dynamic4bitLinearKernel._vllm_fl_arm_w4a8 = True
         Dynamic4bitLinearKernel._vllm_fl_arm_original_process = original_process
         Dynamic4bitLinearKernel._vllm_fl_arm_original_apply = original_apply
-        _INSTALLED = True
         return True

--- a/vllm_fl/quantization/arm_cpu_w4a8.py
+++ b/vllm_fl/quantization/arm_cpu_w4a8.py
@@ -1,0 +1,341 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+
+"""Packed W4A8 checkpoint adapter for vLLM's ARM CPU linear kernels."""
+
+from __future__ import annotations
+
+import threading
+
+import torch
+
+_INSTALL_LOCK = threading.Lock()
+_INSTALLED = False
+
+
+def install_arm_cpu_packed_w4a8() -> bool:
+    """Teach vLLM 0.24 to retain packed W4 G128 checkpoint parameters."""
+    global _INSTALLED
+    with _INSTALL_LOCK:
+        if _INSTALLED:
+            return False
+
+        from compressed_tensors.compressors.pack_quantized.helpers import (
+            unpack_from_int32,
+        )
+        from compressed_tensors.config import CompressionFormat
+
+        from vllm.model_executor.kernels.linear import (
+            MPLinearLayerConfig,
+            choose_mp_linear_kernel,
+        )
+        from vllm.model_executor.kernels.linear.mixed_precision.dynamic_4bit import (
+            Dynamic4bitLinearKernel,
+        )
+        from vllm.model_executor.layers.quantization.compressed_tensors import (
+            compressed_tensors as config_module,
+        )
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+            compressed_tensors_w4a8_int as scheme_module,
+        )
+        from vllm.model_executor.layers.quantization.utils import replace_parameter
+        from vllm.model_executor.parameter import (
+            BasevLLMParameter,
+            ChannelQuantScaleParameter,
+            GroupQuantScaleParameter,
+            PackedvLLMParameter,
+        )
+
+        scheme_cls = scheme_module.CompressedTensorsW4A8Int
+        config_cls = config_module.CompressedTensorsConfig
+        scheme_installed = getattr(scheme_cls, "_vllm_fl_arm_packed_w4a8", False)
+        kernel_installed = getattr(
+            Dynamic4bitLinearKernel, "_vllm_fl_arm_w4a8", False
+        )
+        if scheme_installed != kernel_installed:
+            raise RuntimeError("incomplete ARM W4A8 runtime installation detected")
+        if scheme_installed:
+            _INSTALLED = True
+            return False
+
+        original_init = scheme_cls.__init__
+        original_create_weights = scheme_cls.create_weights
+        original_get_scheme = config_cls._get_scheme_from_parts
+        original_process = Dynamic4bitLinearKernel.process_weights_after_loading
+        original_apply = Dynamic4bitLinearKernel.apply_weights
+
+        def scheme_init(
+            self,
+            strategy: str,
+            num_bits: int,
+            group_size: int | None = None,
+            is_static_input_scheme: bool = False,
+            input_symmetric: bool = True,
+            packed: bool = False,
+        ) -> None:
+            original_init(
+                self,
+                strategy=strategy,
+                num_bits=num_bits,
+                group_size=group_size,
+                is_static_input_scheme=is_static_input_scheme,
+                input_symmetric=input_symmetric,
+            )
+            self._vllm_fl_checkpoint_packed = packed
+            self._vllm_fl_pack_factor = 32 // num_bits
+
+        def create_weights(
+            self,
+            layer: torch.nn.Module,
+            output_size: int,
+            input_size: int,
+            output_partition_sizes: list[int],
+            input_size_per_partition: int,
+            params_dtype: torch.dtype,
+            weight_loader,
+            **kwargs,
+        ) -> None:
+            if not getattr(self, "_vllm_fl_checkpoint_packed", False):
+                return original_create_weights(
+                    self,
+                    layer,
+                    output_size,
+                    input_size,
+                    output_partition_sizes,
+                    input_size_per_partition,
+                    params_dtype,
+                    weight_loader,
+                    **kwargs,
+                )
+
+            output_size_per_partition = sum(output_partition_sizes)
+            row_parallel = input_size != input_size_per_partition
+            effective_group_size = (
+                input_size_per_partition
+                if self.group_size == -1 and row_parallel
+                else input_size
+                if self.group_size == -1
+                else self.group_size
+            )
+            if input_size_per_partition % effective_group_size:
+                raise ValueError(
+                    f"input partition {input_size_per_partition} is not "
+                    f"divisible by W4 group size {effective_group_size}"
+                )
+
+            kernel_config = MPLinearLayerConfig(
+                full_weight_shape=(input_size, output_size),
+                partition_weight_shape=(
+                    input_size_per_partition,
+                    output_size_per_partition,
+                ),
+                weight_type=self.quant_type,
+                act_type=params_dtype,
+                group_size=effective_group_size,
+                zero_points=False,
+                has_g_idx=False,
+            )
+            kernel_type = choose_mp_linear_kernel(kernel_config)
+
+            weight = PackedvLLMParameter(
+                data=torch.empty(
+                    output_size_per_partition,
+                    input_size_per_partition // self._vllm_fl_pack_factor,
+                    dtype=torch.int32,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=weight_loader,
+                packed_factor=self._vllm_fl_pack_factor,
+                packed_dim=1,
+            )
+            layer.register_parameter("weight_packed", weight)
+
+            scale_args = {
+                "weight_loader": weight_loader,
+                "data": torch.empty(
+                    output_size_per_partition,
+                    input_size_per_partition // effective_group_size,
+                    dtype=params_dtype,
+                ),
+            }
+            if self.group_size == -1 and row_parallel:
+                weight_scale = ChannelQuantScaleParameter(
+                    output_dim=0, **scale_args
+                )
+            else:
+                weight_scale = GroupQuantScaleParameter(
+                    output_dim=0, input_dim=1, **scale_args
+                )
+            layer.register_parameter("weight_scale", weight_scale)
+            layer.register_parameter(
+                "weight_shape",
+                BasevLLMParameter(
+                    data=torch.empty(2, dtype=torch.int64),
+                    weight_loader=weight_loader,
+                ),
+            )
+            self.kernel = kernel_type(
+                kernel_config,
+                w_q_param_name="weight_packed",
+                w_s_param_name="weight_scale",
+                w_zp_param_name=None,
+                w_gidx_param_name=None,
+            )
+            # Limit the runtime hooks below to kernels created for the packed
+            # checkpoint path.  Stock vLLM W4A8 kernels must keep their
+            # original loading and execution behavior.
+            self.kernel._vllm_fl_arm_packed_checkpoint = True
+
+        def get_scheme_from_parts(
+            self,
+            weight_quant,
+            input_quant,
+            output_quant=None,
+            format: str | None = None,
+            layer_name: str | None = None,
+        ):
+            resolved_format = format if format is not None else self.quant_format
+            if (
+                resolved_format == CompressionFormat.pack_quantized.value
+                and self._is_dynamic_token_w4a8_int(weight_quant, input_quant)
+            ):
+                return scheme_cls(
+                    num_bits=weight_quant.num_bits,
+                    strategy=weight_quant.strategy,
+                    group_size=weight_quant.group_size,
+                    is_static_input_scheme=False,
+                    input_symmetric=input_quant.symmetric,
+                    packed=True,
+                )
+            return original_get_scheme(
+                self,
+                weight_quant,
+                input_quant,
+                output_quant=output_quant,
+                format=format,
+                layer_name=layer_name,
+            )
+
+        def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+            if not getattr(self, "_vllm_fl_arm_packed_checkpoint", False):
+                return original_process(self, layer)
+
+            config = self.config
+            if config.group_size != 128 or config.zero_points:
+                return original_process(self, layer)
+
+            quantized = getattr(layer, self.w_q_name)
+            scales = getattr(layer, self.w_s_name)
+            k, n = config.partition_weight_shape
+            packed_checkpoint = quantized.dtype == torch.int32 and quantized.shape == (
+                n,
+                k // 8,
+            )
+            if packed_checkpoint:
+                weight_shape = getattr(layer, "weight_shape", None)
+                if weight_shape is not None:
+                    loaded_shape = tuple(int(value) for value in weight_shape.tolist())
+                    if (
+                        len(loaded_shape) != 2
+                        or loaded_shape[1] != k
+                        or not 0 < loaded_shape[0] <= n
+                    ):
+                        raise RuntimeError(
+                            "unexpected packed-Q4 weight_shape: "
+                            f"loaded={loaded_shape}, expected=(*,{k})"
+                        )
+                quantized_nk = unpack_from_int32(
+                    quantized.detach(), 4, torch.Size((n, k))
+                ).contiguous()
+            else:
+                quantized_nk = quantized
+
+            if (
+                quantized_nk.dtype != torch.int8
+                or quantized_nk.shape != (n, k)
+                or scales.shape != (n, k // 128)
+            ):
+                raise RuntimeError("unexpected compressed-tensors G128 parameter shape")
+
+            from flag_gems.quantized_linear import pack_rhs_qsi4c128p
+
+            packed_weight = pack_rhs_qsi4c128p(
+                quantized_nk,
+                scales.detach().to(torch.bfloat16).contiguous(),
+            )
+            replace_parameter(
+                layer,
+                self.w_q_name,
+                torch.nn.Parameter(packed_weight, requires_grad=False),
+            )
+
+            source_alias = getattr(layer, "weight", None)
+            if (
+                self.w_q_name != "weight"
+                and source_alias is not None
+                and source_alias.untyped_storage().data_ptr()
+                == quantized.untyped_storage().data_ptr()
+            ):
+                replace_parameter(
+                    layer,
+                    "weight",
+                    torch.nn.Parameter(
+                        torch.empty(
+                            0,
+                            dtype=quantized.dtype,
+                            device=quantized.device,
+                        ),
+                        requires_grad=False,
+                    ),
+                )
+
+            setattr(layer, self.w_s_name, None)
+            if packed_checkpoint:
+                layer.weight_shape = None
+            self._vllm_fl_arm_w4a8_shape = (n, k)
+
+        def apply_weights(
+            self,
+            layer: torch.nn.Module,
+            input: torch.Tensor,
+            bias: torch.Tensor | None = None,
+        ) -> torch.Tensor:
+            shape = getattr(self, "_vllm_fl_arm_w4a8_shape", None)
+            if shape is None:
+                return original_apply(self, layer, input, bias)
+
+            from flag_gems.quantized_linear import w4a8_g128_linear
+
+            n, k = shape
+            source_dtype = input.dtype
+            input_bf16 = (
+                input if source_dtype == torch.bfloat16 else input.to(torch.bfloat16)
+            )
+            output = w4a8_g128_linear(
+                input_bf16.contiguous(),
+                getattr(layer, self.w_q_name),
+                n,
+                k,
+            )
+            if source_dtype != torch.bfloat16:
+                output = output.to(source_dtype)
+            if bias is not None:
+                output = output + bias.to(output.dtype)
+            return output
+
+        scheme_cls.__init__ = scheme_init
+        scheme_cls.create_weights = create_weights
+        config_cls._get_scheme_from_parts = get_scheme_from_parts
+        Dynamic4bitLinearKernel.process_weights_after_loading = (
+            process_weights_after_loading
+        )
+        Dynamic4bitLinearKernel.apply_weights = apply_weights
+        scheme_cls._vllm_fl_arm_packed_w4a8 = True
+        scheme_cls._vllm_fl_arm_original_init = original_init
+        scheme_cls._vllm_fl_arm_original_create_weights = original_create_weights
+        config_cls._vllm_fl_arm_original_get_scheme = original_get_scheme
+        Dynamic4bitLinearKernel._vllm_fl_arm_w4a8 = True
+        Dynamic4bitLinearKernel._vllm_fl_arm_original_process = original_process
+        Dynamic4bitLinearKernel._vllm_fl_arm_original_apply = original_apply
+        _INSTALLED = True
+        return True


### PR DESCRIPTION
## Summary

This PR adds an ARM CPU integration path for Qwen packed W4A8-G128 checkpoints on vLLM 0.24 and a narrowly scoped compatibility fix for Qwen GDN metadata.

It keeps the generic W4A8 operator in FlagGems and limits this repository to vLLM platform registration, checkpoint metadata handling, and runtime integration.

Support Model: Minicpm5-2B, Minicpm5-1B

## Changes

- Reuse vLLM's built-in `CpuPlatform` on ARM64 when the installed vLLM package provides the CPU backend.
- Recognize `compressed-tensors` `pack-quantized` dynamic W4A8 checkpoints.
- Preserve packed INT4 weights, scales, and shape metadata during parameter creation.
- Convert packed checkpoint weights to the FlagGems W4A8-G128 runtime layout after loading.
- Dispatch packed W4A8 linear execution through the public FlagGems API.
- Materialize dense GDN state indices only when a CPU tensor has a non-unit last-dimension stride.
- Make all runtime hooks idempotent for vLLM's multi-process plugin lifecycle.

## Isolation from existing platforms

The ARM integration is installed only when all of the following are true:

- The host architecture is `arm64` or `aarch64`.
- vLLM selected its CPU platform.
- vLLM's CPU platform plugin is available.
- FlagGems selected the `arm` backend.

ARM64 hosts running CUDA or another accelerator build continue through the existing `PlatformFL` and model-registration paths. They do not import or install the ARM CPU GDN or W4A8 hooks.

The W4A8 hooks are also restricted to kernel instances created for packed checkpoints. Existing non-packed vLLM W4A8 checkpoints continue to use the original PyTorch/KleidiAI loading and execution path.

## FlagGems dependency

The packed W4A8 path depends on the public APIs introduced by the companion FlagGems change:

https://github.com/flagos-ai/FlagGems/compare/master...kevinzs2048:FlagGems:arm64-cpu-upstream

The plugin remains importable without activating this integration, but a packed W4A8 checkpoint requires the companion FlagGems implementation to run through this path.

## Validation

### Mac M5 Pro / macOS ARM64

- Python 3.11.16
- PyTorch 2.11.0
- vLLM 0.24.1.dev0
- Triton CPU 3.7.2
- Related tests: `16 passed`, `0 skipped`
- Loaded all Qwen3.8-27B W4A8 checkpoint shards and completed two consecutive short generation requests.

### CIX P1 / Linux AArch64

- Python 3.11.2
- PyTorch 2.11.0+cpu
- vLLM 0.24.0
- Triton CPU 3.7.2
- Related tests: `16 passed`, `0 skipped`

CIX P1 does not have the Qwen3.8-27B checkpoint, so full-model inference was not claimed there.

### Compatibility coverage

- ARM64 plus CUDA platform registration was simulated in unit tests.
- The accelerator registration path remained active.
- ARM CPU hooks were not imported or installed.
- ARM-only W4A8 tests skip on other backends and restore all patched vLLM methods after execution.
- Pre-commit checks passed for every file changed by this PR.

## Scope

Included:

- ARM CPU platform selection for a vLLM CPU build.
- Qwen packed W4A8-G128 checkpoint integration.
- CPU GDN stride compatibility.
- Focused registration, isolation, and quantization tests.

Depends-on: https://github.com/flagos-ai/FlagGems/pull/5904