### PR TITLE
fix(thead): restore static graph support from #279

### DIFF
--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -346,7 +346,7 @@ class PlatformFL(Platform):
 
     @classmethod
     def support_static_graph_mode(cls) -> bool:
-        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon", "mthreads", "iluvatar"]:
+        if cls.vendor_name in ["nvidia", "ascend", "metax", "hygon", "mthreads", "iluvatar", "thead"]:
             return True
         return False
 


### PR DESCRIPTION
### PR Category
Vendor

### PR Type
Bug Fixes

### Description
Restore static graph support for the `thead` platform from #279, which is missing from the current main branch. Without this whitelist entry, vLLM can reset the configured `cudagraph_mode` to `NONE`, preventing CUDA Graph capture.

### Related Issues
Related to #279.

### Changes
- Add `thead` to `PlatformFL.support_static_graph_mode()`'s supported vendors.
- Cherry-pick commit 464424d2502661339b59da645a4cf10a105dab54 with source attribution.

### Testing
- `git diff FETCH_HEAD...HEAD --check` passed against upstream main.
- Verified the PR contains one commit and only the one-line whitelist change.
- Hardware validation on the T-Head PPU platform using the exact PR head `9c925b692b15b1419d7f23f1062c7999dddc0fd7` and clean vLLM v0.24.0 tag source `ee0da84ab9e04ac7610e28580af62c365e898389`.
- Model/configuration: Qwen3-0.6B, BF16, TP=1, max_model_len=512, max_num_seqs=4, prefix caching disabled, greedy decoding, seed=42, max_tokens=40. Vendor PyTorch 2.10.0 and Triton 3.5.0 were used.
- Compared eager execution, pre-patch behavior (static graph support disabled in-process), and the PR behavior. Each process ran the same three chat prompts twice. Device graph replay calls were counted after initialization.

| Case | Final graph mode | Replay calls during generation | Result |
| --- | --- | ---: | --- |
| Eager | NONE | 0 | Both rounds produced coherent answers |
| Before patch, compilation enabled | NONE | 0 | Both rounds produced coherent answers |
| With this PR | FULL_AND_PIECEWISE | 36 | Both rounds produced coherent answers |

- With the PR, graph capture succeeded for batch sizes **1, 2, and 4** for both mixed prefill/decode **PIECEWISE** and decode **FULL** modes. Actual replay was observed; execution did not silently fall back to NONE.
- Both graph-mode output rounds were token-for-token identical to the pre-patch compiled control. Prompts covered arithmetic, the capital of France, and a short Chinese description of Beijing.
- All three test processes exited successfully. This is a single-device smoke validation; large models, multi-device execution, long contexts, and the full test suite were not tested. These runs are not a performance benchmark.

### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)

