### PR TITLE
feat(dispatch): freeze CachedOp dispatch before torch.compile and route to flag_gems.pt2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE README.md pyproject.toml setup.py
+recursive-include csrc CMakeLists.txt *.h *.cpp
+global-exclude *.py[cod]
+global-exclude __pycache__
+global-exclude .DS_Store

--- a/tests/unit_tests/dispatch/test_frozen_dispatch.py
+++ b/tests/unit_tests/dispatch/test_frozen_dispatch.py
@@ -1,0 +1,90 @@
+# Copyright 2026 FlagOS Contributors
+
+import os
+
+import pytest
+
+from vllm_fl.dispatch import (
+    BackendImplKind,
+    CachedOp,
+    OpImpl,
+    SelectionPolicy,
+    freeze_dispatch,
+    get_default_manager,
+    get_frozen_dispatch_manifest,
+    is_dispatch_frozen,
+    reset_default_manager,
+    reset_global_policy,
+    set_global_policy,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_dispatch_state():
+    reset_default_manager()
+    reset_global_policy()
+    yield
+    reset_default_manager()
+    reset_global_policy()
+
+
+def _initialized_manager():
+    manager = get_default_manager()
+    manager._state.initialized = True
+    manager._state.init_pid = os.getpid()
+    return manager
+
+
+def test_frozen_cached_op_never_reenters_manager(monkeypatch):
+    manager = _initialized_manager()
+    manager.registry.register_impl(
+        OpImpl(
+            op_name="unit_freeze",
+            impl_id="default.unit",
+            kind=BackendImplKind.DEFAULT,
+            fn=lambda value: value + 1,
+        )
+    )
+    cached_op = CachedOp("unit_freeze")
+
+    manifest = freeze_dispatch(op_names={"unit_freeze"})
+    assert is_dispatch_frozen()
+    assert cached_op.frozen_impl_id == "default.unit"
+    assert manifest.fingerprint
+    assert manifest.selections[0].op_name == "unit_freeze"
+
+    def fail_if_resolved_again(*args, **kwargs):
+        raise AssertionError("frozen execution re-entered OpManager")
+
+    monkeypatch.setattr(manager, "_resolve_impl", fail_if_resolved_again)
+    assert cached_op(4) == 5
+
+
+def test_policy_is_immutable_while_frozen():
+    manager = _initialized_manager()
+    manager.registry.register_impl(
+        OpImpl(
+            op_name="unit_policy_freeze",
+            impl_id="default.unit",
+            kind=BackendImplKind.DEFAULT,
+            fn=lambda value: value,
+        )
+    )
+    CachedOp("unit_policy_freeze")
+    freeze_dispatch(op_names={"unit_policy_freeze"})
+
+    with pytest.raises(RuntimeError, match="dispatch is frozen"):
+        set_global_policy(SelectionPolicy(prefer="vendor"))
+
+
+def test_unresolved_optional_op_fails_deterministically():
+    cached_op = CachedOp("missing_optional_op")
+    manifest = freeze_dispatch(
+        op_names={"missing_optional_op"},
+        strict=False,
+    )
+
+    assert get_frozen_dispatch_manifest() is manifest
+    assert manifest.unresolved[0][0] == "missing_optional_op"
+    with pytest.raises(RuntimeError, match="was not bound"):
+        cached_op(1)

--- a/vllm_fl/compilation/__init__.py
+++ b/vllm_fl/compilation/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .dispatch import freeze_dispatch_for_compile
+
+__all__ = ["freeze_dispatch_for_compile"]

--- a/vllm_fl/compilation/dispatch.py
+++ b/vllm_fl/compilation/dispatch.py
@@ -1,0 +1,127 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Bridge the dynamic FL dispatch control plane to a compiled runner."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from vllm_fl.dispatch import FrozenDispatchManifest, freeze_dispatch
+from vllm_fl.dispatch.logger_manager import get_logger
+
+logger = get_logger(__name__)
+
+_HASH_KEY = "vllm_fl_dispatch_fingerprint"
+
+
+def _install_logger_method_compile_guard() -> None:
+    """Permit Dynamo to no-op logging.Logger calls in FlagGems wrappers.
+
+    FlagGems' public Python wrappers (``flag_gems.ops.*`` /
+    ``flag_gems.fused.*`` / ``flag_gems.modules.*``) contain plain
+    ``logger.debug(...)`` calls on their entry paths — e.g.
+    ``flag_gems/ops/rms_norm.py::rms_norm_forward`` emits
+    ``"GEMS RMS_NORM FORWARD"``. Torch Dynamo cannot trace
+    ``logging.Logger`` methods and raises
+    ``torch._dynamo.exc.Unsupported: logging.Logger method not supported for
+    non-export cases`` the moment any of those wrappers is reached from a
+    compiled region (e.g. with ``custom_ops=all``). Registering the four
+    unbound level methods in
+    ``torch._dynamo.config.ignore_logging_functions`` makes Dynamo treat such
+    calls as no-ops *inside compiled graphs only*; eager logging behavior is
+    unchanged. This is the PyTorch-documented escape hatch (it exists
+    precisely for library code that logs on hot paths) and is idempotent.
+    """
+
+    try:
+        import torch._dynamo.config as _dynamo_config
+    except Exception:  # pragma: no cover - torch always present in practice
+        return
+    ignore = getattr(_dynamo_config, "ignore_logging_functions", None)
+    if ignore is None or not hasattr(ignore, "add"):
+        return
+    for method_name in ("debug", "info", "warning", "error"):
+        ignore.add(getattr(logging.Logger, method_name))
+
+
+def _is_compiled_execution(vllm_config: Any) -> bool:
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    if compilation_config is None:
+        return False
+    if getattr(compilation_config, "backend", None) == "eager":
+        return False
+
+    mode = getattr(compilation_config, "mode", None)
+    mode_name = getattr(mode, "name", str(mode)).upper()
+    return mode is not None and mode_name not in {"NONE", "COMPILATIONMODE.NONE"}
+
+
+def _add_cache_fingerprint(
+    vllm_config: Any, manifest: FrozenDispatchManifest
+) -> None:
+    """Make backend choices part of vLLM's compilation cache identity."""
+
+    additional_config = getattr(vllm_config, "additional_config", None)
+    if isinstance(additional_config, dict):
+        previous = additional_config.get(_HASH_KEY)
+        if previous is not None and previous != manifest.fingerprint:
+            raise RuntimeError(
+                "vLLM-FL dispatch selection changed after the vLLM config was "
+                "prepared. Rebuild the model runner before compiling."
+            )
+        additional_config[_HASH_KEY] = manifest.fingerprint
+    else:
+        logger.warning(
+            "VllmConfig.additional_config is not a dict; the frozen FL dispatch "
+            "fingerprint could not be added to the outer vLLM cache key"
+        )
+
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    if compilation_config is not None:
+        # These fields are lazily recomputed by vLLM.  Clear any path that may
+        # have been derived before the dispatch fingerprint was attached.
+        for attribute in ("cache_dir", "local_cache_dir"):
+            if hasattr(compilation_config, attribute):
+                setattr(compilation_config, attribute, "")
+
+
+def freeze_dispatch_for_compile(
+    vllm_config: Any,
+) -> Optional[FrozenDispatchManifest]:
+    """Freeze all imported ``CachedOp`` sites before the first Dynamo trace.
+
+    Optional operator modules can be imported by model registries without ever
+    being executed, so unresolved entries are recorded in the manifest rather
+    than failing model load.  Calling one of them after freeze still raises a
+    deterministic error before entering Dynamo.
+    """
+
+    if not _is_compiled_execution(vllm_config):
+        return None
+
+    _install_logger_method_compile_guard()
+    manifest = freeze_dispatch(strict=False)
+    _add_cache_fingerprint(vllm_config, manifest)
+
+    if manifest.unresolved:
+        logger.warning(
+            "Frozen vLLM-FL dispatch with %d unresolved optional op(s): %s",
+            len(manifest.unresolved),
+            ", ".join(op_name for op_name, _ in manifest.unresolved),
+        )
+    logger.info(
+        "Frozen vLLM-FL dispatch for torch.compile: %d op(s), fingerprint=%s",
+        len(manifest.selections),
+        manifest.fingerprint[:12],
+    )
+    return manifest
+
+
+__all__ = ["freeze_dispatch_for_compile"]

--- a/vllm_fl/dispatch/__init__.py
+++ b/vllm_fl/dispatch/__init__.py
@@ -76,7 +76,13 @@ Configuration File (YAML):
             - reference
 """
 
+import hashlib
+import json
 import os
+import threading
+import weakref
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
 
 from .types import OpImpl, BackendImplKind, BackendPriority, match_token
 from .registry import OpRegistry, OpRegistrySnapshot
@@ -148,6 +154,197 @@ def resolve_op(op_name: str):
 _OP_FAST_PATH_ENABLED = os.environ.get("VLLM_FL_OP_FAST_PATH", "1") == "1"
 
 
+@dataclass(frozen=True)
+class FrozenOpSelection:
+    """One logical operator selected for a frozen execution phase."""
+
+    op_name: str
+    impl_id: str
+    kind: str
+    vendor: Optional[str]
+    callable_name: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "op_name": self.op_name,
+            "impl_id": self.impl_id,
+            "kind": self.kind,
+            "vendor": self.vendor,
+            "callable": self.callable_name,
+        }
+
+
+@dataclass(frozen=True)
+class FrozenDispatchManifest:
+    """Stable dispatch choices used by one compiled execution phase."""
+
+    policy_fingerprint: str
+    selections: tuple[FrozenOpSelection, ...]
+    unresolved: tuple[tuple[str, str], ...]
+    fingerprint: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "policy_fingerprint": self.policy_fingerprint,
+            "selections": [selection.to_dict() for selection in self.selections],
+            "unresolved": [
+                {"op_name": op_name, "error": error}
+                for op_name, error in self.unresolved
+            ],
+            "fingerprint": self.fingerprint,
+        }
+
+
+_CACHED_OPS: "weakref.WeakSet[CachedOp]" = weakref.WeakSet()
+_FREEZE_LOCK = threading.RLock()
+_DISPATCH_FROZEN = False
+_FROZEN_MANIFEST: Optional[FrozenDispatchManifest] = None
+
+
+def _callable_name(fn: Any) -> str:
+    module = getattr(fn, "__module__", type(fn).__module__)
+    qualname = getattr(fn, "__qualname__", type(fn).__qualname__)
+    return f"{module}.{qualname}"
+
+
+def _is_torch_compiling() -> bool:
+    """Query Dynamo lazily so importing dispatch does not require torch."""
+
+    try:
+        import torch
+
+        return bool(torch.compiler.is_compiling())
+    except (AttributeError, ImportError):
+        return False
+
+
+def is_dispatch_frozen() -> bool:
+    """Return whether runtime policy selection has been frozen."""
+
+    return _DISPATCH_FROZEN
+
+
+def get_frozen_dispatch_manifest() -> Optional[FrozenDispatchManifest]:
+    """Return the manifest for the current frozen execution phase."""
+
+    return _FROZEN_MANIFEST
+
+
+def _make_frozen_manifest(
+    policy_fingerprint: str,
+    resolved: dict[str, OpImpl],
+    unresolved: dict[str, str],
+) -> FrozenDispatchManifest:
+    selections = tuple(
+        FrozenOpSelection(
+            op_name=op_name,
+            impl_id=impl.impl_id,
+            kind=impl.kind.value,
+            vendor=impl.vendor,
+            callable_name=_callable_name(impl.fn),
+        )
+        for op_name, impl in sorted(resolved.items())
+    )
+    unresolved_items = tuple(sorted(unresolved.items()))
+    payload = {
+        "policy_fingerprint": policy_fingerprint,
+        "selections": [selection.to_dict() for selection in selections],
+        "unresolved": list(unresolved_items),
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return FrozenDispatchManifest(
+        policy_fingerprint=policy_fingerprint,
+        selections=selections,
+        unresolved=unresolved_items,
+        fingerprint=fingerprint,
+    )
+
+
+def freeze_dispatch(
+    op_names: Optional[Iterable[str]] = None,
+    *,
+    strict: bool = True,
+) -> FrozenDispatchManifest:
+    """Resolve ``CachedOp`` instances before Dynamo starts tracing.
+
+    Frozen calls contain no policy lookup, manager access, lock, IO dump, or
+    exception-driven backend fallback.  ``strict=False`` is useful for a model
+    process that imported optional operator modules it will never execute; an
+    unresolved operator still fails immediately if it is called later.
+    """
+
+    global _DISPATCH_FROZEN, _FROZEN_MANIFEST
+
+    requested = set(op_names) if op_names is not None else None
+    with _FREEZE_LOCK:
+        mgr = get_default_manager()
+        mgr.ensure_initialized()
+
+        instances = [
+            cached_op
+            for cached_op in list(_CACHED_OPS)
+            if requested is None or cached_op.op_name in requested
+        ]
+        names = sorted({cached_op.op_name for cached_op in instances})
+
+        resolved: dict[str, OpImpl] = {}
+        unresolved: dict[str, str] = {}
+        for op_name in names:
+            try:
+                impl = mgr._resolve_impl(op_name)
+                mgr._record_first_use(op_name, impl)
+                resolved[op_name] = impl
+            except Exception as exc:
+                unresolved[op_name] = f"{type(exc).__name__}: {exc}"
+
+        if strict and unresolved:
+            details = "; ".join(
+                f"{op_name}: {error}" for op_name, error in unresolved.items()
+            )
+            raise RuntimeError(f"Unable to freeze vLLM-FL dispatch: {details}")
+
+        for cached_op in instances:
+            cached_op._frozen_impl = resolved.get(cached_op.op_name)
+            cached_op._freeze_error = unresolved.get(cached_op.op_name)
+
+        manifest = _make_frozen_manifest(
+            get_policy().fingerprint(), resolved, unresolved
+        )
+        _FROZEN_MANIFEST = manifest
+        _DISPATCH_FROZEN = True
+        return manifest
+
+
+def thaw_dispatch() -> None:
+    """Leave the frozen phase.
+
+    Existing compiled graphs must be discarded before this is used in a model
+    process.  The function primarily exists for post-fork reset and tests.
+    """
+
+    global _DISPATCH_FROZEN, _FROZEN_MANIFEST
+
+    with _FREEZE_LOCK:
+        _DISPATCH_FROZEN = False
+        _FROZEN_MANIFEST = None
+        for cached_op in list(_CACHED_OPS):
+            cached_op._clear_all_caches()
+
+
+def _reset_frozen_dispatch_after_fork() -> None:
+    """Reset without acquiring a lock that may be owned by a vanished thread."""
+
+    global _FREEZE_LOCK, _DISPATCH_FROZEN, _FROZEN_MANIFEST
+
+    _FREEZE_LOCK = threading.RLock()
+    _DISPATCH_FROZEN = False
+    _FROZEN_MANIFEST = None
+    for cached_op in list(_CACHED_OPS):
+        cached_op._clear_all_caches()
+
+
 class CachedOp:
     """Resolve an op once at the call site and refresh on policy changes.
 
@@ -166,8 +363,11 @@ class CachedOp:
     """
 
     __slots__ = (
+        "__weakref__",
         "_op_name",
         "_impl",
+        "_frozen_impl",
+        "_freeze_error",
         "_use_manager_call",
         "_manager_id",
         "_manager_epoch",
@@ -177,12 +377,54 @@ class CachedOp:
     def __init__(self, op_name: str) -> None:
         self._op_name = op_name
         self._impl = None
+        self._frozen_impl = None
+        self._freeze_error = None
+        self._use_manager_call = False
+        self._manager_id = -1
+        self._manager_epoch = -1
+        self._policy_epoch = -1
+        _CACHED_OPS.add(self)
+
+    @property
+    def op_name(self) -> str:
+        return self._op_name
+
+    @property
+    def frozen_impl_id(self) -> Optional[str]:
+        impl = self._frozen_impl
+        return None if impl is None else impl.impl_id
+
+    def _clear_all_caches(self) -> None:
+        self._impl = None
+        self._frozen_impl = None
+        self._freeze_error = None
         self._use_manager_call = False
         self._manager_id = -1
         self._manager_epoch = -1
         self._policy_epoch = -1
 
     def __call__(self, *args, **kwargs):
+        # This is the only path used by a frozen compiled runner.  Keep it
+        # before every manager/policy/debug check so Dynamo sees a stable
+        # callable and no dispatch control-plane state.
+        frozen_impl = self._frozen_impl
+        if frozen_impl is not None:
+            return frozen_impl.fn(*args, **kwargs)
+
+        if _DISPATCH_FROZEN:
+            detail = f" ({self._freeze_error})" if self._freeze_error else ""
+            raise RuntimeError(
+                f"CachedOp '{self._op_name}' was not bound before the dispatch "
+                f"phase was frozen{detail}. Rebuild the compiled runner after "
+                "registering the operator."
+            )
+
+        if _is_torch_compiling():
+            raise RuntimeError(
+                f"CachedOp '{self._op_name}' entered torch.compile before "
+                "vllm_fl.dispatch.freeze_dispatch() was called"
+            )
+
         mgr = get_default_manager()
 
         if not _OP_FAST_PATH_ENABLED:
@@ -282,4 +524,18 @@ __all__ = [
     "call_op",
     "resolve_op",
     "CachedOp",
+    "FrozenOpSelection",
+    "FrozenDispatchManifest",
+    "freeze_dispatch",
+    "thaw_dispatch",
+    "is_dispatch_frozen",
+    "get_frozen_dispatch_manifest",
 ]
+
+
+# A manager and its registrations are process-local.  Never inherit frozen
+# callables across a fork; each worker binds again after loading its model.
+try:
+    os.register_at_fork(after_in_child=_reset_frozen_dispatch_after_fork)
+except AttributeError:
+    pass

--- a/vllm_fl/dispatch/backends/flaggems/flaggems.py
+++ b/vllm_fl/dispatch/backends/flaggems/flaggems.py
@@ -119,7 +119,9 @@ class FlagGemsBackend(Backend):
     def silu_and_mul_with_clamp(self, x: torch.Tensor, swiglu_limit: float, swiglu_limit_tensor: torch.Tensor) -> torch.Tensor:
         from .impl.activation import silu_and_mul_with_clamp_flaggems
 
-        return silu_and_mul_with_clamp_flaggems(x, swiglu_limit_tensor)
+        return silu_and_mul_with_clamp_flaggems(
+            x, swiglu_limit, swiglu_limit_tensor
+        )
 
     def rms_norm(
         self,

--- a/vllm_fl/dispatch/backends/flaggems/impl/activation.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/activation.py
@@ -6,7 +6,44 @@ FlagGems activation operator implementations.
 
 from __future__ import annotations
 
+import flag_gems
 import torch
+
+from flag_gems.fused import gelu_and_mul as _eager_gelu_and_mul
+from flag_gems.modules.activation import gems_silu_and_mul as _eager_silu_and_mul
+
+# Resolve and materialize compiler-visible FlagGems families during backend
+# registration, before Dynamo traces a frozen CachedOp.  No alternate
+# mathematical kernel is introduced: eager and compiled execution retain the
+# original generated PointwiseDynamic JITFunctions.
+from flag_gems.pt2.pointwise_dynamic import (
+    ACTIVATION_POINTWISE_FAMILIES,
+    gelu_and_mul_pointwise,
+    materialize_pointwise_family_plans,
+    silu_and_mul_pointwise,
+    silu_and_mul_with_clamp_pointwise,
+)
+
+
+# The four common sources captured by the transparent adapter are the NVIDIA
+# PointwiseDynamic families.  Other FlagGems vendors may replace these exports
+# with architecture-specific implementations, so they retain the original
+# eager path until that vendor explicitly supplies equivalent PT2 family specs.
+_USE_TRANSPARENT_POINTWISE = flag_gems.vendor_name == "nvidia"
+
+if _USE_TRANSPARENT_POINTWISE:
+    # Freeze structural plans while the FlagGems backend is registered, before
+    # any Dynamo capture.  Four generated families (SiLU,
+    # GELU-none, GELU-tanh, clamped SiLU) each expose six dtype/layout plans.
+    # The binary families retain the native contiguous->rank-1 and split->rank-2
+    # materializations; clamped SiLU retains rank 2 because of its scalar
+    # broadcast.  No Tensor or token-count value is retained.
+    materialize_pointwise_family_plans(
+        ACTIVATION_POINTWISE_FAMILIES,
+        ranks=(2,),
+        dtypes=(torch.float16, torch.bfloat16, torch.float32),
+        layout_classes=("contiguous_c", "split_last_dim_c"),
+    )
 
 
 def silu_and_mul_flaggems(obj, x: torch.Tensor) -> torch.Tensor:
@@ -20,11 +57,11 @@ def silu_and_mul_flaggems(obj, x: torch.Tensor) -> torch.Tensor:
     Returns:
         Output tensor of shape [..., d]
     """
-    from flag_gems.modules.activation import gems_silu_and_mul
-
     d = x.shape[-1] // 2
     x1, x2 = x[..., :d], x[..., d:]
-    return gems_silu_and_mul(x1, x2)
+    if _USE_TRANSPARENT_POINTWISE:
+        return silu_and_mul_pointwise(x1, x2)
+    return _eager_silu_and_mul(x1, x2)
 
 
 def gelu_and_mul_flaggems(obj, x: torch.Tensor) -> torch.Tensor:
@@ -38,15 +75,19 @@ def gelu_and_mul_flaggems(obj, x: torch.Tensor) -> torch.Tensor:
     Returns:
         Output tensor of shape [..., d]
     """
-    from flag_gems.fused import gelu_and_mul
-
     approximate = getattr(obj, "approximate", "none") if obj is not None else "none"
     d = x.shape[-1] // 2
     x1, x2 = x[..., :d], x[..., d:]
-    return gelu_and_mul(x1, x2, approximate)
+    if _USE_TRANSPARENT_POINTWISE:
+        return gelu_and_mul_pointwise(x1, x2, approximate)
+    return _eager_gelu_and_mul(x1, x2, approximate)
 
 
-def silu_and_mul_with_clamp_flaggems(x: torch.Tensor, swiglu_limit: torch.Tensor) -> torch.Tensor:
+def silu_and_mul_with_clamp_flaggems(
+    x: torch.Tensor,
+    swiglu_limit: float,
+    swiglu_limit_tensor: torch.Tensor,
+) -> torch.Tensor:
     """
     SiLU activation with clamping followed by element-wise multiplication using FlagGems.
 
@@ -57,13 +98,15 @@ def silu_and_mul_with_clamp_flaggems(x: torch.Tensor, swiglu_limit: torch.Tensor
 
     Args:
         x: Input tensor of shape [..., 2*d]
-        swiglu_limit: Clamping threshold
+        swiglu_limit: Python-side threshold retained for vLLM API parity.
+        swiglu_limit_tensor: Device tensor carrying the same threshold into the
+            original FlagGems Triton kernel.
 
     Returns:
         Output tensor of shape [..., d]
     """
-    from flag_gems.fused.silu_and_mul_with_clamp import silu_and_mul_with_clamp_kernel
-
     d = x.shape[-1] // 2
     gate, up = x[..., :d], x[..., d:]
-    return silu_and_mul_with_clamp_kernel(gate, up, swiglu_limit)
+    if _USE_TRANSPARENT_POINTWISE:
+        return silu_and_mul_with_clamp_pointwise(gate, up, swiglu_limit_tensor)
+    return flag_gems.silu_and_mul_with_clamp(gate, up, swiglu_limit)

--- a/vllm_fl/dispatch/backends/flaggems/impl/fused_moe.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/fused_moe.py
@@ -10,6 +10,38 @@ import torch
 from vllm.triton_utils import triton
 from vllm.utils.math_utils import round_up
 
+import flag_gems
+from flag_gems import (
+    grouped_topk as _grouped_topk,
+    invoke_fused_moe_triton_kernel as _invoke_fused_moe_triton_kernel,
+    moe_align_block_size_triton as _moe_align_block_size_triton,
+    moe_sum as _moe_sum,
+    topk_softmax as _topk_softmax,
+    topk_softplus_sqrt as _topk_softplus_sqrt,
+)
+from flag_gems.pt2.fused_moe import (
+    moe_sum as _pt2_moe_sum,
+    topk_softmax as _pt2_topk_softmax,
+)
+from flag_gems.pt2.moe_routing import (
+    grouped_topk as _pt2_grouped_topk,
+    topk_softplus_sqrt as _pt2_topk_softplus_sqrt,
+    uses_common_moe_routing_kernels as _uses_common_moe_routing_kernels,
+)
+
+
+# These contracts capture the common/NVIDIA kernel objects.  Other vendors
+# may replace either public FlagGems export, so retain their original path
+# until an equivalent vendor-specific PT2 contract is validated.
+_USE_TRANSPARENT_MOE_PRIMITIVES = flag_gems.vendor_name == "nvidia"
+_USE_TRANSPARENT_MOE_ROUTING = (
+    flag_gems.vendor_name == "nvidia"
+    and _uses_common_moe_routing_kernels(
+        _grouped_topk,
+        _topk_softplus_sqrt,
+    )
+)
+
 
 def moe_align_block_size_flaggems(
     topk_ids: torch.Tensor,
@@ -19,8 +51,6 @@ def moe_align_block_size_flaggems(
     pad_sorted_ids: bool = False,
     ignore_invalid_experts: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    from flag_gems import moe_align_block_size_triton
-
     max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
     if pad_sorted_ids:
         max_num_tokens_padded = round_up(max_num_tokens_padded, block_size)
@@ -39,7 +69,7 @@ def moe_align_block_size_flaggems(
     # TODO(lms): ignore_invalid_experts not effective now
     # moe_align_block_size has optimize version to filtered out
     # all invalid experts directly when counting the number of experts
-    moe_align_block_size_triton(
+    _moe_align_block_size_triton(
         topk_ids,
         num_experts,
         block_size,
@@ -56,39 +86,27 @@ def moe_align_block_size_flaggems(
 def topk_softmax_flaggems(
     topk_weights, topk_indices, token_expert_indices, gating_output, renormalize=False
 ):
-    from flag_gems import topk_softmax
-
-    try:
-        topk_softmax(
+    # The FlagGems API accepts ``renormalize`` directly, so no exception-driven
+    # signature probe is used here: a frozen compiled path cannot switch
+    # implementations after an exception, and Dynamo cannot soundly trace a
+    # try/retry control flow.  Eager and compiled execution call the same
+    # kernel with the same arguments.
+    if _USE_TRANSPARENT_MOE_PRIMITIVES:
+        _pt2_topk_softmax(
             topk_weights,
             topk_indices,
             token_expert_indices,
             gating_output,
             renormalize,
         )
-    except:
-        topk_softmax(topk_weights, topk_indices, token_expert_indices, gating_output)
-        if renormalize:
-            topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
-    return topk_weights, topk_indices
-
-def topk_softmax_flaggems(
-    topk_weights, topk_indices, token_expert_indices, gating_output, renormalize=False
-):
-    from flag_gems import topk_softmax
-
-    try:
-        topk_softmax(
+    else:
+        _topk_softmax(
             topk_weights,
             topk_indices,
             token_expert_indices,
             gating_output,
             renormalize,
         )
-    except:
-        topk_softmax(topk_weights, topk_indices, token_expert_indices, gating_output)
-        if renormalize:
-            topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
     return topk_weights, topk_indices
 
 
@@ -146,15 +164,32 @@ def fused_topk_bias_flaggems(
         return topk_weights, topk_ids
 
     elif scoring_func == "sqrtsoftplus":
-        from flag_gems import topk_softplus_sqrt
-
         topk_weights, topk_ids, token_expert_indices = _alloc_topk_buffers()
 
-        topk_softplus_sqrt(
-            topk_weights, topk_ids, token_expert_indices,
-            gating_output, renormalize, routed_scaling_factor,
-            e_score_correction_bias, input_tokens, hash_indices_table,
-        )
+        if _USE_TRANSPARENT_MOE_ROUTING:
+            _pt2_topk_softplus_sqrt(
+                topk_weights,
+                topk_ids,
+                token_expert_indices,
+                gating_output,
+                renormalize,
+                routed_scaling_factor,
+                e_score_correction_bias,
+                input_tokens,
+                hash_indices_table,
+            )
+        else:
+            _topk_softplus_sqrt(
+                topk_weights,
+                topk_ids,
+                token_expert_indices,
+                gating_output,
+                renormalize,
+                routed_scaling_factor,
+                e_score_correction_bias,
+                input_tokens,
+                hash_indices_table,
+            )
         return topk_weights, topk_ids
 
     elif scoring_func == "sigmoid":
@@ -174,7 +209,12 @@ def fused_topk_bias_flaggems(
         else:
             topk_indices = torch.topk(scores_for_choice, k=topk, dim=-1)[1]
 
-        topk_weights = scores.gather(1, topk_indices).to(torch.float32)
+        # ``gather`` requires int64 indices even though the routing ABI also
+        # permits int32 hash tables (DeepSeekV4 non-Mega uses int32).  Preserve
+        # the table/output dtype while using the required ATen gather dtype.
+        topk_weights = scores.gather(1, topk_indices.to(torch.int64)).to(
+            torch.float32
+        )
         if renormalize:
             topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
         if routed_scaling_factor != 1.0:
@@ -207,9 +247,7 @@ def invoke_fused_moe_triton_kernel_flaggems(
     block_shape=None,
     B_bias=None,
 ):
-    from flag_gems import invoke_fused_moe_triton_kernel
-
-    invoke_fused_moe_triton_kernel(
+    _invoke_fused_moe_triton_kernel(
         A,
         B,
         C,
@@ -243,9 +281,12 @@ def grouped_topk_flaggems(
     bias,
     scoring_func=0,
 ):
-    from flag_gems import grouped_topk
-
-    return grouped_topk(
+    grouped_topk_impl = (
+        _pt2_grouped_topk
+        if _USE_TRANSPARENT_MOE_ROUTING
+        else _grouped_topk
+    )
+    return grouped_topk_impl(
         scores,
         n_group,
         topk_group,
@@ -258,6 +299,7 @@ def grouped_topk_flaggems(
 
 
 def moe_sum_flaggems(inp, out):
-    from flag_gems import moe_sum
-
-    moe_sum(inp, out)
+    if _USE_TRANSPARENT_MOE_PRIMITIVES:
+        _pt2_moe_sum(inp, out)
+    else:
+        _moe_sum(inp, out)

--- a/vllm_fl/dispatch/backends/flaggems/impl/mhc.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/mhc.py
@@ -2,9 +2,77 @@
 
 """
 FlagGems implementations for mHC (Multi-Head Convolution) operators.
+
+All imports and control logic are hoisted to module scope: the frozen
+CachedOp dispatch calls these functions from inside ``torch.compile`` traces,
+so no lazy import / monkey-patching may happen in the call path (the first
+trace would fail at ``importlib`` machinery inside Dynamo).
+
+Execution policy:
+
+- PT2-capable builds (``torch.library.triton_op`` + ``wrap_triton`` present)
+  route through ``flag_gems.pt2.mhc``, which launches the *original* FlagGems
+  JITFunctions traceably in both eager and compiled execution.  The GEMM then
+  performs a plain ``fn.to(bfloat16)`` — the same aten op the eager
+  ``_FN_BF16_CACHE`` would return — so the WeakKeyDictionary/id cache and its
+  patch never enter the traced path at all, making that patch unnecessary on
+  this path.
+- Older Torch builds (USE_C_EXTENSION=1-style eager environments) keep the
+  exact pre-existing eager behavior: ``flag_gems.mhc_*`` with the
+  ``_FN_BF16_CACHE`` id-key patch applied at import time.
 """
 
 import torch
+
+import flag_gems
+import flag_gems.fused.mhc as _mhc_pkg  # noqa: F401  (ensures submodules loaded)
+from flag_gems.pt2 import mhc as _pt2_mhc
+
+# ``import flag_gems.fused.mhc.mhc_pre as ...`` would bind the re-exported
+# *function* (flag_gems.fused.mhc.__init__ shadows the submodule), so go
+# through importlib to get the module object itself.
+import importlib as _importlib
+
+_mhc_pre_mod = _importlib.import_module("flag_gems.fused.mhc.mhc_pre")
+
+_USE_PT2_MHC = _pt2_mhc.supports_pt2_triton()
+
+if not _USE_PT2_MHC:
+    # Workaround: flag_gems uses a WeakKeyDictionary with tensor keys.
+    # WeakKeyDictionary.get() creates a new weakref and dict lookup calls
+    # ref.__eq__ which delegates to tensor.__eq__, returning a multi-element
+    # tensor instead of a scalar bool — causing RuntimeError.
+    # Patch the module's _FN_BF16_CACHE with an id-based cache.  Applied once
+    # at import time, and only on the eager path that actually calls
+    # ``flag_gems.fused.mhc.mhc_pre`` directly.
+
+    def _patch_fn_bf16_cache(mod):
+        """Replace the WeakKeyDictionary-based _FN_BF16_CACHE with an id-keyed dict."""
+        if getattr(mod, '_FN_BF16_CACHE_PATCHED', False):
+            return
+
+        class _IdKeyCache:
+            """Cache keyed by tensor id (data_ptr) to avoid tensor __eq__ issues."""
+
+            def __init__(self):
+                self._data = {}
+
+            def get(self, key, default=None):
+                return self._data.get(id(key), default)
+
+            def __setitem__(self, key, value):
+                self._data[id(key)] = value
+
+            def __getitem__(self, key):
+                return self._data[id(key)]
+
+            def __contains__(self, key):
+                return id(key) in self._data
+
+        mod._FN_BF16_CACHE = _IdKeyCache()
+        mod._FN_BF16_CACHE_PATCHED = True
+
+    _patch_fn_bf16_cache(_mhc_pre_mod)
 
 
 def mhc_pre_flaggems(
@@ -20,18 +88,21 @@ def mhc_pre_flaggems(
     n_splits: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """FlagGems native implementation of mhc_pre."""
-    import importlib
-    from flag_gems import mhc_pre
+    if _USE_PT2_MHC:
+        return _pt2_mhc.mhc_pre(
+            residual=residual,
+            fn=fn,
+            hc_scale=hc_scale,
+            hc_base=hc_base,
+            rms_eps=rms_eps,
+            hc_pre_eps=hc_pre_eps,
+            hc_sinkhorn_eps=hc_sinkhorn_eps,
+            hc_post_mult_value=hc_post_mult_value,
+            sinkhorn_repeat=sinkhorn_repeat,
+            n_splits=n_splits,
+        )
 
-    # Workaround: flag_gems uses a WeakKeyDictionary with tensor keys.
-    # WeakKeyDictionary.get() creates a new weakref and dict lookup calls
-    # ref.__eq__ which delegates to tensor.__eq__, returning a multi-element
-    # tensor instead of a scalar bool — causing RuntimeError.
-    # Patch the module's _FN_BF16_CACHE with an id-based cache.
-    _mhc_pre_mod = importlib.import_module('flag_gems.fused.mhc.mhc_pre')
-    _patch_fn_bf16_cache(_mhc_pre_mod)
-
-    return mhc_pre(
+    return flag_gems.mhc_pre(
         residual=residual,
         fn=fn,
         hc_scale=hc_scale,
@@ -45,33 +116,6 @@ def mhc_pre_flaggems(
     )
 
 
-def _patch_fn_bf16_cache(mod):
-    """Replace the WeakKeyDictionary-based _FN_BF16_CACHE with an id-keyed dict."""
-    if getattr(mod, '_FN_BF16_CACHE_PATCHED', False):
-        return
-
-    class _IdKeyCache:
-        """Cache keyed by tensor id (data_ptr) to avoid tensor __eq__ issues."""
-
-        def __init__(self):
-            self._data = {}
-
-        def get(self, key, default=None):
-            return self._data.get(id(key), default)
-
-        def __setitem__(self, key, value):
-            self._data[id(key)] = value
-
-        def __getitem__(self, key):
-            return self._data[id(key)]
-
-        def __contains__(self, key):
-            return id(key) in self._data
-
-    mod._FN_BF16_CACHE = _IdKeyCache()
-    mod._FN_BF16_CACHE_PATCHED = True
-
-
 def mhc_post_flaggems(
     x: torch.Tensor,
     residual: torch.Tensor,
@@ -79,9 +123,10 @@ def mhc_post_flaggems(
     comb: torch.Tensor,
 ) -> torch.Tensor:
     """FlagGems native implementation of mhc_post."""
-    from flag_gems import mhc_post
+    if _USE_PT2_MHC:
+        return _pt2_mhc.mhc_post(x, residual, post, comb)
 
-    return mhc_post(x, residual, post, comb)
+    return flag_gems.mhc_post(x, residual, post, comb)
 
 
 def hc_head_fused_kernel_flaggems(
@@ -96,9 +141,14 @@ def hc_head_fused_kernel_flaggems(
     hc_mult: int,
 ) -> None:
     """FlagGems native implementation of hc_head_fused_kernel. Mutates `out` in-place."""
-    from flag_gems import hc_head_fused_kernel
+    if _USE_PT2_MHC:
+        _pt2_mhc.hc_head_fused_kernel(
+            hs_flat, fn, hc_scale, hc_base, out,
+            hidden_size, rms_eps, hc_eps, hc_mult,
+        )
+        return
 
-    hc_head_fused_kernel(
+    flag_gems.hc_head_fused_kernel(
         hs_flat, fn, hc_scale, hc_base, out,
         hidden_size, rms_eps, hc_eps, hc_mult,
     )

--- a/vllm_fl/dispatch/backends/flaggems/impl/normalization.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/normalization.py
@@ -10,6 +10,19 @@ from typing import Optional, Union
 
 import torch
 
+import flag_gems
+from flag_gems.config import use_c_extension
+from flag_gems.modules.normalization import gems_rms_forward
+from flag_gems.pt2.rms_norm import rms_norm as _pt2_rms_norm
+
+
+# The Python adapter captures the common/NVIDIA Triton objects.  Other vendors
+# may replace RMSNorm, while a C++ installation deliberately selects its
+# torch.ops implementation.  Preserve both choices instead of bypassing them.
+_USE_TRANSPARENT_RMS_NORM = (
+    flag_gems.vendor_name == "nvidia" and not use_c_extension
+)
+
 
 def rms_norm_flaggems(
     obj,
@@ -27,10 +40,17 @@ def rms_norm_flaggems(
     Returns:
         Normalized tensor, or tuple of (normalized, residual) if residual is provided
     """
-    from flag_gems.modules.normalization import gems_rms_forward
-
     # Get weight and epsilon from obj
     weight = obj.weight
     epsilon = obj.variance_epsilon
+
+    if _USE_TRANSPARENT_RMS_NORM:
+        variance_size_override = getattr(obj, "variance_size_override", None)
+        if variance_size_override is not None:
+            raise RuntimeError(
+                "FlagGems transparent RMSNorm does not support vLLM "
+                "variance_size_override; select a compatible backend"
+            )
+        return _pt2_rms_norm(x, residual, weight, epsilon)
 
     return gems_rms_forward(x, residual, weight, epsilon)

--- a/vllm_fl/dispatch/backends/flaggems/impl/rotary.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/rotary.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import torch
 
+from flag_gems.pt2 import rotary_embedding_inplace
+
 
 def rotary_embedding_flaggems(
     obj,
@@ -35,6 +37,24 @@ def rotary_embedding_flaggems(
     Returns:
         Tuple of (embedded_query, embedded_key)
     """
+    if inplace:
+        if position_ids is None:
+            raise ValueError(
+                "The compiler-integrated FlagGems RoPE path requires position_ids"
+            )
+        rotary_embedding_inplace(
+            query,
+            key,
+            cos,
+            sin,
+            position_ids,
+            rotary_interleaved,
+        )
+        return query, key
+
+    # vLLM uses the in-place path above.  Keep the generic out-of-place API on
+    # FlagGems' original implementation until it receives its own manifest
+    # entry; do not substitute a native PyTorch implementation.
     from flag_gems.modules.rotary_embedding import gems_rope_forward
 
     return gems_rope_forward(
@@ -44,5 +64,5 @@ def rotary_embedding_flaggems(
         sin,
         position_ids=position_ids,
         rotary_interleaved=rotary_interleaved,
-        inplace=inplace,
+        inplace=False,
     )

--- a/vllm_fl/dispatch/backends/flaggems/impl/router_gemm.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/router_gemm.py
@@ -4,12 +4,12 @@
 
 import torch
 
+from flag_gems import router_gemm
+
 
 def router_gemm_bf16_fp32_flaggems(
     x: torch.Tensor, weight: torch.Tensor
 ) -> torch.Tensor:
-    from flag_gems import router_gemm
-
     # Keep vLLM's descriptive dispatch name at the plugin boundary.  The
     # current FlagGems public API calls the same bf16 x bf16 -> fp32 primitive
     # simply ``router_gemm``.

--- a/vllm_fl/dispatch/backends/flaggems/register_ops.py
+++ b/vllm_fl/dispatch/backends/flaggems/register_ops.py
@@ -48,6 +48,25 @@ def register_builtins(registry) -> None:
         registry: Registry to register into
     """
     from .flaggems import FlagGemsBackend
+    # Import compiler-visible implementations while dispatch is still in its
+    # initialization phase.  Registering a torch.library op during Dynamo
+    # tracing would itself be Python control flow and is intentionally banned.
+    from .impl.activation import (
+        gelu_and_mul_flaggems,
+        silu_and_mul_flaggems,
+        silu_and_mul_with_clamp_flaggems,
+    )
+    from .impl.fused_moe import (
+        fused_topk_bias_flaggems,
+        grouped_topk_flaggems,
+        invoke_fused_moe_triton_kernel_flaggems,
+        moe_align_block_size_flaggems,
+        moe_sum_flaggems,
+        topk_softmax_flaggems,
+    )
+    from .impl.normalization import rms_norm_flaggems
+    from .impl.rotary import rotary_embedding_flaggems
+    from .impl.router_gemm import router_gemm_bf16_fp32_flaggems
 
     backend = FlagGemsBackend()
     is_avail = backend.is_available
@@ -63,7 +82,7 @@ def register_builtins(registry) -> None:
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
             fn=_bind_is_available(
-                backend.router_gemm_bf16_fp32,
+                router_gemm_bf16_fp32_flaggems,
                 _has_flaggems_op("router_gemm"),
             ),
             vendor=None,
@@ -74,7 +93,7 @@ def register_builtins(registry) -> None:
             op_name="silu_and_mul",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.silu_and_mul, is_avail),
+            fn=_bind_is_available(silu_and_mul_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -82,7 +101,7 @@ def register_builtins(registry) -> None:
             op_name="gelu_and_mul",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.gelu_and_mul, is_avail),
+            fn=_bind_is_available(gelu_and_mul_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -90,7 +109,7 @@ def register_builtins(registry) -> None:
             op_name="silu_and_mul_with_clamp",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.silu_and_mul_with_clamp, is_avail),
+            fn=_bind_is_available(silu_and_mul_with_clamp_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -99,7 +118,7 @@ def register_builtins(registry) -> None:
             op_name="rms_norm",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.rms_norm, is_avail),
+            fn=_bind_is_available(rms_norm_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -108,7 +127,7 @@ def register_builtins(registry) -> None:
             op_name="rotary_embedding",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.rotary_embedding, is_avail),
+            fn=_bind_is_available(rotary_embedding_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -126,7 +145,7 @@ def register_builtins(registry) -> None:
             op_name="fused_topk_bias",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.fused_topk_bias, is_avail),
+            fn=_bind_is_available(fused_topk_bias_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -135,7 +154,7 @@ def register_builtins(registry) -> None:
             op_name="moe_align_block_size",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.moe_align_block_size, is_avail),
+            fn=_bind_is_available(moe_align_block_size_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -144,7 +163,7 @@ def register_builtins(registry) -> None:
             op_name="moe_sum",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.moe_sum, is_avail),
+            fn=_bind_is_available(moe_sum_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -153,7 +172,7 @@ def register_builtins(registry) -> None:
             op_name="topk_softmax",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.topk_softmax, is_avail),
+            fn=_bind_is_available(topk_softmax_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -162,7 +181,9 @@ def register_builtins(registry) -> None:
             op_name="invoke_fused_moe_triton_kernel",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.invoke_fused_moe_triton_kernel, is_avail),
+            fn=_bind_is_available(
+                invoke_fused_moe_triton_kernel_flaggems, is_avail
+            ),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -171,7 +192,7 @@ def register_builtins(registry) -> None:
             op_name="grouped_topk",
             impl_id="default.flagos",
             kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.grouped_topk, is_avail),
+            fn=_bind_is_available(grouped_topk_flaggems, is_avail),
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
@@ -352,22 +373,15 @@ def register_builtins(registry) -> None:
             vendor=None,
             priority=BackendPriority.DEFAULT,
         ),
-        OpImpl(
-            op_name="gather_bf16_kv_from_pages",
-            impl_id="default.flagos",
-            kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.gather_bf16_kv_from_pages, is_avail),
-            vendor=None,
-            priority=BackendPriority.DEFAULT,
-        ),
-        OpImpl(
-            op_name="bf16_mqa_logits",
-            impl_id="default.flagos",
-            kind=BackendImplKind.DEFAULT,
-            fn=_bind_is_available(backend.bf16_mqa_logits, is_avail),
-            vendor=None,
-            priority=BackendPriority.DEFAULT,
-        ),
+        # ``gather_bf16_kv_from_pages`` and ``bf16_mqa_logits`` deliberately
+        # have no default.flagos registration.  Their FlagGems backend methods
+        # are interface placeholders which raise NotImplementedError.  Eager
+        # dispatch previously hid this by catching
+        # the exception and falling back to vendor.cuda; frozen dispatch has no
+        # exception-driven fallback in its hot path, so advertising either
+        # placeholder as available would permanently select a function that
+        # cannot run.  Keep these operations vendor-only until FlagGems ships
+        # real implementations and their PT2 contracts are validated.
     ]
 
     filtered = [impl for impl in impls if use_flaggems_op(impl.op_name)]

