### PR TITLE
fix(sunrise): update FlagCX wrapper API call in stream adapter

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/sunrise/patch.py
@@ -75,7 +75,7 @@ def patch_flagcx_stream_adapter():
             new_stream = flagcxStream_t()
             raw_stream_ptr = _extract_raw_stream_ptr(old_stream)
             self.FLAGCX_CHECK(
-                self.handler.contents.devHandle.contents.streamCopy(
+                self.devHandle.contents.streamCopy(
                     ctypes.byref(new_stream), _to_void_p(raw_stream_ptr)
                 )
             )


### PR DESCRIPTION
## Problem

FlagCX v0.13.0 changed the wrapper structure. The `FLAGCXLibrary` class now exposes `devHandle` directly on the instance instead of through `handler.contents`.

The old code path:
```python
self.handler.contents.devHandle.contents.streamCopy(...)
```

Results in:
```
AttributeError: 'FLAGCXLibrary' object has no attribute 'handler'
```

## Solution

Update to the new API structure:
```python
self.devHandle.contents.streamCopy(...)
```

## Testing

Verified on Sunrise S2 hardware with:
- vLLM 0.20.2+empty
- vllm-plugin-FL v0.2.2-rc0  
- FlagGems v5.4.0-rc0
- FlagTree 0.7.0rc0
- FlagCX v0.13.0

Worker process starts successfully and distributed inference works.

Fixes #473