### PR TITLE
feat(dispatch): support appending FlagGems blacklist entries

### DIFF
--- a/tests/unit_tests/flaggems/test_gems_whitelist.py
+++ b/tests/unit_tests/flaggems/test_gems_whitelist.py
@@ -164,6 +164,41 @@ def test_get_flag_gems_whitelist_blacklist_blacklist_only(monkeypatch):
     assert blacklist == ["index", "index_put_"]
 
 
+def test_get_flag_gems_blacklist_append_preserves_platform_defaults(monkeypatch):
+    monkeypatch.delenv("VLLM_FL_FLAGOS_WHITELIST", raising=False)
+    monkeypatch.delenv("VLLM_FL_FLAGOS_BLACKLIST", raising=False)
+    monkeypatch.setenv("VLLM_FL_FLAGOS_BLACKLIST_APPEND", "linear,index")
+
+    with patch(
+        "vllm_fl.dispatch.config.get_flagos_blacklist",
+        return_value=["index", "copy_"],
+    ):
+        whitelist, blacklist = get_flag_gems_whitelist_blacklist()
+
+    assert whitelist is None
+    assert blacklist == ["index", "copy_", "linear"]
+
+
+def test_get_flag_gems_blacklist_append_extends_explicit_blacklist(monkeypatch):
+    monkeypatch.delenv("VLLM_FL_FLAGOS_WHITELIST", raising=False)
+    monkeypatch.setenv("VLLM_FL_FLAGOS_BLACKLIST", "linear")
+    monkeypatch.setenv("VLLM_FL_FLAGOS_BLACKLIST_APPEND", "index,linear")
+
+    whitelist, blacklist = get_flag_gems_whitelist_blacklist()
+    assert whitelist is None
+    assert blacklist == ["linear", "index"]
+
+
+def test_get_flag_gems_whitelist_ignores_blacklist_append(monkeypatch):
+    monkeypatch.setenv("VLLM_FL_FLAGOS_WHITELIST", "rms_norm")
+    monkeypatch.delenv("VLLM_FL_FLAGOS_BLACKLIST", raising=False)
+    monkeypatch.setenv("VLLM_FL_FLAGOS_BLACKLIST_APPEND", "linear,index")
+
+    whitelist, blacklist = get_flag_gems_whitelist_blacklist()
+    assert whitelist == ["rms_norm"]
+    assert blacklist is None
+
+
 def test_get_flag_gems_whitelist_blacklist_both_set_raises(monkeypatch):
     """When both whitelist and blacklist are set, ValueError is raised."""
     monkeypatch.setenv("VLLM_FL_FLAGOS_WHITELIST", "silu_and_mul")

--- a/vllm_fl/dispatch/README.md
+++ b/vllm_fl/dispatch/README.md
@@ -334,8 +334,9 @@ Environment variables can override specific items from platform config. If not s
 | `USE_FLAGGEMS` | `true` | Enable/disable FlagGems |
 | `VLLM_FL_FLAGOS_WHITELIST` | (none) | FlagGems ops whitelist (mutually exclusive with blacklist) |
 | `VLLM_FL_FLAGOS_BLACKLIST` | (none) | FlagGems ops blacklist (mutually exclusive with whitelist) |
+| `VLLM_FL_FLAGOS_BLACKLIST_APPEND` | (none) | Add exclusions without replacing the platform blacklist; ignored when a whitelist is active |
 
-**Priority**: `WHITELIST` > `BLACKLIST` (env) > `flagos_blacklist` (config file)
+**Priority**: `WHITELIST` > (`BLACKLIST` env or platform `flagos_blacklist`) + `BLACKLIST_APPEND`
 
 #### OOT Operator Control
 
@@ -379,6 +380,9 @@ export VLLM_FL_PREFER=vendor
 
 # Override FlagGems blacklist (overrides config file blacklist)
 export VLLM_FL_FLAGOS_BLACKLIST="mm,to_copy,zeros"
+
+# Keep platform defaults and add one deployment-specific exclusion
+export VLLM_FL_FLAGOS_BLACKLIST_APPEND="linear"
 
 # Use whitelist instead (completely ignores any blacklist)
 export VLLM_FL_FLAGOS_WHITELIST="silu_and_mul,rms_norm"
@@ -447,12 +451,16 @@ WHITELIST (env) ──▶ Completely overrides blacklist
                               └── Not set ──▶ Config file blacklist
                                                     │
                                                     └── Not set ──▶ Allow all