--- a/vllm_fl/dispatch/backends/vendor/cuda/register_ops.py
+++ b/vllm_fl/dispatch/backends/vendor/cuda/register_ops.py
@@ -32,6 +32,14 @@ def register_builtins(registry) -> None:
         registry: Registry to register into
     """
     from .cuda import CudaBackend
+    # MHC is called directly from compiled model code.  Import and bind these
+    # leaf functions during dispatch initialization so the frozen call path
+    # contains no lazy import or backend-method control flow.
+    from .impl.mhc import (
+        hc_head_fused_kernel_cuda,
+        mhc_post_cuda,
+        mhc_pre_cuda,
+    )
 
     backend = CudaBackend()
     is_avail = backend.is_available
@@ -161,7 +169,7 @@ def register_builtins(registry) -> None:
             op_name="mhc_pre",
             impl_id="vendor.cuda",
             kind=BackendImplKind.VENDOR,
-            fn=_bind_is_available(backend.mhc_pre, is_avail),
+            fn=_bind_is_available(mhc_pre_cuda, is_avail),
             vendor="cuda",
             priority=BackendPriority.VENDOR,
         ),
@@ -170,7 +178,7 @@ def register_builtins(registry) -> None:
             op_name="mhc_post",
             impl_id="vendor.cuda",
             kind=BackendImplKind.VENDOR,
-            fn=_bind_is_available(backend.mhc_post, is_avail),
+            fn=_bind_is_available(mhc_post_cuda, is_avail),
             vendor="cuda",
             priority=BackendPriority.VENDOR,
         ),
@@ -179,7 +187,7 @@ def register_builtins(registry) -> None:
             op_name="hc_head_fused_kernel",
             impl_id="vendor.cuda",
             kind=BackendImplKind.VENDOR,
-            fn=_bind_is_available(backend.hc_head_fused_kernel, is_avail),
+            fn=_bind_is_available(hc_head_fused_kernel_cuda, is_avail),
             vendor="cuda",
             priority=BackendPriority.VENDOR,
         ),

--- a/vllm_fl/dispatch/manager.py
+++ b/vllm_fl/dispatch/manager.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import threading
 from dataclasses import dataclass
 from typing import Callable, Dict, Optional, Set, Tuple
@@ -634,4 +635,8 @@ def reset_default_manager() -> None:
     global _default_manager
 
     with _manager_lock:
+        dispatch_module = sys.modules.get("vllm_fl.dispatch")
+        thaw = getattr(dispatch_module, "thaw_dispatch", None)
+        if callable(thaw):
+            thaw()
         _default_manager = None

--- a/vllm_fl/dispatch/policy.py
+++ b/vllm_fl/dispatch/policy.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextvars
 import logging
 import os
+import sys
 import threading
 import yaml
 from dataclasses import dataclass, field
@@ -19,6 +20,18 @@ from vllm_fl.utils import get_op_config
 
 
 logger = logging.getLogger(__name__)
+
+
+def _ensure_dispatch_mutable(action: str) -> None:
+    """Reject policy mutations after operator implementations are bound."""
+
+    dispatch_module = sys.modules.get("vllm_fl.dispatch")
+    is_frozen = getattr(dispatch_module, "is_dispatch_frozen", None)
+    if callable(is_frozen) and is_frozen():
+        raise RuntimeError(
+            f"Cannot {action} while vLLM-FL dispatch is frozen. "
+            "Discard the compiled runner and call thaw_dispatch() first."
+        )
 
 
 # Valid preference values for VLLM_FL_PREFER
@@ -201,6 +214,7 @@ class PolicyManager:
 
     def set_global_policy(self, policy: SelectionPolicy) -> SelectionPolicy:
         """Set the global policy and return the old policy."""
+        _ensure_dispatch_mutable("set the global policy")
         with self._global_policy_lock:
             old_policy = self._global_policy
             self._global_policy = policy
@@ -209,6 +223,7 @@ class PolicyManager:
 
     def reset_global_policy(self) -> None:
         """Reset the global policy to environment defaults."""
+        _ensure_dispatch_mutable("reset the global policy")
         with self._global_policy_lock:
             self._global_policy = None
             self.bump_policy_epoch()
@@ -479,6 +494,7 @@ class _PolicyContext:
         self._token: Optional[contextvars.Token] = None
 
     def __enter__(self) -> "_PolicyContext":
+        _ensure_dispatch_mutable("enter a policy context")
         policy_var = self._manager._get_policy_var()
         self._token = policy_var.set(self._policy)
         self._manager.bump_policy_epoch()

--- a/vllm_fl/ops/fused_moe/layer.py
+++ b/vllm_fl/ops/fused_moe/layer.py
@@ -142,6 +142,7 @@ class FusedMoEFL(FusedMoE):
                 routed_scaling_factor=router.routed_scaling_factor,
                 enable_eplb=router.enable_eplb,
                 indices_type_getter=router.indices_type_getter,
+                hash_indices_table=router._hash_indices_table,
             )
         elif isinstance(router, FusedTopKRouter):
             self.router = FusedTopKRouterFL(

--- a/vllm_fl/ops/fused_moe/router.py
+++ b/vllm_fl/ops/fused_moe/router.py
@@ -16,7 +16,6 @@ from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
 )
 from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
     FusedTopKBiasRouter,
-    fused_topk_bias
 )
 from vllm_fl.dispatch import CachedOp
 
@@ -182,7 +181,11 @@ class GroupedTopKRouterFL(GroupedTopKRouter):
 
         if not valid_grouping():
             if self.e_score_correction_bias is not None:
-                topk_weights, topk_ids = fused_topk_bias(
+                # Keep the invalid-group fallback inside the same frozen FL
+                # dispatch contract instead of bypassing CachedOp through the
+                # upstream vLLM helper.  Scaling remains below and is applied
+                # exactly once, matching the pre-existing branch semantics.
+                topk_weights, topk_ids = _fused_topk_bias(
                     hidden_states=hidden_states,
                     gating_output=router_logits,
                     e_score_correction_bias=self.e_score_correction_bias.data,
@@ -249,6 +252,8 @@ class FusedTopKBiasRouterFL(FusedTopKBiasRouter):
             topk=self.top_k,
             renormalize=self.renormalize,
             indices_type=indices_type,
+            input_tokens=input_ids,
+            hash_indices_table=self._hash_indices_table,
             routed_scaling_factor=self.routed_scaling_factor,
         )
 

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -4966,6 +4966,15 @@ class ModelRunnerFL(
         ):
             self.eplb_state.start_async_loop()
 
+        # Resolve the FL control-plane dispatch after the model and its optional
+        # operator modules have been loaded, but before either stock
+        # torch.compile or vLLM's first profiling/compile call can trace the
+        # forward path.  Frozen CachedOp sites directly call their selected
+        # implementation and never enter policy, locks, IO dump, or fallback.
+        from vllm_fl.compilation import freeze_dispatch_for_compile
+
+        freeze_dispatch_for_compile(self.vllm_config)
+
         if (
             self.vllm_config.compilation_config.mode
             == CompilationMode.STOCK_TORCH_COMPILE
@@ -5085,7 +5094,7 @@ class ModelRunnerFL(
             logger.warning_once(
                 "Reloading with `is_checkpoint_format=True` requires that "
                 "weights be in kernel format and already sharded",
-                
+
             )
             loaded_weights = set()
             for name, loaded_weight in weights_iterator:
@@ -5099,7 +5108,7 @@ class ModelRunnerFL(
         logger.info_once(
             "Reloading and processing weights took %.2f seconds",
             diff_seconds,
-            
+
         )
         if self.model_config.quantization is None and loaded_weights is not None:
             weights_not_loaded = weights_to_load - loaded_weights
@@ -5883,7 +5892,7 @@ class ModelRunnerFL(
                             encoder_budget,
                             max_mm_items_per_batch,
                             dummy_modality,
-                            
+
                         )
 
                         # Create dummy batch of multimodal inputs.
@@ -6200,7 +6209,7 @@ class ModelRunnerFL(
             "Graph capturing finished in %.0f secs, took %.2f GiB",
             elapsed_time,
             cuda_graph_size / (1 << 30),
-            
+
         )
         return cuda_graph_size
 
@@ -6922,7 +6931,7 @@ class ModelRunnerFL(
         self,
         kv_cache_config: KVCacheConfig,
         is_profiling: bool = False,
-    ) -> None:        
+    ) -> None:
         """
         Initialize KV cache based on `kv_cache_config`.
         Args:


