### PR TITLE
ci: add /rerun-failed-ci and /cancel-ci PR comment commands

### DIFF
--- a/.github/COMMANDS.md
+++ b/.github/COMMANDS.md
@@ -1,0 +1,32 @@
+# PR Comment Commands
+
+Slash commands typed as a PR comment (the comment must be **exactly** the
+command, with no extra text) so that PR authors — who often have no write
+access to this repository — can manage their own PR's CI from the timeline.
+
+| Command | Who can use | What it does |
+|---|---|---|
+| `/rerun-failed-ci` | PR author, or collaborators with `write`+ | Re-runs the failed jobs of the latest failed workflow runs for the PR's head commit (e.g. the main CI run and CodeQL, up to 5) |
+| `/cancel-ci` | PR author, or collaborators with `write`+ | Cancels all in-progress / queued workflow runs for the PR's head commit — the stop-loss for a hung e2e on a vendor runner |
+
+The bot reacts to the command comment when authorized and posts a result
+comment afterwards; failures include a link to the command's workflow log.
+
+## Safety model (applies to every command workflow)
+
+- Commands never check out or execute PR code. They only orchestrate
+  existing workflow runs through the Actions API, so the classic
+  `pull_request_target` code-execution risk does not apply.
+- Only the PR author and collaborators with `write`/`maintain`/`admin`
+  are honored. Comments from anyone else get an explicit rejection.
+- Runs awaiting admin approval (`action_required`) are never touched.
+- There are intentionally **no** commands that merge, approve, or change
+  pull-request state — merging stays with the native GitHub flow
+  (checks + review + the merge button / auto-merge).
+
+## Adding a new command
+
+One workflow per command under `.github/workflows/`, following the
+structure of `rerun-failed-ci.yml`: exact-match `if:` guard, the shared
+authorization step, an ack reaction, the action itself, and a result
+comment. Document it in the table above in the same PR.

