### PR TITLE
fix(musa): backport 4 MUSA compatibility patches to v0.2.0

### DIFF
--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -1,3 +1,15 @@
+# Inject float4_e2m1fn_x2 sentinel for MUSA torch (missing in torch 2.7.1)
+import torch
+if not hasattr(torch, "float4_e2m1fn_x2"):
+    torch.float4_e2m1fn_x2 = None
+
+# Apply MUSA compatibility patches
+try:
+    from vllm_fl.dispatch.backends.vendor.musa.patch import apply_musa_patches
+    apply_musa_patches()
+except ImportError:
+    pass  # MUSA backend not available
+
 # Copyright (c) 2025 BAAI. All rights reserved.
 
 import os


### PR DESCRIPTION
## Summary

Backport 4 critical MUSA compatibility fixes from v0.3.0-rc0 to v0.2.0-rc0.post1 to enable FlagOS 2.2-RC0 standard stack testing on Moore Threads MUSA platform.

Fixes #458

**Note**: The original issue mentioned 5 fixes, but after testing with the correct rc0 versions, Fix 1 (DeviceDetector path) is **not needed**. FlagGems v5.3.0-rc0.1 uses `device.py` which matches plugin v0.2.0-rc0.post1's import path. Only 4 fixes are required.

## Changes

### Fix 1: float4_e2m1fn_x2 sentinel (`vllm_fl/__init__.py`)
- **Root cause**: MUSA torch 2.7.1 lacks `torch.float4_e2m1fn_x2` type
- **Fix**: Inject `None` sentinel to prevent AttributeError
- **Error before fix**: `AttributeError: module 'torch' has no attribute 'float4_e2m1fn_x2'`

### Fix 2: attention_backend signature (`musa/musa.py`)
- **Root cause**: Function missing `use_sparse` parameter
- **Fix**: Add `use_sparse: bool = False` to function signature
- **Error before fix**: `attention_backend() got an unexpected keyword argument 'use_sparse'`

### Fix 3: attention_backend API paths (`musa/musa.py`)
- **Root cause**: vLLM 0.20.2 uses v1 attention API
- **Fix**: Update import to `vllm.v1.attention.backends.registry.AttentionBackendEnum`
- **Fix**: Return `AttentionBackendEnum.TRITON_ATTN.get_path()`
- **Error before fix**: `ModuleNotFoundError: No module named 'vllm.attention'`

### Fix 4: MUSA torch API compatibility (`musa/patch.py`)
- **Root cause**: MUSA backend doesn't support standard torch accelerator/cuda APIs
- **Fix**: New `patch.py` module with `apply_musa_patches()`
  - Patch `torch.accelerator.synchronize` → `torch_musa.synchronize`
  - Patch `torch.cuda.get_device_properties/capability` for MUSA devices
- **Error before fix**: `RuntimeError: Backend doesn't support synchronizing`

## Test Results

- **Environment**: MUSA S5000, vLLM 0.20.2, plugin v0.2.0-rc0.post1, **FlagGems v5.3.0-rc0.1**
- **Test date**: 2026-09-08
- **Test server**: 10.121.38.26
- **Before fixes**: 4 initialization errors blocking plugin load
- **After fixes**: All imports successful, ready for model inference ✅

## Files Changed

- `vllm_fl/__init__.py`: Add float4 sentinel + apply MUSA patches
- `vllm_fl/dispatch/backends/vendor/musa/musa.py`: Fix attention_backend signature and API paths
- `vllm_fl/dispatch/backends/vendor/musa/patch.py`: New file, MUSA compatibility patch module

## Related Issues

- Fixes #458
- All 4 fixes are already present in v0.3.0-rc0, this PR backports them to v0.2.0 branch