### PR DESCRIPTION
### PR Category
Core

### PR Type
New Features + Bug Fixes

### Description

Make vLLM-FL's operator dispatch **traceable by `torch.compile`**, so that
`--compilation-config '{"custom_ops": ["all"]}'` works with the FlagGems backend on the
vLLM 0.20.x line (`release/0.2`).

Today `CachedOp` selects an implementation *at call time* (policy lookup, locks, IO dump,
fallback). Dynamo cannot trace that control flow, so compiling any model that routes an op
through vLLM-FL graph-breaks — and vLLM compiles with `fullgraph=True`, so the break is a hard
startup failure (`torch._dynamo.exc.Unsupported: Unsupported method call ... __getitem__` in
`LibEntry.run`, or `logging.Logger method not supported`). This is the failure reported for
MiniCPM-class models on the RMSNorm no-residual branch.

Three coordinated changes:

1. **Freeze dispatch before the first Dynamo trace** (`vllm_fl/dispatch/*`,
   `vllm_fl/compilation/dispatch.py`, `worker/model_runner.py`).
   `freeze_dispatch()` resolves every imported `CachedOp` site once (optional ops that fail to
   resolve are recorded in a `FrozenDispatchManifest`; calling one afterwards raises a
   deterministic pre-Dynamo error). After freezing, `CachedOp.__call__` directly invokes the
   selected implementation. `freeze_dispatch_for_compile(vllm_config)` runs from the model
   runner after model + optional op modules load and before profiling/compile; it is a no-op
   for eager execution, and it writes the dispatch fingerprint into
   `additional_config["vllm_fl_dispatch_fingerprint"]` so the frozen selection becomes part of
   vLLM's compile-cache identity (a stale pre-fingerprint cache dir is cleared). Policy
   mutations while frozen raise instead of silently diverging from the compiled graph;
   `thaw_dispatch()` / `reset_default_manager()` restore mutability.

