### PR TITLE
【kunlunxin】Fix CUDA Graph Performance and Accuracy

### DIFF
--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/impl/attention.py
@@ -32,6 +32,7 @@ from vllm.v1.attention.backends.utils import (
     split_decodes_and_prefills,
 )
 from vllm.v1.attention.backend import (
+    AttentionCGSupport,
     AttentionLayer,
     AttentionType,
     AttentionMetadataBuilder,
@@ -301,9 +302,9 @@ class KunlunxinMetadata:
             block_tables = (None if self.block_tables is None else
                         self.block_tables)
             query_start_loc = (None if self.query_start_loc is None else
-                               self.query_start_loc[:-self.num_prefills])
+                               self.query_start_loc)
             query_start_loc_host = (None if self.query_start_loc_host is None else
-                                    self.query_start_loc_host[:-self.num_prefills])
+                                    self.query_start_loc_host)
 
         # Construct & cache decode-phase attention metadata structure
         self._cached_decode_metadata = KunlunxinMetadata(
@@ -335,7 +336,9 @@ class KunlunxinAttentionMetadataBuilder(AttentionMetadataBuilder):
     """Builder for Kunlunxin attention metadata."""
 
     reorder_batch_threshold: ClassVar[int] = 1
-    # _cudagraph_support removed: AttentionCGSupport not available in vllm 0.20.2
+    _cudagraph_support: ClassVar[AttentionCGSupport] = (
+        AttentionCGSupport.UNIFORM_BATCH
+    )
 
     def __init__(self, kv_cache_spec: AttentionSpec,
                  layer_names: list[str],
@@ -886,9 +889,9 @@ class KunlunxinAttentionBackendImpl(AttentionImpl[KunlunxinMetadata]):
                     key_cache,
                     value_cache,
                     tmp_block_tables,
-                    attn_metadata.seq_lens_tensor,
-                    attn_metadata.seq_lens_tensor_host,
-                    attn_metadata.max_decode_seq_len,
+                    decode_meta.seq_lens_tensor,
+                    decode_meta.seq_lens_tensor_host,
+                    decode_meta.max_decode_seq_len,
                     num_decode_tokens,
                     self.kv_cache_dtype,
                     self.num_kv_heads,

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/patch.py
@@ -356,6 +356,33 @@ def patch_decode_attention():
         import vllm_fl.dispatch.backends.vendor.kunlunxin.impl.attention as attn_mod
         import xtorch_ops
 
+        # Keep the original implementation for CUDA graph replay. The
+        # workaround below allocates host-side LOD tensors from the current
+        # sequence lengths. Those allocations happen during graph capture,
+        # not during replay, so replay would otherwise keep using stale KV
+        # lengths as the decode sequence grows.
+        original_forward_decode = attn_mod.KunlunxinPagedAttention.forward_decode
+
+        def use_native_decode_for_cudagraph() -> bool:
+            try:
+                from vllm.config import CUDAGraphMode
+                from vllm.forward_context import (
+                    get_forward_context,
+                    is_forward_context_available,
+                )
+
+                if not is_forward_context_available():
+                    return False
+
+                return (
+                    get_forward_context().cudagraph_runtime_mode
+                    == CUDAGraphMode.FULL
+                )
+            except Exception:
+                # Keep the patch usable across vLLM minor versions that do
+                # not expose the runtime-mode field.
+                return False
+
         @staticmethod
         def patched_forward_decode(
             query, key_cache, value_cache, block_tables,
@@ -365,6 +392,27 @@ def patch_decode_attention():
         ):
             """Use prefill_attention in prefix_cache mode for decode."""
             import torch
+
+            if use_native_decode_for_cudagraph():
+                return original_forward_decode(
+                    query,
+                    key_cache,
+                    value_cache,
+                    block_tables,
+                    seq_lens,
+                    seq_lens_host,
+                    max_seq_len,
+                    num_decode_tokens,
+                    kv_cache_dtype,
+                    num_kv_heads,
+                    scale,
+                    alibi_slopes,
+                    k_scale,
+                    v_scale,
+                    max_window_size=max_window_size,
+                    output=output,
+                )
+
             if output is None:
                 output = torch.empty_like(query)
 

--- a/vllm_fl/dispatch/backends/vendor/kunlunxin/patch.py
+++ b/vllm_fl/dispatch/backends/vendor/kunlunxin/patch.py
@@ -356,13 +356,7 @@ def patch_decode_attention():
         import vllm_fl.dispatch.backends.vendor.kunlunxin.impl.attention as attn_mod
         import xtorch_ops
 
-        # Keep the original implementation for CUDA graph replay. The
-        # workaround below allocates host-side LOD tensors from the current
-        # sequence lengths. Those allocations happen during graph capture,
-        # not during replay, so replay would otherwise keep using stale KV
-        # lengths as the decode sequence grows.
         original_forward_decode = attn_mod.KunlunxinPagedAttention.forward_decode
-
         def use_native_decode_for_cudagraph() -> bool:
             try:
                 from vllm.config import CUDAGraphMode
@@ -370,10 +364,8 @@ def patch_decode_attention():
                     get_forward_context,
                     is_forward_context_available,
                 )
-
                 if not is_forward_context_available():
                     return False
-
                 return (
                     get_forward_context().cudagraph_runtime_mode
                     == CUDAGraphMode.FULL

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -5506,7 +5506,11 @@ class ModelRunnerFL(
                 cum_num_tokens = self._get_cumsum_and_arange(
                     num_scheduled_tokens, self.query_pos.np
                 )
+                self.query_start_loc.np[0] = 0
                 self.query_start_loc.np[1 : num_reqs + 1] = cum_num_tokens
+                self.query_start_loc.np[num_reqs + 1 :].fill(
+                    cum_num_tokens[-1]
+                )
                 self.query_start_loc.copy_to_gpu()
 
                 # Sync block table CPU->GPU so cleared rows from


### PR DESCRIPTION
<!--
 Copyright 2026 FlagOS Contributors

 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

     http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
### PR Category

Vendor

### PR Type

Bug Fixes

### Description

Fix Kunlunxin attention Decode metadata handling and CUDA Graph execution issues.

### Changes

* Fix pure Decode metadata handling.
* Use the correct Decode metadata for attention execution.
* Add uniform-batch CUDA Graph support.
* Use native Decode in FULL CUDA Graph mode.
* Fix `query_start_loc` initialization.

### Testing

* Tested with Qwen3.6-27B on Kunlunxin hardware with CUDA Graph enabled.

### Checklist

* [ ] I have run the existing tests and they pass
* [ ] I have added tests for my changes (if applicable)
* [ ] I have updated the documentation (if applicable)
