### PR TITLE
fix(sunrise): update patch.py to match current FlagCX wrapper API

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -75,7 +75,7 @@ def patch_flagcx_stream_adapter():
             new_stream = flagcxStream_t()
             raw_stream_ptr = _extract_raw_stream_ptr(old_stream)
             self.FLAGCX_CHECK(
-                self.handler.contents.devHandle.contents.streamCopy(
+                self.devHandle.contents.streamCopy(
                     ctypes.byref(new_stream), _to_void_p(raw_stream_ptr)
                 )
             )


### PR DESCRIPTION
Fixes #473

## Problem
`sunrise/patch.py` line 78 uses an obsolete FlagCX wrapper structure (`self.handler.contents.devHandle`), causing `AttributeError: 'FLAGCXLibrary' object has no attribute 'handler'` during distributed init on sunrise/ptpu backend.

## Root cause
The current FlagCX wrapper (v0.13.0+) holds `devHandle` as a direct attribute (`self.devHandle` at `flagcx_wrapper.py:498`), not nested under `self.handler`.

## Fix
Remove the obsolete `handler.contents.` layer to align with the current wrapper API.

## Testing
- Sunrise S2 8-card (ptpu0-7)
- vLLM 0.20.2+flagos, FlagCX v0.13.0
- Qwen3.6-27B TP=4 enforce-eager
- Distributed init now succeeds, text inference works

## Changes
```diff
- self.handler.contents.devHandle.contents.streamCopy(
+ self.devHandle.contents.streamCopy(
```

🤖 Generated with Claude Code