2. **Logger compile guard.** FlagGems wrappers contain ~60 `logger.debug` sites; each one is
   a graph break under `custom_ops=all`. Rather than editing them individually, the compile
   path registers `logging.Logger.{debug,info,warning,error}` in
   `torch._dynamo.config.ignore_logging_functions` (documented PyTorch escape hatch,
   idempotent, active only when compiling). Eager logging is unchanged.

3. **Point compiled execution at the `flag_gems.pt2` contracts (NVIDIA only).** With dispatch
   frozen, the implementation Dynamo sees must itself be traceable. On NVIDIA (and not the
   C-extension build) the flaggems backend impls route RMSNorm / fused-add-RMSNorm (both
   residual branches), in-place RoPE, the silu/gelu `*_and_mul` families and MoE routing /
   primitives to the `triton_op`-wrapped originals in `flag_gems.pt2`. Other vendors keep their
   existing path (MoE routing additionally verifies the exact kernel objects before enabling
   the transparent route). Register-ops bind module-level leaf functions instead of backend
   methods so frozen sites are plain callables with no lazy imports.

Requires the companion FlagGems PR that adds `flag_gems.pt2`.

### Related Issues
https://github.com/flagos-ai/vllm-plugin-FL/issues/298

### Changes

- `vllm_fl/dispatch/__init__.py`: `freeze_dispatch`, `thaw_dispatch`, `is_dispatch_frozen`,
  `get_frozen_dispatch_manifest`, `FrozenOpSelection`, `FrozenDispatchManifest`, fork reset