+
+BLACKLIST_APPEND (env) ──▶ Appended to the selected blacklist above
 ```
 
 **Important Notes:**
 - Whitelist and blacklist environment variables are mutually exclusive (error if both set)
 - If whitelist is set, it completely ignores any blacklist (env or config)
 - Environment blacklist overrides config file blacklist (not merged)
+- `VLLM_FL_FLAGOS_BLACKLIST_APPEND` retains the selected platform or explicit
+  blacklist while adding deployment-specific exclusions
 
 #### Example: Combined Environment Variables
 

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -125,9 +125,11 @@ def get_flag_gems_whitelist_blacklist() -> Tuple[
     1. VLLM_FL_FLAGOS_WHITELIST env var: Only these ops use FlagGems
     2. VLLM_FL_FLAGOS_BLACKLIST env var: These ops don't use FlagGems
     3. Platform config flagos_blacklist: Default blacklist from config file
+    4. VLLM_FL_FLAGOS_BLACKLIST_APPEND: Ops appended to the selected blacklist
 
     Note: VLLM_FL_FLAGOS_WHITELIST and VLLM_FL_FLAGOS_BLACKLIST cannot be set
-    simultaneously. If whitelist is set, it completely overrides any blacklist.
+    simultaneously. If whitelist is set, it completely overrides any blacklist,
+    including VLLM_FL_FLAGOS_BLACKLIST_APPEND.
 
     Returns:
         Tuple[Optional[list[str]], Optional[list[str]]]:
@@ -139,6 +141,7 @@ def get_flag_gems_whitelist_blacklist() -> Tuple[
     """
     whitelist_str = os.environ.get("VLLM_FL_FLAGOS_WHITELIST", "")
     blacklist_str = os.environ.get("VLLM_FL_FLAGOS_BLACKLIST", "")
+    blacklist_append_str = os.environ.get("VLLM_FL_FLAGOS_BLACKLIST_APPEND", "")
 
     # Check if both env vars are set (conflict)
     if whitelist_str and blacklist_str:
@@ -158,17 +161,28 @@ def get_flag_gems_whitelist_blacklist() -> Tuple[
     # Priority 2: Blacklist from env var
     if blacklist_str:
         blacklist = [op.strip() for op in blacklist_str.split(",") if op.strip()]
-        return None, blacklist
+    else:
+        # Priority 3: Blacklist from platform config
+        try:
+            from vllm_fl.dispatch.config import get_flagos_blacklist
 
-    # Priority 3: Blacklist from platform config
-    try:
-        from vllm_fl.dispatch.config import get_flagos_blacklist
+            config_blacklist = get_flagos_blacklist()
+            if config_blacklist:
+                blacklist = list(config_blacklist)
+        except Exception:
+            pass
 
-        config_blacklist = get_flagos_blacklist()
-        if config_blacklist:
-            blacklist = config_blacklist
-    except Exception:
-        pass
+    # Add deployment exclusions without replacing platform safety defaults.
+    # Preserve insertion order so startup logs and dispatch policy stay stable.
+    if blacklist_append_str:
+        if blacklist is None:
+            blacklist = []
+        seen = set(blacklist)
+        for op in blacklist_append_str.split(","):
+            op = op.strip()
+            if op and op not in seen:
+                blacklist.append(op)
+                seen.add(op)
 
     return whitelist, blacklist
 


### PR DESCRIPTION
### PR Category
Core

### PR Type
New Features | Improvements

### Description
Allow deployment-specific FlagGems exclusions to be appended without replacing the platform safety blacklist.

This keeps the existing whitelist and explicit-blacklist precedence while making it possible to add a small number of model or deployment exclusions on top of the selected blacklist.

### Related Issues
N/A

### Changes
- Add `VLLM_FL_FLAGOS_BLACKLIST_APPEND`.
- Append exclusions to either the explicit environment blacklist or the platform-configured blacklist.
- Preserve insertion order and remove duplicates.
- Keep whitelist precedence unchanged; append entries are ignored when a whitelist is active.
- Document the new policy and add focused unit coverage.

### Testing
- `ruff check --output-format=concise .`
- `ruff format --check .`
- `git diff --check origin/main...HEAD`
- Added unit cases for platform defaults, explicit blacklist extension, de-duplication, and whitelist precedence. Isolated CI execution is pending.

### Checklist
- [ ] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
