### PR TITLE
perf(worker): capture common attention metadata in accelerator graphs

### DIFF
--- a/tests/functional_tests/worker/test_common_attention_metadata_graph.py
+++ b/tests/functional_tests/worker/test_common_attention_metadata_graph.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.worker.block_table import MultiGroupBlockTable
 
 from vllm_fl.worker.common_attention_metadata import (
@@ -29,6 +30,10 @@ def _make_block_table(device: torch.device) -> MultiGroupBlockTable:
     )
     table.add_row(([2, 3, 4, 5], [6, 7]), 0)
     table.add_row(([8, 9, 10, 11], [12, 13]), 1)
+    # Simulate stale rows left by a previous larger batch. A real step commits
+    # only active rows; the metadata producer must clear the padded suffix.
+    table.add_row(([14, 15, 16, 17], [18, 19]), 2)
+    table.add_row(([20, 21, 22, 23], [24, 25]), 3)
     table.commit_block_table(4)
     return table
 
@@ -53,6 +58,21 @@ def _expected_slots(
                 )
         expected.append(result)
     return expected
+
+
+def _assert_zero_seq_rows_use_null_block(
+    table: MultiGroupBlockTable,
+    seq_lens: torch.Tensor,
+) -> None:
+    zero_rows = torch.nonzero(seq_lens == 0, as_tuple=False).flatten().cpu().tolist()
+    for group in table.block_tables:
+        for row in zero_rows:
+            torch.testing.assert_close(
+                group.block_table.gpu[row],
+                torch.full_like(group.block_table.gpu[row], NULL_BLOCK_ID),
+                rtol=0,
+                atol=0,
+            )
 
 
 def _assert_matches_vllm_slot_mapping(
@@ -138,12 +158,14 @@ def test_common_attention_metadata_graph_replay_uses_updated_metadata(
         rtol=0,
         atol=0,
     )
+    _assert_zero_seq_rows_use_null_block(table, seq_lens)
 
+    table.commit_block_table(3)
     query_start_loc.copy_(
-        torch.tensor([0, 1, 3, 3, 3], dtype=torch.int32, device=device)
+        torch.tensor([0, 1, 3, 4, 4], dtype=torch.int32, device=device)
     )
-    positions[:3].copy_(torch.tensor([3, 10, 11], dtype=torch.int64, device=device))
-    seq_lens.copy_(torch.tensor([7, 15, 0, 0], dtype=torch.int32, device=device))
+    positions[:4].copy_(torch.tensor([3, 10, 11, 2], dtype=torch.int64, device=device))
+    seq_lens.copy_(torch.tensor([7, 15, 9, 0], dtype=torch.int32, device=device))
     used_graph = runner.run(
         table,
         4,
@@ -163,10 +185,11 @@ def test_common_attention_metadata_graph_replay_uses_updated_metadata(
         torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
     torch.testing.assert_close(
         num_computed_tokens.cpu(),
-        torch.tensor([6, 13, 0, 0], dtype=torch.int32),
+        torch.tensor([6, 13, 8, 0], dtype=torch.int32),
         rtol=0,
         atol=0,
     )
+    _assert_zero_seq_rows_use_null_block(table, seq_lens)
 
 
 def test_common_attention_metadata_graph_off_runs_eager(
@@ -280,3 +303,51 @@ def test_common_attention_metadata_graph_unavailable_falls_back_to_eager(
         rtol=0,
         atol=0,
     )
+
+
+def test_common_attention_metadata_clears_long_context_padded_rows(
+    device: torch.device,
+) -> None:
+    num_groups = 8
+    num_reqs_padded = 64
+    num_actual_reqs = 62
+    table = MultiGroupBlockTable(
+        max_num_reqs=num_reqs_padded,
+        max_model_len=16512,
+        max_num_batched_tokens=16384,
+        pin_memory=False,
+        device=device,
+        block_sizes=[16] * num_groups,
+        kernel_block_sizes=[16] * num_groups,
+        max_num_blocks=[1025] * num_groups,
+    )
+    for group in table.block_tables:
+        group.block_table.cpu.fill_(1)
+    table.commit_block_table(num_reqs_padded)
+
+    query_start_loc = torch.arange(
+        num_reqs_padded + 1, dtype=torch.int32, device=device
+    )
+    query_start_loc[num_actual_reqs:].fill_(num_actual_reqs)
+    positions = torch.zeros(16384, dtype=torch.int64, device=device)
+    positions[:num_actual_reqs].fill_(16383)
+    seq_lens = torch.zeros(num_reqs_padded, dtype=torch.int32, device=device)
+    seq_lens[:num_actual_reqs].fill_(16384)
+    num_computed_tokens = torch.empty(num_reqs_padded, dtype=torch.int32, device=device)
+
+    compute_common_attention_metadata(
+        table,
+        num_reqs_padded,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+    )
+    current_platform.torch_device_fn.synchronize()
+
+    for group in table.block_tables:
+        assert torch.all(group.block_table.gpu[num_actual_reqs:] == NULL_BLOCK_ID)
+        assert torch.all(group.block_table.gpu[num_actual_reqs - 1] == 1)
+        assert torch.all(group.slot_mapping.gpu[num_actual_reqs:] == -1)
+    assert torch.all(num_computed_tokens[:num_actual_reqs] == 16383)
+    assert torch.all(num_computed_tokens[num_actual_reqs:] == 0)

--- a/tests/functional_tests/worker/test_common_attention_metadata_graph.py
+++ b/tests/functional_tests/worker/test_common_attention_metadata_graph.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.block_table import MultiGroupBlockTable
+
+from vllm_fl.worker.common_attention_metadata import (
+    CommonAttentionMetadataGraphRunner,
+    compute_common_attention_metadata,
+    supports_accelerator_graph,
+)
+
+pytestmark = pytest.mark.gpu
+
+
+def _make_block_table(device: torch.device) -> MultiGroupBlockTable:
+    table = MultiGroupBlockTable(
+        max_num_reqs=4,
+        max_model_len=64,
+        max_num_batched_tokens=16,
+        pin_memory=False,
+        device=device,
+        block_sizes=[4, 8],
+        kernel_block_sizes=[4, 8],
+        max_num_blocks=[16, 8],
+    )
+    table.add_row(([2, 3, 4, 5], [6, 7]), 0)
+    table.add_row(([8, 9, 10, 11], [12, 13]), 1)
+    table.commit_block_table(4)
+    return table
+
+
+def _expected_slots(
+    table: MultiGroupBlockTable,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+) -> list[torch.Tensor]:
+    query_start = query_start_loc.cpu().tolist()
+    pos = positions.cpu().tolist()
+    expected = []
+    for group in table.block_tables:
+        result = torch.full((group.max_num_batched_tokens,), -1, dtype=torch.int64)
+        block_table = group.block_table.cpu
+        for req_idx in range(len(query_start) - 1):
+            for token_idx in range(query_start[req_idx], query_start[req_idx + 1]):
+                token_pos = pos[token_idx]
+                block_id = block_table[req_idx, token_pos // group.block_size]
+                result[token_idx] = (
+                    block_id * group.block_size + token_pos % group.block_size
+                )
+        expected.append(result)
+    return expected
+
+
+def _assert_matches_vllm_slot_mapping(
+    table: MultiGroupBlockTable,
+    num_reqs: int,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+    seq_lens: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+) -> None:
+    num_tokens = int(query_start_loc[num_reqs].cpu())
+    table.compute_slot_mapping(
+        num_reqs,
+        query_start_loc,
+        positions[:num_tokens],
+    )
+    current_platform.torch_device_fn.synchronize()
+    expected_slots = [group.slot_mapping.gpu.clone() for group in table.block_tables]
+
+    compute_common_attention_metadata(
+        table,
+        num_reqs,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+    )
+    current_platform.torch_device_fn.synchronize()
+
+    for group, expected in zip(table.block_tables, expected_slots):
+        torch.testing.assert_close(group.slot_mapping.gpu, expected, rtol=0, atol=0)
+    query_lens = query_start_loc[1 : num_reqs + 1] - query_start_loc[:num_reqs]
+    torch.testing.assert_close(
+        num_computed_tokens,
+        seq_lens - query_lens,
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_common_attention_metadata_graph_replay_uses_updated_metadata(
+    device: torch.device,
+) -> None:
+    if not supports_accelerator_graph():
+        pytest.skip("Accelerator graph capture is unavailable")
+
+    table = _make_block_table(device)
+    runner = CommonAttentionMetadataGraphRunner()
+    query_start_loc = torch.tensor([0, 2, 4, 4, 4], dtype=torch.int32, device=device)
+    positions = torch.zeros(16, dtype=torch.int64, device=device)
+    positions[:4] = torch.tensor([0, 1, 8, 9], device=device)
+    seq_lens = torch.tensor([6, 12, 0, 0], dtype=torch.int32, device=device)
+    num_computed_tokens = torch.empty(4, dtype=torch.int32, device=device)
+
+    compute_common_attention_metadata(
+        table,
+        4,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+    )
+    used_graph = runner.run(
+        table,
+        4,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+        use_graph=True,
+        capture=True,
+    )
+    assert used_graph
+    current_platform.torch_device_fn.synchronize()
+    for actual, expected in zip(
+        (group.slot_mapping.gpu for group in table.block_tables),
+        _expected_slots(table, query_start_loc, positions),
+    ):
+        torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        num_computed_tokens.cpu(),
+        torch.tensor([4, 10, 0, 0], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+
+    query_start_loc.copy_(
+        torch.tensor([0, 1, 3, 3, 3], dtype=torch.int32, device=device)
+    )
+    positions[:3].copy_(torch.tensor([3, 10, 11], dtype=torch.int64, device=device))
+    seq_lens.copy_(torch.tensor([7, 15, 0, 0], dtype=torch.int32, device=device))
+    used_graph = runner.run(
+        table,
+        4,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+        use_graph=True,
+        capture=False,
+    )
+    assert used_graph
+    current_platform.torch_device_fn.synchronize()
+    for actual, expected in zip(
+        (group.slot_mapping.gpu for group in table.block_tables),
+        _expected_slots(table, query_start_loc, positions),
+    ):
+        torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        num_computed_tokens.cpu(),
+        torch.tensor([6, 13, 0, 0], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_common_attention_metadata_graph_off_runs_eager(
+    device: torch.device,
+) -> None:
+    table = _make_block_table(device)
+    runner = CommonAttentionMetadataGraphRunner()
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
+    positions = torch.zeros(16, dtype=torch.int64, device=device)
+    positions[:2] = torch.tensor([1, 9], dtype=torch.int64, device=device)
+    seq_lens = torch.tensor([5, 11], dtype=torch.int32, device=device)
+    num_computed_tokens = torch.empty(2, dtype=torch.int32, device=device)
+
+    used_graph = runner.run(
+        table,
+        2,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+        use_graph=False,
+        capture=False,
+    )
+    current_platform.torch_device_fn.synchronize()
+
+    assert not used_graph
+    assert runner.graphs == {}
+    for actual, expected in zip(
+        (group.slot_mapping.gpu for group in table.block_tables),
+        _expected_slots(table, query_start_loc, positions),
+    ):
+        torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        num_computed_tokens.cpu(),
+        torch.tensor([4, 10], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_common_attention_metadata_matches_vllm_with_hybrid_blocks_and_cp(
+    device: torch.device,
+) -> None:
+    table = MultiGroupBlockTable(
+        max_num_reqs=2,
+        max_model_len=64,
+        max_num_batched_tokens=16,
+        pin_memory=False,
+        device=device,
+        block_sizes=[8],
+        kernel_block_sizes=[4],
+        max_num_blocks=[8],
+        cp_kv_cache_interleave_size=2,
+    )
+    table.add_row(([2, 3, 4, 5],), 0)
+    table.add_row(([6, 7, 8, 9],), 1)
+    table.commit_block_table(2)
+    group = table.block_tables[0]
+    group.pcp_world_size = 2
+    group.pcp_rank = 1
+    group.dcp_world_size = 1
+    group.dcp_rank = 0
+
+    query_start_loc = torch.tensor([0, 4, 8], dtype=torch.int32, device=device)
+    positions = torch.zeros(16, dtype=torch.int64, device=device)
+    positions[:8] = torch.tensor(
+        [0, 2, 4, 6, 8, 10, 12, 14], dtype=torch.int64, device=device
+    )
+    seq_lens = torch.tensor([8, 18], dtype=torch.int32, device=device)
+    num_computed_tokens = torch.empty(2, dtype=torch.int32, device=device)
+
+    _assert_matches_vllm_slot_mapping(
+        table,
+        2,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+    )
+
+
+def test_common_attention_metadata_graph_unavailable_falls_back_to_eager(
+    device: torch.device,
+) -> None:
+    table = _make_block_table(device)
+    runner = CommonAttentionMetadataGraphRunner()
+    runner._graph_capture_supported = False
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
+    positions = torch.zeros(16, dtype=torch.int64, device=device)
+    positions[:2] = torch.tensor([1, 9], dtype=torch.int64, device=device)
+    seq_lens = torch.tensor([5, 11], dtype=torch.int32, device=device)
+    num_computed_tokens = torch.empty(2, dtype=torch.int32, device=device)
+
+    used_graph = runner.run(
+        table,
+        2,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+        use_graph=True,
+        capture=True,
+    )
+    current_platform.torch_device_fn.synchronize()
+
+    assert not used_graph
+    assert runner.graphs == {}
+    torch.testing.assert_close(
+        num_computed_tokens,
+        torch.tensor([4, 10], dtype=torch.int32, device=device),
+        rtol=0,
+        atol=0,
+    )

--- a/tests/functional_tests/worker/test_common_attention_metadata_graph.py
+++ b/tests/functional_tests/worker/test_common_attention_metadata_graph.py
@@ -239,19 +239,19 @@ def test_common_attention_metadata_matches_vllm_with_hybrid_blocks_and_cp(
         max_num_batched_tokens=16,
         pin_memory=False,
         device=device,
-        block_sizes=[8],
-        kernel_block_sizes=[4],
-        max_num_blocks=[8],
+        block_sizes=[8, 16],
+        kernel_block_sizes=[4, 8],
+        max_num_blocks=[8, 4],
         cp_kv_cache_interleave_size=2,
     )
-    table.add_row(([2, 3, 4, 5],), 0)
-    table.add_row(([6, 7, 8, 9],), 1)
+    table.add_row(([2, 3, 4, 5], [10, 11, 12, 13]), 0)
+    table.add_row(([6, 7, 8, 9], [14, 15, 16, 17]), 1)
     table.commit_block_table(2)
-    group = table.block_tables[0]
-    group.pcp_world_size = 2
-    group.pcp_rank = 1
-    group.dcp_world_size = 1
-    group.dcp_rank = 0
+    for group in table.block_tables:
+        group.pcp_world_size = 2
+        group.pcp_rank = 1
+        group.dcp_world_size = 1
+        group.dcp_rank = 0
 
     query_start_loc = torch.tensor([0, 4, 8], dtype=torch.int32, device=device)
     positions = torch.zeros(16, dtype=torch.int64, device=device)

--- a/tests/functional_tests/worker/test_common_attention_metadata_graph.py
+++ b/tests/functional_tests/worker/test_common_attention_metadata_graph.py
@@ -333,6 +333,9 @@ def test_common_attention_metadata_clears_long_context_padded_rows(
     positions[:num_actual_reqs].fill_(16383)
     seq_lens = torch.zeros(num_reqs_padded, dtype=torch.int32, device=device)
     seq_lens[:num_actual_reqs].fill_(16384)
+    # seq_len alone does not identify padding; an active row may transiently
+    # carry zero while still owning scheduled query tokens.
+    seq_lens[0] = 0
     num_computed_tokens = torch.empty(num_reqs_padded, dtype=torch.int32, device=device)
 
     compute_common_attention_metadata(
@@ -349,5 +352,8 @@ def test_common_attention_metadata_clears_long_context_padded_rows(
         assert torch.all(group.block_table.gpu[num_actual_reqs:] == NULL_BLOCK_ID)
         assert torch.all(group.block_table.gpu[num_actual_reqs - 1] == 1)
         assert torch.all(group.slot_mapping.gpu[num_actual_reqs:] == -1)
-    assert torch.all(num_computed_tokens[:num_actual_reqs] == 16383)
+    assert num_computed_tokens[0] == -1
+    assert torch.all(num_computed_tokens[1:num_actual_reqs] == 16383)
     assert torch.all(num_computed_tokens[num_actual_reqs:] == 0)
+    for group in table.block_tables:
+        assert torch.all(group.block_table.gpu[0] == 1)

--- a/vllm_fl/worker/common_attention_metadata.py
+++ b/vllm_fl/worker/common_attention_metadata.py
@@ -35,7 +35,6 @@ def supports_accelerator_graph() -> bool:
 def _compute_slot_mapping_graph_kernel(
     max_num_tokens,
     query_start_loc_ptr,
-    seq_lens_ptr,
     positions_ptr,
     block_table_ptr,
     block_table_stride,
@@ -66,10 +65,12 @@ def _compute_slot_mapping_graph_kernel(
 
     # Padded request rows are not refreshed by BlockTable.commit_block_table().
     # Clear them in the existing per-group producer instead of launching one
-    # eager fill per cache group. seq_lens is a fixed-address device buffer, so
-    # the same captured shape can replay with a different actual request count.
-    seq_len = tl.load(seq_lens_ptr + req_idx)
-    if seq_len == 0:
+    # eager fill per cache group. query_start_loc is a fixed-address device
+    # buffer, so the same captured shape can replay with a different actual
+    # request count.
+    # A graph-padded row has no scheduled query tokens. Do not use seq_len as
+    # the predicate: valid scheduler rows can transiently carry seq_len == 0.
+    if start_idx == end_idx:
         row_offset = req_idx * block_table_stride
         for i in range(0, block_table_stride, BLOCK_SIZE):
             offsets = i + tl.arange(0, BLOCK_SIZE)
@@ -140,7 +141,6 @@ def compute_common_attention_metadata(
         _compute_slot_mapping_graph_kernel[(num_reqs + 1,)](
             table.max_num_batched_tokens,
             query_start_loc,
-            seq_lens,
             positions,
             table.block_table.gpu,
             table.block_table.gpu.stride(0),

--- a/vllm_fl/worker/common_attention_metadata.py
+++ b/vllm_fl/worker/common_attention_metadata.py
@@ -10,7 +10,7 @@ import torch
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
 
 from vllm_fl.compilation.graph import Graph
 
@@ -35,6 +35,7 @@ def supports_accelerator_graph() -> bool:
 def _compute_slot_mapping_graph_kernel(
     max_num_tokens,
     query_start_loc_ptr,
+    seq_lens_ptr,
     positions_ptr,
     block_table_ptr,
     block_table_stride,
@@ -43,6 +44,7 @@ def _compute_slot_mapping_graph_kernel(
     TOTAL_CP_WORLD_SIZE: tl.constexpr,
     TOTAL_CP_RANK: tl.constexpr,
     CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    NULL_BLOCK_ID: tl.constexpr,
     PAD_ID: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
@@ -61,6 +63,21 @@ def _compute_slot_mapping_graph_kernel(
 
     start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+
+    # Padded request rows are not refreshed by BlockTable.commit_block_table().
+    # Clear them in the existing per-group producer instead of launching one
+    # eager fill per cache group. seq_lens is a fixed-address device buffer, so
+    # the same captured shape can replay with a different actual request count.
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    if seq_len == 0:
+        row_offset = req_idx * block_table_stride
+        for i in range(0, block_table_stride, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(
+                block_table_ptr + row_offset + offsets,
+                NULL_BLOCK_ID,
+                mask=offsets < block_table_stride,
+            )
 
     virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
     row_offset = req_idx * block_table_stride
@@ -123,6 +140,7 @@ def compute_common_attention_metadata(
         _compute_slot_mapping_graph_kernel[(num_reqs + 1,)](
             table.max_num_batched_tokens,
             query_start_loc,
+            seq_lens,
             positions,
             table.block_table.gpu,
             table.block_table.gpu.stride(0),
@@ -131,6 +149,7 @@ def compute_common_attention_metadata(
             TOTAL_CP_WORLD_SIZE=total_cp_world_size,
             TOTAL_CP_RANK=total_cp_rank,
             CP_KV_CACHE_INTERLEAVE_SIZE=table.cp_kv_cache_interleave_size,
+            NULL_BLOCK_ID=NULL_BLOCK_ID,
             PAD_ID=PAD_SLOT_ID,
             BLOCK_SIZE=1024,
         )

--- a/vllm_fl/worker/common_attention_metadata.py
+++ b/vllm_fl/worker/common_attention_metadata.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+from vllm_fl.compilation.graph import Graph
+
+logger = init_logger(__name__)
+
+_GRAPH_DEVICE_TYPES = frozenset({"cuda", "npu", "musa", "ptpu"})
+
+
+def supports_accelerator_graph() -> bool:
+    """Return whether the active platform exposes the plugin graph API."""
+    return (
+        current_platform.device_type in _GRAPH_DEVICE_TYPES
+        and hasattr(Graph, "graph")
+        and hasattr(current_platform.torch_device_fn, "graph")
+    )
+
+
+# Adapted from vLLM's BlockTable slot-mapping kernel. The padding boundary is
+# read from query_start_loc on device so one captured graph can replay with
+# different request lengths without a host-derived launch argument.
+@triton.jit(do_not_specialize=["max_num_tokens"])
+def _compute_slot_mapping_graph_kernel(
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+
+    if req_idx == tl.num_programs(0) - 1:
+        actual_num_tokens = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+        for i in range(actual_num_tokens, max_num_tokens, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(
+                slot_mapping_ptr + offsets,
+                PAD_ID,
+                mask=offsets < max_num_tokens,
+            )
+        return
+
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+
+    virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
+    row_offset = req_idx * block_table_stride
+    for i in range(start_idx, end_idx, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0)
+        block_indices = pos // virtual_block_size
+        block_numbers = tl.load(block_table_ptr + row_offset + block_indices).to(
+            tl.int64
+        )
+
+        virtual_block_offsets = pos - block_indices * virtual_block_size
+        is_local = (
+            virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+        ) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+        local_block_offsets = (
+            virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+        ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+            virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+        )
+
+        slot_ids = block_numbers * block_size + local_block_offsets
+        slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+
+@triton.jit
+def _compute_num_computed_tokens_kernel(
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    num_computed_tokens_ptr,
+    num_reqs: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_reqs
+    query_start = tl.load(query_start_loc_ptr + offsets, mask=mask, other=0)
+    query_end = tl.load(query_start_loc_ptr + offsets + 1, mask=mask, other=0)
+    seq_len = tl.load(seq_lens_ptr + offsets, mask=mask, other=0)
+    tl.store(
+        num_computed_tokens_ptr + offsets,
+        seq_len - (query_end - query_start),
+        mask=mask,
+    )
+
+
+def compute_common_attention_metadata(
+    block_table: Any,
+    num_reqs: int,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+    seq_lens: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+) -> None:
+    """Populate fixed-address metadata buffers consumed by attention backends."""
+    for table in block_table.block_tables:
+        total_cp_world_size = table.pcp_world_size * table.dcp_world_size
+        total_cp_rank = table.pcp_rank * table.dcp_world_size + table.dcp_rank
+        _compute_slot_mapping_graph_kernel[(num_reqs + 1,)](
+            table.max_num_batched_tokens,
+            query_start_loc,
+            positions,
+            table.block_table.gpu,
+            table.block_table.gpu.stride(0),
+            table.block_size,
+            table.slot_mapping.gpu,
+            TOTAL_CP_WORLD_SIZE=total_cp_world_size,
+            TOTAL_CP_RANK=total_cp_rank,
+            CP_KV_CACHE_INTERLEAVE_SIZE=table.cp_kv_cache_interleave_size,
+            PAD_ID=PAD_SLOT_ID,
+            BLOCK_SIZE=1024,
+        )
+    _compute_num_computed_tokens_kernel[(triton.cdiv(num_reqs, 256),)](
+        query_start_loc,
+        seq_lens,
+        num_computed_tokens,
+        num_reqs=num_reqs,
+        BLOCK_SIZE=256,
+    )
+
+
+class CommonAttentionMetadataGraphRunner:
+    """Capture and replay common attention metadata on accelerator graphs."""
+
+    def __init__(self) -> None:
+        self.graphs: dict[tuple[int, int], Any] = {}
+        self.graph_pool = current_platform.get_global_graph_pool()
+        self._missing_graph_keys: set[tuple[int, int]] = set()
+        self._graph_capture_supported = supports_accelerator_graph()
+        self._warned_graph_unavailable = False
+
+    def clear(self) -> None:
+        self.graphs.clear()
+        self._missing_graph_keys.clear()
+
+    def run(
+        self,
+        block_table: Any,
+        num_reqs: int,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+        seq_lens: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
+        *,
+        use_graph: bool,
+        capture: bool,
+        compute: Callable[
+            [
+                Any,
+                int,
+                torch.Tensor,
+                torch.Tensor,
+                torch.Tensor,
+                torch.Tensor,
+            ],
+            None,
+        ] = compute_common_attention_metadata,
+    ) -> bool:
+        if use_graph and not self._graph_capture_supported:
+            if not self._warned_graph_unavailable:
+                logger.warning(
+                    "Accelerator graph capture is unavailable on %s; falling "
+                    "back to eager common attention metadata generation.",
+                    current_platform.device_type,
+                )
+                self._warned_graph_unavailable = True
+            use_graph = False
+
+        if not use_graph:
+            compute(
+                block_table,
+                num_reqs,
+                query_start_loc,
+                positions,
+                seq_lens,
+                num_computed_tokens,
+            )
+            return False
+
+        key = (id(block_table), num_reqs)
+        graph = self.graphs.get(key)
+        if capture:
+            if graph is not None:
+                graph.replay()
+                return True
+
+            graph = Graph.graph()
+            with current_platform.torch_device_fn.graph(graph, pool=self.graph_pool):
+                compute(
+                    block_table,
+                    num_reqs,
+                    query_start_loc,
+                    positions,
+                    seq_lens,
+                    num_computed_tokens,
+                )
+            self.graphs[key] = graph
+            return True
+
+        if graph is None:
+            if key not in self._missing_graph_keys:
+                logger.warning(
+                    "Common attention metadata graph for %d requests was not "
+                    "captured; falling back to eager execution.",
+                    num_reqs,
+                )
+                self._missing_graph_keys.add(key)
+            compute(
+                block_table,
+                num_reqs,
+                query_start_loc,
+                positions,
+                seq_lens,
+                num_computed_tokens,
+            )
+            return False
+
+        graph.replay()
+        return True

--- a/vllm_fl/worker/common_attention_metadata.py
+++ b/vllm_fl/worker/common_attention_metadata.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -17,6 +18,22 @@ from vllm_fl.compilation.graph import Graph
 logger = init_logger(__name__)
 
 _GRAPH_DEVICE_TYPES = frozenset({"cuda", "npu", "musa", "ptpu"})
+_LAYOUT_ATTR = "_vllm_fl_common_attention_metadata_layout"
+
+
+@dataclass(frozen=True)
+class _CommonAttentionMetadataLayout:
+    """Fixed-address tensors used by the multi-group Triton launch."""
+
+    block_table_ptrs: torch.Tensor
+    block_table_strides: torch.Tensor
+    block_sizes: torch.Tensor
+    slot_mapping_ptrs: torch.Tensor
+    num_groups: int
+    max_num_batched_tokens: int
+    total_cp_world_size: int
+    total_cp_rank: int
+    cp_kv_cache_interleave_size: int
 
 
 def supports_accelerator_graph() -> bool:
@@ -28,18 +45,25 @@ def supports_accelerator_graph() -> bool:
     )
 
 
-# Adapted from vLLM's BlockTable slot-mapping kernel. The padding boundary is
-# read from query_start_loc on device so one captured graph can replay with
-# different request lengths without a host-derived launch argument.
+@triton.jit
+def _load_ptr(ptr_to_ptr, elem_dtype):
+    ptr = tl.load(ptr_to_ptr)
+    ptr = tl.cast(ptr, tl.pointer_type(elem_dtype))
+    return tl.multiple_of(ptr, 16)
+
+
+# Backported from vLLM's multi-group BlockTables slot-mapping kernel. The
+# padding boundary is read from query_start_loc on device so one captured graph
+# can replay with different request lengths without a host-derived argument.
 @triton.jit(do_not_specialize=["max_num_tokens"])
 def _compute_slot_mapping_graph_kernel(
     max_num_tokens,
     query_start_loc_ptr,
     positions_ptr,
-    block_table_ptr,
-    block_table_stride,
-    block_size,
-    slot_mapping_ptr,
+    block_table_ptrs,
+    block_table_strides,
+    block_sizes,
+    slot_mapping_ptrs,
     TOTAL_CP_WORLD_SIZE: tl.constexpr,
     TOTAL_CP_RANK: tl.constexpr,
     CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
@@ -47,9 +71,14 @@ def _compute_slot_mapping_graph_kernel(
     PAD_ID: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    req_idx = tl.program_id(0)
+    group_idx = tl.program_id(0)
+    req_idx = tl.program_id(1)
+    block_table_ptr = _load_ptr(block_table_ptrs + group_idx, tl.int32)
+    block_table_stride = tl.load(block_table_strides + group_idx)
+    block_size = tl.load(block_sizes + group_idx)
+    slot_mapping_ptr = _load_ptr(slot_mapping_ptrs + group_idx, tl.int64)
 
-    if req_idx == tl.num_programs(0) - 1:
+    if req_idx == tl.num_programs(1) - 1:
         actual_num_tokens = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
         for i in range(actual_num_tokens, max_num_tokens, BLOCK_SIZE):
             offsets = i + tl.arange(0, BLOCK_SIZE)
@@ -126,6 +155,83 @@ def _compute_num_computed_tokens_kernel(
     )
 
 
+def _make_ptr_tensor(tensors: list[torch.Tensor]) -> torch.Tensor:
+    # uint64 covers every possible device address. The tensors are persistent,
+    # so these raw pointers remain valid across graph capture and replay.
+    return torch.tensor(
+        [tensor.data_ptr() for tensor in tensors],
+        dtype=torch.uint64,
+        device=tensors[0].device,
+    )
+
+
+def _create_common_attention_metadata_layout(
+    block_table: Any,
+) -> _CommonAttentionMetadataLayout:
+    tables = block_table.block_tables
+    if not tables:
+        raise ValueError("Common attention metadata requires a KV cache group")
+
+    max_num_batched_tokens = tables[0].max_num_batched_tokens
+    total_cp_world_size = tables[0].pcp_world_size * tables[0].dcp_world_size
+    total_cp_rank = tables[0].pcp_rank * tables[0].dcp_world_size + tables[0].dcp_rank
+    cp_kv_cache_interleave_size = tables[0].cp_kv_cache_interleave_size
+    device = tables[0].block_table.gpu.device
+
+    for table in tables[1:]:
+        table_cp_world_size = table.pcp_world_size * table.dcp_world_size
+        table_cp_rank = table.pcp_rank * table.dcp_world_size + table.dcp_rank
+        if (
+            table.block_table.gpu.device != device
+            or table.slot_mapping.gpu.device != device
+        ):
+            raise ValueError("All KV cache groups must be on the same device")
+        if table.max_num_batched_tokens != max_num_batched_tokens:
+            raise ValueError(
+                "All KV cache groups must use the same max_num_batched_tokens"
+            )
+        if (
+            table_cp_world_size != total_cp_world_size
+            or table_cp_rank != total_cp_rank
+            or table.cp_kv_cache_interleave_size != cp_kv_cache_interleave_size
+        ):
+            raise ValueError(
+                "All KV cache groups must use the same context-parallel layout"
+            )
+
+    return _CommonAttentionMetadataLayout(
+        block_table_ptrs=_make_ptr_tensor([table.block_table.gpu for table in tables]),
+        block_table_strides=torch.tensor(
+            [table.block_table.gpu.stride(0) for table in tables],
+            dtype=torch.int64,
+            device=device,
+        ),
+        block_sizes=torch.tensor(
+            [table.block_size for table in tables],
+            dtype=torch.int32,
+            device=device,
+        ),
+        slot_mapping_ptrs=_make_ptr_tensor(
+            [table.slot_mapping.gpu for table in tables]
+        ),
+        num_groups=len(tables),
+        max_num_batched_tokens=max_num_batched_tokens,
+        total_cp_world_size=total_cp_world_size,
+        total_cp_rank=total_cp_rank,
+        cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+    )
+
+
+def _get_common_attention_metadata_layout(
+    block_table: Any,
+) -> _CommonAttentionMetadataLayout:
+    layout = getattr(block_table, _LAYOUT_ATTR, None)
+    if layout is None:
+        layout = _create_common_attention_metadata_layout(block_table)
+        setattr(block_table, _LAYOUT_ATTR, layout)
+    return layout
+
+
 def compute_common_attention_metadata(
     block_table: Any,
     num_reqs: int,
@@ -135,20 +241,19 @@ def compute_common_attention_metadata(
     num_computed_tokens: torch.Tensor,
 ) -> None:
     """Populate fixed-address metadata buffers consumed by attention backends."""
-    for table in block_table.block_tables:
-        total_cp_world_size = table.pcp_world_size * table.dcp_world_size
-        total_cp_rank = table.pcp_rank * table.dcp_world_size + table.dcp_rank
-        _compute_slot_mapping_graph_kernel[(num_reqs + 1,)](
-            table.max_num_batched_tokens,
+    if block_table.block_tables:
+        layout = _get_common_attention_metadata_layout(block_table)
+        _compute_slot_mapping_graph_kernel[(layout.num_groups, num_reqs + 1)](
+            layout.max_num_batched_tokens,
             query_start_loc,
             positions,
-            table.block_table.gpu,
-            table.block_table.gpu.stride(0),
-            table.block_size,
-            table.slot_mapping.gpu,
-            TOTAL_CP_WORLD_SIZE=total_cp_world_size,
-            TOTAL_CP_RANK=total_cp_rank,
-            CP_KV_CACHE_INTERLEAVE_SIZE=table.cp_kv_cache_interleave_size,
+            layout.block_table_ptrs,
+            layout.block_table_strides,
+            layout.block_sizes,
+            layout.slot_mapping_ptrs,
+            TOTAL_CP_WORLD_SIZE=layout.total_cp_world_size,
+            TOTAL_CP_RANK=layout.total_cp_rank,
+            CP_KV_CACHE_INTERLEAVE_SIZE=layout.cp_kv_cache_interleave_size,
             NULL_BLOCK_ID=NULL_BLOCK_ID,
             PAD_ID=PAD_SLOT_ID,
             BLOCK_SIZE=1024,
@@ -226,6 +331,14 @@ class CommonAttentionMetadataGraphRunner:
             if graph is not None:
                 graph.replay()
                 return True
+
+            # Materialize the pointer/stride tensors before entering capture.
+            # Allocating them inside the graph would make replay unsafe.
+            if (
+                compute is compute_common_attention_metadata
+                and block_table.block_tables
+            ):
+                _get_common_attention_metadata_layout(block_table)
 
             graph = Graph.graph()
             with current_platform.torch_device_fn.graph(graph, pool=self.graph_pool):

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -2290,6 +2290,7 @@ class ModelRunnerFL(
         num_scheduled_tokens: dict[str, int] | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         slot_mappings: dict[int, torch.Tensor] | None = None,
+        block_table_rows_are_current: bool = False,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -2329,9 +2330,10 @@ class ModelRunnerFL(
                 blk_table = self.input_batch.block_table[kv_cache_gid]
                 blk_table_tensor = blk_table.get_device_tensor(num_reqs_padded)
 
-            # Fill unused block table entries with NULL_BLOCK_ID (null block)
-            # for CUDAGraph padding. Block 0 is reserved for padding.
-            blk_table_tensor[num_reqs:num_reqs_padded].fill_(NULL_BLOCK_ID)
+            if not block_table_rows_are_current:
+                # Fill unused block table entries with NULL_BLOCK_ID (null
+                # block) for graph padding. Block 0 is reserved for padding.
+                blk_table_tensor[num_reqs:num_reqs_padded].fill_(NULL_BLOCK_ID)
             return blk_table_tensor
 
         assert slot_mappings is not None
@@ -4377,6 +4379,7 @@ class ModelRunnerFL(
                     num_scheduled_tokens=scheduler_output.num_scheduled_tokens,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
                     slot_mappings=slot_mappings_by_group,
+                    block_table_rows_are_current=True,
                 )
             )
 
@@ -6000,6 +6003,7 @@ class ModelRunnerFL(
                     for_cudagraph_capture=is_graph_capturing,
                     slot_mappings=slot_mappings_by_group,
                     use_spec_decode=self.speculative_config is not None,
+                    block_table_rows_are_current=True,
                 )
 
             # Dummy forwards must not update real KV-cache slots. Capture the

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -281,6 +281,11 @@ from vllm_fl.dispatch.io_dumper import (
     init_io_dump_from_env,
     register_io_module_hooks,
 )
+from vllm_fl.worker.common_attention_metadata import (
+    CommonAttentionMetadataGraphRunner,
+    compute_common_attention_metadata,
+)
+
 GraphWrapper = GraphWrapper
 
 if TYPE_CHECKING:
@@ -783,6 +788,7 @@ class ModelRunnerFL(
         self.query_start_loc = self._make_buffer(
             self.max_num_reqs + 1, dtype=torch.int32
         )
+        self.common_attention_metadata_graph = CommonAttentionMetadataGraphRunner()
         self.seq_lens = torch.zeros(
             self.max_num_reqs, dtype=torch.int32, device=self.device
         )
@@ -2186,12 +2192,6 @@ class ModelRunnerFL(
         )
         self.seq_lens[num_reqs:].fill_(0)
 
-        self.input_batch.block_table.compute_slot_mapping(
-            num_reqs,
-            self.query_start_loc.gpu[: num_reqs + 1],
-            self.positions[:total_num_scheduled_tokens],
-        )
-
         # Copy the tensors to the GPU.
         self._prepare_input_ids(
             scheduler_output,
@@ -2403,6 +2403,7 @@ class ModelRunnerFL(
             seq_lens=self.seq_lens[:num_reqs_padded],
             _seq_lens_cpu=seq_lens_cpu,
             _num_computed_tokens_cpu=num_computed_tokens_cpu,
+            _num_computed_tokens_cache=self.num_computed_tokens[:num_reqs_padded],
             seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
             num_reqs=num_reqs_padded,
             num_actual_tokens=num_tokens_padded,
@@ -4038,12 +4039,39 @@ class ModelRunnerFL(
                 pyt_hooks.register_hooks(self.model, self.model.__class__.__name__)
                 self.layerwise_nvtx_hooks_registered = True
 
+    def _run_common_attention_metadata(
+        self,
+        num_reqs: int,
+        cudagraph_mode: CUDAGraphMode,
+        *,
+        capture: bool = False,
+    ) -> bool:
+        # Follow the globally resolved graph mode. The standalone metadata
+        # graph also benefits piecewise execution; ubatching retains eager
+        # generation because its metadata is sliced per microbatch.
+        use_graph = (
+            cudagraph_mode != CUDAGraphMode.NONE
+            and not self.parallel_config.use_ubatching
+        )
+        return self.common_attention_metadata_graph.run(
+            self.input_batch.block_table,
+            num_reqs,
+            self.query_start_loc.gpu[: num_reqs + 1],
+            self.positions,
+            self.seq_lens[:num_reqs],
+            self.num_computed_tokens[:num_reqs],
+            use_graph=use_graph,
+            capture=capture,
+            compute=compute_common_attention_metadata,
+        )
+
     def _get_slot_mappings(
         self,
         num_tokens_padded: int,
         num_reqs_padded: int,
         num_tokens_unpadded: int,
         ubatch_slices: "UBatchSlices | None" = None,
+        slot_mapping_is_current: bool = False,
     ) -> tuple[
         dict[int, torch.Tensor] | None,
         dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None,
@@ -4084,9 +4112,10 @@ class ModelRunnerFL(
                 blk_table = self.input_batch.block_table[kv_cache_gid]
                 slot_mapping = blk_table.slot_mapping.gpu[:num_tokens_padded]
 
-            # Fill unused with -1. Needed for reshape_and_cache in full cuda
-            # graph mode. `blk_table_tensor` -1 to match mamba PAD_SLOT_ID
-            slot_mapping[num_tokens_unpadded:num_tokens_padded].fill_(-1)
+            if not slot_mapping_is_current:
+                # Fill unused with -1. Needed for reshape_and_cache in full
+                # graph mode. `blk_table_tensor` -1 matches mamba PAD_SLOT_ID.
+                slot_mapping[num_tokens_unpadded:num_tokens_padded].fill_(-1)
 
             return slot_mapping
 
@@ -4322,6 +4351,7 @@ class ModelRunnerFL(
             use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
             ubatch_slices_attn = ubatch_slices_padded if pad_attn else ubatch_slices
 
+            self._run_common_attention_metadata(num_reqs_padded, cudagraph_mode)
             slot_mappings_by_group, slot_mappings = self._get_slot_mappings(
                 num_tokens_padded=num_tokens_padded
                 if pad_attn or has_separate_kv_update
@@ -4331,6 +4361,7 @@ class ModelRunnerFL(
                 ),
                 num_tokens_unpadded=num_tokens_unpadded,
                 ubatch_slices=ubatch_slices_padded,
+                slot_mapping_is_current=True,
             )
 
             attn_metadata, spec_decode_common_attn_metadata = (
@@ -5912,13 +5943,8 @@ class ModelRunnerFL(
             num_reqs_padded=num_reqs_padded,
             num_tokens_unpadded=num_tokens_unpadded,
             ubatch_slices=ubatch_slices_padded,
+            slot_mapping_is_current=True,
         )
-
-        # Dummy runs have no real slot assignments — fill with -1 so
-        # concat_and_cache kernels skip the KV write.
-        if slot_mappings_by_group is not None:
-            for sm in slot_mappings_by_group.values():
-                sm.fill_(-1)
 
         # _dummy_run shares pinned CPU buffers (seq_lens, query_start_loc,
         # etc.) with execute_model.  It must participate in the same event
@@ -5958,6 +5984,11 @@ class ModelRunnerFL(
                 # builder. Without this, stale block IDs from finished
                 # requests can corrupt Mamba state.
                 self.input_batch.block_table.commit_block_table(num_reqs_padded)
+                self._run_common_attention_metadata(
+                    num_reqs_padded,
+                    cudagraph_runtime_mode,
+                    capture=is_graph_capturing,
+                )
 
                 pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
                 attn_metadata, _ = self._build_attention_metadata(
@@ -5970,6 +6001,14 @@ class ModelRunnerFL(
                     slot_mappings=slot_mappings_by_group,
                     use_spec_decode=self.speculative_config is not None,
                 )
+
+            # Dummy forwards must not update real KV-cache slots. Capture the
+            # metadata producer first, then restore the existing PAD_SLOT_ID
+            # behavior before the model dummy/capture forward. Runtime replay
+            # overwrites these fixed-address buffers with current metadata.
+            if slot_mappings_by_group is not None:
+                for slot_mapping in slot_mappings_by_group.values():
+                    slot_mapping.fill_(-1)
 
         with self.maybe_dummy_run_with_lora(
             self.lora_config,
@@ -6458,6 +6497,7 @@ class ModelRunnerFL(
 
     def _cleanup_profiling_kv_cache(self) -> None:
         _accelerator_synchronize()
+        self.common_attention_metadata_graph.clear()
         if hasattr(self, "kv_caches") and self.kv_caches:
             for i in range(len(self.kv_caches)):
                 self.kv_caches[i] = None  # type: ignore


### PR DESCRIPTION
### PR Category
Core

### PR Type
Performance | Improvements | Bug Fixes

### Description
Reduce per-step framework CPU and kernel-launch overhead in the vLLM 0.24 model runner by capturing common attention metadata generation in accelerator graphs.

The optimized path generates slot mappings and GPU `num_computed_tokens` from fixed-address device buffers. It also folds graph-padding block-table cleanup into the same metadata producer. Eager execution remains available for unsupported graph platforms, missing capture keys, and ubatching.

### Related Issues
N/A

### Changes
- Add a graph-safe Triton producer for per-cache-group slot mappings.
- Generate `num_computed_tokens` from `query_start_loc` and `seq_lens` on device.
- Capture and replay common attention metadata by block-table identity and padded request count.
- Fold padded block-table-row cleanup into the metadata kernel instead of launching eager `.fill_()` operations per cache group.
- Identify graph-padded rows from zero query length rather than `seq_len == 0`, preserving valid scheduler rows that transiently carry zero sequence length.
- Preserve eager fallback behavior when graph capture is unavailable or no matching graph has been captured.
- Clear captured metadata graphs during profiling KV-cache cleanup.

### Testing
- `ruff check --output-format=concise .`
- `ruff format --check .`
- `git diff --check origin/main...HEAD`
- Added functional coverage for graph capture/replay with updated metadata, eager execution, unavailable-graph fallback, hybrid block sizes, context parallel slot mapping, long-context padded rows, and valid zero-sequence-length rows.
- H100 empty-build vLLM 0.24.0 integration:
  - GLM5.3 TP=16 started with effective `FULL_AND_PIECEWISE` graph mode; mixed batches used PIECEWISE and decode batches used FULL graphs. A strict 1k-input/1k-output request completed successfully.
  - Qwen4 service startup, correctness probes, and 1k/1k serving benchmarks completed on the combined branch.
  - HY4 W8A8 TP=16 eager-mode startup, correctness probes, and a strict 1k/1k request completed, exercising the eager metadata fallback.

### Checklist
- [ ] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
