### PR TITLE
[CICD] kunlunxin validate image response keywords

### DIFF
--- a/tests/platforms/kunlunxin.yaml
+++ b/tests/platforms/kunlunxin.yaml
@@ -57,6 +57,9 @@ device_overrides:
         - name: image
           generated_image: true
           prompt: "Describe all visible text, colors, and shapes in English."
+          expected:
+            - "Hello VLM"
+            - "blue rectangle"
       extra_body:
         chat_template_kwargs:
           enable_thinking: false

--- a/tests/platforms/kunlunxin.yaml
+++ b/tests/platforms/kunlunxin.yaml
@@ -38,6 +38,7 @@ device_overrides:
       - qwen3_6/35b_a3b_tp4_graph
     llm:
       max_model_len: 16384
+      max_num_seqs: 16
       block_size: 128
       gpu_memory_utilization: 0.8
       disable_custom_all_reduce: false

--- a/tests/platforms/kunlunxin.yaml
+++ b/tests/platforms/kunlunxin.yaml
@@ -38,7 +38,6 @@ device_overrides:
       - qwen3_6/35b_a3b_tp4_graph
     llm:
       max_model_len: 16384
-      max_num_seqs: 16
       block_size: 128
       gpu_memory_utilization: 0.8
       disable_custom_all_reduce: false


### PR DESCRIPTION
## Summary

Enable output validation for the Kunlunxin serving E2E image case by requiring the generated response to contain:

- \Hello VLM\
- \lue rectangle\

This matches the generated image fixture and the shared Qwen3.6 serving cases.

## Scope

- Update only \	ests/platforms/kunlunxin.yaml\
- No workflow, test implementation, or operator changes

## Validation

- YAML parsing passed
- Kunlunxin matrix generation passed
- Resolved \27b_tp4_graph\ and \35b_a3b_tp4_eager\ serving configs include both expected keywords
- Hardware validation is delegated to the Kunlunxin PR workflow