### PR TITLE
fix(platform): stub torch.distributed._symmetric_memory for torch < 2.8

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -18,6 +18,23 @@ else:
         _torch.float4_e2m1fn_x2 = _torch.uint8
 del _torch
 
+# torch.distributed._symmetric_memory exists only in PyTorch 2.8+.
+# vllm.distributed.parallel_state imports it at module level, so vendor
+# torch builds < 2.8 (iluvatar corex on 2.7.x) die with ImportError before
+# engine start. vllm's later uses of the module are lazy, so an empty
+# pre-registered stub suffices to get past the import gate.
+import torch.distributed as _torch_distributed
+if not hasattr(_torch_distributed, "_symmetric_memory"):
+    import types as _types
+    _symm_mem_stub = _types.ModuleType("torch.distributed._symmetric_memory")
+    sys.modules["torch.distributed._symmetric_memory"] = _symm_mem_stub
+    # `import torch.distributed._symmetric_memory` resolves via sys.modules
+    # without setting the parent attribute; mirror it so attribute access
+    # and from-imports see the module too.
+    _torch_distributed._symmetric_memory = _symm_mem_stub
+    del _symm_mem_stub, _types
+del _torch_distributed
+
 from vllm_fl.utils import get_op_config as _get_op_config
 
 from . import version as version  # PyTorch-style: vllm_fl.version.git_version


### PR DESCRIPTION
## Summary

`vllm.distributed.parallel_state` imports `torch.distributed._symmetric_memory`
at module level (line 42), but that module only exists in PyTorch 2.8+.
Vendor torch builds on 2.7.x — iluvatar corex ships torch 2.7.1 — therefore
crash with `ImportError` before the engine core starts, in both the API-server
and spawned worker processes.

This PR pre-registers an empty stub module (plus a mirror of the name on the
`torch.distributed` parent package, since a bare `sys.modules` entry does not
set the parent attribute) whenever `torch.distributed._symmetric_memory` is
absent. All of vllm's runtime uses of the module are lazy (inside functions),
so the stub only needs to satisfy the module-level import gate; it is never
consulted on the verified greedy / sampling paths. The capability check keeps
PyTorch 2.8+ builds untouched.

This mirrors the existing module-top sentinel pattern already used for
`torch.float4_e2m1fn_x2` (`vllm_fl/__init__.py`).

## Notes

- Root-caused on-node: iluvatar-corex4.4.0 (torch 2.7.1 + corex), vllm 0.24.0
  app image, serve-gate crash at `vllm/distributed/parallel_state.py:42`.
  A container-level `try/except` around the import made serve fully green
  (greedy decode and temperature>0 sampling both clean).
- Deliberately not gated on a specific vendor: any torch build < 2.8 lacks the
  module, and the stub is a no-op where the module exists.

## Verification

Pending on-node: iluvatar-corex4.4.0 app image serve E2E with Qwen3-4B,
built from the PR-head wheel.

---

This PR was written in part with the assistance of generative AI.