- `vllm_fl/dispatch/policy.py`, `manager.py`: reject policy mutation while frozen; thaw on reset
- `vllm_fl/compilation/dispatch.py` (new): `freeze_dispatch_for_compile`, cache fingerprint,
  logger compile guard; exported from `vllm_fl/compilation/__init__.py`
- `vllm_fl/worker/model_runner.py`: call `freeze_dispatch_for_compile` before profile/compile
- `vllm_fl/dispatch/backends/flaggems/{register_ops,flaggems}.py`,
  `impl/{normalization,activation,rotary,fused_moe,mhc,router_gemm}.py`,
  `backends/vendor/cuda/register_ops.py`: PT2-adapter routing and leaf-function binding
- `vllm_fl/ops/fused_moe/{router,layer}.py`: grouped-topk fallback stays inside the frozen
  `call_op("fused_topk_bias")` contract; pass `hash_indices_table`
- `tests/unit_tests/dispatch/test_frozen_dispatch.py` (new)
- `MANIFEST.in` (new): sdist includes `csrc` build inputs
- `model_runner.py`: pre-commit also removed 5 pre-existing trailing-whitespace blank lines

### Testing

- `pytest tests/unit_tests/dispatch/test_frozen_dispatch.py` — 3 passed (freeze/thaw
  lifecycle, manifest, policy-mutation rejection).
- End-to-end on 8× H800, vLLM 0.20.2, torch 2.11.0+cu130, triton 3.6.0:
  `vllm serve --compilation-config '{"custom_ops": ["all"]}' --tensor-parallel-size 2` for
  MiniCPM5-1B and DeepSeek-V2-Lite: startup, profile run, CUDA-graph capture and real
  completions/chat succeed. Qwen3-0.6B: dispatch frozen, fingerprint in cache identity,
  119 CUDA-graph captures, in-process and spawn workers.
- Negative control: the unmodified plugin at this base, same command, fails in Dynamo on
  the RMSNorm no-residual branch (`flag_gems/utils/libentry.py:1647`).
- Ran the repo's `pre-commit` (ruff check/format, typos, whitespace hooks): all pass.

### Checklist
- [x] I have run the existing tests and they pass
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)