### PR TITLE
fix(register): import ModelRegistry from submodule to avoid lazy-import ImportError on vLLM 0.20.2

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -148,7 +148,7 @@ def register_router():
 
 def register_model():
     """Register FL-specific models not yet upstream."""
-    from vllm import ModelRegistry
+    from vllm.model_executor.models import ModelRegistry
 
     _register_flagcx_connector()
 


### PR DESCRIPTION
### What

One-line fix in `register_model()`:

```diff
- from vllm import ModelRegistry
+ from vllm.model_executor.models import ModelRegistry
```

### Why

vLLM `0.20.2` exposes `ModelRegistry` at the package top level via a **PEP 562 module-level lazy import** (`vllm/__init__.py` maps `"ModelRegistry" -> ".model_executor.models:ModelRegistry"`, resolved in `__getattr__`).

`register_model()` is executed inside the **spawned architecture-inspection subprocess** (`_run_in_subprocess`), where the `vllm` top-level package is only partially initialized. The lazy `__getattr__` resolution for `ModelRegistry` then fails, so `from vllm import ModelRegistry` raises:

```
ImportError: cannot import name 'ModelRegistry' from 'vllm' (unknown location)
```

and vLLM reports `Model architectures [...] failed to be inspected`, aborting startup.

Importing from the concrete submodule `vllm.model_executor.models` uses a real symbol that does not depend on the top-level lazy `__getattr__`, so it resolves correctly in the subprocess. This is also the direction upstream already took — `main` / `0.3.0-rc0` no longer use `from vllm import ModelRegistry`.

### Reproduced

- Branch `0.2.2-rc0` (`d305f58`), vLLM `0.20.2` (`VLLM_TARGET_DEVICE=empty`), MetaX MACA 3.7.0, `VLLM_PLUGINS=fl`, model `Qwen3.5-MoE` (`Qwen3_5MoeForConditionalGeneration`), tp=4.
- Same root cause as #142 (there triggered with MiniMax-M2).

### Verified

- `from vllm.model_executor.models import ModelRegistry` succeeds in the same subprocess context where `from vllm import ModelRegistry` fails.
- With this change, the inspection subprocess no longer raises `ImportError`; serve proceeds past `Resolved architecture: Qwen3_5MoeForConditionalGeneration` into model loading. (It then hit an unrelated MACA `mxkwCreateQueueBlock` queue-timeout at tp=4 — a platform/driver issue independent of this plugin.)

### Notes

- Scope: single line, no behavior change beyond the import source; all subsequent registrations in `register_model()` run unchanged.
- Prefer this over wrapping the import in `try/except ImportError: return` (proposed in #142), which would silently skip every remaining registration on failure.
- `dev` has the same `from vllm import ModelRegistry` line and would need the same change.

Fixes #142

---
- Targeting `release/0.2`. The identical `from vllm import ModelRegistry` line (`vllm_fl/__init__.py:151`) exists on both `release/0.2` and `0.2.2-rc0`, so this one-line change applies cleanly to `release/0.2`.