### PR TITLE
fix(attention): restore FlagGems KV cache updates from #382

### DIFF
--- a/vllm_fl/dispatch/backends/flaggems/impl/attention.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/attention.py
@@ -50,6 +50,11 @@ logger = init_logger(__name__)
 
 class AttentionFLBackend(AttentionBackend):
     accept_output_buffer: bool = True
+    # KV cache update is performed by vLLM via do_kv_cache_update() before
+    # forward(). Without this, vLLM assumes the backend updates the KV cache
+    # inside forward() and never calls do_kv_cache_update, leaving the cache
+    # unwritten (all zeros) and producing garbage output.
+    forward_includes_kv_cache_update: bool = False
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
 
     @staticmethod


### PR DESCRIPTION
### PR Category
Core

### PR Type
Bug Fixes

### Description
Fix garbled generation when `VLLM_FL_USE_FLAGGEMS_ATTN=1` selects `AttentionFLBackend` on the vLLM 0.24 main line. The implementation writes KV cache in `do_kv_cache_update()`, but inherits `forward_includes_kv_cache_update=True`. vLLM therefore skips the separate cache update even though `forward()` only reads the cache.

Declare `forward_includes_kv_cache_update=False` so vLLM updates the cache before attention. The default path, which selects native vLLM Triton attention when the environment switch is unset, is unaffected.

### Related Issues
Source PR: https://github.com/flagos-ai/vllm-plugin-FL/pull/382

Cherry-picked with `-x` from d599e5e8c9fdcc24ee757e0e8e14e3f5cf9d7771. This ports the original fix to the current vLLM 0.24 main lineage; source attribution and original author are preserved.

### Changes
- Declare that FlagGems attention forward does not include KV-cache updates.
- Preserve the explanatory comment from #382.

### Testing
A800-SXM4-80GB, GPU 0, Qwen3-0.6B, BF16, TP=1, eager mode, prefix caching disabled, seed 42, greedy decoding, max_tokens=48. Tested against clean plugin main 8926c11 and clean vLLM v0.24.0 tag source ee0da84ab9e04ac7610e28580af62c365e898389 (the source version string reports 0.24.1.dev0+gee0da84ab.d20260713), using the existing empty-build environment, Torch 2.11.0+cu130, and FlagGems 5.4.0.dev0.

The A/B experiment applied the identical class-attribute change in-process and counted actual `AttentionFLImpl` calls after warmup. Both arms explicitly set `VLLM_FL_USE_FLAGGEMS_ATTN=1`; FlashInfer sampling was disabled in all runs because the reused environment lacked an importable FlashInfer package.

| Run | Cache updates | AttentionFLImpl forwards | Result |
| --- | ---: | ---: | --- |
| Default native Triton control | N/A | 0 | All three prompts produced coherent answers |
| Explicit FlagGems, inherited True | 0 | 1344 | All three prompts produced identical garbled/repetitive output |
| Explicit FlagGems, False | 532 | 532 | All three outputs were token-for-token identical to the Triton control |

Prompts covered 2+2, the capital of France, and a one-sentence description of Beijing. Fixed answers included `2 + 2 = 4.` and `The capital of France is Paris.`

`git diff HEAD^ HEAD --check` passed after cherry-pick. CUDA Graph, multi-GPU, and broader model regression tests were not run; the full test suite was not run.

### Checklist
- [ ] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