--- a/.github/workflows/cancel-ci.yml
+++ b/.github/workflows/cancel-ci.yml
@@ -1,0 +1,98 @@
+# Cancel in-progress CI jobs when a PR author comments /cancel-ci.
+# Long-running e2e jobs on vendor runners can hang and burn 60-minute
+# timeouts on scarce hardware; a comment stops the burn without needing
+# repository write access.
+#
+# Safety model (same as rerun-failed-ci.yml):
+# - Never checks out or executes PR code; it only orchestrates existing
+#   workflow runs via the Actions API.
+# - Only the PR author and collaborators with write/maintain/admin are
+#   honored; comments from anyone else are rejected on the PR.
+# - The comment must be exactly "/cancel-ci" (no extra text).
+name: Cancel CI
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: cancel-ci-${{ github.event.comment.id }}
+  cancel-in-progress: false
+
+jobs:
+  cancel-ci:
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/cancel-ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check commenter authorization
+        id: auth
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+        run: |
+          set -euo pipefail
+          # Allow PR authors and anyone with write access to the repo.
+          pr_author=$(gh api "$PR_URL" --jq '.user.login')
+          if [ "$COMMENTER" = "$pr_author" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if gh api "repos/${{ github.repository }}/collaborators/$COMMENTER/permission" --jq '.permission' | grep -qE 'admin|write|maintain'; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::$COMMENTER is neither the PR author nor a collaborator with write access."
+          exit 1
+
+      - name: React to comment (ack)
+        if: always() && steps.auth.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api -X POST repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions -f content='eyes'
+
+      - name: Cancel running workflow runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+        run: |
+          set -euo pipefail
+          head_sha=$(gh api "$PR_URL" --jq '.head.sha')
+          # Cancel every in-progress / queued run for the PR head commit
+          # (main CI, CodeQL, ...). Runs awaiting admin approval are left
+          # alone on purpose.
+          run_ids=$(gh run list --repo "${{ github.repository }}" \
+            --commit "$head_sha" --limit 30 --json databaseId,status \
+            --jq '.[] | select(.status == "in_progress" or .status == "queued" or .status == "requested") | .databaseId')
+          if [ -z "$run_ids" ]; then
+            echo "::error::No in-progress workflow run found for head SHA $head_sha."
+            exit 1
+          fi
+          for id in $run_ids; do
+            echo "Cancelling run $id"
+            gh run cancel "$id" --repo "${{ github.repository }}"
+          done
+
+      - name: Report result on PR
+        if: always() && steps.auth.outcome != 'cancelled'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          if [ "${{ steps.auth.outcome }}" = "failure" ]; then
+            body="⛔ @$COMMENTER is not authorized to use this command (only the PR author or collaborators with write access)."
+          elif [ "${{ job.status }}" = "success" ]; then
+            body="🛑 CI runs for this PR have been cancelled (requested by @$COMMENTER)."
+          else
+            body="❌ Failed to cancel CI for this PR (requested by @$COMMENTER). See [workflow log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$body"

--- a/.github/workflows/rerun-failed-ci.yml
+++ b/.github/workflows/rerun-failed-ci.yml
@@ -1,0 +1,98 @@
+# Re-run failed CI jobs when a PR author comments /rerun-failed-ci.
+# PR authors without write access cannot use GitHub's native "re-run failed
+# jobs" button; this workflow runs in the base repo context (issue_comment)
+# and performs the re-run on their behalf after verifying authorship.
+#
+# Safety model:
+# - Never checks out or executes PR code; it only orchestrates existing
+#   workflow runs via the Actions API.
+# - Only the PR author and collaborators with write/maintain/admin are
+#   honored; comments from anyone else are rejected on the PR.
+# - The comment must be exactly "/rerun-failed-ci" (no extra text), so bot
+#   replies and quoted commands never re-trigger.
+name: Rerun Failed CI
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: rerun-failed-ci-${{ github.event.comment.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun-failed-jobs:
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/rerun-failed-ci'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check commenter authorization
+        id: auth
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+        run: |
+          set -euo pipefail
+          # Allow PR authors and anyone with write access to the repo.
+          pr_author=$(gh api "$PR_URL" --jq '.user.login')
+          if [ "$COMMENTER" = "$pr_author" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if gh api "repos/${{ github.repository }}/collaborators/$COMMENTER/permission" --jq '.permission' | grep -qE 'admin|write|maintain'; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::$COMMENTER is neither the PR author nor a collaborator with write access."
+          exit 1
+
+      - name: React to comment (ack)
+        if: always() && steps.auth.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api -X POST repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions -f content='rocket'
+
+      - name: Re-run failed jobs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
+        run: |
+          set -euo pipefail
+          head_sha=$(gh api "$PR_URL" --jq '.head.sha')
+          # Re-run every failed run for the PR head commit (e.g. the main CI
+          # run and CodeQL), capped to avoid runaway loops.
+          run_ids=$(gh run list --repo "${{ github.repository }}" \
+            --commit "$head_sha" --status failure --limit 5 --json databaseId \
+            --jq '.[].databaseId')
+          if [ -z "$run_ids" ]; then
+            echo "::error::No failed workflow run found for head SHA $head_sha."
+            exit 1
+          fi
+          for id in $run_ids; do
+            echo "Re-running failed jobs of run $id"
+            gh run rerun "$id" --repo "${{ github.repository }}" --failed
+          done
+
+      - name: Report result on PR
+        if: always() && steps.auth.outcome != 'cancelled'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          if [ "${{ steps.auth.outcome }}" = "failure" ]; then
+            body="⛔ @$COMMENTER is not authorized to use this command (only the PR author or collaborators with write access)."
+          elif [ "${{ job.status }}" = "success" ]; then
+            body="🚀 Re-triggered failed CI jobs for this PR (requested by @$COMMENTER)."
+          else
+            body="❌ Failed to re-run CI for this PR (requested by @$COMMENTER). See [workflow log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+          fi
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$body"


### PR DESCRIPTION
### PR Category
CICD | Tools

### PR Type
New Features | Improvements

### Description
Adds two PR-comment slash commands so PR authors — who often have no write access to this repository — can manage their own PR's CI without escalation:

- `/rerun-failed-ci`: re-runs the failed jobs of the PR head commit's latest failed workflow runs (up to 5, covering the main CI run and CodeQL). PR authors cannot use GitHub's native "Re-run failed jobs" button on fork PRs.
- `/cancel-ci`: cancels all in-progress/queued runs for the PR head commit — the stop-loss for hung e2e jobs on scarce vendor runners. Runs awaiting admin approval (`action_required`) are deliberately left untouched.

### Safety model
- Commands never check out or execute PR code; they only orchestrate existing runs via the Actions API (no `pull_request_target`-style execution risk).
- Authorship-gated: only the PR author and collaborators with `write`/`maintain`/`admin` are honored; anyone else gets an explicit rejection comment.
- Exact-match command text (`github.event.comment.body == '/...'`), so bot replies and quoted commands can never re-trigger.
- The bot reacts to the command and posts the outcome on the PR with a workflow-log link (audit trail).
- Deliberately **no** merge/approve/state-changing commands — merging stays with the native GitHub flow. See `.github/COMMANDS.md`.

### Changes
- `.github/workflows/rerun-failed-ci.yml` (new)
- `.github/workflows/cancel-ci.yml` (new)
- `.github/COMMANDS.md` (new — command table, safety model, and the recipe for adding future commands such as /ping-approve or /ready as a label-only signal)

### Testing
- Both workflows YAML-validated locally; the only mutation calls are `gh run rerun --failed` and `gh run cancel`, scoped to the commenting PR's head SHA.
- Live verification is only possible after merge (`issue_comment` workflows do not run on the PR that introduces them): on any running PR, comment `/cancel-ci` from the PR author account and confirm the runs cancel + bot replies; then comment `/rerun-failed-ci` after a run goes red.

### Checklist
- [x] I have run the existing tests and they pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)