### PR TITLE
fix(quantization): inherit native MXFP8 candidates for OOT

### DIFF
--- a/tests/unit_tests/quantization/test_w8a8_linear.py
+++ b/tests/unit_tests/quantization/test_w8a8_linear.py
@@ -83,6 +83,37 @@ def test_w8a8_linear_registration_keeps_native_fallback():
     ]
 
 
+def test_oot_quant_registry_inherits_mxfp8_candidates(monkeypatch):
+    from vllm.model_executor.kernels import linear as linear_kernels
+
+    from vllm_fl.quantization import quant_linear
+    from vllm_fl.quantization.w8a8 import moe, packed
+
+    candidate = object()
+    monkeypatch.setattr(
+        quant_linear,
+        "_resolve_source_platform",
+        lambda: PlatformEnum.CUDA,
+    )
+    monkeypatch.setitem(
+        linear_kernels._POSSIBLE_MXFP8_KERNELS,
+        PlatformEnum.CUDA,
+        [candidate],
+    )
+    monkeypatch.delitem(
+        linear_kernels._POSSIBLE_MXFP8_KERNELS,
+        PlatformEnum.OOT,
+        raising=False,
+    )
+    monkeypatch.setattr(linear, "register_fl_w8a8_linear_kernel", lambda _: True)
+    monkeypatch.setattr(moe, "install_fl_w8a8_moe_selector", lambda: None)
+    monkeypatch.setattr(packed, "install_packed_w8a8_scheme", lambda: None)
+
+    quant_linear.add_oot_quant_kernel()
+
+    assert linear_kernels._POSSIBLE_MXFP8_KERNELS[PlatformEnum.OOT] == [candidate]
+
+
 def test_w8a8_linear_uses_common_flaggems_policy(monkeypatch):
     monkeypatch.setattr(linear, "is_oot_enabled", lambda: True)
     policy_calls = []

--- a/vllm_fl/quantization/quant_linear.py
+++ b/vllm_fl/quantization/quant_linear.py
@@ -36,6 +36,7 @@ def add_oot_quant_kernel() -> None:
         _POSSIBLE_FP8_KERNELS,
         _POSSIBLE_INT8_KERNELS,
         _POSSIBLE_KERNELS,
+        _POSSIBLE_MXFP8_KERNELS,
     )
 
     source = _resolve_source_platform()
@@ -56,6 +57,14 @@ def add_oot_quant_kernel() -> None:
     if PlatformEnum.OOT not in _POSSIBLE_FP8_BLOCK_KERNELS:
         _POSSIBLE_FP8_BLOCK_KERNELS[PlatformEnum.OOT] = list(
             _POSSIBLE_FP8_BLOCK_KERNELS.get(source, [])
+        )
+
+    # ModelOpt MXFP8 has a separate registry from ordinary FP8. PlatformFL
+    # reports OOT even on NVIDIA, so inherit the native candidates, including
+    # the emulation fallback, without adding or reordering device kernels.
+    if PlatformEnum.OOT not in _POSSIBLE_MXFP8_KERNELS:
+        _POSSIBLE_MXFP8_KERNELS[PlatformEnum.OOT] = list(
+            _POSSIBLE_MXFP8_KERNELS.get(source, [])
         )
 
     # compressed-tensors selects its Linear and MoE implementations while the


### PR DESCRIPTION
### PR Category
Core

### PR Type
Bug Fixes

### Description
Make vLLM 0.24 ModelOpt MXFP8 linear selection work when FlagOS reports `PlatformEnum.OOT`.

MXFP8 uses a separate candidate registry from ordinary FP8. The existing OOT registration copied the generic, INT8, FP8, and block-FP8 lists but omitted the MXFP8 list.

### Related Issues
N/A

### Changes
- Inherit `_POSSIBLE_MXFP8_KERNELS` from the resolved native platform for `PlatformEnum.OOT`.
- Copy the candidate list without changing its order.
- Preserve an existing OOT registration and keep candidate-level capability filtering unchanged.
- Add focused unit coverage for the OOT MXFP8 registry.

### Testing
- `ruff check --output-format=concise .`
- `ruff format --check .`
- `git diff --check origin/main...HEAD`
- Added focused registry coverage; isolated CI execution is pending.
- The combined common branch was validated with the HY4 W8A8 checkpoint on H100 using the empty-build vLLM 0.24.0 wheel.

### Checklist
- [ ] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
