### PR TITLE
fix(dispatch): keep available reference fallbacks registered

### DIFF
--- a/tests/unit_tests/dispatch/test_builtin_ops.py
+++ b/tests/unit_tests/dispatch/test_builtin_ops.py
@@ -8,6 +8,7 @@ from vllm_fl.dispatch.builtin_ops import (
     _find_vendor_backend_dir,
     _register_vendor_backends,
 )
+from vllm_fl.dispatch.registry import OpRegistry
 
 
 class TestFindVendorBackendDir:
@@ -54,3 +55,33 @@ class TestRegisterVendorBackends:
             package="vllm_fl.dispatch",
         )
         module.register_builtins.assert_called_once_with(registry)
+
+
+def test_reference_registration_keeps_implemented_fallbacks():
+    """A missing optional method must not drop every reference fallback."""
+    from vllm_fl.dispatch.backends.reference.register_ops import (
+        register_builtins as register_reference,
+    )
+
+    registry = OpRegistry()
+    register_reference(registry)
+
+    implemented = {
+        "dynamic_per_token_quant_int8",
+        "silu_and_mul",
+        "gelu_and_mul",
+        "rms_norm",
+        "rotary_embedding",
+        "attention_backend",
+        "invoke_fused_moe_triton_kernel",
+    }
+    missing = {
+        "moe_align_block_size",
+        "moe_sum",
+        "topk_softmax",
+        "grouped_topk",
+    }
+    for op_name in implemented:
+        assert registry.get_implementation(op_name, "reference.torch") is not None
+    for op_name in missing:
+        assert registry.get_implementation(op_name, "reference.torch") is None

--- a/vllm_fl/dispatch/backends/reference/register_ops.py
+++ b/vllm_fl/dispatch/backends/reference/register_ops.py
@@ -36,108 +36,36 @@ def register_builtins(registry) -> None:
     backend = ReferenceBackend()
     is_avail = backend.is_available
 
-    impls = [
-        # Quantization
-        OpImpl(
-            op_name="dynamic_per_token_quant_int8",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(
-                backend.dynamic_per_token_quant_int8,
-                is_avail,
-            ),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # Activation
-        OpImpl(
-            op_name="silu_and_mul",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.silu_and_mul, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        OpImpl(
-            op_name="gelu_and_mul",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.gelu_and_mul, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # Normalization
-        OpImpl(
-            op_name="rms_norm",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.rms_norm, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # Rotary Embedding
-        OpImpl(
-            op_name="rotary_embedding",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.rotary_embedding, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # Attention Backend
-        OpImpl(
-            op_name="attention_backend",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.attention_backend, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # MoE align
-        OpImpl(
-            op_name="moe_align_block_size",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.moe_align_block_size, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # MoE sum
-        OpImpl(
-            op_name="moe_sum",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.moe_sum, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # topk softmax
-        OpImpl(
-            op_name="topk_softmax",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.topk_softmax, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # invoke fused moe triton kernel
-        OpImpl(
-            op_name="invoke_fused_moe_triton_kernel",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.invoke_fused_moe_triton_kernel, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # grouped topk
-        OpImpl(
-            op_name="grouped_topk",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.grouped_topk, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-    ]
+    # ReferenceBackend implements only part of the dispatch surface on some
+    # vLLM 0.24 builds. One absent optional MoE helper must not prevent all
+    # available PyTorch fallbacks from registering.
+    op_names = (
+        "dynamic_per_token_quant_int8",
+        "silu_and_mul",
+        "gelu_and_mul",
+        "rms_norm",
+        "rotary_embedding",
+        "attention_backend",
+        "moe_align_block_size",
+        "moe_sum",
+        "topk_softmax",
+        "invoke_fused_moe_triton_kernel",
+        "grouped_topk",
+    )
+    impls = []
+    for op_name in op_names:
+        fn = getattr(backend, op_name, None)
+        if fn is None:
+            continue
+        impls.append(
+            OpImpl(
+                op_name=op_name,
+                impl_id="reference.torch",
+                kind=BackendImplKind.REFERENCE,
+                fn=_bind_is_available(fn, is_avail),
+                vendor=None,
+                priority=BackendPriority.REFERENCE,
+            )
+        )
 
     registry.register_many(impls)


### PR DESCRIPTION
### PR Category
Core

### PR Type
Bug Fixes

### Description
Keep available PyTorch reference fallbacks registered when a vLLM 0.24 `ReferenceBackend` build does not implement every optional dispatch method.

Previously, eagerly accessing one absent optional MoE helper aborted the whole registration function and removed otherwise available reference implementations.

### Related Issues
N/A

### Changes
- Resolve each reference method with `getattr(..., None)`.
- Skip only methods that are not implemented by the active backend.
- Preserve implementation IDs, priority, availability checks, and registration behavior for implemented fallbacks.
- Add unit coverage for both retained and absent implementations.

### Testing
- `ruff check --output-format=concise .`
- `ruff format --check .`
- `git diff --check origin/main...HEAD`
- Added focused registration coverage; isolated CI execution is pending.
- The combined common branch containing this fix was exercised during H100 empty-build vLLM 0.24.0 bring-up for GLM5.3, Qwen4, and HY4.

### Checklist
- [ ] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
