### PR TITLE
[MetaX] Add GLM-5.3 PR454 compatibility fixes

### DIFF
--- a/MULTIMODAL_ADAPTATION_REPORT.md
+++ b/MULTIMODAL_ADAPTATION_REPORT.md
@@ -1,0 +1,255 @@
+# GLM5.3-Flash Multimodal Day0 Adaptation — Audit, Fixes & H100 Validation
+
+Status: **reviewed and committed locally in `/root/day0-work/vllm-plugin-FL-glm53`**, branch
+`day0-glm53`; not pushed. The parent of this delivery commit is
+`1a6d293c7fc4ecd8c740a367c3e1a83c88886929` (PR [#454](https://github.com/flagos-ai/vllm-plugin-FL/pull/454)
+head).
+A real single-GPU H100 validation was completed. Nothing is reported as passing unless it ran.
+
+---
+
+## 0. TL;DR
+
+| Item | Outcome |
+| --- | --- |
+| Video prompt frame count vs encoder `grid_t` | **Bug found & fixed** (real H100: 3 == 3) |
+| Video encoder token ceiling | **Bug found & fixed** (real: 37170 vs inherited 2242) |
+| Vision SwiGLU clamp | **Investigated, NOT changed** — checkpoint declares `glm5_next_vision`; validated native runtime clamps; real-weight output matched native runtime **maxdiff 0.0** |
+| Real H100 image E2E | **Passed** (grid `[1,22,30]`, 660 patches, 165 embed tokens) |
+| Real H100 video E2E | **Passed** (grid `[3,16,16]`, 768 patches, timestamps 3 == grid_t) |
+| Real-weight vision forward | **Passed** — plugin tower == validated native tower, `maxdiff 0.0`, finite |
+| Full image→text generation | **Not run** — blocker: 642.7 GB BF16 weights / 8×80 GB ≈ 80.3 GB/GPU weights alone |
+
+---
+
+## 1. Scope and evidence sources
+
+Target ABI: **vLLM 0.24.0** on H100. Model: GLM5.3-Flash (`model_type=glm5_next`,
+arch `Glm5NextForConditionalGeneration`).
+
+Sources read (all under `/root`; `/vllm-workspace` never accessed):
+
+- `vllm_fl/models/glm5_next_multimodal.py`, `vllm_fl/transformers_utils/processors/glm5_next.py`,
+  `vllm_fl/configs/glm5_next.py`, `vllm_fl/patches/glm5_next_v024.py`
+- native vLLM 0.24 ABI: `/root/glm5.3/vllm-v0.24.0/vllm/model_executor/models/{glm4_1v,glm_ocr}.py`
+- official native reference: `/root/glm5.3/vllm-glm5next-ref/vllm/models/glm5next/nvidia/*`
+- older 0808 references: `/root/glm5.3/glm-5-next-adapt-0808/glm-5-next-{transformers,sgl,vllm-glm5next}.patch`
+- released plugin patch: `/root/glm5.3/glm5.3-flash-flagrelease-20260827/patches/vllm-plugin-FL-1dfd969-glm5-next.patch`
+- checkpoint config evidence: `/public-nvme/models/GLM-5.3-Flash-BF16/{config.json,processor_config.json}`
+  and `model.safetensors.index.json`
+- validated native runtime baked into `glm5-next/native-vllm024:20260826-tp8-fix1`
+  (`vllm_glm5_next` package; the plugin's processor is byte-identical to it)
+
+### Connectivity map verified (static)
+
+- **Registration**: `apply_glm5_next_v024_patches()` registers
+  `Glm5NextForConditionalGeneration` in `_VLLM_MODELS`/`ModelRegistry`; the class carries
+  `@MULTIMODAL_REGISTRY.register_processor(Glm5NextMultiModalProcessor, info=Glm5NextProcessingInfo,
+  dummy_inputs=Glm4vDummyInputsBuilder)`; config registry + arch convertor installed. **Connected.**
+- **Weight mapping**: in the vLLM 0.24 ABI `Glm4vVisionTransformer.load_weights` uses an explicit
+  stacked mapping (`attn.q/k/v→attn.qkv`, `gate_proj/up_proj→gate_up_proj`), so the self-contained
+  `nn.Module` fork is safe (it does not read `self.hf_to_vllm_mapper`). Verified on real weights:
+  347 checkpoint tensors → 298 params loaded.
+- **MM embedding / position**: `_process_image_input`/`_process_video_input` and
+  `run_dp_sharded_mrope_vision_model` match the fork forward signature. Real forward executed.
+- **CUDA-graph boundary**: `encoder_cudagraph_forward(view…)` calls
+  `self.visual(pixel_values, None, encoder_metadata=…)`; the fork supports it and
+  `get_encoder_cudagraph_config()` strips `pos_embeds`. Static check only (not replayed on H100).
+
+---
+
+## 2. Findings
+
+### Finding 1 — Vision SwiGLU clamp: INVESTIGATED, NOT A DEFECT (no change)
+
+Initial audit against the 0808 references suggested the vision MLP/merger should be **unclamped**
+(`GlmOcrVisionMlp`/`GlmOcrVisionPatchMerger = ACT2FN`, sglang and native vLLM `GlmOcrVisionTransformer`
+both unclamped). That was a false positive:
+
+- The actual checkpoint declares `vision_config.model_type = "glm5_next_vision"` (not
+  `glm_ocr_vision`, which the 0808 transformers patch defaults to).
+- The **validated native runtime for this exact checkpoint** (`vllm_glm5_next` in
+  `glm5-next/native-vllm024:20260826-tp8-fix1`) defines `Glm5NextVisionConfig(model_type =
+  "glm5_next_vision")` and **clamps** both the block MLP and the merger, with the same comment as the
+  plugin.
+- Real-weight H100 forward (below) shows the plugin tower with the clamp retained is **bit-identical**
+  (`maxdiff 0.0`) to that validated native runtime.
+
+Action: **no code change**; a regression test locks the clamped behavior. (`swiglu_limit=10.0`
+appears in both text and vision configs; the text clamp is untouched.)
+
+### Finding 2 — Video prompt frame count did not match the encoder `grid_t` (FIXED)
+
+The plugin returns `_hf_processor_applies_updates=False`, so vLLM expands the prompt via
+`Glm4vMultiModalProcessor._get_prompt_updates`. For non-`Glm4vProcessor`/non-GLMGA processors this
+uses `Glm4vProcessingInfo._get_video_second_idx_glm46v`, whose **duration-threshold** policy
+(fps 3/1/0.5, cap 640) differs from the plugin's **`fps_interval`** sampler
+(`Glm5NextVideoProcessor.sample_frames`, default 2, cap 2048). Measured pure-Python mismatch:
+
+```
+ 30s@30fps : fork grid_t=30, vllm ts=90   -> mismatch
+100s@30fps : fork grid_t=100, vllm ts=100 -> ok
+ 10s@30fps : fork grid_t=10, vllm ts=30   -> mismatch
+ 24s@2fps  : fork grid_t=24, vllm ts=24   -> ok
+  5s@25fps : fork grid_t=5,  vllm ts=15   -> mismatch
+```
+
+Fix: `glm_video_timestamp_seconds(video_processor, metadata)` in the processor module (one source of
+truth calling the processor's own `sample_frames`, then `[::2]`), consumed by
+`Glm5NextProcessingInfo._get_video_second_idx_glm46v`.
+
+### Finding 3 — Video encoder ceiling used the unused placeholder `size` (FIXED)
+
+`Glm5NextVideoProcessor` sets `size={"longest_edge": 1}` (token-budget schema), but the vLLM 0.24
+base `get_mm_max_tokens_per_item` reads `video_processor.size["longest_edge"]` (`glm4_1v.py:1015`)
+and computes `max_vision_tokens = 0`. Fix: override `get_mm_max_tokens_per_item` to use
+`_get_video_max_pixels()` and `max_frame_count_dynamic`. Real checkpoint: **37170 vs 2242** inherited.
+
+### Finding 4 (latent / not changed) — generic-backend `get_number_of_video_patches`
+
+`_get_num_multimodal_tokens` calls `self.video_processor.get_number_of_video_patches`, undefined on
+the plugin's video processor. Against `/root/glm5.3/vllm-v0.24.0`: this API is used only by the
+generic HF backend (`vllm/model_executor/models/transformers/multimodal.py:71,222`), never by the
+native model path; upstream transformers 5.5.3 (`models/glm46v/processing_glm46v.py:205`) has the
+same undefined call. **No change** (off-path, documented).
+
+---
+
+## 3. Files changed in the model-specific commit
+
+```
+ M vllm_fl/models/glm5_next_multimodal.py             (+73)
+ M vllm_fl/transformers_utils/processors/glm5_next.py (+35)
+?? MULTIMODAL_ADAPTATION_REPORT.md
+?? tests/unit_tests/glm5_next/test_multimodal_connectivity.py
+```
+
+- `glm5_next_multimodal.py`: `Glm5NextProcessingInfo.get_mm_max_tokens_per_item` and
+  `_get_video_second_idx_glm46v`. Vision tower/activation unchanged.
+- `glm5_next.py`: `glm_video_timestamp_seconds` + `__all__`.
+- `test_multimodal_connectivity.py` (10 tests): static contracts (clamp retained; overrides
+  present; budget uses `_get_video_max_pixels`), numeric sampler/`grid_t` alignment over 6 shapes,
+  legacy-policy desync regression, `do_sample_frames=False` path.
+
+---
+
+## 4. Real H100 validation (executed)
+
+### 4.1 Host / GPU preflight
+
+- Host: `p-ef-ch-su05-gpu05-h1-dell-2f-4-cm-232-3-8u-2-90` (alias `aiops-10-8-2-90`), 8× H100 80GB,
+  all idle before the run.
+- Container runtime `nvidia` present, default `runc`. A plain `--gpus device=0` container did **not**
+  inject `/dev/nvidia*` (known 10.8.2.* behavior); the proven pattern was used instead:
+  explicit `--device /dev/nvidia0`, `/dev/nvidiactl`, `/dev/nvidia-uvm`, `/dev/nvidia-uvm-tools`,
+  `/dev/nvidia-caps/nvidia-cap{0,1,2}` + read-only `/driver/lib{cuda,nvidia-ml,nvidia-ptxjitcompiler}`
+  mounts and `LD_LIBRARY_PATH=/driver:...`.
+- Preflight result inside the container: `/dev/nvidia0` present; `torch.cuda.is_available()=True`,
+  `device_count()=1`, device name `NVIDIA H100 80GB HBM3`. GPU used: **device 0**.
+
+### 4.2 Image / worktree
+
+- Image: `glm5-next/native-vllm024:20260826-tp8-fix1`
+  (torch 2.11.0+cu129, vLLM 0.24.0, transformers 5.12.1; `vllm._C_stable_libtorch` present,
+  `deep_gemm` available; no FlagGems, no `vllm_fl`). It ships the validated native `vllm_glm5_next`
+  reference runtime.
+- The current worktree was archived, hashed, transferred, and extracted:
+  `sha256(eb15f0b4ffd383ce1a9d3744702214d1037755e4418b40eae273c077357119a2)` verified on both ends,
+  mounted read-only at `/opt/glm53` with `PYTHONPATH=/opt/glm53`. In-container checks confirmed the
+  two overrides (`get_mm_max_tokens_per_item`, `_get_video_second_idx_glm46v`), the helper, and the
+  retained vision clamp were the ones under test.
+- Real weights: `/public-nvme/models/GLM-5.3-Flash-BF16` (mounted read-only).
+
+### 4.3 Test 1 — real-weight vision forward (plugin vs validated native runtime)
+
+Built both `vllm_fl...Glm5NextVisionTransformer` and `vllm_glm5_next...Glm5NextVisionTransformer` with
+the real `vision_config`, loaded the 347 real `model.visual.*` tensors (1.127 GB, one shard), and ran
+a forward on a synthetic grid `[[1,32,32]]` (bf16, GPU 0):
+
+```
+our loaded 298 ref loaded 298
+vit attention backend: AttentionBackendEnum.TRITON_ATTN
+our (256, 4096) ref (256, 4096)
+maxdiff 0.0  meandiff 0.0  finite True
+VISION_FORWARD_OK
+```
+
+→ plugin vision tower (merge 2×2, out_hidden 4096, clamp retained) is **bit-identical** to the
+validated native runtime on the real checkpoint weights; the interpolation/position path executed.
+
+### 4.4 Test 2 — processor → placeholder/`grid_t` (real config + tokenizer)
+
+```
+image min/max tokens 16 8000  patch_expand 1  resize_mode pad
+video min/max tokens 16 30000  fps_interval 2.0  max_frame_count_dynamic 2048
+image_grid_thw [1, 22, 30]  pixel_values (660, 1176)  embed tokens 165  image_token present
+video_grid_thw [3, 16, 16]  pixel_values_videos (768, 1176)
+sampled frames 6  grid_t 3  prompt timestamps 3        # aligned (Finding 2)
+override video ceiling 37170  expected 37170  inherited-buggy 2242   # Finding 3
+PROCESSOR_E2E_OK
+```
+
+Image: `pixel_values.shape[0] == grid.prod()` and placeholder token count `== grid.prod()//merge²`.
+Video: prompt timestamp count `== grid_t` exactly. These use the real `processor_config.json`
+(`min/max_image_tokens`, `patch_expand_factor=1`, `resize_mode=pad`, `fps_interval=2`) and tokenizer.
+
+### 4.5 Not executed: full image/video → generation request
+
+Blocked by memory: the BF16 checkpoint is **642.7 GB across 120 shards**; TP8 on this single 8×80 GB
+node is **≈80.3 GB/GPU of weights alone** before activations/KV, so an in-memory vLLM service cannot
+start here (the release used 2 nodes / TP16). Generation was therefore not attempted. This is the
+documented fallback from the assignment (single-GPU minimal real vision forward + processor E2E).
+
+### 4.6 Cleanup
+
+All containers were ephemeral (`--rm`, image mode); no service was started. Remote archive and
+extraction directory were removed; `docker ps -a | grep glm53` = none. Pre-existing exited
+containers from other users were left untouched.
+
+---
+
+## 5. Verification run (all commands, local + H100)
+
+Interpreter for local tests: `/root/qwen3.8_handoff/.venv-v0202-patchcheck/bin/python`
+(torch 2.11.0, transformers 4.57.6). H100 runs used the native image above.
+
+| Command | Result |
+| --- | --- |
+| `ruff check <3 changed files>` | **All checks passed!** |
+| `ruff format --check <3 changed files>` | **3 files already formatted** |
+| `pytest tests/unit_tests/glm5_next/test_multimodal_connectivity.py -q` | **10 passed** |
+| `pytest test_graph_boundaries.py test_multimodal_connectivity.py -q` | **14 passed, 1 failed** (only `No module named 'vllm'`) |
+| `pytest tests/unit_tests/glm5_next/ --collect-only` | **30 collected, 8 collection errors** (`flag_gems`/`vllm` absent locally) |
+| H100 vision forward (real weights, plugin vs native) | **maxdiff 0.0, finite** |
+| H100 processor E2E (real image + video) | **PASS** (165 image tokens; 3==3 video frames; 37170 ceiling) |
+
+Local full-processor preprocess remains blocked by transformers 4.57 API drift
+(`KeyError: do_convert_rgb`); the target stack (transformers 5.12/5.16) was exercised on the H100.
+
+---
+
+## 6. Risks / limitations
+
+1. **Full generation not validated** (memory blocker, §4.5). The language model + KV cache path for
+   multimodal prompts was not exercised on this node.
+2. **Vision-clamp decision is reference + native-runtime based**, now corroborated by a real-weight
+   bit-exact match against the validated runtime; it does not independently prove the checkpoint's
+   training-time activation beyond that agreement.
+3. **Request-level video overrides** (`fps`/`max_frames`) are not visible to the prompt-timestamp
+   helper; alignment holds for default processor settings (same limitation as vLLM's GLM-4.6V path).
+4. CUDA-graph replay of the encoder was not re-run on H100 (static boundary checks only).
+5. Finding 4 (generic-HF-backend patch count) remains a latent, off-path gap.
+
+## 7. Suggested follow-ups (main thread)
+
+- Run a full TP16/2-node image+video generation once such a resource is assigned; assert
+  `num_image_tokens == grid.prod()//merge²` and video frame counts, and compare clamped-vs-reference
+  image features.
+- Add `get_number_of_video_patches` if generic-transformers-backend loading is ever needed.
+
+## 8. Artifacts
+
+- Changed source/test paths: §3.
+- Worktree archive SHA256: `eb15f0b4ffd383ce1a9d3744702214d1037755e4418b40eae273c077357119a2`
+  (assembled with the two fixes + retained clamp; remote copy cleaned up).
+- The model-specific commit is local only; no push was performed.

--- a/tests/functional_tests/worker/test_common_attention_metadata_graph.py
+++ b/tests/functional_tests/worker/test_common_attention_metadata_graph.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from vllm.platforms import current_platform
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 from vllm.v1.worker.block_table import MultiGroupBlockTable
 
 from vllm_fl.worker.common_attention_metadata import (
@@ -29,6 +30,10 @@ def _make_block_table(device: torch.device) -> MultiGroupBlockTable:
     )
     table.add_row(([2, 3, 4, 5], [6, 7]), 0)
     table.add_row(([8, 9, 10, 11], [12, 13]), 1)
+    # Simulate stale rows left by a previous larger batch. A real step commits
+    # only active rows; the metadata producer must clear the padded suffix.
+    table.add_row(([14, 15, 16, 17], [18, 19]), 2)
+    table.add_row(([20, 21, 22, 23], [24, 25]), 3)
     table.commit_block_table(4)
     return table
 
@@ -53,6 +58,21 @@ def _expected_slots(
                 )
         expected.append(result)
     return expected
+
+
+def _assert_zero_seq_rows_use_null_block(
+    table: MultiGroupBlockTable,
+    seq_lens: torch.Tensor,
+) -> None:
+    zero_rows = torch.nonzero(seq_lens == 0, as_tuple=False).flatten().cpu().tolist()
+    for group in table.block_tables:
+        for row in zero_rows:
+            torch.testing.assert_close(
+                group.block_table.gpu[row],
+                torch.full_like(group.block_table.gpu[row], NULL_BLOCK_ID),
+                rtol=0,
+                atol=0,
+            )
 
 
 def _assert_matches_vllm_slot_mapping(
@@ -138,12 +158,14 @@ def test_common_attention_metadata_graph_replay_uses_updated_metadata(
         rtol=0,
         atol=0,
     )
+    _assert_zero_seq_rows_use_null_block(table, seq_lens)
 
+    table.commit_block_table(3)
     query_start_loc.copy_(
-        torch.tensor([0, 1, 3, 3, 3], dtype=torch.int32, device=device)
+        torch.tensor([0, 1, 3, 4, 4], dtype=torch.int32, device=device)
     )
-    positions[:3].copy_(torch.tensor([3, 10, 11], dtype=torch.int64, device=device))
-    seq_lens.copy_(torch.tensor([7, 15, 0, 0], dtype=torch.int32, device=device))
+    positions[:4].copy_(torch.tensor([3, 10, 11, 2], dtype=torch.int64, device=device))
+    seq_lens.copy_(torch.tensor([7, 15, 9, 0], dtype=torch.int32, device=device))
     used_graph = runner.run(
         table,
         4,
@@ -163,10 +185,11 @@ def test_common_attention_metadata_graph_replay_uses_updated_metadata(
         torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
     torch.testing.assert_close(
         num_computed_tokens.cpu(),
-        torch.tensor([6, 13, 0, 0], dtype=torch.int32),
+        torch.tensor([6, 13, 8, 0], dtype=torch.int32),
         rtol=0,
         atol=0,
     )
+    _assert_zero_seq_rows_use_null_block(table, seq_lens)
 
 
 def test_common_attention_metadata_graph_off_runs_eager(
@@ -280,3 +303,51 @@ def test_common_attention_metadata_graph_unavailable_falls_back_to_eager(
         rtol=0,
         atol=0,
     )
+
+
+def test_common_attention_metadata_clears_long_context_padded_rows(
+    device: torch.device,
+) -> None:
+    num_groups = 8
+    num_reqs_padded = 64
+    num_actual_reqs = 62
+    table = MultiGroupBlockTable(
+        max_num_reqs=num_reqs_padded,
+        max_model_len=16512,
+        max_num_batched_tokens=16384,
+        pin_memory=False,
+        device=device,
+        block_sizes=[16] * num_groups,
+        kernel_block_sizes=[16] * num_groups,
+        max_num_blocks=[1025] * num_groups,
+    )
+    for group in table.block_tables:
+        group.block_table.cpu.fill_(1)
+    table.commit_block_table(num_reqs_padded)
+
+    query_start_loc = torch.arange(
+        num_reqs_padded + 1, dtype=torch.int32, device=device
+    )
+    query_start_loc[num_actual_reqs:].fill_(num_actual_reqs)
+    positions = torch.zeros(16384, dtype=torch.int64, device=device)
+    positions[:num_actual_reqs].fill_(16383)
+    seq_lens = torch.zeros(num_reqs_padded, dtype=torch.int32, device=device)
+    seq_lens[:num_actual_reqs].fill_(16384)
+    num_computed_tokens = torch.empty(num_reqs_padded, dtype=torch.int32, device=device)
+
+    compute_common_attention_metadata(
+        table,
+        num_reqs_padded,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+    )
+    current_platform.torch_device_fn.synchronize()
+
+    for group in table.block_tables:
+        assert torch.all(group.block_table.gpu[num_actual_reqs:] == NULL_BLOCK_ID)
+        assert torch.all(group.block_table.gpu[num_actual_reqs - 1] == 1)
+        assert torch.all(group.slot_mapping.gpu[num_actual_reqs:] == -1)
+    assert torch.all(num_computed_tokens[:num_actual_reqs] == 16383)
+    assert torch.all(num_computed_tokens[num_actual_reqs:] == 0)

--- a/tests/functional_tests/worker/test_common_attention_metadata_graph.py
+++ b/tests/functional_tests/worker/test_common_attention_metadata_graph.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.worker.block_table import MultiGroupBlockTable
+
+from vllm_fl.worker.common_attention_metadata import (
+    CommonAttentionMetadataGraphRunner,
+    compute_common_attention_metadata,
+    supports_accelerator_graph,
+)
+
+pytestmark = pytest.mark.gpu
+
+
+def _make_block_table(device: torch.device) -> MultiGroupBlockTable:
+    table = MultiGroupBlockTable(
+        max_num_reqs=4,
+        max_model_len=64,
+        max_num_batched_tokens=16,
+        pin_memory=False,
+        device=device,
+        block_sizes=[4, 8],
+        kernel_block_sizes=[4, 8],
+        max_num_blocks=[16, 8],
+    )
+    table.add_row(([2, 3, 4, 5], [6, 7]), 0)
+    table.add_row(([8, 9, 10, 11], [12, 13]), 1)
+    table.commit_block_table(4)
+    return table
+
+
+def _expected_slots(
+    table: MultiGroupBlockTable,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+) -> list[torch.Tensor]:
+    query_start = query_start_loc.cpu().tolist()
+    pos = positions.cpu().tolist()
+    expected = []
+    for group in table.block_tables:
+        result = torch.full((group.max_num_batched_tokens,), -1, dtype=torch.int64)
+        block_table = group.block_table.cpu
+        for req_idx in range(len(query_start) - 1):
+            for token_idx in range(query_start[req_idx], query_start[req_idx + 1]):
+                token_pos = pos[token_idx]
+                block_id = block_table[req_idx, token_pos // group.block_size]
+                result[token_idx] = (
+                    block_id * group.block_size + token_pos % group.block_size
+                )
+        expected.append(result)
+    return expected
+
+
+def _assert_matches_vllm_slot_mapping(
+    table: MultiGroupBlockTable,
+    num_reqs: int,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+    seq_lens: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+) -> None:
+    num_tokens = int(query_start_loc[num_reqs].cpu())
+    table.compute_slot_mapping(
+        num_reqs,
+        query_start_loc,
+        positions[:num_tokens],
+    )
+    current_platform.torch_device_fn.synchronize()
+    expected_slots = [group.slot_mapping.gpu.clone() for group in table.block_tables]
+
+    compute_common_attention_metadata(
+        table,
+        num_reqs,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+    )
+    current_platform.torch_device_fn.synchronize()
+
+    for group, expected in zip(table.block_tables, expected_slots):
+        torch.testing.assert_close(group.slot_mapping.gpu, expected, rtol=0, atol=0)
+    query_lens = query_start_loc[1 : num_reqs + 1] - query_start_loc[:num_reqs]
+    torch.testing.assert_close(
+        num_computed_tokens,
+        seq_lens - query_lens,
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_common_attention_metadata_graph_replay_uses_updated_metadata(
+    device: torch.device,
+) -> None:
+    if not supports_accelerator_graph():
+        pytest.skip("Accelerator graph capture is unavailable")
+
+    table = _make_block_table(device)
+    runner = CommonAttentionMetadataGraphRunner()
+    query_start_loc = torch.tensor([0, 2, 4, 4, 4], dtype=torch.int32, device=device)
+    positions = torch.zeros(16, dtype=torch.int64, device=device)
+    positions[:4] = torch.tensor([0, 1, 8, 9], device=device)
+    seq_lens = torch.tensor([6, 12, 0, 0], dtype=torch.int32, device=device)
+    num_computed_tokens = torch.empty(4, dtype=torch.int32, device=device)
+
+    compute_common_attention_metadata(
+        table,
+        4,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+    )
+    used_graph = runner.run(
+        table,
+        4,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+        use_graph=True,
+        capture=True,
+    )
+    assert used_graph
+    current_platform.torch_device_fn.synchronize()
+    for actual, expected in zip(
+        (group.slot_mapping.gpu for group in table.block_tables),
+        _expected_slots(table, query_start_loc, positions),
+    ):
+        torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        num_computed_tokens.cpu(),
+        torch.tensor([4, 10, 0, 0], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+
+    query_start_loc.copy_(
+        torch.tensor([0, 1, 3, 3, 3], dtype=torch.int32, device=device)
+    )
+    positions[:3].copy_(torch.tensor([3, 10, 11], dtype=torch.int64, device=device))
+    seq_lens.copy_(torch.tensor([7, 15, 0, 0], dtype=torch.int32, device=device))
+    used_graph = runner.run(
+        table,
+        4,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+        use_graph=True,
+        capture=False,
+    )
+    assert used_graph
+    current_platform.torch_device_fn.synchronize()
+    for actual, expected in zip(
+        (group.slot_mapping.gpu for group in table.block_tables),
+        _expected_slots(table, query_start_loc, positions),
+    ):
+        torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        num_computed_tokens.cpu(),
+        torch.tensor([6, 13, 0, 0], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_common_attention_metadata_graph_off_runs_eager(
+    device: torch.device,
+) -> None:
+    table = _make_block_table(device)
+    runner = CommonAttentionMetadataGraphRunner()
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
+    positions = torch.zeros(16, dtype=torch.int64, device=device)
+    positions[:2] = torch.tensor([1, 9], dtype=torch.int64, device=device)
+    seq_lens = torch.tensor([5, 11], dtype=torch.int32, device=device)
+    num_computed_tokens = torch.empty(2, dtype=torch.int32, device=device)
+
+    used_graph = runner.run(
+        table,
+        2,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+        use_graph=False,
+        capture=False,
+    )
+    current_platform.torch_device_fn.synchronize()
+
+    assert not used_graph
+    assert runner.graphs == {}
+    for actual, expected in zip(
+        (group.slot_mapping.gpu for group in table.block_tables),
+        _expected_slots(table, query_start_loc, positions),
+    ):
+        torch.testing.assert_close(actual.cpu(), expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        num_computed_tokens.cpu(),
+        torch.tensor([4, 10], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_common_attention_metadata_matches_vllm_with_hybrid_blocks_and_cp(
+    device: torch.device,
+) -> None:
+    table = MultiGroupBlockTable(
+        max_num_reqs=2,
+        max_model_len=64,
+        max_num_batched_tokens=16,
+        pin_memory=False,
+        device=device,
+        block_sizes=[8],
+        kernel_block_sizes=[4],
+        max_num_blocks=[8],
+        cp_kv_cache_interleave_size=2,
+    )
+    table.add_row(([2, 3, 4, 5],), 0)
+    table.add_row(([6, 7, 8, 9],), 1)
+    table.commit_block_table(2)
+    group = table.block_tables[0]
+    group.pcp_world_size = 2
+    group.pcp_rank = 1
+    group.dcp_world_size = 1
+    group.dcp_rank = 0
+
+    query_start_loc = torch.tensor([0, 4, 8], dtype=torch.int32, device=device)
+    positions = torch.zeros(16, dtype=torch.int64, device=device)
+    positions[:8] = torch.tensor(
+        [0, 2, 4, 6, 8, 10, 12, 14], dtype=torch.int64, device=device
+    )
+    seq_lens = torch.tensor([8, 18], dtype=torch.int32, device=device)
+    num_computed_tokens = torch.empty(2, dtype=torch.int32, device=device)
+
+    _assert_matches_vllm_slot_mapping(
+        table,
+        2,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+    )
+
+
+def test_common_attention_metadata_graph_unavailable_falls_back_to_eager(
+    device: torch.device,
+) -> None:
+    table = _make_block_table(device)
+    runner = CommonAttentionMetadataGraphRunner()
+    runner._graph_capture_supported = False
+    query_start_loc = torch.tensor([0, 1, 2], dtype=torch.int32, device=device)
+    positions = torch.zeros(16, dtype=torch.int64, device=device)
+    positions[:2] = torch.tensor([1, 9], dtype=torch.int64, device=device)
+    seq_lens = torch.tensor([5, 11], dtype=torch.int32, device=device)
+    num_computed_tokens = torch.empty(2, dtype=torch.int32, device=device)
+
+    used_graph = runner.run(
+        table,
+        2,
+        query_start_loc,
+        positions,
+        seq_lens,
+        num_computed_tokens,
+        use_graph=True,
+        capture=True,
+    )
+    current_platform.torch_device_fn.synchronize()
+
+    assert not used_graph
+    assert runner.graphs == {}
+    torch.testing.assert_close(
+        num_computed_tokens,
+        torch.tensor([4, 10], dtype=torch.int32, device=device),
+        rtol=0,
+        atol=0,
+    )

--- a/tests/functional_tests/worker/test_common_attention_metadata_graph.py
+++ b/tests/functional_tests/worker/test_common_attention_metadata_graph.py
@@ -333,6 +333,9 @@ def test_common_attention_metadata_clears_long_context_padded_rows(
     positions[:num_actual_reqs].fill_(16383)
     seq_lens = torch.zeros(num_reqs_padded, dtype=torch.int32, device=device)
     seq_lens[:num_actual_reqs].fill_(16384)
+    # seq_len alone does not identify padding; an active row may transiently
+    # carry zero while still owning scheduled query tokens.
+    seq_lens[0] = 0
     num_computed_tokens = torch.empty(num_reqs_padded, dtype=torch.int32, device=device)
 
     compute_common_attention_metadata(
@@ -349,5 +352,8 @@ def test_common_attention_metadata_clears_long_context_padded_rows(
         assert torch.all(group.block_table.gpu[num_actual_reqs:] == NULL_BLOCK_ID)
         assert torch.all(group.block_table.gpu[num_actual_reqs - 1] == 1)
         assert torch.all(group.slot_mapping.gpu[num_actual_reqs:] == -1)
-    assert torch.all(num_computed_tokens[:num_actual_reqs] == 16383)
+    assert num_computed_tokens[0] == -1
+    assert torch.all(num_computed_tokens[1:num_actual_reqs] == 16383)
     assert torch.all(num_computed_tokens[num_actual_reqs:] == 0)
+    for group in table.block_tables:
+        assert torch.all(group.block_table.gpu[0] == 1)

--- a/tests/unit_tests/dispatch/test_builtin_ops.py
+++ b/tests/unit_tests/dispatch/test_builtin_ops.py
@@ -8,6 +8,7 @@ from vllm_fl.dispatch.builtin_ops import (
     _find_vendor_backend_dir,
     _register_vendor_backends,
 )
+from vllm_fl.dispatch.registry import OpRegistry
 
 
 class TestFindVendorBackendDir:
@@ -54,3 +55,33 @@ class TestRegisterVendorBackends:
             package="vllm_fl.dispatch",
         )
         module.register_builtins.assert_called_once_with(registry)
+
+
+def test_reference_registration_keeps_implemented_fallbacks():
+    """A missing optional method must not drop every reference fallback."""
+    from vllm_fl.dispatch.backends.reference.register_ops import (
+        register_builtins as register_reference,
+    )
+
+    registry = OpRegistry()
+    register_reference(registry)
+
+    implemented = {
+        "dynamic_per_token_quant_int8",
+        "silu_and_mul",
+        "gelu_and_mul",
+        "rms_norm",
+        "rotary_embedding",
+        "attention_backend",
+        "invoke_fused_moe_triton_kernel",
+    }
+    missing = {
+        "moe_align_block_size",
+        "moe_sum",
+        "topk_softmax",
+        "grouped_topk",
+    }
+    for op_name in implemented:
+        assert registry.get_implementation(op_name, "reference.torch") is not None
+    for op_name in missing:
+        assert registry.get_implementation(op_name, "reference.torch") is None

--- a/tests/unit_tests/flaggems/test_gems_whitelist.py
+++ b/tests/unit_tests/flaggems/test_gems_whitelist.py
@@ -164,6 +164,41 @@ def test_get_flag_gems_whitelist_blacklist_blacklist_only(monkeypatch):
     assert blacklist == ["index", "index_put_"]
 
 
+def test_get_flag_gems_blacklist_append_preserves_platform_defaults(monkeypatch):
+    monkeypatch.delenv("VLLM_FL_FLAGOS_WHITELIST", raising=False)
+    monkeypatch.delenv("VLLM_FL_FLAGOS_BLACKLIST", raising=False)
+    monkeypatch.setenv("VLLM_FL_FLAGOS_BLACKLIST_APPEND", "linear,index")
+
+    with patch(
+        "vllm_fl.dispatch.config.get_flagos_blacklist",
+        return_value=["index", "copy_"],
+    ):
+        whitelist, blacklist = get_flag_gems_whitelist_blacklist()
+
+    assert whitelist is None
+    assert blacklist == ["index", "copy_", "linear"]
+
+
+def test_get_flag_gems_blacklist_append_extends_explicit_blacklist(monkeypatch):
+    monkeypatch.delenv("VLLM_FL_FLAGOS_WHITELIST", raising=False)
+    monkeypatch.setenv("VLLM_FL_FLAGOS_BLACKLIST", "linear")
+    monkeypatch.setenv("VLLM_FL_FLAGOS_BLACKLIST_APPEND", "index,linear")
+
+    whitelist, blacklist = get_flag_gems_whitelist_blacklist()
+    assert whitelist is None
+    assert blacklist == ["linear", "index"]
+
+
+def test_get_flag_gems_whitelist_ignores_blacklist_append(monkeypatch):
+    monkeypatch.setenv("VLLM_FL_FLAGOS_WHITELIST", "rms_norm")
+    monkeypatch.delenv("VLLM_FL_FLAGOS_BLACKLIST", raising=False)
+    monkeypatch.setenv("VLLM_FL_FLAGOS_BLACKLIST_APPEND", "linear,index")
+
+    whitelist, blacklist = get_flag_gems_whitelist_blacklist()
+    assert whitelist == ["rms_norm"]
+    assert blacklist is None
+
+
 def test_get_flag_gems_whitelist_blacklist_both_set_raises(monkeypatch):
     """When both whitelist and blacklist are set, ValueError is raised."""
     monkeypatch.setenv("VLLM_FL_FLAGOS_WHITELIST", "silu_and_mul")

--- a/tests/unit_tests/glm5_next/test_graph_boundaries.py
+++ b/tests/unit_tests/glm5_next/test_graph_boundaries.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Static contracts for GLM5-Next breakable CUDA-graph boundaries."""
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _method_calls(path: Path, class_name: str, method_name: str) -> set[str]:
+    module = ast.parse(path.read_text())
+    cls = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    method = next(
+        node
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == method_name
+    )
+    return {
+        ast.unparse(node.func)
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+    }
+
+
+def test_kda_forward_calls_breakable_body_directly() -> None:
+    calls = _method_calls(
+        ROOT / "vllm_fl/models/glm5_next.py",
+        "Glm5NextLinearAttention",
+        "forward",
+    )
+    assert "self._forward" in calls
+    assert "super().forward" not in calls
+    assert not any(call.startswith("torch.ops.vllm.kda_attention") for call in calls)
+
+
+def test_flagos_cuda_runner_honors_breakable_graph() -> None:
+    source = (ROOT / "vllm_fl/worker/model_runner.py").read_text()
+    assert "is_breakable_cudagraph_enabled()" in source
+    assert "BreakableCUDAGraphWrapper(self.model, self.vllm_config)" in source
+
+
+def test_kpool_custom_op_is_a_piecewise_split() -> None:
+    patch_source = (ROOT / "vllm_fl/patches/glm5_next_v024.py").read_text()
+    assert '"vllm::sparse_attn_indexer_kpool"' in patch_source
+
+
+def test_indexer_translated_block_table_keeps_a_stable_base_address() -> None:
+    patch_source = (ROOT / "vllm_fl/patches/glm5_next_kpool_v024.py").read_text()
+    assert "scheduler_config.max_num_batched_tokens" in patch_source
+    assert "block_table_tensor=translated_table" in patch_source
+    assert "buffer.shape != compressed.shape" not in patch_source

--- a/tests/unit_tests/glm5_next/test_graph_boundaries.py
+++ b/tests/unit_tests/glm5_next/test_graph_boundaries.py
@@ -3,6 +3,7 @@
 
 import ast
 from pathlib import Path
+from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[3]
 
@@ -53,3 +54,40 @@ def test_indexer_translated_block_table_keeps_a_stable_base_address() -> None:
     assert "scheduler_config.max_num_batched_tokens" in patch_source
     assert "block_table_tensor=translated_table" in patch_source
     assert "buffer.shape != compressed.shape" not in patch_source
+
+
+def test_graph_config_disables_glm5_allreduce_fusion(monkeypatch) -> None:
+    """Graph mode must not inherit the generic H100 O2 allreduce fusion."""
+    from vllm.model_executor.models.config import HybridAttentionMambaModelConfig
+
+    from vllm_fl.patches.glm5_next_v024 import Glm5NextForCausalLMConfig
+
+    # Keep this a focused config test; the common hybrid checks are covered by
+    # vLLM and are unrelated to the GLM5 graph safety override.
+    monkeypatch.setattr(
+        HybridAttentionMambaModelConfig,
+        "verify_and_update_config",
+        classmethod(lambda cls, _config: None),
+    )
+
+    def make_config(*, enforce_eager: bool, fuse_allreduce_rms):
+        return SimpleNamespace(
+            model_config=SimpleNamespace(
+                enforce_eager=enforce_eager,
+                hf_text_config=SimpleNamespace(index_kpool_compress=False),
+            ),
+            compilation_config=SimpleNamespace(
+                pass_config=SimpleNamespace(
+                    fuse_allreduce_rms=fuse_allreduce_rms,
+                )
+            ),
+            cache_config=SimpleNamespace(cache_dtype="auto", block_size=16),
+        )
+
+    graph_config = make_config(enforce_eager=False, fuse_allreduce_rms=True)
+    Glm5NextForCausalLMConfig.verify_and_update_config(graph_config)
+    assert graph_config.compilation_config.pass_config.fuse_allreduce_rms is False
+
+    eager_config = make_config(enforce_eager=True, fuse_allreduce_rms=True)
+    Glm5NextForCausalLMConfig.verify_and_update_config(eager_config)
+    assert eager_config.compilation_config.pass_config.fuse_allreduce_rms is True

--- a/tests/unit_tests/glm5_next/test_kpool_decode_update_batched.py
+++ b/tests/unit_tests/glm5_next/test_kpool_decode_update_batched.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit test for the batched kpool decode-update kernel.
+
+Validates ``kpool_decode_update_and_maybe_write_cache_batched`` against an
+independent pure-torch reference that replicates the per-request, in-position
+order semantics: stash each token into a paged tail ring; on pool completion
+(``pos % pool_size == pool_size-1``) softmax(gate+ape)-weighted sum + Hadamard-128
++ per-vector fp8 absmax quant + write to the indexer K cache. Covers
+no-completion, completion-at-end, completion-mid-batch, non-uniform padding,
+plain decode, plus a randomized fuzz pass.
+
+The kernel iterates each request's ``next_n`` tokens in position order inside
+one program (grid = num_requests) to preserve the pool-completion
+read-after-stash dependency; the reference mirrors that ordering.
+
+``test_decode_writer_matches_prefill_writer`` is deliberately NOT
+reference-based: it checks the decode writer against the *prefill* writer
+(``kpool_compress_and_write_cache``), the invariant that actually matters in
+production. A hand-written reference can drift to match a buggy kernel -- that
+is exactly how the stash-gating bug (intra-pool tokens never entering the tail
+ring, because the stash was gated on the pool-granular ``slot_mapping``) stayed
+green here.
+"""
+
+import math
+
+import pytest
+import torch
+
+from vllm_fl.kernels.glm5_next.kpool_compress import (
+    kpool_compress_and_write_cache,
+    kpool_decode_update_and_maybe_write_cache_batched,
+)
+
+HEAD_DIM = 128
+POOL_SIZE = 16
+PAGE_SIZE = 64
+NUM_BLOCKS = 32
+ROUND_SCALE = True
+FP8_MAX = 448.0
+
+
+def _make_caches():
+    kv = torch.zeros(
+        NUM_BLOCKS, PAGE_SIZE, HEAD_DIM + 4, dtype=torch.uint8, device="cuda"
+    )
+    tail = torch.zeros(
+        NUM_BLOCKS, 2, POOL_SIZE, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    )
+    return kv, tail
+
+
+def _tail_slot_for(blocks, pos):
+    """tail_slot = block*POOL + pos%POOL; each request owns a distinct tail block."""
+    blk = torch.tensor(blocks, device=pos.device, dtype=torch.int32).unsqueeze(1)
+    return (blk * POOL_SIZE + pos % POOL_SIZE).to(torch.int32)
+
+
+def _seed_prior(tail, blocks, n_prior, seed=42):
+    if n_prior <= 0:
+        return
+    g = torch.Generator(device=tail.device).manual_seed(seed)
+    prior_k = torch.randn(
+        len(blocks),
+        n_prior,
+        HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=tail.device,
+        generator=g,
+    )
+    prior_s = torch.randn(
+        len(blocks),
+        n_prior,
+        HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=tail.device,
+        generator=g,
+    )
+    for i, blk in enumerate(blocks):
+        tail[blk, 0, :n_prior, :] = prior_k[i]
+        tail[blk, 1, :n_prior, :] = prior_s[i]
+
+
+def _hadamard128_torch(x: torch.Tensor) -> torch.Tensor:
+    """Reference Hadamard-128 on the last dim (must be 128)."""
+    n = x.shape[-1]
+    assert n == 128
+    h = torch.tensor([[1.0, 1.0], [1.0, -1.0]], dtype=torch.float32, device=x.device)
+    while h.shape[0] < n:
+        h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
+    h = h / math.sqrt(n)
+    return x @ h
+
+
+def _torch_reference(
+    kv: torch.Tensor,
+    tail: torch.Tensor,
+    tail_slot: torch.Tensor,
+    key: torch.Tensor,
+    score: torch.Tensor,
+    ape: torch.Tensor,
+    slot_map: torch.Tensor,
+    pos: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Independent reference for the batched decode-update kernel.
+
+    For each request, iterate its next_n tokens in order. On each token:
+      - if pos%POOL == POOL-1 and pos_valid: compress the pool (slots
+        [pool_start..pool_start+POOL-1], current token via is_current) and write
+        fp8 K + fp32 scale to kv_cache at cache_loc.
+      - always stash the current token's K/score into tail[block, pos%POOL].
+    """
+    kv = kv.clone()
+    tail = tail.clone()
+    B, next_n = pos.shape
+    # The indexer K cache is [num_blocks, PAGE_SIZE, HEAD_DIM+4] uint8 but the
+    # kernels interpret each page as [HEAD_DIM*PAGE_SIZE bytes of K (token-major)
+    # | 4*PAGE_SIZE bytes of fp32 scale (token-major)]. Operate on a flat byte
+    # view so the reference writes K and scale at the exact offsets the kernel
+    # uses (page_base + tok*HEAD_DIM for K; page_base + HEAD_DIM*PAGE_SIZE +
+    # tok*4 for scale).
+    page_bytes = PAGE_SIZE * (HEAD_DIM + 4)
+    k_region = HEAD_DIM * PAGE_SIZE
+    tail_slot_cpu = tail_slot.cpu().tolist()
+    slot_map_cpu = slot_map.cpu().tolist()
+    pos_cpu = pos.cpu().tolist()
+    key_cpu = key.float().cpu()
+    score_cpu = score.float().cpu()
+    ape_cpu = ape.cpu()
+    tail_cpu = tail.float().cpu()
+    kv_flat = kv.view(torch.uint8).reshape(-1).cpu()
+
+    for b in range(B):
+        for t in range(next_n):
+            cache_loc = slot_map_cpu[b][t]
+            p = pos_cpu[b][t]
+            pos_valid = cache_loc >= 0 and p >= 0
+            safe_pos = max(p, 0)
+            slot = safe_pos % POOL_SIZE
+            phys_slot = safe_pos % POOL_SIZE
+            # Per-token block derivation (a leading invalid sentinel must not
+            # poison the base for the rest of the request); clamped like the
+            # kernel so an invalid entry can't form a negative base.
+            block = max(tail_slot_cpu[b][t], 0) // POOL_SIZE
+
+            cur_key = key_cpu[b, t]
+            cur_score = score_cpu[b, t]
+
+            if pos_valid and slot == POOL_SIZE - 1:
+                pool_logical_start = safe_pos - slot
+                pool_scores = []
+                pool_ks = []
+                for ps in range(POOL_SIZE):
+                    is_current = ps == slot
+                    phys = (pool_logical_start + ps) % POOL_SIZE
+                    if is_current:
+                        s = cur_score
+                        k = cur_key
+                    else:
+                        s = tail_cpu[block, 1, phys]
+                        k = tail_cpu[block, 0, phys]
+                    s = s + ape_cpu[ps]
+                    pool_scores.append(s)
+                    pool_ks.append(k)
+                pool_scores = torch.stack(pool_scores)  # [POOL, D]
+                pool_ks = torch.stack(pool_ks)  # [POOL, D]
+                max_score = pool_scores.max(dim=0).values
+                prob = torch.exp(pool_scores - max_score)
+                denom = prob.sum(dim=0)
+                acc = (pool_ks * prob).sum(dim=0)
+                x = (acc / denom).to(torch.bfloat16).to(torch.float32)
+                x = _hadamard128_torch(x).to(torch.bfloat16).to(torch.float32)
+                absmax = torch.clamp(x.abs().max(), min=1e-4)
+                if ROUND_SCALE:
+                    scale = torch.exp2(torch.ceil(torch.log2(absmax / FP8_MAX)))
+                else:
+                    scale = absmax / FP8_MAX
+                quantized = torch.clamp(x / scale, -FP8_MAX, FP8_MAX).to(
+                    torch.float8_e4m3fn
+                )
+                # write K and scale at the separated-layout offsets
+                loc = cache_loc
+                loc_page_index = loc // PAGE_SIZE
+                loc_tok = loc % PAGE_SIZE
+                page_base = loc_page_index * page_bytes
+                k_off = page_base + loc_tok * HEAD_DIM
+                s_off = page_base + k_region + loc_tok * 4
+                kv_flat[k_off : k_off + HEAD_DIM] = quantized.view(torch.uint8)
+                kv_flat[s_off : s_off + 4] = scale.detach().reshape(1).view(torch.uint8)
+
+            # stash -- gated on the TOKEN-granular tail slot, not on pos_valid.
+            # pos_valid keys off the pool-granular cache_loc, which is -1 for
+            # every token that is not the pool's last, so gating the stash on it
+            # would drop all intra-pool tokens.
+            if p >= 0 and tail_slot_cpu[b][t] >= 0:
+                tail_cpu[block, 0, phys_slot] = cur_key
+                tail_cpu[block, 1, phys_slot] = cur_score
+
+    kv_out = kv_flat.view(NUM_BLOCKS, PAGE_SIZE, HEAD_DIM + 4).to(device="cuda")
+    return kv_out, tail_cpu.to(torch.bfloat16).to(device="cuda")
+
+
+def _assert_eq(r_ref, r_kern):
+    kv_ref, tail_ref = r_ref
+    kv_kern, tail_kern = r_kern
+    assert torch.equal(kv_ref, kv_kern), (
+        "kv_cache differs: max diff "
+        f"{(kv_ref.int() - kv_kern.int()).abs().max().item()}"
+    )
+    assert torch.equal(tail_ref, tail_kern), (
+        "tail_kv_cache differs: max diff "
+        f"{(tail_ref.float() - tail_kern.float()).abs().max().item()}"
+    )
+
+
+def _run_kernel(kv, tail, tail_slot, key, score, ape, slot_map, pos):
+    kv = kv.clone()
+    tail = tail.clone()
+    kpool_decode_update_and_maybe_write_cache_batched(
+        kv,
+        tail,
+        tail_slot,
+        key,
+        score,
+        ape,
+        slot_map,
+        pos,
+        POOL_SIZE,
+        HEAD_DIM,
+        round_scale=ROUND_SCALE,
+    )
+    return kv, tail
+
+
+@pytest.mark.parametrize("pool_size", [4, 16])
+def test_decode_writer_matches_prefill_writer(pool_size):
+    """A pool built token-by-token by decode must equal one built by prefill.
+
+    The indexer K cache has two writers: ``kpool_compress_and_write_cache``
+    compresses the prompt during prefill, and this kernel compresses the
+    generated tokens during decode. They must produce byte-identical entries,
+    because the fraction of the cache written by the decode path grows with the
+    generation length -- so an asymmetry between them silently degrades sparse
+    top-k selection more and more the longer the model generates, and is
+    invisible below ``index_topk`` (where every pool is selected anyway).
+
+    Unlike the reference-based tests above, this one uses the *other production
+    kernel* as the oracle, so it cannot be defeated by the reference drifting
+    to match a buggy implementation. `pool_size=4` is the shipping
+    ``index_kpool`` for GLM5-Next; 16 covers the wider layout.
+    """
+    n_pools, page, nblk = 8, 64, 4
+    n_tok = n_pools * pool_size
+    dev = "cuda"
+    torch.manual_seed(0)
+    k = torch.randn(n_tok, HEAD_DIM, dtype=torch.bfloat16, device=dev)
+    score = torch.randn(n_tok, HEAD_DIM, dtype=torch.bfloat16, device=dev)
+    ape = torch.randn(pool_size, HEAD_DIM, dtype=torch.float32, device=dev)
+
+    kv_prefill = torch.zeros(nblk, page, HEAD_DIM + 4, dtype=torch.uint8, device=dev)
+    kpool_compress_and_write_cache(
+        kv_prefill,
+        k.view(n_pools, pool_size, HEAD_DIM),
+        score.view(n_pools, pool_size, HEAD_DIM),
+        ape,
+        torch.arange(n_pools, dtype=torch.int64, device=dev),
+        pool_size=pool_size,
+        head_dim=HEAD_DIM,
+        round_scale=ROUND_SCALE,
+    )
+
+    # One request owning tail block 0, fed one token per decode step.
+    kv_decode = torch.zeros_like(kv_prefill)
+    tail = torch.zeros(nblk, 2, pool_size, HEAD_DIM, dtype=torch.bfloat16, device=dev)
+    for t in range(n_tok):
+        completes = t % pool_size == pool_size - 1
+        kpool_decode_update_and_maybe_write_cache_batched(
+            kv_decode,
+            tail,
+            # token-granular: every token has a valid tail slot
+            torch.tensor([[t % pool_size]], dtype=torch.int32, device=dev),
+            k[t].view(1, 1, HEAD_DIM),
+            score[t].view(1, 1, HEAD_DIM),
+            ape,
+            # pool-granular: only the pool's last token carries a cache slot
+            torch.tensor(
+                [[t // pool_size if completes else -1]], dtype=torch.int32, device=dev
+            ),
+            torch.tensor([[t]], dtype=torch.int32, device=dev),
+            pool_size,
+            HEAD_DIM,
+            round_scale=ROUND_SCALE,
+        )
+
+    differing = [
+        p
+        for p in range(n_pools)
+        if not torch.equal(
+            kv_prefill[p // page, p % page], kv_decode[p // page, p % page]
+        )
+    ]
+    assert not differing, (
+        f"decode-written pools differ from prefill-written pools: "
+        f"{len(differing)}/{n_pools} (pool_size={pool_size}, first={differing[:5]})"
+    )
+
+
+def test_leading_invalid_tail_slot():
+    """A request whose FIRST token carries an invalid (-1) tail slot while a
+    later token is a real pool completion.
+
+    The tail block must be derived per token, not from token 0: a leading
+    invalid sentinel would otherwise poison the base address for the whole
+    request (out-of-bounds tail reads on the completion).
+    """
+    torch.manual_seed(0)
+    B, next_n, blocks = 2, 4, [3, 5]
+    # req 0: token 0 invalid (pos -1), tokens 1..3 valid, completion at pos 15
+    # req 1: all valid, no completion
+    pos = torch.tensor(
+        [[-1, 13, 14, 15], [4, 5, 6, 7]], dtype=torch.int32, device="cuda"
+    )
+    safe_pos = torch.where(pos >= 0, pos, 0)
+    tail_slot = _tail_slot_for(blocks, safe_pos)
+    # leading invalid entry carries the -1 sentinel, as the scatter path emits
+    tail_slot[0, 0] = -1
+    slot_map = torch.full((B, next_n), -1, dtype=torch.int32, device="cuda")
+    slot_map[0, 3] = 15  # req 0 completes its pool on the last verify token
+
+    key = torch.randn(B, next_n, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    score = torch.randn(B, next_n, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    ape = torch.randn(POOL_SIZE, HEAD_DIM, dtype=torch.float32, device="cuda")
+
+    kv, tail = _make_caches()
+    _seed_prior(tail, blocks, 13)
+    r_ref = _torch_reference(kv, tail, tail_slot, key, score, ape, slot_map, pos)
+    r_kern = _run_kernel(kv, tail, tail_slot, key, score, ape, slot_map, pos)
+    _assert_eq(r_ref, r_kern)
+
+
+@pytest.mark.parametrize(
+    "case_id",
+    [
+        "no_completion",
+        "completion_at_end",
+        "completion_mid_batch",
+        "non_uniform_padding",
+        "plain_decode",
+    ],
+)
+def test_batched_matches_reference(case_id):
+    torch.manual_seed(0)
+    if case_id == "no_completion":
+        B, next_n, blocks = 3, 4, [0, 1, 2]
+        pos = (
+            torch.arange(next_n, device="cuda", dtype=torch.int32)
+            .unsqueeze(0)
+            .expand(B, -1)
+            .contiguous()
+        )
+        slot_map = torch.full((B, next_n), -1, dtype=torch.int32, device="cuda")
+        n_prior = 0
+    elif case_id == "completion_at_end":
+        B, next_n, blocks = 2, 4, [0, 1]
+        pos = torch.tensor(
+            [[12, 13, 14, 15], [12, 13, 14, 15]], dtype=torch.int32, device="cuda"
+        )
+        slot_map = torch.full((B, next_n), -1, dtype=torch.int32, device="cuda")
+        slot_map[:, 3] = torch.tensor(
+            [15, PAGE_SIZE + 15], dtype=torch.int32, device="cuda"
+        )
+        n_prior = POOL_SIZE - next_n
+    elif case_id == "completion_mid_batch":
+        B, next_n, blocks = 3, 4, [0, 1, 2]
+        pos = torch.tensor([[13, 14, 15, 16]] * B, dtype=torch.int32, device="cuda")
+        slot_map = torch.full((B, next_n), -1, dtype=torch.int32, device="cuda")
+        slot_map[:, 2] = torch.tensor(
+            [15, PAGE_SIZE + 15, 2 * PAGE_SIZE + 15], dtype=torch.int32, device="cuda"
+        )
+        n_prior = 13
+    elif case_id == "non_uniform_padding":
+        B, next_n, blocks = 2, 4, [0, 1]
+        pos = torch.tensor(
+            [[12, 13, 14, 15], [12, 13, -1, -1]], dtype=torch.int32, device="cuda"
+        )
+        slot_map = torch.full((B, next_n), -1, dtype=torch.int32, device="cuda")
+        slot_map[0, 3] = 15
+        n_prior = POOL_SIZE - 4
+    else:  # plain_decode
+        B, next_n, blocks = 4, 1, [0, 1, 2, 3]
+        pos = torch.tensor([[5], [6], [7], [8]], dtype=torch.int32, device="cuda")
+        slot_map = torch.full((B, next_n), -1, dtype=torch.int32, device="cuda")
+        n_prior = 0
+
+    if case_id == "non_uniform_padding":
+        safe_pos = torch.where(pos >= 0, pos, 0)
+        tail_slot = torch.where(pos >= 0, _tail_slot_for(blocks, safe_pos), 0)
+    else:
+        tail_slot = _tail_slot_for(blocks, pos)
+
+    key = torch.randn(B, next_n, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    score = torch.randn(B, next_n, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    ape = torch.randn(POOL_SIZE, HEAD_DIM, dtype=torch.float32, device="cuda")
+
+    kv, tail = _make_caches()
+    _seed_prior(tail, blocks, n_prior)
+    r_ref = _torch_reference(kv, tail, tail_slot, key, score, ape, slot_map, pos)
+    r_kern = _run_kernel(kv, tail, tail_slot, key, score, ape, slot_map, pos)
+    _assert_eq(r_ref, r_kern)
+
+
+@pytest.mark.parametrize("seed", list(range(20)))
+def test_batched_matches_reference_fuzz(seed):
+    """Random B / next_n / start positions; covers 0, 1, and multi completion."""
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    B = int(torch.randint(1, 6, (1,), generator=g, device="cuda").item())
+    next_n = int(torch.randint(1, 8, (1,), generator=g, device="cuda").item())
+    blocks = list(range(B))
+
+    starts = torch.randint(0, 33, (B,), generator=g, device="cuda", dtype=torch.int32)
+    pos = starts.unsqueeze(1) + torch.arange(
+        next_n, device="cuda", dtype=torch.int32
+    ).unsqueeze(0)
+    tail_slot = _tail_slot_for(blocks, pos)
+
+    is_completion = pos % POOL_SIZE == POOL_SIZE - 1
+    blk = torch.tensor(blocks, device="cuda", dtype=torch.int32).unsqueeze(1)
+    pool_slot = blk * PAGE_SIZE + (POOL_SIZE - 1)
+    slot_map = torch.where(is_completion, pool_slot, torch.full_like(pos, -1))
+
+    key = torch.randn(
+        B, next_n, HEAD_DIM, dtype=torch.bfloat16, device="cuda", generator=g
+    )
+    score = torch.randn(
+        B, next_n, HEAD_DIM, dtype=torch.bfloat16, device="cuda", generator=g
+    )
+    ape = torch.randn(
+        POOL_SIZE, HEAD_DIM, dtype=torch.float32, device="cuda", generator=g
+    )
+
+    kv, tail = _make_caches()
+    prior_g = torch.Generator(device="cuda").manual_seed(seed + 1000)
+    for b in range(B):
+        n_prior = int(starts[b].item()) % POOL_SIZE
+        if n_prior > 0:
+            pk = torch.randn(
+                n_prior,
+                HEAD_DIM,
+                dtype=torch.bfloat16,
+                device="cuda",
+                generator=prior_g,
+            )
+            ps = torch.randn(
+                n_prior,
+                HEAD_DIM,
+                dtype=torch.bfloat16,
+                device="cuda",
+                generator=prior_g,
+            )
+            tail[blocks[b], 0, :n_prior, :] = pk
+            tail[blocks[b], 1, :n_prior, :] = ps
+
+    r_ref = _torch_reference(kv, tail, tail_slot, key, score, ape, slot_map, pos)
+    r_kern = _run_kernel(kv, tail, tail_slot, key, score, ape, slot_map, pos)
+    _assert_eq(r_ref, r_kern)

--- a/tests/unit_tests/glm5_next/test_kpool_tail_slot_mapping.py
+++ b/tests/unit_tests/glm5_next/test_kpool_tail_slot_mapping.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU regression tests for the per-request KPool tail ring."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.attention.backend import CommonAttentionMetadata
+
+from vllm_fl.models.glm5_next_kpool import (
+    KpoolTailMetadataBuilder,
+    compute_kpool_tail_slot_mapping,
+)
+
+KPOOL = 4
+
+
+def _make_tail_block_table(own_blocks: list[int], width: int = 64) -> torch.Tensor:
+    block_table = torch.zeros(len(own_blocks), width, dtype=torch.int32)
+    block_table[:, 0] = torch.tensor(own_blocks, dtype=torch.int32)
+    return block_table
+
+
+def _legacy_tail_slots(
+    block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    slots = []
+    for request in range(block_table.shape[0]):
+        for token in range(query_start_loc[request], query_start_loc[request + 1]):
+            position = int(positions[token])
+            block = int(block_table[request, position // KPOOL])
+            slots.append(block * KPOOL + position % KPOOL)
+    return torch.tensor(slots, dtype=torch.int64)
+
+
+def _make_batch(per_request_positions, padded_len=None):
+    positions = torch.cat(
+        [torch.tensor(values, dtype=torch.int64) for values in per_request_positions]
+    )
+    num_actual_tokens = positions.numel()
+    num_reqs = len(per_request_positions)
+    lengths = [len(values) for values in per_request_positions]
+    query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int64)
+    torch.cumsum(torch.tensor(lengths, dtype=torch.int64), 0, out=query_start_loc[1:])
+    if padded_len is None:
+        padded_len = num_actual_tokens
+    slot_mapping = torch.full((padded_len,), -1, dtype=torch.int64)
+    return (
+        positions,
+        query_start_loc,
+        slot_mapping,
+        num_actual_tokens,
+        num_reqs,
+    )
+
+
+def _circular_tail_slots(
+    slot_mapping,
+    block_table,
+    query_start_loc,
+    positions,
+    num_actual_tokens,
+    num_reqs,
+):
+    return compute_kpool_tail_slot_mapping(
+        slot_mapping,
+        block_table,
+        query_start_loc,
+        positions,
+        num_actual_tokens,
+        num_reqs,
+        KPOOL,
+    )
+
+
+def test_legacy_mapping_collapses_long_requests_onto_block_zero() -> None:
+    own_blocks = [5, 9]
+    per_request = [list(range(10)), list(range(12))]
+    positions, query_start_loc, _, _, _ = _make_batch(per_request)
+    legacy = _legacy_tail_slots(
+        _make_tail_block_table(own_blocks), query_start_loc, positions
+    )
+
+    offset = 0
+    request_slots = []
+    for request, prompt in enumerate(per_request):
+        slots = set()
+        for position in range(len(prompt)):
+            slot = int(legacy[offset + position])
+            if position >= KPOOL:
+                assert slot // KPOOL == 0
+                assert slot // KPOOL != own_blocks[request]
+            slots.add(slot)
+        request_slots.append(slots)
+        offset += len(prompt)
+    assert request_slots[0] & request_slots[1]
+
+
+def test_circular_mapping_isolates_concurrent_requests() -> None:
+    own_blocks = [5, 9]
+    per_request = [list(range(10)), list(range(12))]
+    args = _make_batch(per_request)
+    out = _circular_tail_slots(
+        args[2],
+        _make_tail_block_table(own_blocks),
+        args[1],
+        args[0],
+        args[3],
+        args[4],
+    )
+
+    offset = 0
+    request_slots = []
+    for request, prompt in enumerate(per_request):
+        slots = set()
+        for position in range(len(prompt)):
+            slot = int(out[offset + position])
+            assert slot // KPOOL == own_blocks[request]
+            assert slot % KPOOL == position % KPOOL
+            slots.add(slot)
+        request_slots.append(slots)
+        offset += len(prompt)
+    assert not request_slots[0] & request_slots[1]
+
+
+@pytest.mark.parametrize("prompt_len", [1, 2, 3, 4])
+def test_circular_mapping_matches_generic_for_first_pool(prompt_len: int) -> None:
+    per_request = [list(range(prompt_len))]
+    positions, query_start_loc, slot_mapping, num_actual_tokens, num_reqs = _make_batch(
+        per_request
+    )
+    block_table = _make_tail_block_table([7])
+    legacy = _legacy_tail_slots(block_table, query_start_loc, positions)
+    circular = _circular_tail_slots(
+        slot_mapping,
+        block_table,
+        query_start_loc,
+        positions,
+        num_actual_tokens,
+        num_reqs,
+    )
+    assert torch.equal(circular, legacy)
+
+
+def test_circular_mapping_preserves_padding_and_empty_batch() -> None:
+    per_request = [list(range(10)), list(range(12))]
+    args = _make_batch(per_request, padded_len=30)
+    block_table = _make_tail_block_table([5, 9])
+    out = _circular_tail_slots(args[2], block_table, args[1], args[0], args[3], args[4])
+    assert torch.equal(out[args[3] :], torch.full_like(out[args[3] :], -1))
+
+    empty = _circular_tail_slots(args[2], block_table, args[1], args[0][:0], 0, args[4])
+    assert torch.equal(empty, args[2])
+
+
+def _make_common_metadata(
+    per_request_positions, own_blocks, with_positions: bool = True
+):
+    positions, query_start_loc, slot_mapping, num_actual_tokens, num_reqs = _make_batch(
+        per_request_positions,
+        padded_len=sum(len(values) for values in per_request_positions) + 4,
+    )
+    seq_lens = torch.tensor(
+        [max(values) + 1 if values else 1 for values in per_request_positions],
+        dtype=torch.int64,
+    )
+    return CommonAttentionMetadata(
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc.clone(),
+        seq_lens=seq_lens,
+        num_reqs=num_reqs,
+        num_actual_tokens=num_actual_tokens,
+        max_query_len=max(map(len, per_request_positions), default=1),
+        max_seq_len=int(seq_lens.max()) if num_reqs else 1,
+        block_table_tensor=_make_tail_block_table(own_blocks),
+        slot_mapping=slot_mapping,
+        positions=positions if with_positions else None,
+    )
+
+
+def _make_tail_builder():
+    builder = object.__new__(KpoolTailMetadataBuilder)
+    builder.kv_cache_spec = SimpleNamespace(block_size=KPOOL)
+    return builder
+
+
+def test_builder_uses_circular_mapping() -> None:
+    per_request = [list(range(10)), list(range(12))]
+    own_blocks = [5, 9]
+    metadata = _make_common_metadata(per_request, own_blocks)
+    built = KpoolTailMetadataBuilder.build(_make_tail_builder(), 0, metadata)
+
+    offset = 0
+    for request, prompt in enumerate(per_request):
+        for position in range(len(prompt)):
+            slot = int(built.slot_mapping[offset + position])
+            assert slot // KPOOL == own_blocks[request]
+            assert slot % KPOOL == position % KPOOL
+        offset += len(prompt)
+
+
+def test_builder_keeps_generic_mapping_without_positions() -> None:
+    metadata = _make_common_metadata([list(range(10))], [5], with_positions=False)
+    built = KpoolTailMetadataBuilder.build(_make_tail_builder(), 0, metadata)
+    assert built.slot_mapping is metadata.slot_mapping

--- a/tests/unit_tests/glm5_next/test_mhc_broadcast_tilelang.py
+++ b/tests/unit_tests/glm5_next/test_mhc_broadcast_tilelang.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness and CUDA Graph tests for first-layer mHC broadcast."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+def test_mhc_broadcast_weight_collapse_is_algebraically_exact() -> None:
+    torch.manual_seed(20260827)
+    tokens, hidden_size, streams = 7, 32, 4
+    mix_size = streams * (2 + streams)
+    residual = torch.randn(tokens, hidden_size, dtype=torch.float64)
+    fn = torch.randn(mix_size, streams * hidden_size, dtype=torch.float64)
+
+    expanded = residual.unsqueeze(1).expand(-1, streams, -1).reshape(tokens, -1)
+    collapsed = fn.view(mix_size, streams, hidden_size).sum(dim=1)
+
+    torch.testing.assert_close(
+        expanded @ fn.t(),
+        residual @ collapsed.t(),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def _require_cuda_broadcast_kernel():
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    from vllm.utils.deep_gemm import is_deep_gemm_supported
+
+    if not is_deep_gemm_supported():
+        pytest.skip("requires the DeepGEMM TF32 mHC projection")
+
+    from vllm.model_executor.kernels.mhc.tilelang import mhc_pre_tilelang
+
+    from vllm_fl.kernels.glm5_next.mhc_broadcast_tilelang import (
+        mhc_pre_broadcast_tilelang,
+    )
+
+    return mhc_pre_tilelang, mhc_pre_broadcast_tilelang
+
+
+def _make_inputs(tokens: int):
+    torch.manual_seed(20260827 + tokens)
+    hidden_size, streams = 4096, 4
+    mix_size = streams * (2 + streams)
+    fn = (
+        torch.randn(
+            mix_size,
+            streams * hidden_size,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        * 0.01
+    ).contiguous()
+    return {
+        "residual": torch.randn(
+            tokens, hidden_size, device="cuda", dtype=torch.bfloat16
+        ),
+        "fn": fn,
+        "fn_broadcast": fn.view(mix_size, streams, hidden_size)
+        .sum(dim=1)
+        .contiguous(),
+        "scale": torch.tensor(
+            [0.8, 0.7, 0.6], device="cuda", dtype=torch.float32
+        ),
+        "base": (
+            torch.randn(mix_size, device="cuda", dtype=torch.float32) * 0.1
+        ).contiguous(),
+        "norm_weight": (
+            1
+            + torch.randn(hidden_size, device="cuda", dtype=torch.float32)
+            * 0.05
+        )
+        .to(torch.bfloat16)
+        .contiguous(),
+        "streams": streams,
+    }
+
+
+def _generic_outputs(mhc_pre_tilelang, values):
+    expanded = (
+        values["residual"]
+        .unsqueeze(1)
+        .expand(-1, values["streams"], -1)
+        .contiguous()
+    )
+    post, comb, layer_input = mhc_pre_tilelang(
+        expanded,
+        values["fn"],
+        values["scale"],
+        values["base"],
+        1e-5,
+        1e-6,
+        1e-6,
+        2.5,
+        20,
+        norm_weight=values["norm_weight"],
+        norm_eps=1e-5,
+    )
+    return expanded, post, comb, layer_input
+
+
+def _broadcast_outputs(mhc_pre_broadcast_tilelang, values):
+    return mhc_pre_broadcast_tilelang(
+        values["residual"],
+        values["fn"],
+        values["scale"],
+        values["base"],
+        1e-5,
+        1e-6,
+        1e-6,
+        2.5,
+        20,
+        norm_weight=values["norm_weight"],
+        norm_eps=1e-5,
+        fn_broadcast=values["fn_broadcast"],
+    )
+
+
+def _assert_outputs_close(reference, actual) -> None:
+    assert torch.equal(reference[0], actual[0])
+    torch.testing.assert_close(reference[1], actual[1], rtol=2e-3, atol=1e-3)
+    torch.testing.assert_close(reference[2], actual[2], rtol=2e-3, atol=1e-3)
+    torch.testing.assert_close(reference[3], actual[3], rtol=2e-2, atol=4e-2)
+
+
+@pytest.mark.parametrize("tokens", [1, 24, 257, 1024])
+def test_mhc_broadcast_matches_materialized_reference(tokens: int) -> None:
+    generic, broadcast = _require_cuda_broadcast_kernel()
+    values = _make_inputs(tokens)
+
+    reference = _generic_outputs(generic, values)
+    actual = _broadcast_outputs(broadcast, values)
+    repeated = _broadcast_outputs(broadcast, values)
+    torch.cuda.synchronize()
+
+    _assert_outputs_close(reference, actual)
+    for lhs, rhs in zip(actual, repeated):
+        assert torch.equal(lhs, rhs)
+
+
+def test_mhc_broadcast_cuda_graph_replay() -> None:
+    generic, broadcast = _require_cuda_broadcast_kernel()
+    values = _make_inputs(24)
+
+    # Compile both DeepGEMM and TileLang before stream capture.
+    _broadcast_outputs(broadcast, values)
+    torch.cuda.synchronize()
+
+    static_residual = values["residual"].clone()
+    graph_values = dict(values, residual=static_residual)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_outputs = _broadcast_outputs(broadcast, graph_values)
+
+    next_residual = torch.randn_like(static_residual)
+    static_residual.copy_(next_residual)
+    graph.replay()
+    torch.cuda.synchronize()
+    replayed = tuple(value.clone() for value in graph_outputs)
+
+    reference_values = dict(values, residual=next_residual)
+    reference = _generic_outputs(generic, reference_values)
+    torch.cuda.synchronize()
+    _assert_outputs_close(reference, replayed)

--- a/tests/unit_tests/glm5_next/test_mhc_broadcast_tilelang.py
+++ b/tests/unit_tests/glm5_next/test_mhc_broadcast_tilelang.py
@@ -61,19 +61,13 @@ def _make_inputs(tokens: int):
             tokens, hidden_size, device="cuda", dtype=torch.bfloat16
         ),
         "fn": fn,
-        "fn_broadcast": fn.view(mix_size, streams, hidden_size)
-        .sum(dim=1)
-        .contiguous(),
-        "scale": torch.tensor(
-            [0.8, 0.7, 0.6], device="cuda", dtype=torch.float32
-        ),
+        "fn_broadcast": fn.view(mix_size, streams, hidden_size).sum(dim=1).contiguous(),
+        "scale": torch.tensor([0.8, 0.7, 0.6], device="cuda", dtype=torch.float32),
         "base": (
             torch.randn(mix_size, device="cuda", dtype=torch.float32) * 0.1
         ).contiguous(),
         "norm_weight": (
-            1
-            + torch.randn(hidden_size, device="cuda", dtype=torch.float32)
-            * 0.05
+            1 + torch.randn(hidden_size, device="cuda", dtype=torch.float32) * 0.05
         )
         .to(torch.bfloat16)
         .contiguous(),
@@ -83,10 +77,7 @@ def _make_inputs(tokens: int):
 
 def _generic_outputs(mhc_pre_tilelang, values):
     expanded = (
-        values["residual"]
-        .unsqueeze(1)
-        .expand(-1, values["streams"], -1)
-        .contiguous()
+        values["residual"].unsqueeze(1).expand(-1, values["streams"], -1).contiguous()
     )
     post, comb, layer_input = mhc_pre_tilelang(
         expanded,

--- a/tests/unit_tests/glm5_next/test_mla_boundary_compat.py
+++ b/tests/unit_tests/glm5_next/test_mla_boundary_compat.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+from vllm_fl.patches import glm5_next_v024 as glm5_patch
+
+_install_mla_boundary_compat_ops = glm5_patch._install_mla_boundary_compat_ops
+
+
+def _fake_ops(*, cache_impl):
+    module = ModuleType("fake_vllm_custom_ops")
+
+    def concat_mla_q(q_nope, q_pe, output):
+        output.copy_(torch.cat((q_nope, q_pe), dim=-1))
+
+    module.concat_mla_q = concat_mla_q
+    module.concat_and_cache_mla = cache_impl
+    return module
+
+
+def test_mla_boundary_compat_keeps_vendor_fast_paths(monkeypatch) -> None:
+    monkeypatch.setattr(glm5_patch, "_has_vllm_cache_op", lambda name: False)
+    calls = {"cache": 0, "q": 0}
+
+    def vendor_cache(kv_c, k_pe, cache, slots, cache_dtype, scale):
+        del k_pe, slots, cache_dtype, scale
+        calls["cache"] += 1
+        cache.view(-1, cache.shape[-1])[: kv_c.shape[0]].copy_(kv_c)
+
+    ops = _fake_ops(cache_impl=vendor_cache)
+    original_q = ops.concat_mla_q
+
+    def counted_q(*args):
+        calls["q"] += 1
+        return original_q(*args)
+
+    ops.concat_mla_q = counted_q
+    assert _install_mla_boundary_compat_ops(ops)
+    assert not _install_mla_boundary_compat_ops(ops)
+
+    q_nope = torch.randn(2, 3, 4)
+    q_pe_empty = torch.empty(2, 3, 0)
+    q_out = torch.empty_like(q_nope)
+    ops.concat_mla_q(q_nope, q_pe_empty, q_out)
+    torch.testing.assert_close(q_out, q_nope)
+    assert calls["q"] == 0
+
+    q_pe = torch.randn(2, 3, 2)
+    q_out_with_pe = torch.empty(2, 3, 6)
+    ops.concat_mla_q(q_nope, q_pe, q_out_with_pe)
+    torch.testing.assert_close(q_out_with_pe, torch.cat((q_nope, q_pe), -1))
+    assert calls["q"] == 1
+
+    kv_c = torch.randn(3, 4)
+    cache = torch.zeros(2, 4, 4)
+    ops.concat_and_cache_mla(
+        kv_c,
+        torch.empty(3, 0),
+        cache,
+        torch.arange(3),
+        "auto",
+        torch.ones(1),
+    )
+    assert calls["cache"] == 1
+    torch.testing.assert_close(cache.view(-1, 4)[:3], kv_c)
+
+
+def test_mla_cache_missing_vendor_op_uses_bf16_slot_fallback(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(glm5_patch, "_has_vllm_cache_op", lambda name: False)
+    calls = {"cache": 0}
+
+    def missing_vendor_cache(*args, **kwargs):
+        del args, kwargs
+        calls["cache"] += 1
+        raise AttributeError(
+            "'_OpNamespace' '_C_cache_ops' object has no attribute "
+            "'concat_and_cache_mla'"
+        )
+
+    # Make the test independent of whether its host environment has FlagGems.
+    monkeypatch.setitem(sys.modules, "flag_gems.fused.concat_and_cache_mla", None)
+    ops = _fake_ops(cache_impl=missing_vendor_cache)
+    _install_mla_boundary_compat_ops(ops)
+
+    kv_c = torch.arange(12, dtype=torch.float32).view(4, 3)
+    slots = torch.tensor([0, 3, -1, 7])
+    cache = torch.zeros(2, 4, 3)
+    empty_pe = torch.empty(4, 0)
+    scale = torch.ones(1)
+
+    ops.concat_and_cache_mla(kv_c, empty_pe, cache, slots, "bfloat16", scale)
+    torch.testing.assert_close(cache.view(-1, 3)[slots[:2]], kv_c[:2])
+    torch.testing.assert_close(cache.view(-1, 3)[slots[3:]], kv_c[3:])
+
+    # The missing native ABI is remembered, so subsequent calls do not pay
+    # for another exception before taking the fallback.
+    cache.zero_()
+    ops.concat_and_cache_mla(kv_c, empty_pe, cache, slots, "auto", scale)
+    assert calls["cache"] == 1
+
+    with pytest.raises(NotImplementedError, match="only supports BF16"):
+        ops.concat_and_cache_mla(kv_c, empty_pe, cache, slots, "fp8_ds_mla", scale)
+
+
+def test_mla_cache_does_not_hide_unrelated_vendor_errors(monkeypatch) -> None:
+    monkeypatch.setattr(glm5_patch, "_has_vllm_cache_op", lambda name: False)
+
+    def broken_vendor_cache(*args, **kwargs):
+        del args, kwargs
+        raise AttributeError("vendor metadata is missing")
+
+    ops = _fake_ops(cache_impl=broken_vendor_cache)
+    _install_mla_boundary_compat_ops(ops)
+
+    with pytest.raises(AttributeError, match="vendor metadata"):
+        ops.concat_and_cache_mla(
+            torch.randn(1, 3),
+            torch.empty(1, 0),
+            torch.zeros(1, 1, 3),
+            torch.zeros(1, dtype=torch.int64),
+            "auto",
+            torch.ones(1),
+        )
+
+
+def test_mla_cache_wrapper_is_not_installed_when_vendor_abi_exists(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(glm5_patch, "_has_vllm_cache_op", lambda name: True)
+
+    def vendor_cache(*args, **kwargs):
+        del args, kwargs
+
+    ops = _fake_ops(cache_impl=vendor_cache)
+    _install_mla_boundary_compat_ops(ops)
+
+    assert ops.concat_and_cache_mla is vendor_cache
+
+
+def test_explicit_flaggems_rejects_accidental_vendor_attention(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(glm5_patch, "get_glm5_provider", lambda: "flaggems")
+
+    def vendor_cache(*args, **kwargs):
+        del args, kwargs
+
+    ops = _fake_ops(cache_impl=vendor_cache)
+    _install_mla_boundary_compat_ops(ops)
+
+    with pytest.raises(RuntimeError, match="did not select FlagGemsSparseMLABackend"):
+        ops.concat_mla_q(
+            torch.randn(1, 2, 3),
+            torch.empty(1, 2, 0),
+            torch.empty(1, 2, 3),
+        )

--- a/tests/unit_tests/glm5_next/test_multimodal_connectivity.py
+++ b/tests/unit_tests/glm5_next/test_multimodal_connectivity.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Connectivity contracts for the GLM5-Next multimodal path.
+
+Two defects were found while auditing PR #454 against the native vLLM 0.24
+GLM5.3-Flash runtime (``vllm_glm5_next``, 20260826) and vLLM 0.24's inherited
+GLM-4.6V prompt machinery:
+
+1. Video prompt timestamps must come from the exact frame sampler that the
+   vision tower consumes, not vLLM's duration-threshold GLM-4.6V re-derivation.
+2. The video encoder token ceiling must come from the token-budget pixel cap,
+   because ``video_processor.size`` is intentionally unused by this checkpoint.
+
+The vision MLP/merger clamp is **intentionally kept**: this checkpoint declares
+``vision_config.model_type = "glm5_next_vision"`` and the validated native
+runtime clamps it, even though the older 0808 references mapped vision to
+``glm_ocr_vision`` (unclamped).
+"""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+MULTIMODAL = ROOT / "vllm_fl/models/glm5_next_multimodal.py"
+
+
+def _module() -> ast.Module:
+    return ast.parse(MULTIMODAL.read_text())
+
+
+def _class(module: ast.Module, name: str) -> ast.ClassDef:
+    return next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == name
+    )
+
+
+def _method(cls: ast.ClassDef, name: str) -> ast.FunctionDef:
+    return next(
+        node
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _self_attribute_calls(method: ast.FunctionDef, attr: str) -> set[str]:
+    return {
+        ast.unparse(node.value)
+        for node in ast.walk(method)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Attribute) and target.attr == attr
+    }
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    return {
+        ast.unparse(call.func) for call in ast.walk(node) if isinstance(call, ast.Call)
+    }
+
+
+def test_vision_mlp_and_merger_keep_checkpoint_swiglu_clamp() -> None:
+    """GLM5.3-Flash declares ``glm5_next_vision`` and clamps the vision SwiGLU.
+
+    This is a regression guard: the checkpoint-specific native runtime clamps,
+    so the plugin must not silently drop the clamp.
+    """
+    module = _module()
+
+    for class_name in ("Glm5NextVisionMLP", "Glm5NextPatchMerger"):
+        init = _method(_class(module, class_name), "__init__")
+        act_assignments = _self_attribute_calls(init, "act_fn")
+        assert act_assignments == {"SiluAndMulWithClamp(swiglu_limit=swiglu_limit)"}, (
+            class_name,
+            act_assignments,
+        )
+
+
+def test_processing_info_overrides_video_prompt_and_budget() -> None:
+    module = _module()
+    info = _class(module, "Glm5NextProcessingInfo")
+    methods = {node.name for node in info.body if isinstance(node, ast.FunctionDef)}
+
+    assert "get_mm_max_tokens_per_item" in methods
+    assert "_get_video_second_idx_glm46v" in methods
+
+    budget = _method(info, "get_mm_max_tokens_per_item")
+    budget_calls = _called_names(budget)
+    assert "self._get_video_max_pixels" in budget_calls
+    # The inherited vLLM 0.24 base reads the unused placeholder size.
+    size_subscripts = [
+        node
+        for node in ast.walk(budget)
+        if isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "size"
+    ]
+    assert not size_subscripts
+
+    timestamps = _method(info, "_get_video_second_idx_glm46v")
+    timestamp_calls = _called_names(timestamps)
+    assert "self.get_video_processor" in timestamp_calls
+    assert "glm_video_timestamp_seconds" in timestamp_calls
+
+
+def _vllm_glm46v_second_idxs(meta_frames, video_fps, duration, temporal_patch_size=2):
+    """Replica of vLLM 0.24's ``_get_video_second_idx_glm46v`` frame policy."""
+    import numpy as np
+
+    duration = duration or (round((meta_frames - 1) / video_fps) + 1)
+    effective_duration = min(duration, 2400)
+    if effective_duration <= 30:
+        target_fps = 3
+    elif effective_duration <= 300:
+        target_fps = 1
+    else:
+        target_fps = 0.5
+
+    extract_t = min(int(effective_duration * target_fps * temporal_patch_size), 640)
+    timestamps = [i / video_fps for i in range(meta_frames)]
+    max_second = int(duration)
+    if meta_frames < extract_t:
+        frame_indices = np.linspace(0, meta_frames - 1, extract_t, dtype=int).tolist()
+    else:
+        frame_indices = []
+        current_second = 0.0
+        inv_fps = 1 / (temporal_patch_size * target_fps)
+        for frame_index in range(meta_frames):
+            if timestamps[frame_index] >= current_second:
+                current_second += inv_fps
+                frame_indices.append(frame_index)
+                if current_second >= max_second:
+                    break
+    if len(frame_indices) < extract_t:
+        start, end = (
+            (frame_indices[0], frame_indices[-1])
+            if frame_indices
+            else (0, max(meta_frames - 1, 0))
+        )
+        frame_indices = np.linspace(start, end, extract_t, dtype=int).tolist()
+    elif len(frame_indices) > extract_t:
+        frame_indices = np.linspace(0, meta_frames - 1, extract_t, dtype=int).tolist()
+
+    seen, uniq = set(), []
+    for idx in frame_indices:
+        if idx not in seen:
+            seen.add(idx)
+            uniq.append(int(idx))
+    if len(uniq) & 1:
+        uniq.append(uniq[-1])
+    return [int(idx / video_fps) for idx in uniq][::2]
+
+
+VIDEO_CASES = [
+    (900, 30.0, 30.0),
+    (3000, 30.0, 100.0),
+    (300, 30.0, 10.0),
+    (48, 2.0, 24.0),
+    (125, 25.0, 5.0),
+    (72000, 30.0, 2400.0),
+]
+
+
+@pytest.mark.parametrize(("total_frames", "fps", "duration"), VIDEO_CASES)
+def test_video_prompt_timestamps_match_encoder_grid(
+    total_frames: int, fps: float, duration: float
+) -> None:
+    """Frame placeholders must equal the sampler's ``grid_t``."""
+    torch = pytest.importorskip("torch")
+    del torch
+    from vllm_fl.transformers_utils.processors.glm5_next import (
+        Glm5NextVideoProcessor,
+        glm_video_timestamp_seconds,
+    )
+
+    video_processor = Glm5NextVideoProcessor()
+    metadata = SimpleNamespace(
+        fps=fps,
+        duration=duration,
+        total_num_frames=total_frames,
+        do_sample_frames=True,
+    )
+
+    sampled = list(video_processor.sample_frames(metadata))
+    grid_t = len(sampled) // video_processor.temporal_patch_size
+    timestamps = glm_video_timestamp_seconds(video_processor, metadata)
+
+    assert len(timestamps) == grid_t
+    assert len(sampled) % video_processor.temporal_patch_size == 0
+
+
+def test_legacy_vllm_frame_policy_would_desync() -> None:
+    """Documents the bug the override fixes: vLLM's GLM-4.6V policy differs."""
+    pytest.importorskip("torch")
+    from vllm_fl.transformers_utils.processors.glm5_next import (
+        Glm5NextVideoProcessor,
+        glm_video_timestamp_seconds,
+    )
+
+    video_processor = Glm5NextVideoProcessor()
+    mismatches = 0
+    for total_frames, fps, duration in VIDEO_CASES:
+        metadata = SimpleNamespace(
+            fps=fps,
+            duration=duration,
+            total_num_frames=total_frames,
+            do_sample_frames=True,
+        )
+        aligned = len(glm_video_timestamp_seconds(video_processor, metadata))
+        legacy = len(
+            _vllm_glm46v_second_idxs(
+                total_frames, fps, duration, video_processor.temporal_patch_size
+            )
+        )
+        if aligned != legacy:
+            mismatches += 1
+    assert mismatches > 0
+
+
+def test_no_sample_frames_uses_provided_indices() -> None:
+    pytest.importorskip("torch")
+    from vllm_fl.transformers_utils.processors.glm5_next import (
+        Glm5NextVideoProcessor,
+        glm_video_timestamp_seconds,
+    )
+
+    video_processor = Glm5NextVideoProcessor()
+    metadata = SimpleNamespace(
+        fps=30.0,
+        duration=10.0,
+        total_num_frames=300,
+        do_sample_frames=False,
+        frames_indices=[0, 10, 20, 30, 40, 50],
+    )
+    timestamps = glm_video_timestamp_seconds(video_processor, metadata)
+    assert timestamps == [0, 0, 1]

--- a/tests/unit_tests/glm5_next/test_portable.py
+++ b/tests/unit_tests/glm5_next/test_portable.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+import math
+
+import pytest
+import torch
+
+from vllm_fl.kernels.glm5_next import portable
+
+
+def test_safe_gate_matches_fp32_definition() -> None:
+    raw = torch.tensor([[1.0, -2.0, 0.5, 3.0]])
+    a_log = torch.tensor([math.log(0.5), math.log(2.0)])
+    bias = torch.tensor([[0.25, -0.5], [0.0, 1.0]])
+
+    actual = portable.safe_kda_gate(raw, a_log, 2, bias, lower_bound=-5.0)
+    expected = -5.0 * torch.sigmoid(
+        torch.exp(a_log).reshape(1, 2, 1) * (raw.reshape(1, 2, 2) + bias)
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_safe_gate_chunk_cumsum_resets_at_sequence_and_chunk() -> None:
+    raw = torch.zeros(1, 7, 1, 1)
+    a_log = torch.zeros(1)
+    boundaries = torch.tensor([0, 3, 7], dtype=torch.int32)
+
+    actual = portable.safe_kda_gate_chunk_cumsum(
+        raw,
+        a_log,
+        cu_seqlens=boundaries,
+        chunk_size=2,
+    ).flatten()
+    gate = -2.5 / math.log(2.0)
+    expected = torch.tensor([gate, 2 * gate, gate, gate, 2 * gate, gate, 2 * gate])
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_recurrent_kda_matches_independent_loop() -> None:
+    torch.manual_seed(7)
+    q = torch.randn(1, 4, 2, 3)
+    k = torch.randn_like(q)
+    v = torch.randn(1, 4, 2, 5)
+    gate = -torch.rand_like(q)
+    beta = torch.rand(1, 4, 2)
+    initial = torch.randn(1, 2, 3, 5)
+    scale = 0.25
+
+    state = initial[0].float().clone()
+    expected = torch.empty_like(v)
+    for token in range(q.shape[1]):
+        state *= torch.exp(gate[0, token].float()).unsqueeze(-1)
+        residual = v[0, token].float() - torch.einsum(
+            "hk,hkv->hv", k[0, token].float(), state
+        )
+        state += torch.einsum(
+            "hk,hv->hkv",
+            beta[0, token].float().unsqueeze(-1) * k[0, token].float(),
+            residual,
+        )
+        expected[0, token] = torch.einsum(
+            "hk,hkv->hv", q[0, token].float() * scale, state
+        )
+
+    actual, final_state = portable.recurrent_kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        scale=scale,
+        initial_state=initial,
+    )
+
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(final_state[0], state)
+
+
+def test_portable_causal_conv_prefill_and_decode_update_state() -> None:
+    x = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    weight = torch.tensor([[1.0, 10.0, 100.0], [2.0, 20.0, 200.0]])
+    state = torch.zeros(1, 2, 2)
+    boundaries = torch.tensor([0, 3], dtype=torch.int32)
+    state_ids = torch.tensor([0], dtype=torch.int32)
+
+    actual = portable.causal_conv1d_fn(
+        x,
+        weight,
+        None,
+        state,
+        boundaries,
+        cache_indices=state_ids,
+        has_initial_state=torch.tensor([False]),
+        activation=None,
+    )
+    expected = torch.tensor([[100.0, 210.0, 321.0], [800.0, 1080.0, 1308.0]])
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(state[0], torch.tensor([[2.0, 3.0], [5.0, 6.0]]))
+
+    decoded = portable.causal_conv1d_update(
+        torch.tensor([[7.0, 8.0]]),
+        state,
+        weight,
+        conv_state_indices=state_ids,
+        activation=None,
+    )
+    torch.testing.assert_close(decoded, torch.tensor([[732.0, 1730.0]]))
+    torch.testing.assert_close(state[0], torch.tensor([[3.0, 7.0], [6.0, 8.0]]))
+
+
+def test_hadamard128_is_normalized_and_self_inverse() -> None:
+    torch.manual_seed(11)
+    value = torch.randn(3, 128)
+    transformed = portable.hadamard128(value)
+    restored = portable.hadamard128(transformed)
+
+    torch.testing.assert_close(restored, value, atol=2e-5, rtol=2e-5)
+    torch.testing.assert_close(
+        transformed.square().sum(-1),
+        value.square().sum(-1),
+        atol=2e-5,
+        rtol=2e-5,
+    )
+
+
+def test_fwht_quant_matches_materialized_reference() -> None:
+    try:
+        portable.get_fp8_dtype_and_max()
+    except RuntimeError as exc:
+        pytest.skip(str(exc))
+
+    torch.manual_seed(13)
+    query = torch.randn(7, 128, dtype=torch.bfloat16)
+    rotated = portable.hadamard128(query).to(torch.bfloat16).float()
+    expected_q, expected_scale = portable._quantize_fp8_vector(
+        rotated, round_scale=True
+    )
+    actual_q, actual_scale = portable.fwht128_quant_fp8(query)
+
+    assert torch.equal(actual_q.view(torch.uint8), expected_q.view(torch.uint8))
+    torch.testing.assert_close(actual_scale, expected_scale.unsqueeze(-1))
+
+
+def test_tail_seed_keeps_each_requests_last_pool() -> None:
+    kpool = 4
+    tail = torch.full((12, 2, kpool, 3), float("nan"))
+    slots = torch.tensor(
+        [
+            *(5 * kpool + position % kpool for position in range(6)),
+            *(9 * kpool + position % kpool for position in range(7)),
+        ],
+        dtype=torch.int64,
+    )
+    keys = torch.arange(slots.numel() * 3, dtype=torch.float32).reshape(-1, 3)
+    scores = keys + 1000
+
+    portable.kpool_seed_tail_cache(tail, keys, scores, slots, kpool)
+
+    # Request 0 retains positions 2..5, request 1 retains positions 3..6.
+    for block, start, length, offset in ((5, 2, 6, 0), (9, 3, 7, 6)):
+        for position in range(start, length):
+            source = offset + position
+            ring_offset = position % kpool
+            torch.testing.assert_close(tail[block, 0, ring_offset], keys[source])
+            torch.testing.assert_close(tail[block, 1, ring_offset], scores[source])
+
+
+def test_kpool_fp8_cache_layout_matches_returned_compression() -> None:
+    try:
+        portable.get_fp8_dtype_and_max()
+    except RuntimeError as exc:
+        pytest.skip(str(exc))
+
+    torch.manual_seed(19)
+    cache = torch.zeros(1, 2, 132, dtype=torch.uint8)
+    keys = torch.randn(1, 4, 128, dtype=torch.bfloat16)
+    scores = torch.randn(1, 4, 128, dtype=torch.bfloat16)
+    ape = torch.randn(4, 128)
+    locations = torch.tensor([1], dtype=torch.int64)
+
+    try:
+        quantized, scales = portable.kpool_compress_and_write_cache(
+            cache,
+            keys,
+            scores,
+            ape,
+            locations,
+            pool_size=4,
+            return_compressed=True,
+        )
+    except RuntimeError as exc:
+        pytest.skip(f"CPU float8 conversion is unavailable: {exc}")
+
+    cache_values, cache_scales = portable._cache_views(cache, 128)
+    torch.testing.assert_close(
+        cache_values[0, 1], quantized[0].view(torch.uint8), rtol=0, atol=0
+    )
+    torch.testing.assert_close(cache_scales[0, 1, 0], scales[0])
+
+
+def test_pool_expansion_and_tail_append_keep_request_local_indices() -> None:
+    pools = torch.tensor([[2, 5], [0, 3]], dtype=torch.int32)
+    valid = torch.tensor([[True, False], [True, True]])
+    expanded = portable.expand_pools_to_tokens(pools, valid, topk=8, pool_size=4)
+    expected = torch.tensor(
+        [[8, 9, 10, 11, -1, -1, -1, -1], [0, 1, 2, 3, 12, 13, 14, 15]],
+        dtype=torch.int32,
+    )
+    torch.testing.assert_close(expanded, expected)
+
+    with_tail = portable.append_tail_to_topk(
+        expanded,
+        seq_lens=torch.tensor([14, 18]),
+        pool_lens=torch.tensor([3, 4]),
+        pool_size=4,
+    )
+    torch.testing.assert_close(
+        with_tail[:, -3:],
+        torch.tensor([[12, 13, -1], [16, 17, -1]], dtype=torch.int32),
+    )

--- a/tests/unit_tests/glm5_next/test_processor_config_compat.py
+++ b/tests/unit_tests/glm5_next/test_processor_config_compat.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm_fl.configs.glm5_next import Glm5NextTextConfig
+from vllm_fl.patches.glm5_next_v024 import (
+    Glm5NextModelArchConfigConvertor,
+)
+from vllm_fl.transformers_utils.processors.glm5_next import (
+    _LEGACY_MM_MAX_PIXELS,
+    _MAX_VIDEO_TOKENS,
+    Glm5NextProcessor,
+    _normalize_processor_config,
+    glm_sample_frame_indices,
+    glm_sample_frame_indices_legacy,
+)
+
+
+class _TokenizerStub:
+    init_kwargs = {}
+
+    def __init__(self) -> None:
+        self.last_text = None
+
+    def __call__(self, text, **kwargs):
+        self.last_text = text
+        return {"input_ids": [[11, 12]]}
+
+
+class _ImageProcessorStub:
+    def __call__(self, images, **kwargs):
+        return {"pixel_values": "pixels", "image_grid_thw": "grid"}
+
+
+class _ProcessorCallHarness:
+    def __init__(self) -> None:
+        self.tokenizer = _TokenizerStub()
+        self.image_processor = _ImageProcessorStub()
+
+    def _merge_kwargs(self, *args, **kwargs):
+        return {
+            "text_kwargs": {
+                "return_mm_token_type_ids": False,
+            },
+            "images_kwargs": {},
+            "videos_kwargs": {},
+        }
+
+
+def test_legacy_size_config_is_normalized_without_changing_geometry_mode() -> None:
+    config = _normalize_processor_config(
+        {
+            "size": {
+                "shortest_edge": 112 * 112,
+                "longest_edge": 100_000_000,
+            },
+            "patch_size": 14,
+            "merge_size": 2,
+            "temporal_patch_size": 2,
+            "patch_expand_factor": 2,
+        },
+        default_min_tokens=16,
+        default_max_tokens=8000,
+        is_video=False,
+    )
+
+    pixels_per_token = 2 * (14 * 2) ** 2
+    assert config["min_image_tokens"] == 8
+    assert config["max_image_tokens"] == _LEGACY_MM_MAX_PIXELS // pixels_per_token
+    assert config["patch_expand_factor"] == 2
+    assert config["resize_mode"] == "resize"
+    assert config["sampling_policy"] == "legacy_dynamic"
+    assert "size" not in config
+
+
+def test_token_budget_image_config_keeps_checkpoint_budget() -> None:
+    config = _normalize_processor_config(
+        {
+            "min_image_tokens": 16,
+            "max_image_tokens": 8000,
+            "patch_size": 14,
+            "merge_size": 2,
+            "temporal_patch_size": 2,
+            "patch_expand_factor": 1,
+            "resize_mode": "pad",
+        },
+        default_min_tokens=16,
+        default_max_tokens=8000,
+        is_video=False,
+    )
+
+    assert config["min_image_tokens"] == 16
+    assert config["max_image_tokens"] == 8000
+    assert config["patch_expand_factor"] == 1
+    assert config["resize_mode"] == "pad"
+    assert config["sampling_policy"] == "fps_interval"
+
+
+def test_token_budget_video_config_uses_reference_serving_cap() -> None:
+    config = _normalize_processor_config(
+        {
+            "min_image_tokens": 16,
+            "max_image_tokens": 240000,
+            "patch_size": 14,
+            "merge_size": 2,
+            "temporal_patch_size": 2,
+        },
+        default_min_tokens=16,
+        default_max_tokens=240000,
+        is_video=True,
+    )
+
+    assert config["min_image_tokens"] == 16
+    assert config["max_image_tokens"] == _MAX_VIDEO_TOKENS
+
+
+def test_deepseek_sparse_attention_layer_alias() -> None:
+    layer_types = ["linear_attention", "deepseek_sparse_attention"]
+    config = Glm5NextTextConfig(
+        num_hidden_layers=len(layer_types), layer_types=layer_types
+    )
+
+    assert config.layer_types == layer_types
+    assert config.layers_block_type == ["linear_attention", "attention"]
+
+
+def test_explicit_zero_head_dim_keeps_nope_mla_layout() -> None:
+    config = Glm5NextTextConfig(
+        head_dim=0,
+        kv_lora_rank=512,
+        qk_nope_head_dim=256,
+        qk_rope_head_dim=0,
+    )
+    convertor = Glm5NextModelArchConfigConvertor(config, config)
+
+    assert config.head_dim == 0
+    assert convertor.is_deepseek_mla()
+    assert convertor.get_head_size() == 512
+
+
+def test_feature_processor_leaves_prompt_placeholders_unchanged() -> None:
+    processor = _ProcessorCallHarness()
+    prompt = "before <|image|> after"
+
+    output = Glm5NextProcessor.__call__(processor, images=object(), text=prompt)
+
+    assert processor.tokenizer.last_text == [prompt]
+    assert output["image_grid_thw"] == "grid"
+
+
+def test_video_sampling_remains_config_selectable() -> None:
+    new_indices = glm_sample_frame_indices(
+        300,
+        30.0,
+        10.0,
+        target_fps=2.0,
+        max_frame_count=2048,
+        temporal_patch_size=2,
+    )
+    legacy_indices = glm_sample_frame_indices_legacy(
+        300,
+        30.0,
+        10.0,
+        target_fps=3.0,
+        max_frame_count=640,
+        temporal_patch_size=2,
+    )
+
+    assert len(new_indices) == 20
+    assert len(legacy_indices) == 60
+    assert new_indices[-1] == 299
+    assert legacy_indices[-1] == 299

--- a/tests/unit_tests/glm5_next/test_processor_geometry.py
+++ b/tests/unit_tests/glm5_next/test_processor_geometry.py
@@ -1,0 +1,436 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the FlagOS GLM-5-Next multimodal processor.
+
+Expected ``smart_resize`` outputs are checked against the alignment/budget
+invariants of the training-side geometry: sides round UP to the spatial
+factor (``patch_size * merge_size * patch_expand_factor``, 28 for the
+checkpoint's ``patch_expand_factor=1``), an over-budget canvas is refit by
+binary search so ``t_bar * h_bar * w_bar`` never exceeds the cap, and
+``resize_mode="pad"`` keeps the content aspect ratio while zero-padding the
+canvas right/bottom. Pixel budgets derive from the token bounds
+(``min/max_image_tokens``) exactly as in the checkpoint's
+``processor_config.json``.
+"""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+from PIL import Image
+from transformers.image_utils import PILImageResampling
+from transformers.video_utils import VideoMetadata
+
+from vllm_fl.models.glm5_next_multimodal import Glm5NextProcessingInfo
+from vllm_fl.transformers_utils.processors.glm5_next import (
+    Glm5NextImageProcessor,
+    Glm5NextVideoProcessor,
+    _get_pad_content_size,
+    _resize_or_pad,
+    glm_sample_frame_indices,
+    smart_resize,
+)
+
+PATCH_SIZE = 14
+MERGE_SIZE = 2
+PATCH_EXPAND_FACTOR = 1  # checkpoint processor_config.json
+FACTOR = PATCH_SIZE * MERGE_SIZE * PATCH_EXPAND_FACTOR  # 28
+PIXELS_PER_TOKEN = 2 * (PATCH_SIZE * MERGE_SIZE) ** 2  # 1568
+MIN_TOKENS = 16
+MAX_TOKENS = 800  # serving-cap equivalent budget, keeps test canvases small
+MIN_PIXELS = MIN_TOKENS * PIXELS_PER_TOKEN
+MAX_PIXELS = MAX_TOKENS * PIXELS_PER_TOKEN
+
+
+def resize(height: int, width: int, t: int = 2) -> tuple[int, int]:
+    return smart_resize(
+        t,
+        height,
+        width,
+        t_factor=2,
+        h_factor=FACTOR,
+        w_factor=FACTOR,
+        min_pixels=MIN_PIXELS,
+        max_pixels=MAX_PIXELS,
+    )
+
+
+@pytest.mark.parametrize(
+    ("height", "width", "t", "expected"),
+    [
+        (300, 400, 2, (308, 420)),  # ceil alignment, no budget pressure
+        (50, 80, 2, (112, 168)),  # below min budget: proportional upscale
+        (57, 3, 2, (504, 28)),  # slim side ceils to one factor
+        (2160, 3840, 2, (588, 1064)),  # shrink: max canvas under the cap
+        (112, 11200, 2, (84, 7420)),  # extreme aspect stays proportional
+        (300, 400, 16, (252, 308)),  # frame count eats into the budget
+        (112, 11200, 16, (28, 2800)),  # slim side stays positive, budget holds
+    ],
+)
+def test_smart_resize_reference_values(height, width, t, expected):
+    got = smart_resize(
+        t,
+        height,
+        width,
+        t_factor=2,
+        h_factor=FACTOR,
+        w_factor=FACTOR,
+        min_pixels=MIN_PIXELS,
+        max_pixels=MAX_PIXELS,
+    )
+    assert got == expected
+    # The aligned canvas never exceeds the budget it was fitted against.
+    t_bar = max(2, round(t / 2) * 2)
+    assert t_bar * got[0] * got[1] <= MAX_PIXELS
+
+
+def test_smart_resize_stays_snapped_and_positive():
+    heights = (1, 27, 57, 111, 113, 300, 720, 2160)
+    widths = (1, 27, 57, 111, 113, 400, 1280, 11200)
+    for h in heights:
+        for w in widths:
+            for t in (2, 4, 16, 64):
+                resized_h, resized_w = resize(h, w, t)
+                assert resized_h > 0 and resized_w > 0
+                assert resized_h % FACTOR == 0
+                assert resized_w % FACTOR == 0
+                t_bar = max(2, round(t / 2) * 2)
+                assert t_bar * resized_h * resized_w <= MAX_PIXELS
+
+
+@pytest.mark.parametrize(
+    ("height", "width", "match"),
+    [
+        (0, 100, "must be positive"),
+        (100, 0, "must be positive"),
+    ],
+)
+def test_smart_resize_rejects_degenerate_inputs(height, width, match):
+    with pytest.raises(ValueError, match=match):
+        resize(height, width, 2)
+
+
+def test_smart_resize_rejects_inverted_budget():
+    with pytest.raises(ValueError, match="min_pixels must be less than or equal"):
+        smart_resize(
+            2,
+            100,
+            100,
+            t_factor=2,
+            h_factor=FACTOR,
+            w_factor=FACTOR,
+            min_pixels=MAX_PIXELS,
+            max_pixels=MIN_PIXELS,
+        )
+
+
+def test_dummy_video_frame_probe_keeps_one_aligned_patch_per_frame(monkeypatch):
+    """A frame-count bisection probe just over the budget must not raise."""
+    info = object.__new__(Glm5NextProcessingInfo)
+    vision_config = SimpleNamespace(
+        patch_size=14,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+    )
+    image_processor = SimpleNamespace(patch_expand_factor=2)
+    monkeypatch.setattr(
+        info,
+        "get_hf_config",
+        lambda: SimpleNamespace(vision_config=vision_config),
+    )
+    monkeypatch.setattr(
+        info,
+        "get_hf_processor",
+        lambda: SimpleNamespace(image_processor=image_processor),
+    )
+
+    # 15,000 frames fit exactly in the inherited 47,040,000-pixel budget.
+    # Its binary search probes 15,002 next; one 56x56 patch per frame needs
+    # 47,046,272 pixels and previously raised before returning a token count.
+    size, num_tokens = info._get_vision_info(
+        image_width=448,
+        image_height=448,
+        num_frames=15002,
+        max_image_pixels=47_040_000,
+    )
+
+    assert (size.height, size.width) == (56, 56)
+    assert num_tokens == 30_004
+
+
+def test_get_pad_content_size():
+    # Oversized content shrinks proportionally, never upscales by default.
+    assert _get_pad_content_size(300, 400, 308, 420) == (300, 400)
+    assert _get_pad_content_size(600, 800, 308, 420) == (308, 410)
+    # allow_upscale enlarges small content toward the canvas.
+    assert _get_pad_content_size(28, 28, 112, 112, allow_upscale=True) == (112, 112)
+
+
+def test_resize_or_pad_pads_right_and_bottom():
+    stacked = torch.rand(1, 3, 300, 400)
+
+    def identity_resize(x, size, resample=None):
+        assert (size.height, size.width) == (300, 400)
+        return x
+
+    padded = _resize_or_pad(stacked, 308, 420, "pad", None, identity_resize)
+    assert padded.shape == (1, 3, 308, 420)
+    torch.testing.assert_close(padded[..., :300, :400], stacked)
+    assert padded[..., 300:, :].eq(0).all()
+    assert padded[..., :, 400:].eq(0).all()
+
+    def force_resize(x, size, resample=None):
+        return torch.zeros(x.shape[0], x.shape[1], size.height, size.width)
+
+    assert _resize_or_pad(stacked, 308, 420, "resize", None, force_resize).shape == (
+        1,
+        3,
+        308,
+        420,
+    )
+    with pytest.raises(ValueError, match="resize_mode"):
+        _resize_or_pad(stacked, 308, 420, "crop", None, identity_resize)
+
+
+@pytest.fixture(scope="module")
+def image_processor():
+    return Glm5NextImageProcessor(
+        min_image_tokens=MIN_TOKENS, max_image_tokens=MAX_TOKENS
+    )
+
+
+@pytest.mark.parametrize(
+    ("height", "width"),
+    [(50, 80), (300, 400), (2160, 3840), (112, 11200)],
+)
+def test_image_grid_matches_smart_resize(image_processor, height, width):
+    out = image_processor(Image.new("RGB", (width, height)), return_tensors="pt")
+    resized_h, resized_w = resize(height, width)
+    grid = out["image_grid_thw"][0].tolist()
+    assert grid == [1, resized_h // PATCH_SIZE, resized_w // PATCH_SIZE]
+    assert out["pixel_values"].shape == (
+        grid[1] * grid[2],
+        3 * 2 * PATCH_SIZE * PATCH_SIZE,
+    )
+
+
+@pytest.mark.parametrize(
+    ("height", "width"),
+    [(50, 80), (300, 400), (2160, 3840), (112, 11200)],
+)
+def test_image_patch_count_matches_preprocess(image_processor, height, width):
+    out = image_processor(Image.new("RGB", (width, height)), return_tensors="pt")
+    grid = out["image_grid_thw"][0].tolist()
+    expected = grid[1] * grid[2]
+    assert image_processor.get_number_of_image_patches(height, width) == expected
+
+
+@pytest.fixture(scope="module")
+def video_processor():
+    return Glm5NextVideoProcessor(
+        min_image_tokens=MIN_TOKENS, max_image_tokens=MAX_TOKENS
+    )
+
+
+def run_video_preprocess(video_processor, frames, **overrides):
+    kwargs = dict(
+        resample=PILImageResampling.BICUBIC,
+        image_mean=(0.48145466, 0.4578275, 0.40821073),
+        image_std=(0.26862954, 0.26130258, 0.27577711),
+        patch_size=PATCH_SIZE,
+        temporal_patch_size=2,
+        merge_size=MERGE_SIZE,
+        patch_expand_factor=PATCH_EXPAND_FACTOR,
+        return_tensors="pt",
+    )
+    kwargs.update(overrides)
+    return video_processor._preprocess([frames], **kwargs)
+
+
+def test_video_preprocess_pads_odd_frame_count(video_processor):
+    out = run_video_preprocess(video_processor, torch.rand(7, 3, 300, 400))
+    grid = out["video_grid_thw"][0].tolist()
+    # 7 frames padded to 8 -> grid_t 4; canvas ceil-aligned (308, 420).
+    assert grid == [4, 22, 30]
+    assert out["pixel_values_videos"].shape == (
+        4 * 22 * 30,
+        3 * 2 * PATCH_SIZE * PATCH_SIZE,
+    )
+
+
+def test_video_preprocess_keeps_min_side_under_frame_budget(video_processor):
+    out = run_video_preprocess(video_processor, torch.rand(16, 3, 112, 11200))
+    # Budget-fitted canvas (28, 2800): 16 * 28 * 2800 == the pixel cap.
+    assert out["video_grid_thw"][0].tolist() == [8, 2, 200]  # height 28, not 0
+
+
+def test_video_preprocess_pads_content_not_distort(video_processor):
+    frames = torch.zeros(4, 3, 300, 400)
+    frames[..., 50, 60] = 1.0  # marker inside the content area
+    # Bypass rescale/normalize so zero padding stays exactly zero.
+    out = run_video_preprocess(
+        video_processor, frames, do_rescale=False, do_normalize=False
+    )
+    # Pad mode keeps the 300x400 content aspect on the (308, 420) canvas
+    # with zero padding on the right/bottom.
+    grid = out["video_grid_thw"][0].tolist()
+    assert grid == [2, 22, 30]
+    patches = out["pixel_values_videos"].view(
+        grid[0],
+        grid[1] // MERGE_SIZE,
+        grid[2] // MERGE_SIZE,
+        MERGE_SIZE,
+        MERGE_SIZE,
+        3 * 2 * PATCH_SIZE * PATCH_SIZE,
+    )
+    frame = patches[0].permute(0, 3, 1, 4, 2).reshape(grid[1], grid[2], -1)
+    # Patch columns fully right of the 400px content are pure padding.
+    assert frame[:, math.ceil(400 / PATCH_SIZE) :].abs().max() == 0
+
+
+@pytest.mark.parametrize(
+    ("total_frames", "fps", "duration", "expected_len", "first", "last"),
+    [
+        # Dense source: the tp-scaled greedy overshoots extract_t, so the
+        # fixup spreads picks uniformly across the whole video (linspace).
+        (900, 30.0, 30.0, 60, 0, 899),
+        (3000, 30.0, 100.0, 200, 0, 2999),
+        # extract_t capped at 2048 frames.
+        (72000, 30.0, 2400.0, 2048, 0, 71999),
+        # Low container fps: the greedy picks every frame.
+        (48, 2.0, 24.0, 48, 0, 47),
+        # Duration derived from the frame count when metadata lacks it.
+        (300, 25.0, 0, 26, 0, 299),
+    ],
+)
+def test_glm_sample_frame_indices_behaviour(
+    total_frames, fps, duration, expected_len, first, last
+):
+    indices = glm_sample_frame_indices(total_frames, fps, duration)
+    assert len(indices) == expected_len
+    assert indices[0] == first
+    assert indices[-1] == last
+    assert len(indices) % 2 == 0
+    assert indices == sorted(indices)
+    assert all(0 <= idx < total_frames for idx in indices)
+
+
+def test_glm_sample_frame_indices_short_clip_floor_spread():
+    # extract_t (20) > total (7): evenly spaced timestamps, deduplicated,
+    # then pair-padded to an even count.
+    assert glm_sample_frame_indices(7, 30.0, 10.0) == [0, 1, 2, 3, 4, 5, 6, 6]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_len"),
+    [
+        ({"target_fps": 0.5}, 16),
+        ({"max_frame_count": 16}, 16),
+        ({"target_fps": 8}, 240),  # 30s * 8 = 240, under the 2048 cap
+    ],
+)
+def test_glm_sample_frame_indices_request_overrides(kwargs, expected_len):
+    indices = glm_sample_frame_indices(900, 30.0, 30.0, **kwargs)
+    assert len(indices) == expected_len
+    assert len(indices) % 2 == 0
+
+
+def test_sample_frames_fps_interval(video_processor):
+    indices = video_processor.sample_frames(
+        VideoMetadata(total_num_frames=900, fps=30.0, duration=30.0)
+    )
+    assert len(indices) == 60
+    assert indices[0] == 0
+    assert indices[-1] == 899  # uniform spread reaches the final frame
+
+    # Request overrides reach the sampler through both kwarg spellings. The
+    # 15-frame spread is odd, so pair-padding duplicates the last frame.
+    assert (
+        len(
+            video_processor.sample_frames(
+                VideoMetadata(total_num_frames=900, fps=30.0, duration=30.0),
+                fps=0.5,
+            )
+        )
+        == 16
+    )
+    assert (
+        len(
+            video_processor.sample_frames(
+                VideoMetadata(total_num_frames=900, fps=30.0, duration=30.0),
+                target_fps=0.5,
+            )
+        )
+        == 16
+    )
+    assert (
+        len(
+            video_processor.sample_frames(
+                VideoMetadata(total_num_frames=900, fps=30.0, duration=30.0),
+                max_frames=16,
+            )
+        )
+        == 16
+    )
+
+
+def test_defaults_mirror_checkpoint_config():
+    """Bare instantiation matches the checkpoint's ``processor_config.json``
+    token-budget style defaults; ``size`` carries no budget."""
+    image_processor = Glm5NextImageProcessor()
+    assert image_processor.patch_expand_factor == 1
+    assert image_processor.min_image_tokens == 16
+    assert image_processor.max_image_tokens == 8000
+    assert image_processor.resize_mode == "pad"
+
+    video_processor = Glm5NextVideoProcessor()
+    assert video_processor.patch_expand_factor == 1
+    assert video_processor.min_image_tokens == 16
+    assert video_processor.max_image_tokens == 240000
+    assert video_processor.fps_interval == 2.0
+    assert video_processor.max_frame_count_dynamic == 2048
+
+
+def test_token_budgets_drive_geometry():
+    """The token bounds fully determine the pixel budget and the grid."""
+    token_proc = Glm5NextImageProcessor(min_image_tokens=64, max_image_tokens=512)
+    img = Image.new("RGB", (400, 300))
+    grid = token_proc(img, return_tensors="pt")["image_grid_thw"][0].tolist()
+    # Budgets 100,352..802,816 px: the 300x400 canvas ceils to (308, 420)
+    # without hitting either bound -> 22x30 patches.
+    assert grid == [1, 22, 30]
+    assert token_proc.get_number_of_image_patches(300, 400) == 22 * 30
+
+
+def test_missing_token_budgets_rejected():
+    proc = Glm5NextImageProcessor(min_image_tokens=None)
+    with pytest.raises(ValueError, match="min_image_tokens"):
+        proc(Image.new("RGB", (400, 300)), return_tensors="pt")
+
+
+def test_video_config_fields_land():
+    """fps_interval / max_frame_count_dynamic from the dedicated config
+    shape sampling without any request overrides."""
+    proc = Glm5NextVideoProcessor(
+        fps_interval=4,
+        max_frame_count_dynamic=32,
+    )
+    indices = proc.sample_frames(
+        VideoMetadata(total_num_frames=900, fps=30.0, duration=30.0)
+    )
+    # 30s * 4 = 120 candidates, capped at 32 -> uniform spread of 32.
+    assert len(indices) == 32
+    assert indices[0] == 0
+    assert indices[-1] == 899
+
+    # Request overrides still win over the config values.
+    assert (
+        len(
+            proc.sample_frames(
+                VideoMetadata(total_num_frames=900, fps=30.0, duration=30.0),
+                fps=0.5,
+            )
+        )
+        == 16
+    )

--- a/tests/unit_tests/glm5_next/test_provider.py
+++ b/tests/unit_tests/glm5_next/test_provider.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from vllm_fl.kernels.glm5_next import provider
+
+
+@pytest.fixture(autouse=True)
+def clear_provider_cache():
+    provider.get_glm5_provider.cache_clear()
+    yield
+    provider.get_glm5_provider.cache_clear()
+
+
+def test_auto_uses_nvidia_reference_on_cuda(monkeypatch) -> None:
+    monkeypatch.delenv(provider.ENV_NAME, raising=False)
+    monkeypatch.setattr(provider.current_platform, "is_cuda", lambda: True)
+
+    assert provider.get_glm5_provider() == "auto"
+    assert provider.use_nvidia_reference()
+
+
+def test_flaggems_overrides_cuda_reference(monkeypatch) -> None:
+    monkeypatch.setenv(provider.ENV_NAME, "flaggems")
+    monkeypatch.setattr(provider.current_platform, "is_cuda", lambda: True)
+
+    assert provider.get_glm5_provider() == "flaggems"
+    assert not provider.use_nvidia_reference()
+
+
+def test_nvidia_is_rejected_on_non_cuda(monkeypatch) -> None:
+    monkeypatch.setenv(provider.ENV_NAME, "nvidia")
+    monkeypatch.setattr(provider.current_platform, "is_cuda", lambda: False)
+
+    with pytest.raises(RuntimeError, match="requires an NVIDIA CUDA platform"):
+        provider.get_glm5_provider()
+
+
+def test_invalid_provider_is_rejected(monkeypatch) -> None:
+    monkeypatch.setenv(provider.ENV_NAME, "portable")
+
+    with pytest.raises(ValueError, match="auto\\|nvidia\\|flaggems"):
+        provider.get_glm5_provider()

--- a/tests/unit_tests/glm5_next/test_provider.py
+++ b/tests/unit_tests/glm5_next/test_provider.py
@@ -7,16 +7,30 @@ from vllm_fl.kernels.glm5_next import provider
 @pytest.fixture(autouse=True)
 def clear_provider_cache():
     provider.get_glm5_provider.cache_clear()
+    provider._has_nvidia_reference_kernels.cache_clear()
     yield
     provider.get_glm5_provider.cache_clear()
+    provider._has_nvidia_reference_kernels.cache_clear()
 
 
 def test_auto_uses_nvidia_reference_on_cuda(monkeypatch) -> None:
     monkeypatch.delenv(provider.ENV_NAME, raising=False)
     monkeypatch.setattr(provider.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(provider, "_has_vllm_native_extension", lambda: True)
+    monkeypatch.setattr(provider, "_has_deep_gemm", lambda: True)
 
     assert provider.get_glm5_provider() == "auto"
     assert provider.use_nvidia_reference()
+
+
+def test_auto_falls_back_without_nvidia_reference_prerequisites(monkeypatch) -> None:
+    monkeypatch.delenv(provider.ENV_NAME, raising=False)
+    monkeypatch.setattr(provider.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(provider, "_has_vllm_native_extension", lambda: False)
+    monkeypatch.setattr(provider, "_has_deep_gemm", lambda: True)
+
+    assert provider.get_glm5_provider() == "auto"
+    assert not provider.use_nvidia_reference()
 
 
 def test_flaggems_overrides_cuda_reference(monkeypatch) -> None:

--- a/tests/unit_tests/glm5_next/test_sparse_indexer_decode_seq_lens.py
+++ b/tests/unit_tests/glm5_next/test_sparse_indexer_decode_seq_lens.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU tests for the decode top-k row->token mapping (no GPU required).
+
+On non-uniform decode batches (``requires_padding`` -- mixed plain-decode and
+spec-verify requests, or variable MTP verify lens; taken on Hopper where the
+varlen/flatten logits path is unavailable), the pool-topk rows follow the
+PADDED ``[batch_size, next_n]`` grid: row ``(b, t)`` is flat decode token
+``offset_b + t``. The former inline ``dec_seq = positions[:n] + 1``
+(``n = batch_size * next_n``) indexes the flat per-token layout with padded
+coordinates, so rows after the first non-uniform request read another
+request's positions and rows past the decode region read prefill tokens --
+``expand_pools_and_append_tail`` then anchors the tail at a foreign length.
+
+These tests pin the defect with the exact production arithmetic and verify
+the layout-aware replacement (``_decode_topk_seq_lens``), including the tail
+expansion consequences via the pure-torch expand/append pair that the fused
+kernel is documented to replicate.
+"""
+
+import torch
+
+from vllm_fl.kernels.glm5_next.portable import (
+    append_tail_to_topk,
+    expand_pools_to_tokens,
+)
+from vllm_fl.kernels.glm5_next.sparse_attn_indexer_kpool import (
+    _decode_topk_seq_lens,
+    _decode_write_layout,
+)
+
+KPOOL = 4
+TOPK_TOKENS = 16
+SELECT_K = TOPK_TOKENS // KPOOL
+
+
+class LegacyDecodeMetadata:
+    """Exact field surface exposed by stock vLLM 0.24 decode metadata."""
+
+    def __init__(self, decode_lens: torch.Tensor, requires_padding: bool):
+        self.decode_lens = decode_lens
+        self.requires_padding = requires_padding
+
+
+def test_decode_write_layout_accepts_v024_metadata_without_extension_fields():
+    """Stock 0.24 metadata must not require GLM5-Next-only attributes."""
+    decode_lens = torch.tensor([1, 1], dtype=torch.int32)
+    metadata = LegacyDecodeMetadata(decode_lens, requires_padding=False)
+
+    use_uniform, group_lens, lmax = _decode_write_layout(metadata, 2, 2)
+
+    assert use_uniform
+    assert group_lens is decode_lens
+    assert lmax == 1
+
+
+def test_decode_write_layout_keeps_v024_nonuniform_fallback_host_static():
+    decode_lens = torch.tensor([1, 3], dtype=torch.int32)
+    metadata = LegacyDecodeMetadata(decode_lens, requires_padding=True)
+
+    use_uniform, group_lens, lmax = _decode_write_layout(metadata, 2, 4)
+
+    assert not use_uniform
+    assert group_lens is decode_lens
+    assert lmax == 4
+
+
+def make_non_uniform_batch():
+    """3 requests: plain decode (1 token), MTP verify (4), adaptive verify (3).
+
+    Flat decode positions (production layout: decode tokens first, then any
+    prefill tokens of the same batch):
+      req0: [30]           (context len 30)
+      req1: [100..103]     (verify at context len 100)
+      req2: [7, 8, 9]      (verify at context len 7)
+    Followed by 4 prefill tokens at positions 555..558 so the flat tensor is
+    at least ``n = 3 * 4`` long, as it is in a real mixed batch.
+    """
+    decode_lens = torch.tensor([1, 4, 3], dtype=torch.int64)
+    per_req_positions = [[30], [100, 101, 102, 103], [7, 8, 9]]
+    flat_decode = [p for req in per_req_positions for p in req]
+    positions = torch.tensor(flat_decode + [555, 556, 557, 558], dtype=torch.int64)
+    return decode_lens, per_req_positions, positions
+
+
+def expected_row_seq_lens(per_req_positions, batch_size, next_n):
+    """Ground truth: row (b, t) -> pos + 1 for real rows, 0 for pad rows."""
+    out = torch.zeros(batch_size * next_n, dtype=torch.int32)
+    for b, req in enumerate(per_req_positions):
+        for t, pos in enumerate(req):
+            out[b * next_n + t] = pos + 1
+    return out
+
+
+def test_legacy_flat_layout_misaligns_and_bleeds():
+    """The bug: ``positions[:n] + 1`` with padded-row coordinates reads other
+    requests' positions and prefill positions."""
+    decode_lens, per_req, positions = make_non_uniform_batch()
+    batch_size = decode_lens.shape[0]
+    next_n = int(decode_lens.max())
+    n = batch_size * next_n
+    assert n == 12
+
+    legacy = positions[:n].to(torch.int32) + 1
+    expected = expected_row_seq_lens(per_req, batch_size, next_n)
+
+    # Row (1, 0): req1's first verify token (pos 100, seq 101) reads flat
+    # index 4 -> req1's LAST verify token (pos 103). Its true tail token is
+    # dropped and the tail anchors 3 tokens late.
+    assert int(legacy[4]) == 104 and int(expected[4]) == 101
+
+    # Rows (2, *): req2 starts at flat offset 5, but padded coordinates point
+    # at flat indices 8..11 -- the batch's PREFILL positions.
+    for t in range(3):
+        assert int(legacy[2 * next_n + t]) >= 556, (
+            "legacy row (2, t) should read prefill positions"
+        )
+    assert not torch.equal(legacy, expected)
+
+
+def test_helper_uniform_layout_matches_flat_slice():
+    """Uniform batches keep the flat shortcut (zero behavior/perf change)."""
+    per_req = [[200, 201, 202, 203], [50, 51, 52, 53]]
+    positions = torch.tensor([p for r in per_req for p in r], dtype=torch.int64)
+    decode_lens = torch.tensor([4, 4], dtype=torch.int64)
+    out = _decode_topk_seq_lens(positions, decode_lens, 8, 2, 4, requires_padding=False)
+    assert torch.equal(out, positions[:8].to(torch.int32) + 1)
+
+
+def test_helper_padded_layout_per_row():
+    """Non-uniform batches map every padded row to its own token's position;
+    pad rows get 0 (empty tail)."""
+    decode_lens, per_req, positions = make_non_uniform_batch()
+    out = _decode_topk_seq_lens(positions, decode_lens, 8, 3, 4, requires_padding=True)
+    expected = expected_row_seq_lens(per_req, 3, 4)
+    assert torch.equal(out, expected)
+    # Pad rows (0, 1..3) and (2, 3) collapse to 0 -> no tail appended.
+    assert out[1] == 0 and out[2] == 0 and out[3] == 0 and out[11] == 0
+
+
+def expand_tail_region(dec_seq):
+    """Run the production pure-torch expand + append pair (the fused kernel
+    replicates it exactly on the identity path) and return the tail columns
+    [TOPK_TOKENS, TOPK_TOKENS + KPOOL - 1)."""
+    rows = dec_seq.shape[0]
+    pool_ids = torch.arange(SELECT_K, dtype=torch.int64).expand(rows, SELECT_K)
+    valid = torch.ones_like(pool_ids, dtype=torch.bool)
+    expanded = expand_pools_to_tokens(pool_ids, valid, TOPK_TOKENS, KPOOL)
+    seq_lens = dec_seq.to(torch.int32)
+    pool_lens = (seq_lens // KPOOL).to(torch.int32)
+    out = append_tail_to_topk(expanded, seq_lens, pool_lens, KPOOL)
+    return out[:, TOPK_TOKENS:]
+
+
+def test_tail_expansion_legacy_vs_fixed():
+    """End-to-end tail consequence: the fixed mapping appends exactly the
+    request's trailing incomplete pool; the legacy flat slice drops real tail
+    tokens and emits indices far past the request's own sequence."""
+    decode_lens, per_req, positions = make_non_uniform_batch()
+    n = 12
+    fixed = _decode_topk_seq_lens(
+        positions, decode_lens, 8, 3, 4, requires_padding=True
+    )
+    legacy = positions[:n].to(torch.int32) + 1
+
+    fixed_tail = expand_tail_region(fixed)
+    legacy_tail = expand_tail_region(legacy)
+
+    # Fixed: row (1, 0) (seq 101) keeps its single tail token 100; row (2, 2)
+    # (seq 10) keeps its full trailing pool [8, 9].
+    assert fixed_tail[4, 0].item() == 100
+    assert fixed_tail[10, :2].tolist() == [8, 9]
+
+    # Legacy: row (1, 0) loses its tail token (anchored at 104, count 0)...
+    assert legacy_tail[4, 0].item() == -1
+    # ...and row (2, 2) reads prefill position 557 -> tail indices 556/557,
+    # way past req2's 10-token sequence -> out-of-bounds block-table reads.
+    assert legacy_tail[10, :2].tolist() == [556, 557]
+
+    assert not torch.equal(legacy_tail, fixed_tail)

--- a/tests/unit_tests/glm5_next/test_sparse_mla_physical_indices.py
+++ b/tests/unit_tests/glm5_next/test_sparse_mla_physical_indices.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for FlagGems sparse-MLA logical-to-physical mapping."""
+
+import torch
+
+from vllm_fl.dispatch.backends.flaggems.impl.mla_sparse import (
+    _convert_request_to_physical_indices,
+)
+
+
+def test_invalid_middle_block_is_compacted_out() -> None:
+    request_ids = torch.tensor([0], dtype=torch.int32)
+    block_table = torch.tensor([[10, -1, 12]], dtype=torch.int32)
+    token_indices = torch.tensor([[0, 64, 128, 1]], dtype=torch.int32)
+
+    physical, valid_lengths = _convert_request_to_physical_indices(
+        request_ids, block_table, token_indices, block_size=64
+    )
+
+    assert physical.tolist() == [[640, 768, 641, -1]]
+    assert valid_lengths.tolist() == [3]
+
+
+def test_negative_and_out_of_range_tokens_stay_after_valid_prefix() -> None:
+    request_ids = torch.tensor([0, 1], dtype=torch.int32)
+    block_table = torch.tensor([[2, 3], [5, -1]], dtype=torch.int32)
+    token_indices = torch.tensor([[-1, 65, 0, 128], [64, 1, -1, 0]], dtype=torch.int32)
+
+    physical, valid_lengths = _convert_request_to_physical_indices(
+        request_ids, block_table, token_indices, block_size=64
+    )
+
+    assert physical.tolist() == [[193, 128, -1, -1], [321, 320, -1, -1]]
+    assert valid_lengths.tolist() == [2, 2]

--- a/tests/unit_tests/patches/test_flaggems_mm_shape_aware.py
+++ b/tests/unit_tests/patches/test_flaggems_mm_shape_aware.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_fl.patches import flaggems_mm_shape_aware as shape_aware
+
+
+class _FakeTensor:
+    def __init__(
+        self,
+        *,
+        m=1,
+        ndim=2,
+        dtype=torch.bfloat16,
+        device_type="cuda",
+        stride=(4096, 1),
+    ):
+        self.shape = (m, 4096) if ndim == 2 else (m, 4096, 1)
+        self.ndim = ndim
+        self.dtype = dtype
+        self.device = SimpleNamespace(type=device_type)
+        self._stride = stride
+
+    def stride(self):
+        return self._stride
+
+
+class _FakeLibrary:
+    def __init__(self):
+        self.impl_calls = []
+
+    def impl(
+        self,
+        op_name,
+        fn,
+        dispatch_key,
+        *,
+        with_keyset=False,
+        allow_override=False,
+    ):
+        self.impl_calls.append(
+            (op_name, fn, dispatch_key, with_keyset, allow_override)
+        )
+
+
+class _FakeSafeKernel:
+    def __init__(self, fn):
+        self.fn = fn
+
+    def call_boxed(self, dispatch_keys, *args):
+        return self.fn(dispatch_keys, *args)
+
+
+def test_default_is_disabled_and_does_not_touch_torch(monkeypatch):
+    monkeypatch.delenv(shape_aware.ENABLE_ENV, raising=False)
+    monkeypatch.delenv(shape_aware.THRESHOLD_ENV, raising=False)
+    monkeypatch.setattr(shape_aware, "_STATE", None)
+
+    def fail_get_kernel(*args, **kwargs):
+        raise AssertionError("disabled feature must not inspect dispatch state")
+
+    monkeypatch.setattr(shape_aware.torch.library, "get_kernel", fail_get_kernel)
+    assert shape_aware.apply_shape_aware_mm() is False
+    assert shape_aware._STATE is None
+
+
+def test_caller_default_can_enable_but_explicit_disable_wins(monkeypatch):
+    monkeypatch.delenv(shape_aware.ENABLE_ENV, raising=False)
+    assert shape_aware.is_shape_aware_mm_enabled(default=True) is True
+
+    monkeypatch.setenv(shape_aware.ENABLE_ENV, "0")
+    assert shape_aware.is_shape_aware_mm_enabled(default=True) is False
+
+
+@pytest.mark.parametrize(
+    ("whitelist", "blacklist", "expected"),
+    [
+        (None, None, True),
+        (None, ["linear"], True),
+        (None, ["mm"], False),
+        (["mm", "rms_norm"], None, True),
+        (["linear"], None, False),
+        ([], ["mm"], False),
+    ],
+)
+def test_mm_dispatch_guard_preserves_explicit_flaggems_selection(
+    whitelist, blacklist, expected
+):
+    assert (
+        shape_aware.is_mm_dispatch_enabled(whitelist, blacklist) is expected
+    )
+
+
+@pytest.mark.parametrize("value", ["", "2 ", " 2", "+2", "-1", "1.0", "abc"])
+def test_threshold_rejects_ambiguous_values(monkeypatch, value):
+    monkeypatch.setenv(shape_aware.THRESHOLD_ENV, value)
+    with pytest.raises(ValueError, match=shape_aware.THRESHOLD_ENV):
+        shape_aware._parse_threshold_env()
+
+
+def test_default_threshold_covers_running_64_and_128_is_configurable(monkeypatch):
+    monkeypatch.delenv(shape_aware.THRESHOLD_ENV, raising=False)
+    assert shape_aware._parse_threshold_env() == 64
+
+    monkeypatch.setenv(shape_aware.THRESHOLD_ENV, "128")
+    assert shape_aware._parse_threshold_env() == 128
+
+
+@pytest.mark.parametrize("value", ["0", "false"])
+def test_disable_values_are_strict_but_supported(monkeypatch, value):
+    monkeypatch.setenv(shape_aware.ENABLE_ENV, value)
+    assert shape_aware._parse_bool_env(shape_aware.ENABLE_ENV) is False
+
+
+def test_enable_value_rejects_ambiguous_values(monkeypatch):
+    monkeypatch.setenv(shape_aware.ENABLE_ENV, "TRUE")
+    with pytest.raises(ValueError, match=shape_aware.ENABLE_ENV):
+        shape_aware._parse_bool_env(shape_aware.ENABLE_ENV)
+
+
+def test_native_candidate_boundary_dtype_and_stride():
+    a = _FakeTensor(m=1, stride=(4096, 1))
+    # A transposed/column-major weight is a normal vLLM linear layout.
+    b_column_major = _FakeTensor(m=4096, stride=(1, 4096))
+    assert shape_aware._is_native_candidate(a, b_column_major, 1)
+
+    assert shape_aware._is_native_candidate(
+        _FakeTensor(m=64), b_column_major, 64
+    )
+    assert not shape_aware._is_native_candidate(
+        _FakeTensor(m=65), b_column_major, 64
+    )
+
+    assert not shape_aware._is_native_candidate(
+        _FakeTensor(m=2), b_column_major, 1
+    )
+    assert not shape_aware._is_native_candidate(
+        a, _FakeTensor(dtype=torch.float16, stride=(1, 4096)), 1
+    )
+    assert not shape_aware._is_native_candidate(
+        a, _FakeTensor(stride=(8192, 2)), 1
+    )
+    assert not shape_aware._is_native_candidate(
+        _FakeTensor(stride=(8192, 2)), b_column_major, 1
+    )
+    assert not shape_aware._is_native_candidate(
+        _FakeTensor(device_type="cpu"), b_column_major, 1
+    )
+    assert not shape_aware._is_native_candidate(
+        _FakeTensor(ndim=3), _FakeTensor(ndim=3), 1
+    )
+
+
+def test_apply_captures_flaggems_before_override_and_routes_shapes(monkeypatch):
+    monkeypatch.setenv(shape_aware.ENABLE_ENV, "1")
+    monkeypatch.setenv(shape_aware.THRESHOLD_ENV, "2")
+    monkeypatch.setattr(shape_aware, "_STATE", None)
+
+    calls = []
+
+    def flaggems_mm(a, b):
+        calls.append(("flaggems", a, b))
+        return "flaggems-result"
+
+    def native_mm(keyset, a, b):
+        calls.append(("native", keyset, a, b))
+        return "native-result"
+
+    native_kernel = _FakeSafeKernel(native_mm)
+    flaggems_kernel = _FakeSafeKernel(
+        lambda dispatch_keys, a, b: flaggems_mm(a, b)
+    )
+    library = _FakeLibrary()
+    monkeypatch.setattr(
+        shape_aware.torch.library,
+        "get_kernel",
+        lambda op_name, dispatch_key: flaggems_kernel,
+    )
+    monkeypatch.setattr(
+        shape_aware.torch.library,
+        "Library",
+        lambda namespace, kind: library,
+    )
+
+    assert shape_aware.apply_shape_aware_mm(native_mm_kernel=native_kernel) is True
+    assert len(library.impl_calls) == 1
+    op_name, wrapper, dispatch_key, with_keyset, allow_override = (
+        library.impl_calls[0]
+    )
+    assert (op_name, dispatch_key, with_keyset, allow_override) == (
+        "mm",
+        "CUDA",
+        True,
+        True,
+    )
+    assert wrapper._vllm_fl_original_flaggems_mm is flaggems_kernel
+    assert wrapper._vllm_fl_native_mm is native_kernel
+
+    a = _FakeTensor(m=1)
+    b = _FakeTensor(m=4096, stride=(1, 4096))
+    assert wrapper("dispatch-key", a, b) == "native-result"
+    assert calls[0][0] == "native"
+
+    # Boundary is inclusive: M == threshold is still decode/native.
+    calls.clear()
+    assert wrapper("dispatch-key", _FakeTensor(m=2), b) == "native-result"
+    assert calls[0][0] == "native"
+
+    calls.clear()
+    assert wrapper("dispatch-key", _FakeTensor(m=3), b) == "flaggems-result"
+    assert calls[0][0] == "flaggems"
+
+    # Unsupported dtype/stride remains on the captured FlagGems callable.
+    calls.clear()
+    assert (
+        wrapper("dispatch-key", _FakeTensor(dtype=torch.int8), b)
+        == "flaggems-result"
+    )
+    assert calls[0][0] == "flaggems"
+
+    # Reapplying is idempotent and does not replace the captured kernel again.
+    assert shape_aware.apply_shape_aware_mm() is False
+
+
+def test_apply_fails_without_safe_override_api(monkeypatch):
+    monkeypatch.setenv(shape_aware.ENABLE_ENV, "1")
+    monkeypatch.delenv(shape_aware.THRESHOLD_ENV, raising=False)
+    monkeypatch.setattr(shape_aware, "_STATE", None)
+    safe_kernel = _FakeSafeKernel(lambda dispatch_keys, a, b: None)
+    monkeypatch.setattr(
+        shape_aware.torch.library, "get_kernel", lambda *_: safe_kernel
+    )
+
+    class _NoAllowOverrideLibrary:
+        def impl(self, op_name, fn, dispatch_key):
+            del op_name, fn, dispatch_key
+
+    monkeypatch.setattr(
+        shape_aware.torch.library,
+        "Library",
+        lambda namespace, kind: _NoAllowOverrideLibrary(),
+    )
+    with pytest.raises(RuntimeError, match="with_keyset|allow_override"):
+        shape_aware.apply_shape_aware_mm(native_mm_kernel=safe_kernel)
+    assert shape_aware._STATE is None
+
+
+def test_apply_requires_capture_before_flaggems(monkeypatch):
+    monkeypatch.setenv(shape_aware.ENABLE_ENV, "1")
+    monkeypatch.setattr(shape_aware, "_STATE", None)
+    with pytest.raises(RuntimeError, match="before flag_gems.enable"):
+        shape_aware.apply_shape_aware_mm()

--- a/tests/unit_tests/patches/test_flaggems_mm_shape_aware.py
+++ b/tests/unit_tests/patches/test_flaggems_mm_shape_aware.py
@@ -41,9 +41,7 @@ class _FakeLibrary:
         with_keyset=False,
         allow_override=False,
     ):
-        self.impl_calls.append(
-            (op_name, fn, dispatch_key, with_keyset, allow_override)
-        )
+        self.impl_calls.append((op_name, fn, dispatch_key, with_keyset, allow_override))
 
 
 class _FakeSafeKernel:
@@ -89,9 +87,7 @@ def test_caller_default_can_enable_but_explicit_disable_wins(monkeypatch):
 def test_mm_dispatch_guard_preserves_explicit_flaggems_selection(
     whitelist, blacklist, expected
 ):
-    assert (
-        shape_aware.is_mm_dispatch_enabled(whitelist, blacklist) is expected
-    )
+    assert shape_aware.is_mm_dispatch_enabled(whitelist, blacklist) is expected
 
 
 @pytest.mark.parametrize("value", ["", "2 ", " 2", "+2", "-1", "1.0", "abc"])
@@ -127,22 +123,14 @@ def test_native_candidate_boundary_dtype_and_stride():
     b_column_major = _FakeTensor(m=4096, stride=(1, 4096))
     assert shape_aware._is_native_candidate(a, b_column_major, 1)
 
-    assert shape_aware._is_native_candidate(
-        _FakeTensor(m=64), b_column_major, 64
-    )
-    assert not shape_aware._is_native_candidate(
-        _FakeTensor(m=65), b_column_major, 64
-    )
+    assert shape_aware._is_native_candidate(_FakeTensor(m=64), b_column_major, 64)
+    assert not shape_aware._is_native_candidate(_FakeTensor(m=65), b_column_major, 64)
 
-    assert not shape_aware._is_native_candidate(
-        _FakeTensor(m=2), b_column_major, 1
-    )
+    assert not shape_aware._is_native_candidate(_FakeTensor(m=2), b_column_major, 1)
     assert not shape_aware._is_native_candidate(
         a, _FakeTensor(dtype=torch.float16, stride=(1, 4096)), 1
     )
-    assert not shape_aware._is_native_candidate(
-        a, _FakeTensor(stride=(8192, 2)), 1
-    )
+    assert not shape_aware._is_native_candidate(a, _FakeTensor(stride=(8192, 2)), 1)
     assert not shape_aware._is_native_candidate(
         _FakeTensor(stride=(8192, 2)), b_column_major, 1
     )
@@ -170,9 +158,7 @@ def test_apply_captures_flaggems_before_override_and_routes_shapes(monkeypatch):
         return "native-result"
 
     native_kernel = _FakeSafeKernel(native_mm)
-    flaggems_kernel = _FakeSafeKernel(
-        lambda dispatch_keys, a, b: flaggems_mm(a, b)
-    )
+    flaggems_kernel = _FakeSafeKernel(lambda dispatch_keys, a, b: flaggems_mm(a, b))
     library = _FakeLibrary()
     monkeypatch.setattr(
         shape_aware.torch.library,
@@ -187,9 +173,7 @@ def test_apply_captures_flaggems_before_override_and_routes_shapes(monkeypatch):
 
     assert shape_aware.apply_shape_aware_mm(native_mm_kernel=native_kernel) is True
     assert len(library.impl_calls) == 1
-    op_name, wrapper, dispatch_key, with_keyset, allow_override = (
-        library.impl_calls[0]
-    )
+    op_name, wrapper, dispatch_key, with_keyset, allow_override = library.impl_calls[0]
     assert (op_name, dispatch_key, with_keyset, allow_override) == (
         "mm",
         "CUDA",
@@ -216,8 +200,7 @@ def test_apply_captures_flaggems_before_override_and_routes_shapes(monkeypatch):
     # Unsupported dtype/stride remains on the captured FlagGems callable.
     calls.clear()
     assert (
-        wrapper("dispatch-key", _FakeTensor(dtype=torch.int8), b)
-        == "flaggems-result"
+        wrapper("dispatch-key", _FakeTensor(dtype=torch.int8), b) == "flaggems-result"
     )
     assert calls[0][0] == "flaggems"
 
@@ -230,9 +213,7 @@ def test_apply_fails_without_safe_override_api(monkeypatch):
     monkeypatch.delenv(shape_aware.THRESHOLD_ENV, raising=False)
     monkeypatch.setattr(shape_aware, "_STATE", None)
     safe_kernel = _FakeSafeKernel(lambda dispatch_keys, a, b: None)
-    monkeypatch.setattr(
-        shape_aware.torch.library, "get_kernel", lambda *_: safe_kernel
-    )
+    monkeypatch.setattr(shape_aware.torch.library, "get_kernel", lambda *_: safe_kernel)
 
     class _NoAllowOverrideLibrary:
         def impl(self, op_name, fn, dispatch_key):

--- a/tests/unit_tests/quantization/test_w8a8_linear.py
+++ b/tests/unit_tests/quantization/test_w8a8_linear.py
@@ -83,6 +83,37 @@ def test_w8a8_linear_registration_keeps_native_fallback():
     ]
 
 
+def test_oot_quant_registry_inherits_mxfp8_candidates(monkeypatch):
+    from vllm.model_executor.kernels import linear as linear_kernels
+
+    from vllm_fl.quantization import quant_linear
+    from vllm_fl.quantization.w8a8 import moe, packed
+
+    candidate = object()
+    monkeypatch.setattr(
+        quant_linear,
+        "_resolve_source_platform",
+        lambda: PlatformEnum.CUDA,
+    )
+    monkeypatch.setitem(
+        linear_kernels._POSSIBLE_MXFP8_KERNELS,
+        PlatformEnum.CUDA,
+        [candidate],
+    )
+    monkeypatch.delitem(
+        linear_kernels._POSSIBLE_MXFP8_KERNELS,
+        PlatformEnum.OOT,
+        raising=False,
+    )
+    monkeypatch.setattr(linear, "register_fl_w8a8_linear_kernel", lambda _: True)
+    monkeypatch.setattr(moe, "install_fl_w8a8_moe_selector", lambda: None)
+    monkeypatch.setattr(packed, "install_packed_w8a8_scheme", lambda: None)
+
+    quant_linear.add_oot_quant_kernel()
+
+    assert linear_kernels._POSSIBLE_MXFP8_KERNELS[PlatformEnum.OOT] == [candidate]
+
+
 def test_w8a8_linear_uses_common_flaggems_policy(monkeypatch):
     monkeypatch.setattr(linear, "is_oot_enabled", lambda: True)
     policy_calls = []

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -18,7 +18,16 @@ else:
         _torch.float4_e2m1fn_x2 = _torch.uint8
 del _torch
 
-from vllm_fl.utils import get_op_config as _get_op_config
+try:
+    from vllm_fl.utils import get_op_config as _get_op_config
+except ModuleNotFoundError as exc:
+    # The native GLM5-Next baseline reuses only this package's config/model
+    # modules and deliberately does not install or activate FlagGems.
+    if exc.name != "flag_gems":
+        raise
+
+    def _get_op_config():
+        return None
 
 from . import version as version  # PyTorch-style: vllm_fl.version.git_version
 
@@ -140,9 +149,15 @@ def register_model():
     """Register FL-specific models not yet upstream."""
     # General plugins are loaded independently in spawned model-inspection and
     # worker processes, so all runtime compatibility hooks must be idempotent.
+    from vllm_fl.patches.glm5_next_v024 import (
+        apply_glm5_next_v024_patches,
+    )
     from vllm_fl.patches.moe_sum import patch_vllm_moe_sum
     from vllm_fl.patches.qwen3_5_text import apply_qwen3_5_text_patches
 
+    # GLM5-Next is intentionally registered only by its vLLM-0.24 adapter;
+    # the plugin main branch is ABI-pinned to that release line.
+    apply_glm5_next_v024_patches()
     apply_qwen3_5_text_patches()
     patch_vllm_moe_sum()
 

--- a/vllm_fl/__init__.py
+++ b/vllm_fl/__init__.py
@@ -44,12 +44,34 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def _patch_torchvision_video_compat():
+    """Restore the torchvision video helper expected by Transformers."""
+    try:
+        import torchvision.transforms.v2.functional as tvF
+    except (ImportError, AttributeError):
+        return
+    if hasattr(tvF, "grayscale_to_rgb"):
+        return
+
+    def grayscale_to_rgb(video):
+        if getattr(video, "ndim", 0) >= 3 and video.shape[-3] == 1:
+            return video.repeat_interleave(3, dim=-3)
+        return video
+
+    tvF.grayscale_to_rgb = grayscale_to_rgb
+
+
 def _patch_transformers_compat():
     """Patch transformers compatibility for ALLOWED_LAYER_TYPES and tokenizer."""
     import transformers.configuration_utils as cfg
     if not hasattr(cfg, "ALLOWED_LAYER_TYPES"):
         cfg.ALLOWED_LAYER_TYPES = getattr(
             cfg, "ALLOWED_ATTENTION_LAYER_TYPES", ()
+        )
+
+    if "deepseek_sparse_attention" not in cfg.ALLOWED_LAYER_TYPES:
+        cfg.ALLOWED_LAYER_TYPES = tuple(cfg.ALLOWED_LAYER_TYPES) + (
+            "deepseek_sparse_attention",
         )
 
 
@@ -106,6 +128,7 @@ def _patch_custom_ops():
 
 def register():
     """Register the FL platform."""
+    _patch_torchvision_video_compat()
     _patch_custom_ops()
     _patch_flash_attn_import()
     _patch_transformers_compat()

--- a/vllm_fl/configs/glm5_next.py
+++ b/vllm_fl/configs/glm5_next.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transformers config classes for GLM5-Next.
+
+These classes preserve the released checkpoint's nested text/vision schema
+and expose the aliases consumed by vLLM's KDA, MLA, MoE, and multimodal paths.
+"""
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class Glm5NextTextConfig(PretrainedConfig):
+    model_type = "glm5_next_text"
+    base_config_key = "text_config"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size: int = 154880,
+        hidden_size: int = 4096,
+        intermediate_size: int = 12288,
+        moe_intermediate_size: int = 2048,
+        num_hidden_layers: int = 45,
+        num_attention_heads: int = 64,
+        num_key_value_heads: int | None = None,
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 1048576,
+        rms_norm_eps: float = 1e-5,
+        head_dim: int | None = None,
+        q_lora_rank: int | None = 1536,
+        kv_lora_rank: int = 512,
+        qk_nope_head_dim: int = 256,
+        qk_rope_head_dim: int = 0,
+        v_head_dim: int = 256,
+        mla_use_nope: bool = True,
+        n_shared_experts: int = 1,
+        n_routed_experts: int | None = 288,
+        num_experts_per_tok: int = 8,
+        norm_topk_prob: bool = True,
+        routed_scaling_factor: float = 2.5,
+        first_k_dense_replace: int = 3,
+        moe_layer_freq: int = 1,
+        n_group: int = 1,
+        topk_group: int = 1,
+        scoring_func: str = "sigmoid",
+        topk_method: str = "noaux_tc",
+        moe_router_dtype: str = "float32",
+        layer_types: list[str] | None = None,
+        mlp_layer_types: list[str] | None = None,
+        linear_attn_config: dict | None = None,
+        index_topk: int | None = 2048,
+        index_head_dim: int = 128,
+        index_n_heads: int = 32,
+        indexer_rope_interleave: bool = True,
+        index_kpool: int = 4,
+        index_kpool_compress: bool = True,
+        index_kpool_always_select_tail: bool = True,
+        mhc: bool = True,
+        hc_mult: int = 4,
+        hc_eps: float = 1e-6,
+        hc_sinkhorn_iters: int = 20,
+        mhc_tau: float = 0.05,
+        mhc_no_norm_weight: bool = False,
+        mhc_post_mult_value: float = 2.0,
+        swiglu_limit: float | None = 10.0,
+        num_nextn_predict_layers: int = 1,
+        rope_parameters: dict | None = None,
+        pad_token_id: int | None = 154820,
+        bos_token_id: int | None = None,
+        eos_token_id: int | list[int] | None = None,
+        tie_word_embeddings: bool = False,
+        dtype: str = "bfloat16",
+        **kwargs,
+    ) -> None:
+        if num_key_value_heads is None:
+            num_key_value_heads = num_attention_heads
+        if rope_parameters is None:
+            rope_parameters = {"rope_type": "default"}
+        if linear_attn_config is None:
+            linear_attn_config = {
+                "num_heads": 64,
+                "head_dim": 128,
+                "short_conv_kernel_size": 4,
+                "gate_lower_bound": -5.0,
+            }
+
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.moe_intermediate_size = moe_intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        # GLM5-Next uses an explicit zero to represent its NoPE layout.
+        # Only fall back to the conventional per-head width when the field is
+        # absent; treating zero as false silently turns the real config into a
+        # 64-dimensional RoPE layout.
+        self.head_dim = (
+            head_dim if head_dim is not None else hidden_size // num_attention_heads
+        )
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.rms_norm_eps = rms_norm_eps
+
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.mla_use_nope = mla_use_nope
+        self.mla_nope = mla_use_nope
+        self.mla = True
+        self.rope_parameters = rope_parameters
+
+        self.n_shared_experts = n_shared_experts
+        self.n_routed_experts = n_routed_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.norm_topk_prob = norm_topk_prob
+        self.routed_scaling_factor = routed_scaling_factor
+        self.first_k_dense_replace = first_k_dense_replace
+        self.moe_layer_freq = moe_layer_freq
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.scoring_func = scoring_func
+        self.topk_method = topk_method
+        self.moe_router_dtype = moe_router_dtype
+
+        # Aliases used by KimiLinear's v0.24 KDA/MoE implementation.
+        self.num_experts = n_routed_experts
+        self.num_shared_experts = n_shared_experts
+        self.num_experts_per_token = num_experts_per_tok
+        self.moe_renormalize = norm_topk_prob
+        self.use_grouped_topk = True
+        self.num_expert_group = n_group
+        self.moe_router_activation_func = scoring_func
+
+        self.layer_types = layer_types or [
+            "deepseek_sparse_attention" if (i + 1) % 4 == 0
+            else "linear_attention"
+            for i in range(num_hidden_layers)
+        ]
+        self.mlp_layer_types = mlp_layer_types or (
+            ["dense"] * first_k_dense_replace
+            + ["sparse"] * (num_hidden_layers - first_k_dense_replace)
+        )
+        self.linear_attn_config = linear_attn_config
+        self.linear_num_heads = linear_attn_config["num_heads"]
+        self.linear_head_dim = linear_attn_config["head_dim"]
+        self.linear_conv_kernel_dim = linear_attn_config[
+            "short_conv_kernel_size"
+        ]
+        self.linear_lower_bound = linear_attn_config.get("gate_lower_bound")
+
+        self.index_topk = index_topk
+        self.index_head_dim = index_head_dim
+        self.index_n_heads = index_n_heads
+        self.indexer_rope_interleave = indexer_rope_interleave
+        self.index_kpool = index_kpool
+        self.index_kpool_compress = index_kpool_compress
+        self.index_kpool_always_select_tail = index_kpool_always_select_tail
+
+        self.mhc = mhc
+        self.hc_mult = hc_mult
+        self.mhc_num_residual_streams = hc_mult
+        self.hc_eps = hc_eps
+        self.hc_sinkhorn_iters = hc_sinkhorn_iters
+        self.mhc_sinkhorn_iterations = hc_sinkhorn_iters
+        self.mhc_tau = mhc_tau
+        self.mhc_no_norm_weight = mhc_no_norm_weight
+        self.mhc_post_mult_value = mhc_post_mult_value
+        self.swiglu_limit = swiglu_limit
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            dtype=dtype,
+            **kwargs,
+        )
+
+    @property
+    def is_moe(self) -> bool:
+        return self.n_routed_experts is not None
+
+    @property
+    def is_linear_attn(self) -> bool:
+        return any(t == "linear_attention" for t in self.layer_types)
+
+    def is_kda_layer(self, layer_idx: int) -> bool:
+        return self.layer_types[layer_idx] == "linear_attention"
+
+    @property
+    def layers_block_type(self) -> list[str]:
+        return [
+            "linear_attention" if t == "linear_attention" else "attention"
+            for t in self.layer_types
+        ]
+
+
+class Glm5NextVisionConfig(PretrainedConfig):
+    model_type = "glm5_next_vision"
+    base_config_key = "vision_config"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class Glm5NextConfig(PretrainedConfig):
+    model_type = "glm5_next"
+    sub_configs = {
+        "text_config": Glm5NextTextConfig,
+        "vision_config": Glm5NextVisionConfig,
+    }
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        image_token_id: int = 154854,
+        video_token_id: int = 154855,
+        image_start_token_id: int = 154830,
+        image_end_token_id: int = 154831,
+        video_start_token_id: int = 154832,
+        video_end_token_id: int = 154833,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.text_config = (
+            Glm5NextTextConfig(**text_config)
+            if isinstance(text_config, dict)
+            else text_config or Glm5NextTextConfig(**kwargs)
+        )
+        self.vision_config = (
+            Glm5NextVisionConfig(**vision_config)
+            if isinstance(vision_config, dict)
+            else vision_config or Glm5NextVisionConfig()
+        )
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.image_start_token_id = image_start_token_id
+        self.image_end_token_id = image_end_token_id
+        self.video_start_token_id = video_start_token_id
+        self.video_end_token_id = video_end_token_id
+
+    def get_text_config(self, decoder: bool = False):
+        del decoder
+        # Transformers 5.12 validates token IDs from PretrainedConfig.__init__,
+        # before this class has constructed the nested text config.
+        return getattr(self, "text_config", self)
+
+    def __getattr__(self, key):
+        # Several vLLM 0.24 MLA metadata builders still read text attributes
+        # from hf_config rather than hf_text_config.
+        text_config = self.__dict__.get("text_config")
+        if text_config is not None and hasattr(text_config, key):
+            return getattr(text_config, key)
+        raise AttributeError(key)

--- a/vllm_fl/dispatch/README.md
+++ b/vllm_fl/dispatch/README.md
@@ -334,8 +334,9 @@ Environment variables can override specific items from platform config. If not s
 | `USE_FLAGGEMS` | `true` | Enable/disable FlagGems |
 | `VLLM_FL_FLAGOS_WHITELIST` | (none) | FlagGems ops whitelist (mutually exclusive with blacklist) |
 | `VLLM_FL_FLAGOS_BLACKLIST` | (none) | FlagGems ops blacklist (mutually exclusive with whitelist) |
+| `VLLM_FL_FLAGOS_BLACKLIST_APPEND` | (none) | Add exclusions without replacing the platform blacklist; ignored when a whitelist is active |
 
-**Priority**: `WHITELIST` > `BLACKLIST` (env) > `flagos_blacklist` (config file)
+**Priority**: `WHITELIST` > (`BLACKLIST` env or platform `flagos_blacklist`) + `BLACKLIST_APPEND`
 
 #### OOT Operator Control
 
@@ -379,6 +380,9 @@ export VLLM_FL_PREFER=vendor
 
 # Override FlagGems blacklist (overrides config file blacklist)
 export VLLM_FL_FLAGOS_BLACKLIST="mm,to_copy,zeros"
+
+# Keep platform defaults and add one deployment-specific exclusion
+export VLLM_FL_FLAGOS_BLACKLIST_APPEND="linear"
 
 # Use whitelist instead (completely ignores any blacklist)
 export VLLM_FL_FLAGOS_WHITELIST="silu_and_mul,rms_norm"
@@ -447,12 +451,16 @@ WHITELIST (env) ──▶ Completely overrides blacklist
                               └── Not set ──▶ Config file blacklist
                                                     │
                                                     └── Not set ──▶ Allow all
+
+BLACKLIST_APPEND (env) ──▶ Appended to the selected blacklist above
 ```
 
 **Important Notes:**
 - Whitelist and blacklist environment variables are mutually exclusive (error if both set)
 - If whitelist is set, it completely ignores any blacklist (env or config)
 - Environment blacklist overrides config file blacklist (not merged)
+- `VLLM_FL_FLAGOS_BLACKLIST_APPEND` retains the selected platform or explicit
+  blacklist while adding deployment-specific exclusions
 
 #### Example: Combined Environment Variables
 

--- a/vllm_fl/dispatch/backends/flaggems/flaggems.py
+++ b/vllm_fl/dispatch/backends/flaggems/flaggems.py
@@ -161,7 +161,29 @@ class FlagGemsBackend(Backend):
         Returns:
             Fully qualified class path string
         """
+        from vllm.platforms import current_platform
         from vllm.v1.attention.backends.registry import AttentionBackendEnum
+        from vllm_fl.kernels.glm5_next.provider import use_nvidia_reference
+
+        if use_sparse and not use_mla:
+            raise ValueError("use_sparse=True requires use_mla=True.")
+
+        # Keep the validated NVIDIA vendor implementation in the default
+        # provider path.  The FlagGems MLA implementation is an explicit
+        # portable/A-B path and must not be selected accidentally by the
+        # process-wide FlagGems dispatcher.
+        if use_mla and current_platform.is_cuda() and use_nvidia_reference():
+            raise NotImplementedError(
+                "FlagGems portable MLA is reserved for non-NVIDIA platforms"
+            )
+
+        if use_mla and use_sparse:
+            return (
+                "vllm_fl.dispatch.backends.flaggems.impl.mla_sparse."
+                "FlagGemsSparseMLABackend"
+            )
+        if use_mla:
+            return "vllm_fl.dispatch.backends.flaggems.impl.mla.MLAFLBackend"
 
         # TritonAttentionBackend requires CUDA, check if available
         if not torch.cuda.is_available():
@@ -169,12 +191,6 @@ class FlagGemsBackend(Backend):
                 "TritonAttentionBackend requires CUDA but CUDA is not available. "
                 "Falling back to vendor implementation."
             )
-
-        if use_mla:
-            raise NotImplementedError("NOT support mla now!")
-
-        if use_sparse:
-            raise ValueError("use_sparse=True requires use_mla=True.")
 
         use_flaggems_attn = os.environ.get(
             "VLLM_FL_USE_FLAGGEMS_ATTN", "0"

--- a/vllm_fl/dispatch/backends/flaggems/impl/mla_prefill.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/mla_prefill.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""FlagGems MLA prefill backend for GLM5 empty-build bring-up.
+
+The vLLM 0.24 Hopper selector only considers its FlashAttention C extension
+for MLA prefill.  Empty-build wheels intentionally omit that extension, while
+FlagGems already exposes the compatible varlen FlashAttention entry point.
+Keep this adapter scoped to the GLM5 portable provider instead of changing the
+process-wide vLLM selector.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.v1.attention.backends.mla.prefill.base import MLAPrefillBackend
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+
+class FlagGemsMLAPrefillBackend(MLAPrefillBackend):
+    """Use FlagGems' varlen FlashAttention for MLA prefill."""
+
+    @staticmethod
+    def get_name() -> str:
+        return "FLAGGEMS"
+
+    @classmethod
+    def is_available(cls) -> bool:
+        try:
+            from flag_gems import flash_attn_varlen_func  # noqa: F401
+        except (ImportError, OSError):
+            return False
+        return True
+
+    def __init__(
+        self,
+        num_heads: int,
+        scale: float,
+        kv_lora_rank: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        vllm_config: VllmConfig,
+    ) -> None:
+        super().__init__(
+            num_heads=num_heads,
+            scale=scale,
+            kv_lora_rank=kv_lora_rank,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            vllm_config=vllm_config,
+        )
+        from flag_gems import flash_attn_varlen_func
+
+        self.flash_attn_varlen_func = flash_attn_varlen_func
+        self.requires_v_padding = (
+            v_head_dim != qk_nope_head_dim + qk_rope_head_dim
+        )
+
+    def _run_flash_attn(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        causal: bool,
+        return_softmax_lse: bool,
+        out: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if output_scale is not None:
+            raise NotImplementedError(
+                "FlagGems MLA prefill does not support quantized output"
+            )
+
+        original_v = v
+        if self.requires_v_padding:
+            v = torch.nn.functional.pad(v, [0, q.shape[-1] - v.shape[-1]])
+
+        # FlagGems uses the same varlen argument names and LSE convention as
+        # vLLM's FlashAttention backend.  ``fa_version=2`` is the portable
+        # Triton path; no vLLM native CUDA extension is required.
+        result = self.flash_attn_varlen_func(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            softmax_scale=self.scale,
+            causal=causal,
+            return_softmax_lse=return_softmax_lse,
+            # The caller's output has the unpadded value width. Let FlagGems
+            # allocate when padding is needed, then copy the trimmed result.
+            out=out if v is original_v else None,
+            fa_version=2,
+        )
+        lse = None
+        if isinstance(result, tuple):
+            result, lse = result[0], result[1]
+        if v is not original_v:
+            result = result[..., : original_v.shape[-1]]
+            if out is not None:
+                out.copy_(result)
+                result = out
+        if return_softmax_lse:
+            if lse is None:
+                raise RuntimeError(
+                    "FlagGems MLA prefill did not return softmax LSE"
+                )
+            return result, lse
+        return result
+
+    def run_prefill_new_tokens(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        return_softmax_lse: bool,
+        out: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        return self._run_flash_attn(
+            q,
+            k,
+            v,
+            cu_seqlens_q=self._prefill_metadata.query_start_loc,
+            cu_seqlens_k=self._prefill_metadata.query_start_loc,
+            max_seqlen_q=self._prefill_metadata.max_query_len,
+            max_seqlen_k=self._prefill_metadata.max_query_len,
+            causal=True,
+            return_softmax_lse=return_softmax_lse,
+            out=out,
+            output_scale=output_scale,
+        )
+
+    def run_prefill_context_chunk(
+        self,
+        chunk_idx: int,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        assert self._prefill_metadata.chunked_context is not None
+        chunked = self._prefill_metadata.chunked_context
+        result = self._run_flash_attn(
+            q,
+            k,
+            v,
+            cu_seqlens_q=self._prefill_metadata.query_start_loc,
+            cu_seqlens_k=chunked.cu_seq_lens[chunk_idx],
+            max_seqlen_q=self._prefill_metadata.max_query_len,
+            max_seqlen_k=chunked.max_seq_lens[chunk_idx],
+            causal=False,
+            return_softmax_lse=True,
+        )
+        assert isinstance(result, tuple)
+        return result
+
+
+__all__ = ["FlagGemsMLAPrefillBackend"]

--- a/vllm_fl/dispatch/backends/flaggems/impl/mla_sparse.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/mla_sparse.py
@@ -36,7 +36,10 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
 
-from vllm_fl.kernels.glm5_next.provider import get_glm5_provider
+from vllm_fl.kernels.glm5_next.provider import (
+    get_glm5_provider,
+    use_nvidia_reference,
+)
 
 logger = init_logger(__name__)
 
@@ -132,7 +135,7 @@ class FlagGemsSparseMLAMetadataBuilder(
     # kernel can fall back to code containing host scalar reads.
     _cudagraph_support: ClassVar[AttentionCGSupport] = (
         AttentionCGSupport.UNIFORM_BATCH
-        if current_platform.is_cuda() and get_glm5_provider() == "flaggems"
+        if current_platform.is_cuda() and not use_nvidia_reference()
         else AttentionCGSupport.NEVER
     )
 
@@ -190,6 +193,14 @@ class FlagGemsSparseMLAMetadataBuilder(
 class FlagGemsSparseMLABackend(AttentionBackend):
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
     supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+    # vLLM 0.24 resolves cudagraph support through the metadata builder, but
+    # newer runners also inspect the backend class. Keep both declarations in
+    # sync so the portable GLM5 path can participate in piecewise capture.
+    _cudagraph_support: ClassVar[AttentionCGSupport] = (
+        AttentionCGSupport.UNIFORM_BATCH
+        if current_platform.is_cuda() and not use_nvidia_reference()
+        else AttentionCGSupport.NEVER
+    )
 
     @staticmethod
     def get_name() -> str:

--- a/vllm_fl/dispatch/backends/flaggems/impl/mla_sparse.py
+++ b/vllm_fl/dispatch/backends/flaggems/impl/mla_sparse.py
@@ -1,0 +1,461 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""FlagGems-backed sparse MLA for out-of-tree accelerators.
+
+The metadata and cache contract match vLLM 0.24's sparse MLA backend.  Kernel
+selection is backend-neutral: use FlagGems when its sparse MLA/cache writer is
+available, otherwise retain a slow PyTorch correctness implementation.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+import numpy as np
+import torch
+
+from vllm.config import VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionLayer,
+    AttentionMetadata,
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+    MultipleOf,
+    SparseMLAAttentionImpl,
+)
+from vllm.v1.kv_cache_interface import AttentionSpec
+
+from vllm_fl.kernels.glm5_next.provider import get_glm5_provider
+
+logger = init_logger(__name__)
+
+
+def _flagtree_version_tuple() -> tuple[int, ...] | None:
+    """Return the numeric FlagTree release tuple when package metadata exists."""
+    try:
+        version = importlib.metadata.version("flagtree")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    numbers = re.match(r"^(\d+(?:\.\d+)*)", version)
+    if numbers is None:
+        return None
+    return tuple(int(part) for part in numbers.group(1).split("."))
+
+
+def _configure_sparse_mla_tle(loaded: Any) -> None:
+    """Select the known-good FlagGems sparse-MLA implementation.
+
+    FlagTree 0.6.1 exposes the complete TLE API, but its select-encodings pass
+    rejects the FlagGems sparse-MLA kernel at the scalar ``local_ptr`` load.
+    Keep using FlagGems' non-TLE Triton implementation for released versions
+    through 0.6.1.  The override is intentionally plugin-scoped so an upstream
+    fix can be qualified without changing the process-wide FlagGems setting.
+    """
+    if not getattr(loaded, "HAS_TLE_FLASHMLA_SPARSE", False):
+        return
+
+    mode = os.getenv("VLLM_FL_GLM5_SPARSE_MLA_TLE", "auto").strip().lower()
+    if mode not in {"auto", "0", "1", "false", "true", "off", "on"}:
+        raise ValueError(
+            "VLLM_FL_GLM5_SPARSE_MLA_TLE must be auto, on/1/true, or "
+            f"off/0/false; got {mode!r}"
+        )
+    if mode in {"1", "true", "on"}:
+        return
+
+    tle = getattr(loaded, "tle", None)
+    tle_gpu = getattr(tle, "gpu", None)
+    required_gpu_apis = ("alloc", "copy", "local_ptr", "warp_specialize")
+    missing_api = not hasattr(tle, "pipe") or any(
+        not hasattr(tle_gpu, api) for api in required_gpu_apis
+    )
+    flagtree_version = _flagtree_version_tuple()
+    known_bad_release = flagtree_version is not None and flagtree_version <= (0, 6, 1)
+    explicitly_disabled = mode in {"0", "false", "off"}
+    if explicitly_disabled or missing_api or known_bad_release:
+        loaded.HAS_TLE_FLASHMLA_SPARSE = False
+        if explicitly_disabled:
+            reason = "disabled by VLLM_FL_GLM5_SPARSE_MLA_TLE"
+        elif missing_api:
+            reason = "required FlagTree pipe/GPU APIs are unavailable"
+        else:
+            reason = (
+                "FlagTree <= 0.6.1 fails TritonTleSelectEncodings for the "
+                "FlagGems sparse-MLA kernel"
+            )
+        logger.warning_once(
+            "FlagGems sparse MLA TLE path is %s; using its non-TLE Triton kernel",
+            reason,
+        )
+
+
+def _flag_op(module: str, name: str):
+    try:
+        loaded = importlib.import_module(f"flag_gems.fused.{module}")
+        if module == "flashmla_sparse":
+            _configure_sparse_mla_tle(loaded)
+        return getattr(loaded, name)
+    except (ImportError, AttributeError, OSError):
+        return None
+
+
+@dataclass
+class FlagGemsSparseMLAMetadata(AttentionMetadata):
+    num_reqs: int
+    max_query_len: int
+    max_seq_len: int
+    num_actual_tokens: int
+    query_start_loc: torch.Tensor
+    slot_mapping: torch.Tensor
+    block_table: torch.Tensor
+    req_id_per_token: torch.Tensor
+    block_size: int = 64
+    topk_tokens: int = 2048
+
+
+class FlagGemsSparseMLAMetadataBuilder(
+    AttentionMetadataBuilder[FlagGemsSparseMLAMetadata]
+):
+    # H100 A/B explicitly exercises the FlagGems kernels under graph capture.
+    # Real non-NVIDIA bring-up remains conservative because a missing per-op
+    # kernel can fall back to code containing host scalar reads.
+    _cudagraph_support: ClassVar[AttentionCGSupport] = (
+        AttentionCGSupport.UNIFORM_BATCH
+        if current_platform.is_cuda() and get_glm5_provider() == "flaggems"
+        else AttentionCGSupport.NEVER
+    )
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        self.kv_cache_spec = kv_cache_spec
+        self.layer_names = layer_names
+        self.vllm_config = vllm_config
+        self.device = device
+        self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.req_id_per_token_buffer = torch.empty(
+            max_tokens, dtype=torch.int32, device=device
+        )
+        self.topk_tokens = vllm_config.model_config.hf_config.index_topk
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> FlagGemsSparseMLAMetadata:
+        del common_prefix_len, fast_build
+        metadata = common_attn_metadata
+        starts = np.asarray(metadata.query_start_loc_cpu, dtype=np.int32)
+        segment_lengths = np.diff(starts)
+        request_ids = np.repeat(
+            np.arange(segment_lengths.shape[0], dtype=np.int32), segment_lengths
+        )
+        self.req_id_per_token_buffer.fill_(0)
+        if request_ids.size:
+            request_ids_tensor = torch.from_numpy(request_ids)
+            self.req_id_per_token_buffer[: request_ids.size].copy_(
+                request_ids_tensor, non_blocking=True
+            )
+        return FlagGemsSparseMLAMetadata(
+            num_reqs=metadata.num_reqs,
+            max_query_len=metadata.max_query_len,
+            max_seq_len=metadata.max_seq_len,
+            num_actual_tokens=metadata.num_actual_tokens,
+            query_start_loc=metadata.query_start_loc,
+            slot_mapping=metadata.slot_mapping,
+            block_table=metadata.block_table_tensor,
+            req_id_per_token=self.req_id_per_token_buffer[: metadata.num_actual_tokens],
+            block_size=self.kv_cache_spec.block_size,
+            topk_tokens=self.topk_tokens,
+        )
+
+
+class FlagGemsSparseMLABackend(AttentionBackend):
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "FLAGGEMS_MLA_SPARSE"
+
+    @staticmethod
+    def get_builder_cls() -> type[FlagGemsSparseMLAMetadataBuilder]:
+        return FlagGemsSparseMLAMetadataBuilder
+
+    @staticmethod
+    def get_impl_cls() -> type[FlagGemsSparseMLAImpl]:
+        return FlagGemsSparseMLAImpl
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        # GLM5-Next is 512-NoPE; DeepSeek-V3.2 is 512-NoPE + 64-RoPE.
+        return [512, 576]
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [64]
+
+    @classmethod
+    def is_mla(cls) -> bool:
+        return True
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        del capability
+        return True
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        del cache_dtype_str
+        if num_kv_heads != 1:
+            raise ValueError("Sparse MLA requires one latent KV head")
+        return (num_blocks, block_size, head_size)
+
+
+def _convert_request_to_physical_indices(
+    request_ids: torch.Tensor,
+    block_table: torch.Tensor,
+    token_indices: torch.Tensor,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    token_indices_i64 = token_indices.to(torch.int64)
+    request_ids_i64 = request_ids.to(torch.int64).reshape(-1, 1)
+    block_ids = torch.div(token_indices_i64, block_size, rounding_mode="floor")
+    valid = (token_indices_i64 >= 0) & (block_ids < block_table.shape[1])
+    safe_blocks = block_ids.clamp(min=0, max=block_table.shape[1] - 1)
+    rows = request_ids_i64.expand_as(safe_blocks)
+    physical_blocks = block_table[rows, safe_blocks].to(torch.int64)
+    valid = valid & (physical_blocks >= 0)
+    physical = physical_blocks * block_size + torch.remainder(
+        token_indices_i64, block_size
+    )
+    valid_lengths = valid.sum(dim=-1).to(torch.int32)
+
+    # ``flash_mla_sparse_fwd`` consumes only ``indices[:topk_length]``.  A
+    # missing logical block can create an invalid entry in the middle of the
+    # indexer's result, so merely replacing invalid entries with -1 would both
+    # expose -1 to the kernel and drop later valid tokens.  Compact valid
+    # physical slots to a contiguous prefix, matching vLLM's reference
+    # ``COMPACT_TO_FRONT`` conversion contract.  The extra column is a sink for
+    # every invalid entry and keeps this path free of host synchronization.
+    width = physical.shape[-1]
+    compact_dst = valid.to(torch.int64).cumsum(dim=-1) - 1
+    compact_dst = torch.where(valid, compact_dst, width)
+    compact = torch.full(
+        (*physical.shape[:-1], width + 1),
+        -1,
+        dtype=physical.dtype,
+        device=physical.device,
+    )
+    compact.scatter_(dim=-1, index=compact_dst, src=physical)
+    return compact[..., :width].to(torch.int32), valid_lengths
+
+
+def _sparse_mla_torch(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    scale: float,
+    value_dim: int,
+    valid_lengths: torch.Tensor,
+) -> torch.Tensor:
+    rows, heads, _ = q.shape
+    output = torch.zeros(rows, heads, value_dim, dtype=q.dtype, device=q.device)
+    for row in range(rows):
+        length = int(valid_lengths[row].item())
+        if length == 0:
+            continue
+        selected = indices[row, :length].to(torch.int64)
+        selected_kv = kv.index_select(0, selected).squeeze(1).float()
+        scores = torch.einsum("hd,kd->hk", q[row].float(), selected_kv) * scale
+        probabilities = torch.softmax(scores, dim=-1)
+        output[row] = torch.einsum(
+            "hk,kv->hv", probabilities, selected_kv[:, :value_dim]
+        ).to(output.dtype)
+    return output
+
+
+class FlagGemsSparseMLAImpl(SparseMLAAttentionImpl[FlagGemsSparseMLAMetadata]):
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None,
+        sliding_window: int | None,
+        kv_cache_dtype: str,
+        logits_soft_cap: float | None,
+        attn_type: str,
+        kv_sharing_target_layer_name: str | None,
+        topk_indices_buffer: torch.Tensor | None = None,
+        indexer: Any | None = None,
+        **mla_args,
+    ) -> None:
+        del (
+            alibi_slopes,
+            sliding_window,
+            logits_soft_cap,
+            attn_type,
+            kv_sharing_target_layer_name,
+        )
+        if kv_cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError(
+                "FlagGems sparse MLA portable path currently requires BF16 KV cache"
+            )
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.num_kv_heads = num_kv_heads
+        self.kv_cache_dtype = kv_cache_dtype
+        self.softmax_scale = float(scale)
+        self.kv_lora_rank = int(mla_args["kv_lora_rank"])
+        self.topk_indices_buffer = (
+            indexer.topk_indices_buffer if indexer is not None else topk_indices_buffer
+        )
+
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,
+    ) -> None:
+        if kv_cache.numel() == 0:
+            return
+        fn = _flag_op("concat_and_cache_mla", "concat_and_cache_mla")
+        if fn is not None:
+            flag_cache_dtype = (
+                "auto" if kv_cache_dtype == "bfloat16" else kv_cache_dtype
+            )
+            try:
+                fn(
+                    kv_c_normed,
+                    k_pe.squeeze(1),
+                    kv_cache,
+                    slot_mapping.flatten(),
+                    kv_cache_dtype=flag_cache_dtype,
+                    scale=k_scale,
+                )
+                return
+            except (NotImplementedError, RuntimeError) as exc:
+                logger.warning(
+                    "FlagGems MLA cache writer rejected this workload; using "
+                    "the PyTorch correctness fallback: %s",
+                    exc,
+                )
+        if kv_cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError("Portable MLA cache write only supports BF16")
+        source = (
+            kv_c_normed
+            if k_pe.shape[-1] == 0
+            else torch.cat((kv_c_normed, k_pe.squeeze(1)), dim=-1)
+        )
+        slots = slot_mapping.flatten().to(torch.int64)
+        valid = slots >= 0
+        cache_flat = kv_cache.view(-1, kv_cache.shape[-1])
+        cache_flat[slots[valid]] = source[valid]
+
+    def forward_mqa(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: FlagGemsSparseMLAMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        del layer
+        if isinstance(q, tuple):
+            q_nope, q_pe = q
+            q = q_nope if q_pe.shape[-1] == 0 else torch.cat((q_nope, q_pe), dim=-1)
+        num_tokens = q.shape[0]
+        if self.topk_indices_buffer is None:
+            raise RuntimeError("Sparse MLA requires the indexer's top-k buffer")
+        request_topk = self.topk_indices_buffer[:num_tokens]
+        physical_topk, valid_lengths = _convert_request_to_physical_indices(
+            attn_metadata.req_id_per_token,
+            attn_metadata.block_table,
+            request_topk,
+            attn_metadata.block_size,
+        )
+        cache = kv_c_and_k_pe_cache.contiguous().view(
+            -1, 1, kv_c_and_k_pe_cache.shape[-1]
+        )
+        actual_heads = q.shape[1]
+        padded_heads = 64 if actual_heads <= 64 else 128
+        if actual_heads not in (64, 128):
+            q_padded = q.new_zeros(num_tokens, padded_heads, q.shape[-1])
+            q_padded[:, :actual_heads].copy_(q)
+        else:
+            q_padded = q
+
+        sparse_fn = _flag_op("flashmla_sparse", "flash_mla_sparse_fwd")
+        if sparse_fn is not None:
+            try:
+                output = sparse_fn(
+                    q_padded.contiguous(),
+                    cache,
+                    physical_topk.unsqueeze(1).contiguous(),
+                    self.softmax_scale,
+                    d_v=self.kv_lora_rank,
+                    topk_length=valid_lengths.contiguous(),
+                )[0]
+            except (NotImplementedError, RuntimeError) as exc:
+                logger.warning(
+                    "FlagGems sparse MLA rejected this workload; using the "
+                    "PyTorch correctness fallback: %s",
+                    exc,
+                )
+                output = _sparse_mla_torch(
+                    q_padded,
+                    cache,
+                    physical_topk,
+                    self.softmax_scale,
+                    self.kv_lora_rank,
+                    valid_lengths,
+                )
+        else:
+            output = _sparse_mla_torch(
+                q_padded,
+                cache,
+                physical_topk,
+                self.softmax_scale,
+                self.kv_lora_rank,
+                valid_lengths,
+            )
+        return output[:, :actual_heads], None
+
+
+__all__ = [
+    "FlagGemsSparseMLABackend",
+    "FlagGemsSparseMLAImpl",
+    "FlagGemsSparseMLAMetadata",
+    "FlagGemsSparseMLAMetadataBuilder",
+]

--- a/vllm_fl/dispatch/backends/reference/register_ops.py
+++ b/vllm_fl/dispatch/backends/reference/register_ops.py
@@ -36,108 +36,36 @@ def register_builtins(registry) -> None:
     backend = ReferenceBackend()
     is_avail = backend.is_available
 
-    impls = [
-        # Quantization
-        OpImpl(
-            op_name="dynamic_per_token_quant_int8",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(
-                backend.dynamic_per_token_quant_int8,
-                is_avail,
-            ),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # Activation
-        OpImpl(
-            op_name="silu_and_mul",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.silu_and_mul, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        OpImpl(
-            op_name="gelu_and_mul",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.gelu_and_mul, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # Normalization
-        OpImpl(
-            op_name="rms_norm",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.rms_norm, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # Rotary Embedding
-        OpImpl(
-            op_name="rotary_embedding",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.rotary_embedding, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # Attention Backend
-        OpImpl(
-            op_name="attention_backend",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.attention_backend, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # MoE align
-        OpImpl(
-            op_name="moe_align_block_size",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.moe_align_block_size, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # MoE sum
-        OpImpl(
-            op_name="moe_sum",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.moe_sum, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # topk softmax
-        OpImpl(
-            op_name="topk_softmax",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.topk_softmax, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # invoke fused moe triton kernel
-        OpImpl(
-            op_name="invoke_fused_moe_triton_kernel",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.invoke_fused_moe_triton_kernel, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-        # grouped topk
-        OpImpl(
-            op_name="grouped_topk",
-            impl_id="reference.torch",
-            kind=BackendImplKind.REFERENCE,
-            fn=_bind_is_available(backend.grouped_topk, is_avail),
-            vendor=None,
-            priority=BackendPriority.REFERENCE,
-        ),
-    ]
+    # ReferenceBackend implements only part of the dispatch surface on some
+    # vLLM 0.24 builds. One absent optional MoE helper must not prevent all
+    # available PyTorch fallbacks from registering.
+    op_names = (
+        "dynamic_per_token_quant_int8",
+        "silu_and_mul",
+        "gelu_and_mul",
+        "rms_norm",
+        "rotary_embedding",
+        "attention_backend",
+        "moe_align_block_size",
+        "moe_sum",
+        "topk_softmax",
+        "invoke_fused_moe_triton_kernel",
+        "grouped_topk",
+    )
+    impls = []
+    for op_name in op_names:
+        fn = getattr(backend, op_name, None)
+        if fn is None:
+            continue
+        impls.append(
+            OpImpl(
+                op_name=op_name,
+                impl_id="reference.torch",
+                kind=BackendImplKind.REFERENCE,
+                fn=_bind_is_available(fn, is_avail),
+                vendor=None,
+                priority=BackendPriority.REFERENCE,
+            )
+        )
 
     registry.register_many(impls)

--- a/vllm_fl/kernels/glm5_next/PROVENANCE.md
+++ b/vllm_fl/kernels/glm5_next/PROVENANCE.md
@@ -1,0 +1,40 @@
+# GLM5-Next kernel provenance
+
+The kpool implementation is vendored from the supplied
+`glm-5-next-adapt-0808` vLLM reference tree:
+
+- reference commit: `a9b39d6` plus `vllm-glm5next-0808.patch`
+- original paths:
+  - `vllm/models/glm5next/nvidia/ops/kpool_compress.py`
+  - `vllm/model_executor/layers/sparse_attn_indexer_kpool.py`
+- license: Apache-2.0
+
+Before vendoring, the equivalent Hugging Face Transformers and SGLang
+implementations in the same handoff bundle were checked. The plugin keeps the
+reference formulas and cache lifecycle; only import paths and vLLM 0.24
+metadata compatibility reads differ.
+
+The upstream vLLM repository was re-checked at commit
+`bd6536071cec4dcd8cf91c0e2aa04aec83fc1c37` (2026-08-10). Its Kimi K3 KDA,
+KDA metadata, and latent-MoE tail files are byte-identical to the copies in the
+supplied `a9b39d6` reference tree. Kimi K3 confirms the bounded-gate wrapper and
+`eager_break_during_capture` pattern; its latent-MoE tail is not a KV tail cache
+and was not transplanted into the GLM kpool implementation.
+
+The first-layer mHC broadcast specialization was ported on 2026-08-27 from the
+newer local `vllm-glm5next-ref` handoff snapshot:
+
+- original paths:
+  - `vllm/model_executor/kernels/mhc/tilelang.py:mhc_pre_broadcast_tilelang`
+  - `vllm/model_executor/kernels/mhc/tilelang_kernels.py:mhc_pre_big_fuse_broadcast_with_norm_tilelang`
+  - `vllm/models/deepseek_v4/nvidia/model.py:finalize_mhc_broadcast_weights`
+- snapshot base commit: `a9b39d6dcbe9970a33b5d1ceb9848ba975167b1b`
+- source file SHA256:
+  - wrapper: `c8ce81539c779436eb2b9fbba84738f3114bf3ac0a149f2b606f7d38bd1067ce`
+  - TileLang kernel: `03aeb3f7c0eabfe8391006ff80f8d4cfedba7cf3d0a168e0dee2d678d3e3bd24`
+  - model integration: `d9573aa0a926cce853c856cc81cb991b02388f55c9d98f1fd4cfe915fc234a6a`
+- license: Apache-2.0
+
+The TileLang function body is AST-identical to the reference. Plugin changes
+are limited to ownership-safe imports, explicit NVIDIA/DeepGEMM dispatch, and a
+generic materialized-broadcast fallback when the specialization is unavailable.

--- a/vllm_fl/kernels/glm5_next/__init__.py
+++ b/vllm_fl/kernels/glm5_next/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM5-Next inference kernels vendored from the 2026-08-08 reference port."""

--- a/vllm_fl/kernels/glm5_next/indexer_backend.py
+++ b/vllm_fl/kernels/glm5_next/indexer_backend.py
@@ -1,0 +1,751 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Platform dispatch for the GLM5-Next sparse indexer operator chain.
+
+NVIDIA keeps the reference vLLM/DeepGEMM/Triton path.  Other accelerators use
+matching FlagGems kernels when present and fall back, per operator, to the
+backend-neutral PyTorch implementations in this module.
+"""
+
+from __future__ import annotations
+
+import importlib
+from functools import cached_property
+from typing import Callable
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+from . import portable
+from .provider import get_glm5_provider, use_nvidia_reference
+
+logger = init_logger(__name__)
+
+
+def _graph_safe_flaggems_paged_mqa_logits(
+    loaded,
+    q,
+    kv_cache,
+    weights,
+    context_lens,
+    block_tables,
+    schedule_metadata,
+    max_model_len,
+    clean_logits=False,
+):
+    """Launch FlagGems paged MQA without a device-to-host sync.
+
+    FlagGems 5.3.3 derives its launch grid with
+    ``context_lens.max().item()``.  Decode context lengths live in a static
+    graph input, so that host read is both unnecessary and illegal during
+    CUDA graph capture.  Use the configured model length as the static launch
+    bound; the kernel already exits tiles beyond each row's actual context.
+    """
+    del schedule_metadata
+    q_values, _q_scale = q
+    if q_values.dim() == 3:
+        q_values = q_values.unsqueeze(1)
+
+    batch, next_n, num_heads, head_dim = q_values.shape
+    total_rows = batch * next_n
+    block_size = kv_cache.shape[1]
+    cache_head_dim = kv_cache.shape[3] - 4
+    if cache_head_dim != head_dim:
+        raise ValueError(
+            f"Paged MQA head mismatch: query={head_dim}, cache={cache_head_dim}"
+        )
+
+    if context_lens.dim() == 2:
+        context_lens_flat = (
+            context_lens.reshape(-1)[:total_rows].contiguous().to(torch.int32)
+        )
+    else:
+        context_lens_flat = (
+            context_lens.repeat_interleave(next_n).contiguous().to(torch.int32)
+        )
+
+    num_physical_blocks = kv_cache.shape[0]
+    flat_size = num_physical_blocks * block_size
+    block_stride = block_size * (head_dim + 4)
+    cache_flat = kv_cache.reshape(num_physical_blocks, block_stride)
+    cache_values = cache_flat[:, : block_size * head_dim]
+    cache_values = cache_values.reshape(flat_size, head_dim).contiguous()
+    scale_bytes = cache_flat[:, block_size * head_dim :]
+    cache_scales = (
+        scale_bytes.reshape(num_physical_blocks, block_size, 4)
+        .contiguous()
+        .reshape(flat_size, 4)
+        .view(torch.float32)
+        .reshape(flat_size)
+        .contiguous()
+    )
+
+    if block_tables.dim() == 2:
+        block_tables_expanded = (
+            block_tables.unsqueeze(1)
+            .expand(batch, next_n, -1)
+            .reshape(total_rows, -1)
+            .contiguous()
+            .to(torch.int32)
+        )
+    else:
+        block_tables_expanded = block_tables.contiguous().to(torch.int32)
+
+    query = q_values.reshape(total_rows, num_heads, head_dim).contiguous()
+    query_bytes = query.view(torch.uint8).reshape(
+        total_rows, num_heads * head_dim
+    )
+    logits = torch.full(
+        (total_rows, max_model_len),
+        float("-inf") if clean_logits else 0.0,
+        device=q_values.device,
+        dtype=torch.float32,
+    )
+
+    block_kv, num_blocks = loaded._select_block_kv(max_model_len, block_size)
+    max_blocks_per_sequence = block_tables_expanded.shape[1]
+    grid = (loaded.triton.cdiv(max_model_len, block_kv), total_rows)
+    loaded._mqa_logits_kernel[grid](
+        query_bytes,
+        cache_values,
+        cache_scales,
+        weights,
+        block_tables_expanded,
+        logits,
+        context_lens_flat,
+        total_rows=total_rows,
+        max_ctx=max_model_len,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        max_model_len=max_model_len,
+        block_size=block_size,
+        max_blocks_per_seq=max_blocks_per_sequence,
+        num_phys_blocks=num_physical_blocks,
+        stride_q_row=num_heads * head_dim,
+        stride_kv_flat=head_dim,
+        stride_bt_row=max_blocks_per_sequence,
+        stride_out_row=max_model_len,
+        stride_w_row=num_heads,
+        BLOCK_KV=block_kv,
+        BLOCK_D=128,
+        NUM_BLOCKS=num_blocks,
+    )
+    return logits
+
+
+def _load_flaggems_op(module: str, name: str) -> Callable | None:
+    try:
+        loaded = importlib.import_module(f"flag_gems.fused.{module}")
+        # FlagGems enables its TLE top-k implementation from the Triton version
+        # alone.  Some Triton 3.6 packages expose the TLE namespace without the
+        # ``cumsum`` primitive required by that implementation.  In that case
+        # select FlagGems' own non-TLE Triton kernel instead of failing at the
+        # first JIT launch (or falling all the way back to PyTorch).  Triton's
+        # dependency scanner still resolves the dead TLE branch while hashing
+        # the shared JIT helper, so provide the standard tl.cumsum symbol too.
+        if module in {"top_k_per_row_prefill", "top_k_per_row_decode"}:
+            tle = getattr(loaded, "tle", None)
+            compat_cumsum = getattr(tle, "_vllm_fl_cumsum_compat", False)
+            if getattr(loaded, "HAS_TLE", False) and (
+                compat_cumsum or not hasattr(tle, "cumsum")
+            ):
+                loaded.HAS_TLE = False
+                if not hasattr(tle, "cumsum"):
+                    setattr(tle, "cumsum", loaded.tl.cumsum)
+                    setattr(tle, "_vllm_fl_cumsum_compat", True)
+                logger.warning_once(
+                    "FlagGems %s TLE path requires tle.cumsum; using its "
+                    "non-TLE Triton kernel for GLM5-Next",
+                    name,
+                )
+        function = getattr(loaded, name)
+        if module == "fp8_fp4_paged_mqa_logits":
+            required = ("_mqa_logits_kernel", "_select_block_kv", "triton")
+            if all(hasattr(loaded, attr) for attr in required):
+                logger.info_once(
+                    "Using graph-safe FlagGems paged-MQA wrapper without "
+                    "context_lens.max().item()"
+                )
+
+                def graph_safe_paged_mqa(*args, **kwargs):
+                    return _graph_safe_flaggems_paged_mqa_logits(
+                        loaded, *args, **kwargs
+                    )
+
+                return graph_safe_paged_mqa
+        return function
+    except (ImportError, AttributeError, OSError) as exc:
+        logger.debug("FlagGems GLM5-Next op %s is unavailable: %s", name, exc)
+        return None
+
+
+def _load_flaggems_ops_op(module: str, name: str) -> Callable | None:
+    try:
+        loaded = importlib.import_module(f"flag_gems.ops.{module}")
+        return getattr(loaded, name)
+    except (ImportError, AttributeError, OSError) as exc:
+        logger.debug("FlagGems GLM5-Next op %s is unavailable: %s", name, exc)
+        return None
+
+
+def _torch_per_token_group_quant_fp8(
+    x: torch.Tensor,
+    group_size: int,
+    eps: float = 1e-10,
+    dtype: torch.dtype | None = None,
+    column_major_scales: bool = False,
+    use_ue8m0: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if x.shape[-1] % group_size:
+        raise ValueError("Last dimension must be divisible by group_size")
+    default_dtype, fp8_max = portable.get_fp8_dtype_and_max()
+    fp8_dtype = dtype or default_dtype
+    fp8_max = float(torch.finfo(fp8_dtype).max) if dtype is not None else fp8_max
+    grouped = x.float().reshape(*x.shape[:-1], -1, group_size)
+    scales = grouped.abs().amax(dim=-1).clamp_min(eps) / fp8_max
+    if use_ue8m0:
+        scales = torch.pow(2.0, torch.ceil(torch.log2(scales)))
+    quantized = (grouped / scales.unsqueeze(-1)).clamp(-fp8_max, fp8_max)
+    quantized = quantized.reshape_as(x).to(fp8_dtype)
+    if column_major_scales:
+        scales = scales.transpose(-1, -2)
+    return quantized, scales.float()
+
+
+def _torch_indexer_k_quant_and_cache(
+    k: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    quant_block_size: int,
+    scale_fmt: str | None,
+) -> None:
+    num_tokens, head_dim = k.shape
+    if head_dim % quant_block_size:
+        raise ValueError("head_dim must be divisible by quant_block_size")
+    blocks = k.float().view(num_tokens, -1, quant_block_size)
+    fp8_dtype, fp8_max = portable.get_fp8_dtype_and_max()
+    absmax = blocks.abs().amax(dim=-1).clamp_min(1e-4)
+    scales = absmax / fp8_max
+    if scale_fmt is not None:
+        scales = torch.pow(2.0, torch.ceil(torch.log2(scales)))
+    quantized = (blocks / scales.unsqueeze(-1)).clamp(
+        -fp8_max, fp8_max
+    )
+    try:
+        quantized = quantized.reshape(num_tokens, head_dim).to(fp8_dtype)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "The portable indexer cache writer requires float8_e4m3fn support"
+        ) from exc
+    portable.write_fp8_cache(
+        kv_cache,
+        quantized,
+        scales.float(),
+        slot_mapping,
+        head_dim,
+    )
+
+
+def _torch_cp_gather_indexer_k_quant_cache(
+    k_cache: torch.Tensor,
+    k_fp8: torch.Tensor,
+    k_fp8_scale: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+) -> None:
+    head_dim = k_fp8.shape[-1]
+    values, scales = portable._cache_views(k_cache, head_dim)
+    page_size = k_cache.shape[1]
+    boundaries = cu_seqlen.detach().to("cpu", torch.int64).tolist()
+    cursor = 0
+    for request, (start, end) in enumerate(zip(boundaries[:-1], boundaries[1:])):
+        length = end - start
+        num_pages = (length + page_size - 1) // page_size
+        physical = block_table[request, :num_pages].to(torch.int64)
+        gathered_values = values.index_select(0, physical).reshape(-1, head_dim)[:length]
+        gathered_scales = scales.index_select(0, physical).reshape(
+            -1, scales.shape[-1]
+        )[:length]
+        k_fp8[cursor : cursor + length].view(torch.uint8).copy_(gathered_values)
+        k_fp8_scale[cursor : cursor + length].view(torch.float32).copy_(
+            gathered_scales
+        )
+        cursor += length
+
+
+def _dequantize_grouped(
+    values: torch.Tensor, scales: torch.Tensor | None
+) -> torch.Tensor:
+    output = values.float()
+    if scales is None:
+        return output
+    scales = scales.float()
+    num_groups = scales.shape[-1]
+    if num_groups == 1:
+        return output * scales
+    if output.shape[-1] % num_groups:
+        raise ValueError("Quantized width must be divisible by the scale groups")
+    group_size = output.shape[-1] // num_groups
+    grouped = output.reshape(*output.shape[:-1], num_groups, group_size)
+    return (grouped * scales.unsqueeze(-1)).reshape_as(output)
+
+
+def _torch_mqa_logits(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    del clean_logits
+    q_values, q_scale = q
+    k_values, k_scale = kv
+    q_float = _dequantize_grouped(q_values, q_scale)
+    k_float = _dequantize_grouped(k_values, k_scale)
+    score = torch.einsum("mhd,nd->hmn", q_float, k_float)
+    logits = (score.relu() * weights.float().transpose(0, 1).unsqueeze(-1)).sum(0)
+    columns = torch.arange(k_values.shape[0], device=q_values.device).unsqueeze(0)
+    valid = (columns >= cu_seqlen_ks.reshape(-1, 1)) & (
+        columns < cu_seqlen_ke.reshape(-1, 1)
+    )
+    return logits.masked_fill(~valid, float("-inf"))
+
+
+def _dequantize_cache(kv_cache: torch.Tensor, head_dim: int) -> torch.Tensor:
+    values, scales = portable._cache_views(kv_cache, head_dim)
+    fp8_dtype, _ = portable.get_fp8_dtype_and_max()
+    return _dequantize_grouped(values.view(fp8_dtype), scales)
+
+
+def _torch_paged_mqa_logits(
+    q: tuple[torch.Tensor, torch.Tensor | None],
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    schedule_metadata,
+    max_model_len: int,
+    clean_logits: bool = False,
+) -> torch.Tensor:
+    del schedule_metadata, clean_logits
+    q_values, q_scale = q
+    if q_values.ndim == 3:
+        q_values = q_values.unsqueeze(1)
+    batch, next_n, heads, head_dim = q_values.shape
+    cache = _dequantize_cache(kv_cache.squeeze(-2), head_dim)
+    page_size = cache.shape[1]
+    logits = torch.full(
+        (batch * next_n, max_model_len),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q_values.device,
+    )
+    q_float = _dequantize_grouped(q_values, q_scale)
+
+    for request in range(batch):
+        request_lens = context_lens[request]
+        if request_lens.ndim == 0:
+            limits = request_lens.expand(next_n)
+        else:
+            limits = request_lens.reshape(-1)[:next_n]
+        max_len = int(limits.max().item())
+        num_pages = (max_len + page_size - 1) // page_size
+        physical = block_tables[request, :num_pages].to(torch.int64)
+        keys = cache.index_select(0, physical).reshape(-1, head_dim)[:max_len]
+        scores = torch.einsum("thd,nd->htn", q_float[request], keys)
+        scores = scores.relu() * weights[
+            request * next_n : (request + 1) * next_n
+        ].float().transpose(0, 1).unsqueeze(-1)
+        request_logits = scores.sum(dim=0)
+        columns = torch.arange(max_len, device=q_values.device).unsqueeze(0)
+        request_logits.masked_fill_(columns >= limits.reshape(-1, 1), float("-inf"))
+        logits[
+            request * next_n : (request + 1) * next_n, :max_len
+        ] = request_logits
+    return logits
+
+
+def _torch_topk(
+    logits: torch.Tensor,
+    starts: torch.Tensor,
+    ends: torch.Tensor,
+    top_k: int,
+    relative_to_start: bool,
+) -> torch.Tensor:
+    columns = torch.arange(logits.shape[1], device=logits.device).unsqueeze(0)
+    starts = starts.reshape(-1, 1).to(columns.dtype)
+    ends = ends.reshape(-1, 1).to(columns.dtype)
+    masked = logits.masked_fill((columns < starts) | (columns >= ends), float("-inf"))
+    actual_k = min(top_k, logits.shape[1])
+    values, indices = torch.topk(masked, k=actual_k, dim=-1)
+    indices = indices.to(torch.int32)
+    if relative_to_start:
+        indices = indices - starts.to(torch.int32)
+    indices = torch.where(values == float("-inf"), -1, indices)
+    if actual_k == top_k:
+        return indices
+    out = torch.full(
+        (logits.shape[0], top_k), -1, dtype=torch.int32, device=logits.device
+    )
+    out[:, :actual_k] = indices
+    return out
+
+
+def _torch_pack_seq(
+    tensor: torch.Tensor, lengths: torch.Tensor, pad_value=-float("inf")
+) -> torch.Tensor:
+    lengths_cpu = lengths.detach().to("cpu", torch.int64).tolist()
+    max_length = max(lengths_cpu, default=0)
+    out = torch.full(
+        (len(lengths_cpu), max_length, *tensor.shape[1:]),
+        pad_value,
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    cursor = 0
+    for request, length in enumerate(lengths_cpu):
+        out[request, :length].copy_(tensor[cursor : cursor + length])
+        cursor += length
+    return out
+
+
+def _torch_unpack_seq(tensor: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+    lengths_cpu = lengths.detach().to("cpu", torch.int64).tolist()
+    pieces = [tensor[request, :length] for request, length in enumerate(lengths_cpu)]
+    if not pieces:
+        return tensor.new_empty((0, *tensor.shape[2:]))
+    return torch.cat(pieces, dim=0)
+
+
+class Glm5NextIndexerBackend:
+    """Per-op provider selection with a stable NVIDIA reference path."""
+
+    def __init__(self) -> None:
+        self.is_nvidia = use_nvidia_reference()
+        # kpool has no FlagGems equivalent yet.  When H100 explicitly forces
+        # the FlagGems A/B path, retain the plugin's reference Triton kpool
+        # rather than replacing it with the intentionally slow PyTorch
+        # bring-up fallback.  Real non-NVIDIA platforms still use portable.
+        self.use_nvidia_kpool = current_platform.is_cuda()
+        self._flag_ops: dict[str, Callable | None] = {}
+        self._provider_logged: set[str] = set()
+        if self.is_nvidia:
+            self.name = "nvidia-reference"
+        else:
+            probe = _load_flaggems_op(
+                "indexer_k_quant_and_cache", "indexer_k_quant_and_cache"
+            )
+            self._flag_ops["indexer_k_quant_and_cache"] = probe
+            self.name = "flaggems" if probe is not None else "torch-portable"
+        logger.info_once(
+            "GLM5-Next provider override=%s, indexer provider=%s",
+            get_glm5_provider(),
+            self.name,
+        )
+
+    def _flag(self, module: str, name: str) -> Callable | None:
+        if name not in self._flag_ops:
+            self._flag_ops[name] = _load_flaggems_op(module, name)
+        fn = self._flag_ops[name]
+        if name not in self._provider_logged:
+            logger.info(
+                "GLM5-Next op %s provider: %s",
+                name,
+                "FlagGems" if fn is not None else "PyTorch correctness fallback",
+            )
+            self._provider_logged.add(name)
+        return fn
+
+    def _call_flag(
+        self,
+        name: str,
+        fn: Callable | None,
+        fallback: Callable,
+        *args,
+        **kwargs,
+    ):
+        if fn is not None:
+            try:
+                return fn(*args, **kwargs)
+            except (NotImplementedError, RuntimeError) as exc:
+                logger.warning(
+                    "FlagGems op %s rejected this GLM5-Next workload; "
+                    "using the PyTorch correctness fallback: %s",
+                    name,
+                    exc,
+                )
+        return fallback(*args, **kwargs)
+
+    def per_token_group_quant_fp8(self, *args, **kwargs):
+        if self.is_nvidia:
+            from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+                per_token_group_quant_fp8,
+            )
+
+            return per_token_group_quant_fp8(*args, **kwargs)
+        name = "per_token_group_quant_fp8"
+        if name not in self._flag_ops:
+            self._flag_ops[name] = _load_flaggems_ops_op(name, name)
+        fn = self._flag_ops[name]
+        if name not in self._provider_logged:
+            logger.info(
+                "GLM5-Next op %s provider: %s",
+                name,
+                "FlagGems" if fn is not None else "PyTorch correctness fallback",
+            )
+            self._provider_logged.add(name)
+        if fn is not None:
+            flag_kwargs = dict(kwargs)
+            flag_kwargs["scale_ue8m0"] = flag_kwargs.pop("use_ue8m0", False)
+            try:
+                return fn(*args, **flag_kwargs)
+            except (NotImplementedError, RuntimeError) as exc:
+                logger.warning(
+                    "FlagGems op %s rejected this GLM5-Next workload; "
+                    "using the PyTorch correctness fallback: %s",
+                    name,
+                    exc,
+                )
+        return _torch_per_token_group_quant_fp8(*args, **kwargs)
+
+    def fwht128_quant_fp8(self, q: torch.Tensor):
+        if self.use_nvidia_kpool:
+            from .kpool_compress import fwht128_quant_fp8
+
+            return fwht128_quant_fp8(q)
+        return portable.fwht128_quant_fp8(q)
+
+    @cached_property
+    def has_nvidia_deep_gemm(self) -> bool:
+        if not self.is_nvidia:
+            return False
+        from vllm.utils.deep_gemm import has_deep_gemm
+
+        return has_deep_gemm()
+
+    def indexer_k_quant_and_cache(self, *args, **kwargs) -> None:
+        if self.is_nvidia:
+            from vllm import _custom_ops as ops
+
+            return ops.indexer_k_quant_and_cache(*args, **kwargs)
+        fn = self._flag("indexer_k_quant_and_cache", "indexer_k_quant_and_cache")
+        return self._call_flag(
+            "indexer_k_quant_and_cache",
+            fn,
+            _torch_indexer_k_quant_and_cache,
+            *args,
+            **kwargs,
+        )
+
+    def cp_gather_indexer_k_quant_cache(self, *args, **kwargs) -> None:
+        if self.is_nvidia:
+            from vllm import _custom_ops as ops
+
+            return ops.cp_gather_indexer_k_quant_cache(*args, **kwargs)
+        fn = self._flag(
+            "cp_gather_indexer_k_quant_cache", "cp_gather_indexer_k_quant_cache"
+        )
+        return self._call_flag(
+            "cp_gather_indexer_k_quant_cache",
+            fn,
+            _torch_cp_gather_indexer_k_quant_cache,
+            *args,
+            **kwargs,
+        )
+
+    def mqa_logits(self, *args, **kwargs) -> torch.Tensor:
+        if self.is_nvidia:
+            from vllm.utils.deep_gemm import fp8_fp4_mqa_logits
+
+            return fp8_fp4_mqa_logits(*args, **kwargs)
+        fn = self._flag("fp8_fp4_mqa_logits", "fp8_fp4_mqa_logits")
+        return self._call_flag(
+            "fp8_fp4_mqa_logits", fn, _torch_mqa_logits, *args, **kwargs
+        )
+
+    def paged_mqa_logits(self, *args, **kwargs) -> torch.Tensor:
+        if self.is_nvidia:
+            from vllm.utils.deep_gemm import fp8_fp4_paged_mqa_logits
+
+            return fp8_fp4_paged_mqa_logits(*args, **kwargs)
+        fn = self._flag("fp8_fp4_paged_mqa_logits", "fp8_fp4_paged_mqa_logits")
+        # A failed GPU launch invalidates CUDA graph capture, so attempting a
+        # PyTorch fallback from an exception only obscures the first error.
+        # Fall back when the FlagGems operator is absent; otherwise surface a
+        # launch error directly.
+        if fn is not None:
+            return fn(*args, **kwargs)
+        return _torch_paged_mqa_logits(*args, **kwargs)
+
+    def topk_prefill(
+        self,
+        logits: torch.Tensor,
+        row_starts: torch.Tensor,
+        row_ends: torch.Tensor,
+        indices: torch.Tensor,
+        num_rows: int,
+        stride0: int,
+        stride1: int,
+        top_k: int,
+    ) -> None:
+        if self.is_nvidia:
+            torch.ops._C.top_k_per_row_prefill(
+                logits,
+                row_starts,
+                row_ends,
+                indices,
+                num_rows,
+                stride0,
+                stride1,
+                top_k,
+            )
+            return
+        fn = self._flag("top_k_per_row_prefill", "top_k_per_row_prefill")
+        if fn is not None:
+            try:
+                fn(
+                    logits,
+                    row_starts,
+                    row_ends,
+                    indices,
+                    num_rows,
+                    stride0,
+                    stride1,
+                    top_k,
+                )
+                return
+            except (NotImplementedError, RuntimeError) as exc:
+                logger.warning(
+                    "FlagGems top_k_per_row_prefill rejected this workload; "
+                    "using the PyTorch correctness fallback: %s",
+                    exc,
+                )
+        indices.copy_(_torch_topk(logits, row_starts, row_ends, top_k, True))
+
+    def topk_decode(
+        self,
+        logits: torch.Tensor,
+        next_n: int,
+        seq_lens: torch.Tensor,
+        indices: torch.Tensor,
+        num_rows: int,
+        stride0: int,
+        stride1: int,
+        top_k: int,
+    ) -> None:
+        if self.is_nvidia:
+            torch.ops._C.top_k_per_row_decode(
+                logits,
+                next_n,
+                seq_lens,
+                indices,
+                num_rows,
+                stride0,
+                stride1,
+                top_k,
+            )
+            return
+        fn = self._flag("top_k_per_row_decode", "top_k_per_row_decode")
+        if fn is not None:
+            try:
+                fn(
+                    logits,
+                    next_n,
+                    seq_lens,
+                    indices,
+                    num_rows,
+                    stride0,
+                    stride1,
+                    top_k,
+                )
+                return
+            except (NotImplementedError, RuntimeError) as exc:
+                logger.warning(
+                    "FlagGems top_k_per_row_decode rejected this workload; "
+                    "using the PyTorch correctness fallback: %s",
+                    exc,
+                )
+        if seq_lens.ndim == 2:
+            ends = seq_lens.reshape(-1)[:num_rows]
+        else:
+            ends = seq_lens.repeat_interleave(next_n)[:num_rows]
+        starts = torch.zeros_like(ends)
+        indices.copy_(_torch_topk(logits, starts, ends, top_k, False))
+
+    def pack_seq(self, tensor, lengths, pad_value=-float("inf")):
+        if self.is_nvidia:
+            from vllm.v1.attention.ops.common import pack_seq_triton
+
+            return pack_seq_triton(tensor, lengths, pad_value=pad_value)
+        fn = self._flag("pack_seq", "pack_seq_triton")
+        return self._call_flag(
+            "pack_seq_triton",
+            fn,
+            _torch_pack_seq,
+            tensor,
+            lengths,
+            pad_value=pad_value,
+        )
+
+    def unpack_seq(self, tensor, lengths):
+        if self.is_nvidia:
+            from vllm.v1.attention.ops.common import unpack_seq_triton
+
+            return unpack_seq_triton(tensor, lengths)
+        fn = self._flag("unpack_seq", "unpack_seq_triton")
+        return self._call_flag(
+            "unpack_seq_triton", fn, _torch_unpack_seq, tensor, lengths
+        )
+
+    def kpool_compress_and_write_cache(self, *args, **kwargs):
+        if self.use_nvidia_kpool:
+            from .kpool_compress import kpool_compress_and_write_cache
+
+            return kpool_compress_and_write_cache(*args, **kwargs)
+        return portable.kpool_compress_and_write_cache(*args, **kwargs)
+
+    def kpool_decode_update_and_maybe_write_cache_batched(self, *args, **kwargs):
+        if self.use_nvidia_kpool:
+            from .kpool_compress import (
+                kpool_decode_update_and_maybe_write_cache_batched,
+            )
+
+            return kpool_decode_update_and_maybe_write_cache_batched(*args, **kwargs)
+        return portable.kpool_decode_update_and_maybe_write_cache_batched(
+            *args, **kwargs
+        )
+
+    def kpool_seed_tail_cache(self, *args, **kwargs):
+        if self.use_nvidia_kpool:
+            from .kpool_compress import kpool_seed_tail_cache
+
+            return kpool_seed_tail_cache(*args, **kwargs)
+        return portable.kpool_seed_tail_cache(*args, **kwargs)
+
+    def expand_pools_to_tokens(self, *args, **kwargs):
+        if self.use_nvidia_kpool:
+            from .kpool_compress import expand_pools_to_tokens
+
+            return expand_pools_to_tokens(*args, **kwargs)
+        return portable.expand_pools_to_tokens(*args, **kwargs)
+
+    def append_tail_to_topk(self, *args, **kwargs):
+        if self.use_nvidia_kpool:
+            from .kpool_compress import append_tail_to_topk
+
+            return append_tail_to_topk(*args, **kwargs)
+        return portable.append_tail_to_topk(*args, **kwargs)
+
+    def expand_pools_and_append_tail(self, *args, **kwargs):
+        if self.use_nvidia_kpool:
+            from .kpool_compress import expand_pools_and_append_tail
+
+            return expand_pools_and_append_tail(*args, **kwargs)
+        return portable.expand_pools_and_append_tail(*args, **kwargs)
+
+
+INDEXER_BACKEND = Glm5NextIndexerBackend()
+
+__all__ = ["Glm5NextIndexerBackend", "INDEXER_BACKEND"]

--- a/vllm_fl/kernels/glm5_next/indexer_backend.py
+++ b/vllm_fl/kernels/glm5_next/indexer_backend.py
@@ -566,6 +566,11 @@ class Glm5NextIndexerBackend:
         )
 
     def paged_mqa_logits(self, *args, **kwargs) -> torch.Tensor:
+        if getattr(current_platform, "vendor_name", "") == "metax":
+            logger.warning_once(
+                "FlagGems paged-MQA logits disabled on MetaX; using PyTorch fallback"
+            )
+            return _torch_paged_mqa_logits(*args, **kwargs)
         if self.is_nvidia:
             from vllm.utils.deep_gemm import fp8_fp4_paged_mqa_logits
 
@@ -635,6 +640,17 @@ class Glm5NextIndexerBackend:
         stride1: int,
         top_k: int,
     ) -> None:
+        if getattr(current_platform, "vendor_name", "") == "metax":
+            logger.warning_once(
+                "FlagGems top-k decode disabled on MetaX; using PyTorch fallback"
+            )
+            ends = (
+                seq_lens.reshape(-1)[:num_rows]
+                if seq_lens.ndim == 2
+                else seq_lens.repeat_interleave(next_n)[:num_rows]
+            )
+            indices.copy_(_torch_topk(logits, torch.zeros_like(ends), ends, top_k, False))
+            return
         if self.is_nvidia:
             torch.ops._C.top_k_per_row_decode(
                 logits,

--- a/vllm_fl/kernels/glm5_next/kpool_compress.py
+++ b/vllm_fl/kernels/glm5_next/kpool_compress.py
@@ -1,0 +1,981 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""kpool (key-pooling) Triton kernels for the sparse-attention indexer.
+
+The cache stores POOLS (1 entry per ``pool_size`` consecutive tokens) rather
+than individual tokens. ``compress_ratio == pool_size`` on the kv_cache_spec
+makes the metadata builder emit pool-granular slot_mapping / seq_lens /
+cu_seq_lens / page_table for free; this file supplies the compress-write
+kernel (replacing ``indexer_k_quant_and_cache``) and the pool-level topk
+helpers (select pools -> expand to tokens -> append tail).
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+# The indexer head dim is fixed at 128 in the current GLM5Next config; the
+# Hadamard rotation below is the hard-coded H128 transform.
+INDEX_HEAD_DIM = 128
+
+
+# ---------------------------------------------------------------------------
+# Hadamard-128 rotation (ported verbatim from sglang)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _hadamard128_stage(x, GROUPS: tl.constexpr, STRIDE: tl.constexpr):
+    x3 = tl.reshape(x, (GROUPS, 2, STRIDE))
+    x3 = tl.trans(x3, 0, 2, 1)
+    a, b = tl.split(x3)
+    x3 = tl.join(a + b, a - b)
+    x3 = tl.trans(x3, 0, 2, 1)
+    return tl.reshape(x3, (128,))
+
+
+@triton.jit
+def _hadamard128(x):
+    x = _hadamard128_stage(x, 64, 1)
+    x = _hadamard128_stage(x, 32, 2)
+    x = _hadamard128_stage(x, 16, 4)
+    x = _hadamard128_stage(x, 8, 8)
+    x = _hadamard128_stage(x, 4, 16)
+    x = _hadamard128_stage(x, 2, 32)
+    x = _hadamard128_stage(x, 1, 64)
+    return x * 0.08838834764831845  # 1/sqrt(128)
+
+
+def _hadamard128_torch(x: torch.Tensor) -> torch.Tensor:
+    """Reference / fallback Hadamard-128 on the last dim (must be 128)."""
+    import math
+
+    n = x.shape[-1]
+    assert n == 128, f"_hadamard128 expects last dim 128, got {n}"
+    h = torch.tensor([[1.0, 1.0], [1.0, -1.0]], dtype=torch.float32, device=x.device)
+    while h.shape[0] < n:
+        h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
+    h = h / math.sqrt(n)
+    return x @ h
+
+
+@triton.jit
+def _fwht_stage(x, N: tl.constexpr, GROUPS: tl.constexpr, STRIDE: tl.constexpr):
+    # One FWHT butterfly stage on a flat tensor of N = GROUPS*2*STRIDE elems;
+    # same construction as _hadamard128_stage but with a parametric N so it can
+    # process BLOCK_R rows at once.
+    x3 = tl.reshape(x, (GROUPS, 2, STRIDE))
+    x3 = tl.trans(x3, 0, 2, 1)
+    a, b = tl.split(x3)
+    x3 = tl.join(a + b, a - b)
+    x3 = tl.trans(x3, 0, 2, 1)
+    return tl.reshape(x3, (N,))
+
+
+@triton.jit
+def _fwht_quant_kernel(
+    q_ptr,
+    qout_ptr,
+    sout_ptr,
+    n_rows,
+    BLOCK_R: tl.constexpr,
+):
+    """Fused Hadamard-128 rotation + per-row absmax FP8 (ue8m0) quant.
+
+    Per row of 128 elements (one indexer head): load bf16 -> fp32 butterflies
+    (exact adds/subs; the 1/sqrt(128) scale stays fp32) -> round to bf16 ->
+    absmax quant with power-of-2 scale. Numerically identical to the unfused
+    sglang chain ``rotate_activation(q)`` (fast FWHT, bf16 out) followed by
+    ``act_quant`` (absmax clamp 1e-4, exp2(ceil(log2)) scale, clamp +-448).
+    """
+    pid = tl.program_id(0)
+    rows = pid * BLOCK_R + tl.arange(0, BLOCK_R)
+    rmask = rows < n_rows
+    offs = tl.arange(0, 128)
+    x = tl.load(
+        q_ptr + rows[:, None] * 128 + offs[None, :], mask=rmask[:, None], other=0.0
+    ).to(tl.float32)
+
+    # Flatten so each row's 128 lanes stay contiguous: every stage's
+    # (GROUPS, 2, STRIDE) tiling has 2*STRIDE dividing 128, so pairs never
+    # straddle a row boundary. GROUPS of each stage scales by BLOCK_R.
+    N: tl.constexpr = BLOCK_R * 128
+    x = tl.reshape(x, (N,))
+    x = _fwht_stage(x, N, BLOCK_R * 64, 1)
+    x = _fwht_stage(x, N, BLOCK_R * 32, 2)
+    x = _fwht_stage(x, N, BLOCK_R * 16, 4)
+    x = _fwht_stage(x, N, BLOCK_R * 8, 8)
+    x = _fwht_stage(x, N, BLOCK_R * 4, 16)
+    x = _fwht_stage(x, N, BLOCK_R * 2, 32)
+    x = _fwht_stage(x, N, BLOCK_R, 64)
+    x = x * 0.08838834764831845  # 1/sqrt(128), exact in fp32
+
+    # Match the unfused path's bf16 materialization before quantizing.
+    x = x.to(tl.bfloat16).to(tl.float32)
+    x = tl.reshape(x, (BLOCK_R, 128))
+
+    absmax = tl.maximum(tl.max(tl.abs(x), axis=1), 1e-4)
+    scale = tl.exp2(tl.ceil(tl.log2(absmax * (1.0 / 448.0))))
+    y = tl.minimum(tl.maximum(x / scale[:, None], -448.0), 448.0)
+
+    tl.store(qout_ptr + rows[:, None] * 128 + offs[None, :], y, mask=rmask[:, None])
+    tl.store(sout_ptr + rows, scale, mask=rmask)
+
+
+def fwht128_quant_fp8(q: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Rotate each 128-wide row by the Hadamard-128 transform, then FP8-quant.
+
+    Replaces ``q @ H`` (bf16 GEMM whose H entries are bf16-rounded) plus
+    ``per_token_group_quant_fp8`` with one kernel: the rotation runs in fp32
+    with the exact 1/sqrt(128) constant (matching sglang's fast FWHT), and the
+    quant replicates sglang's ``act_quant`` (block 128, ue8m0 scale).
+
+    Args:
+        q: ``[rows, 128]`` bf16 — one head vector per row.
+
+    Returns:
+        (q_fp8 ``[rows, 128]`` float8_e4m3fn, scale ``[rows, 1]`` float32).
+    """
+    assert q.ndim == 2 and q.shape[1] == 128, q.shape
+    assert q.dtype == torch.bfloat16
+    assert q.is_contiguous()
+    n_rows = q.shape[0]
+    q_fp8 = torch.empty((n_rows, 128), dtype=torch.float8_e4m3fn, device=q.device)
+    q_scale = torch.empty((n_rows, 1), dtype=torch.float32, device=q.device)
+    if n_rows == 0:
+        return q_fp8, q_scale
+    BLOCK_R = 32
+    grid = (triton.cdiv(n_rows, BLOCK_R),)
+    _fwht_quant_kernel[grid](q, q_fp8, q_scale, n_rows, BLOCK_R=BLOCK_R, num_warps=2)
+    return q_fp8, q_scale
+
+
+# ---------------------------------------------------------------------------
+# compute_pooled_write_locs : pool_id -> physical flat slot
+# ---------------------------------------------------------------------------
+
+
+def compute_pooled_write_locs(
+    page_table_64: torch.Tensor,
+    pool_ids: torch.Tensor,
+    pool_size: int,
+) -> torch.Tensor:
+    """Map logical pooled-K ids to physical flat cache slots.
+
+    ``pool_size`` consecutive tokens share one pool slot that lives at the
+    *first* token page of each page-group. ``page_table_64`` maps token pages
+    to physical block ids; we gather the block id of each pool's page-group
+    and add the in-block pool offset.
+    """
+    assert page_table_64.ndim == 1
+    pool_ids = pool_ids.to(torch.int64)
+    block_size = 64  # indexer cache page size (matches sglang hard-code)
+    pool_page_group = torch.div(pool_ids, block_size, rounding_mode="floor")
+    token_page_row = pool_page_group * pool_size
+    packed_page = page_table_64.index_select(0, token_page_row.to(torch.int64))
+    return packed_page.to(torch.int64) * block_size + torch.remainder(
+        pool_ids, block_size
+    )
+
+
+def build_pooled_page_table(
+    page_table: torch.Tensor,
+    pool_size: int,
+) -> torch.Tensor:
+    """Build a pool-granular page table by taking every ``pool_size``-th
+    token-page column (one pool maps to ``pool_size`` token pages).
+
+    Uses gather (not strided slicing) so the result is always a fresh
+    row-major tensor — some downstream kernels require stride(-1) == 1.
+    """
+    block_size = page_table.shape[-1]
+    assert block_size % pool_size == 0, (
+        f"pool_size ({pool_size}) must divide page columns ({block_size})"
+    )
+    idx = torch.arange(0, block_size, pool_size, device=page_table.device)
+    return page_table[..., idx].contiguous()
+
+
+# ---------------------------------------------------------------------------
+# kpool_softmax_rotate_write_cache : the fused compress-write kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _kpool_softmax_rotate_write_cache_kernel(
+    buf_fp8_ptr,
+    buf_fp32_ptr,
+    slot_k_ptr,
+    slot_score_ptr,
+    ape_ptr,
+    loc_ptr,
+    write_mask_ptr,
+    compressed_k_ptr,
+    compressed_scale_ptr,
+    slot_k_stride_0,
+    slot_k_stride_1,
+    slot_score_stride_0,
+    slot_score_stride_1,
+    ape_stride_0,
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    ROUND_SCALE: tl.constexpr,
+    HAS_WRITE_MASK: tl.constexpr,
+    RETURN_COMPRESSED: tl.constexpr,
+    WRITE_CACHE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """One program per pool. softmax(slot_score+ape)-weighted sum of slot_k ->
+    Hadamard-128 -> per-vector fp8 absmax quant -> write to cache at ``loc``."""
+    row = tl.program_id(0)
+    do_write = True
+    if HAS_WRITE_MASK:
+        do_write = tl.load(write_mask_ptr + row)
+
+    offs = tl.arange(0, BLOCK_D)
+    mask = (offs < HEAD_DIM) & do_write
+
+    # --- Pass 1: per-dim max over the pool (softmax numerical stability) ---
+    max_score = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        score = tl.load(
+            slot_score_ptr
+            + row * slot_score_stride_0
+            + slot * slot_score_stride_1
+            + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        score += tl.load(ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        max_score = tl.maximum(max_score, score)
+
+    # --- Pass 2: softmax-weighted sum of K ---
+    acc = tl.full((BLOCK_D,), 0.0, tl.float32)
+    denom = tl.full((BLOCK_D,), 0.0, tl.float32)
+    for slot in tl.static_range(0, POOL_SIZE):
+        score = tl.load(
+            slot_score_ptr
+            + row * slot_score_stride_0
+            + slot * slot_score_stride_1
+            + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        score += tl.load(ape_ptr + slot * ape_stride_0 + offs, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        prob = tl.exp(score - max_score)
+        denom += prob
+        k = tl.load(
+            slot_k_ptr + row * slot_k_stride_0 + slot * slot_k_stride_1 + offs,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        acc += k * prob
+
+    x = acc / denom
+    x = tl.where(do_write, x, 0.0).to(tl.bfloat16).to(tl.float32)
+
+    # Hadamard-128 rotation (spreads energy for uniform fp8 quant error).
+    # Match sglang: bf16 round-trip after the Hadamard so the fp8 absmax/scale
+    # sees the same precision as the unfused (bf16-stored) pooled-K path.
+    x = _hadamard128(x).to(tl.bfloat16).to(tl.float32)
+
+    # --- per-vector absmax fp8 quant ---
+    fp8_max = 448.0
+    fp8_max_inv = 1.0 / fp8_max
+    absmax = tl.max(tl.abs(x), axis=0)
+    absmax = tl.maximum(absmax, 1e-4)
+    if ROUND_SCALE:
+        scale = tl.exp2(tl.ceil(tl.log2(absmax * fp8_max_inv)))
+    else:
+        scale = absmax * fp8_max_inv
+    quantized = x / scale
+    quantized = tl.minimum(tl.maximum(quantized, -fp8_max), fp8_max)
+
+    if WRITE_CACHE:
+        loc = tl.load(loc_ptr + row, mask=do_write, other=0)
+        loc_page_index = loc // PAGE_SIZE
+        loc_token_offset_in_page = loc % PAGE_SIZE
+        out_k_offsets = (
+            loc_page_index * BUF_NUMEL_PER_PAGE
+            + loc_token_offset_in_page * HEAD_DIM
+            + offs
+        )
+        out_s_offset = (
+            loc_page_index * BUF_NUMEL_PER_PAGE // 4
+            + S_OFFSET_NBYTES_IN_PAGE // 4
+            + loc_token_offset_in_page
+        )
+        tl.store(buf_fp8_ptr + out_k_offsets, quantized, mask=mask)
+        tl.store(buf_fp32_ptr + out_s_offset, scale, mask=do_write)
+
+    if RETURN_COMPRESSED:
+        tl.store(
+            compressed_k_ptr + row * HEAD_DIM + offs,
+            quantized,
+            mask=offs < HEAD_DIM,
+        )
+        tl.store(compressed_scale_ptr + row, scale)
+
+
+def kpool_compress_and_write_cache(
+    kv_cache: torch.Tensor,
+    slot_k: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    loc: torch.Tensor,
+    pool_size: int,
+    head_dim: int = INDEX_HEAD_DIM,
+    write_mask: torch.Tensor | None = None,
+    round_scale: bool = True,
+    return_compressed: bool = False,
+    write_cache: bool = True,
+):
+    """Compress ``pool_size`` tokens into one fp8 K and write at ``loc``.
+
+    Args:
+        kv_cache: indexer K cache ``[num_blocks, block_size, head_dim+4]`` uint8.
+        slot_k: ``[n_pools, pool_size, head_dim]`` bf16 — raw per-token K.
+        slot_score: ``[n_pools, pool_size, head_dim]`` — per-token gate score.
+        ape: ``[pool_size, head_dim]`` fp32 — per-slot position bias.
+        loc: ``[n_pools]`` int64 — flat physical slot per pool.
+    """
+    assert slot_k.ndim == 3
+    assert slot_score.shape == slot_k.shape
+    assert ape.shape == slot_k.shape[1:]
+    assert slot_k.shape[2] == head_dim
+    assert slot_k.dtype == torch.bfloat16
+    assert ape.dtype == torch.float32
+    assert kv_cache.dtype == torch.uint8
+    assert loc.dtype == torch.int64
+    assert write_cache or return_compressed
+
+    page_size = kv_cache.shape[1]
+    buf = kv_cache
+    slot_k = slot_k.contiguous()
+    slot_score = slot_score.contiguous()
+    ape = ape.contiguous()
+    loc = loc.contiguous()
+    if write_mask is None:
+        write_mask = torch.empty((1,), dtype=torch.bool, device=slot_k.device)
+        has_write_mask = False
+    else:
+        assert write_mask.shape == (slot_k.shape[0],)
+        write_mask = write_mask.contiguous()
+        has_write_mask = True
+        assert not return_compressed
+
+    if slot_k.shape[0] == 0:
+        if return_compressed:
+            return (
+                torch.empty(
+                    (0, head_dim),
+                    dtype=torch.float8_e4m3fn,
+                    device=slot_k.device,
+                ),
+                torch.empty((0,), dtype=torch.float32, device=slot_k.device),
+            )
+        return None
+
+    buf_fp8 = buf.view(torch.float8_e4m3fn)
+    buf_fp32 = buf.view(torch.float32)
+    # bytes per page (last dim of kv_cache) viewed as uint8
+    buf_numel_per_page = buf.stride(0)
+    s_offset_nbytes_in_page = page_size * head_dim
+
+    if return_compressed:
+        compressed_k = torch.empty(
+            (slot_k.shape[0], head_dim),
+            dtype=torch.float8_e4m3fn,
+            device=slot_k.device,
+        )
+        compressed_scale = torch.empty(
+            (slot_k.shape[0],), dtype=torch.float32, device=slot_k.device
+        )
+    else:
+        compressed_k = buf_fp8
+        compressed_scale = buf_fp32
+
+    _kpool_softmax_rotate_write_cache_kernel[(slot_k.shape[0],)](
+        buf_fp8,
+        buf_fp32,
+        slot_k,
+        slot_score,
+        ape,
+        loc,
+        write_mask,
+        compressed_k,
+        compressed_scale,
+        slot_k.stride(0),
+        slot_k.stride(1),
+        slot_score.stride(0),
+        slot_score.stride(1),
+        ape.stride(0),
+        PAGE_SIZE=page_size,
+        BUF_NUMEL_PER_PAGE=buf_numel_per_page,
+        POOL_SIZE=slot_k.shape[1],
+        HEAD_DIM=head_dim,
+        S_OFFSET_NBYTES_IN_PAGE=s_offset_nbytes_in_page,
+        ROUND_SCALE=round_scale,
+        HAS_WRITE_MASK=has_write_mask,
+        RETURN_COMPRESSED=return_compressed,
+        WRITE_CACHE=write_cache,
+        BLOCK_D=triton.next_power_of_2(head_dim),
+    )
+
+    if return_compressed:
+        return compressed_k, compressed_scale
+    return None
+
+
+# ---------------------------------------------------------------------------
+# kpool_seed_tail_cache : prefill step
+# Persist each request's trailing (<= pool_size) raw K + gate score into the
+# paged tail ring, replacing the nonzero/boolean-mask scatter chain (which
+# cost ~12 elementwise ops + 4 device syncs per layer on the eager prefill
+# path). One program per prefill token; most exit after two loads.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _kpool_tail_seed_kernel(
+    key_ptr,
+    score_ptr,
+    tslot_ptr,
+    tail_ptr,
+    n_tokens,
+    HEAD_DIM: tl.constexpr,
+    KPOOL: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """Copy token ``i``'s raw K + gate into its request's tail block.
+
+    Token ``i`` is among its request's last KPOOL tokens iff the token KPOOL
+    ahead belongs to a different tail block (or is past the batch / padding,
+    slot < 0). ``tslot = block * KPOOL + pos % KPOOL``; the destination is
+    ``tail[block, {0:K, 1:score}, pos % KPOOL, :]``.
+    """
+    i = tl.program_id(0)
+    t = tl.load(tslot_ptr + i).to(tl.int64)
+    if t < 0:
+        return
+    blk = t // KPOOL  # t >= 0 here, so trunc == floor
+    ahead = tl.load(tslot_ptr + i + KPOOL, mask=i + KPOOL < n_tokens, other=-1).to(
+        tl.int64
+    )
+    # Match the torch semantics exactly: a negative ahead slot floors to a
+    # block id that differs from every real block -> token is in the tail.
+    # Only divide non-negative slots (Triton int div truncates, torch floors).
+    if ahead >= 0 and ahead // KPOOL == blk:
+        return
+    offs = tl.arange(0, BLOCK_D)
+    m = offs < HEAD_DIM
+    base = (blk * 2 * KPOOL + t % KPOOL) * HEAD_DIM
+    k = tl.load(key_ptr + i * HEAD_DIM + offs, mask=m)
+    s = tl.load(score_ptr + i * HEAD_DIM + offs, mask=m)
+    tl.store(tail_ptr + base + offs, k, mask=m)
+    tl.store(tail_ptr + base + KPOOL * HEAD_DIM + offs, s, mask=m)
+
+
+def kpool_seed_tail_cache(
+    tail_kv_cache: torch.Tensor,
+    key: torch.Tensor,
+    gate_score: torch.Tensor,
+    tslot: torch.Tensor,
+    kpool: int,
+    head_dim: int = INDEX_HEAD_DIM,
+) -> None:
+    """Seed the paged tail cache from a prefill batch (see the kernel)."""
+    assert tail_kv_cache.dtype == torch.bfloat16
+    assert key.dtype == torch.bfloat16
+    n = tslot.shape[0]
+    if n == 0:
+        return
+    _kpool_tail_seed_kernel[(n,)](
+        key,
+        gate_score,
+        tslot,
+        tail_kv_cache,
+        n,
+        HEAD_DIM=head_dim,
+        KPOOL=kpool,
+        BLOCK_D=triton.next_power_of_2(head_dim),
+    )
+
+
+# ---------------------------------------------------------------------------
+# kpool_decode_update_and_maybe_write_cache_batched : decode step
+# Append each request's verify tokens to its per-request tail ring; when a pool
+# fills (pos % pool_size == pool_size-1), compress and write at the pool slot.
+# One launch over [num_requests, next_n]; the kernel iterates each request's
+# tokens in position order (see the kernel docstring for the completion
+# read-after-stash dependency). Plain decode collapses to next_n == 1.
+#
+# vLLM simplification vs sglang: compress_ratio makes slot_mapping hand us the
+# pool slot directly at pool completion, so the write loc == cache_loc. No
+# block_table recomputation needed.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _kpool_decode_update_batched_kernel(
+    buf_fp8_ptr,
+    buf_fp32_ptr,
+    tail_kv_ptr,
+    tail_slot_mapping_ptr,  # [B, NEXT_N] int32
+    key_ptr,  # [B, NEXT_N, HEAD_DIM] bf16
+    key_stride_b,
+    key_stride_t,
+    slot_score_ptr,  # [B, NEXT_N, HEAD_DIM] bf16
+    ss_stride_b,
+    ss_stride_t,
+    ape_ptr,
+    ape_stride_0,
+    slot_mapping_ptr,  # [B, NEXT_N] int32
+    positions_ptr,  # [B, NEXT_N] int32
+    NEXT_N,  # runtime token count per request (no .item() needed)
+    PAGE_SIZE: tl.constexpr,
+    BUF_NUMEL_PER_PAGE: tl.constexpr,
+    POOL_SIZE: tl.constexpr,
+    TAIL_BLOCK_ELEMS: tl.constexpr,
+    KPOOL_HEAD: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    ROUND_SCALE: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """One program per request; iterates its NEXT_N verify tokens in order.
+
+    Replaces the caller's per-token sequential launch loop. The intra-request
+    iteration MUST stay in position order: a pool-completion at token t* reads
+    the tail-ring slots that tokens t < t* (same request) just stashed in this
+    same invocation. ``tl.range`` iterates sequentially within the program, so
+    those stashes are visible to the later completion read. Cross-request
+    programs are independent (distinct tail blocks). With NEXT_N < POOL_SIZE
+    (the spec-verify case: NEXT_N ~= num_spec+1, POOL_SIZE=16) at most one
+    completion can occur per request per call, but the ordered loop is correct
+    for any NEXT_N.
+    """
+    req = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_D)
+    dim_mask = offs < HEAD_DIM
+
+    for t in tl.range(0, NEXT_N):
+        idx = req * NEXT_N + t
+        cache_loc = tl.load(slot_mapping_ptr + idx)
+        pos = tl.load(positions_ptr + idx)
+        safe_pos = tl.maximum(pos, 0)
+        pos_valid = (cache_loc >= 0) & (pos >= 0)
+
+        slot = safe_pos % POOL_SIZE
+        phys_slot = safe_pos % POOL_SIZE
+
+        # Derive the tail block from THIS token's tail_slot (the request's block
+        # is constant across a pool, but a padded / invalid entry carries a
+        # negative sentinel -- reading it from token 0 would poison every
+        # token's base address). Clamp so an invalid entry can never form an
+        # out-of-bounds base; the accesses below are gated on pos_valid anyway.
+        tail_slot = tl.load(tail_slot_mapping_ptr + idx)
+        block = tl.maximum(tail_slot, 0).to(tl.int64) // POOL_SIZE
+        block_base = block * TAIL_BLOCK_ELEMS
+
+        # The tail-ring stash must run for EVERY real token, so it is gated on
+        # the token-granular tail slot -- not on `pos_valid`, which keys off the
+        # POOL-granular `slot_mapping` and is therefore only true on the pool's
+        # last token. Gating the stash on pos_valid dropped every intra-pool
+        # token, so a decode-built pool compressed 3 stale ring entries (the
+        # prefill-seeded prompt tail, frozen forever) plus the current token.
+        stash_valid = (pos >= 0) & (tail_slot >= 0)
+
+        key = tl.load(
+            key_ptr + req * key_stride_b + t * key_stride_t + offs,
+            mask=dim_mask,
+            other=0.0,
+        ).to(tl.float32)
+        score_current = tl.load(
+            slot_score_ptr + req * ss_stride_b + t * ss_stride_t + offs,
+            mask=dim_mask,
+            other=0.0,
+        ).to(tl.float32)
+
+        if pos_valid & (slot == POOL_SIZE - 1):
+            pool_logical_start = safe_pos - slot
+
+            max_score = tl.full((BLOCK_D,), -float("inf"), tl.float32)
+            for pool_slot in tl.static_range(0, POOL_SIZE):
+                is_current = pool_slot == slot
+                phys = (pool_logical_start + pool_slot) % POOL_SIZE
+                score_buf = tl.load(
+                    tail_kv_ptr + block_base + KPOOL_HEAD + phys * HEAD_DIM + offs,
+                    mask=dim_mask,
+                    other=0.0,
+                ).to(tl.float32)
+                score = tl.where(is_current, score_current, score_buf)
+                score += tl.load(
+                    ape_ptr + pool_slot * ape_stride_0 + offs,
+                    mask=dim_mask,
+                    other=0.0,
+                ).to(tl.float32)
+                max_score = tl.maximum(max_score, score)
+
+            acc = tl.full((BLOCK_D,), 0.0, tl.float32)
+            denom = tl.full((BLOCK_D,), 0.0, tl.float32)
+            for pool_slot in tl.static_range(0, POOL_SIZE):
+                is_current = pool_slot == slot
+                phys = (pool_logical_start + pool_slot) % POOL_SIZE
+                score_buf = tl.load(
+                    tail_kv_ptr + block_base + KPOOL_HEAD + phys * HEAD_DIM + offs,
+                    mask=dim_mask,
+                    other=0.0,
+                ).to(tl.float32)
+                score = tl.where(is_current, score_current, score_buf)
+                score += tl.load(
+                    ape_ptr + pool_slot * ape_stride_0 + offs,
+                    mask=dim_mask,
+                    other=0.0,
+                ).to(tl.float32)
+                prob = tl.exp(score - max_score)
+                denom += prob
+                k_buf = tl.load(
+                    tail_kv_ptr + block_base + phys * HEAD_DIM + offs,
+                    mask=dim_mask,
+                    other=0.0,
+                ).to(tl.float32)
+                k = tl.where(is_current, key, k_buf)
+                acc += k * prob
+
+            x = (acc / denom).to(tl.bfloat16).to(tl.float32)
+            x = _hadamard128(x).to(tl.bfloat16).to(tl.float32)
+
+            fp8_max = 448.0
+            fp8_max_inv = 1.0 / fp8_max
+            absmax = tl.maximum(tl.max(tl.abs(x), axis=0), 1e-4)
+            if ROUND_SCALE:
+                scale = tl.exp2(tl.ceil(tl.log2(absmax * fp8_max_inv)))
+            else:
+                scale = absmax * fp8_max_inv
+            quantized = tl.minimum(tl.maximum(x / scale, -fp8_max), fp8_max)
+
+            loc = cache_loc.to(tl.int64)
+            loc_page_index = loc // PAGE_SIZE
+            loc_token_offset_in_page = loc % PAGE_SIZE
+            out_k_offsets = (
+                loc_page_index * BUF_NUMEL_PER_PAGE
+                + loc_token_offset_in_page * HEAD_DIM
+                + offs
+            )
+            out_s_offset = (
+                loc_page_index * BUF_NUMEL_PER_PAGE // 4
+                + S_OFFSET_NBYTES_IN_PAGE // 4
+                + loc_token_offset_in_page
+            )
+            tl.store(buf_fp8_ptr + out_k_offsets, quantized, mask=dim_mask)
+            tl.store(buf_fp32_ptr + out_s_offset, scale)
+
+        # Stash the current token AFTER any completion read so the completion
+        # uses prior stashes (and the current token's own key/score via
+        # is_current), then leaves this token for future pools. Order matches
+        # the per-token kernel: completion read first, stash second.
+        update_mask = dim_mask & stash_valid
+        tl.store(
+            tail_kv_ptr + block_base + phys_slot * HEAD_DIM + offs,
+            key,
+            mask=update_mask,
+        )
+        tl.store(
+            tail_kv_ptr + block_base + KPOOL_HEAD + phys_slot * HEAD_DIM + offs,
+            score_current,
+            mask=update_mask,
+        )
+
+
+def kpool_decode_update_and_maybe_write_cache_batched(
+    kv_cache: torch.Tensor,
+    tail_kv_cache: torch.Tensor,
+    tail_slot_mapping: torch.Tensor,
+    key: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    pool_size: int,
+    head_dim: int = INDEX_HEAD_DIM,
+    round_scale: bool = True,
+) -> None:
+    """Batched decode-step kpool update for spec verify (``next_n > 1``).
+
+    One launch replaces the caller's per-token loop. Inputs are grouped per
+    request: ``[num_requests, next_n, ...]``. Each program handles one
+    request's ``next_n`` tokens in position order (see the kernel docstring for
+    why ordering is required for pool-completion correctness).
+
+    Plain decode (``next_n == 1``) is handled here too — the kernel collapses
+    to a single-iteration loop.
+
+    Args:
+        kv_cache: indexer K cache ``[num_blocks, block_size, head_dim+4]`` uint8.
+        tail_kv_cache: paged tail cache ``[num_blocks, 2, pool_size, head_dim]``
+            bf16 (K at half 0, gate score at half 1).
+        tail_slot_mapping: ``[num_requests, next_n]`` int32.
+        key / slot_score: ``[num_requests, next_n, head_dim]`` bf16.
+        ape: ``[pool_size, head_dim]`` fp32.
+        slot_mapping / positions: ``[num_requests, next_n]`` int32.
+    """
+    num_requests, next_n = key.shape[0], key.shape[1]
+    if num_requests == 0 or next_n == 0:
+        return
+    assert tail_kv_cache.ndim == 4
+    assert tail_kv_cache.shape[1] == 2
+    assert tail_kv_cache.shape[2] == pool_size
+    assert tail_kv_cache.shape[3] == head_dim
+    assert tail_kv_cache.dtype == torch.bfloat16
+    assert key.ndim == 3 and key.shape[2] == head_dim
+    assert slot_score.shape == key.shape
+    assert ape.shape == (pool_size, head_dim)
+    assert tail_slot_mapping.shape == (num_requests, next_n)
+    assert slot_mapping.shape == (num_requests, next_n)
+    assert positions.shape == (num_requests, next_n)
+    assert key.dtype == torch.bfloat16
+    assert slot_score.dtype == torch.bfloat16
+    assert ape.dtype == torch.float32
+    assert kv_cache.dtype == torch.uint8
+
+    page_size = kv_cache.shape[1]
+    buf = kv_cache
+    buf_fp8 = buf.view(torch.float8_e4m3fn)
+    buf_fp32 = buf.view(torch.float32)
+
+    # The kernel indexes the int tensors as ``req * next_n + t`` (row-major),
+    # so they must be contiguous. Callers pass either a view of a contiguous
+    # slice or a freshly scattered tensor, making these no-ops; the calls guard
+    # against a future caller handing over a strided view.
+    tail_slot_mapping = tail_slot_mapping.contiguous()
+    slot_mapping = slot_mapping.contiguous()
+    positions = positions.contiguous()
+
+    _kpool_decode_update_batched_kernel[(num_requests,)](
+        buf_fp8,
+        buf_fp32,
+        tail_kv_cache,
+        tail_slot_mapping,
+        key,
+        key.stride(0),
+        key.stride(1),
+        slot_score,
+        slot_score.stride(0),
+        slot_score.stride(1),
+        ape,
+        ape.stride(0),
+        slot_mapping,
+        positions,
+        next_n,
+        PAGE_SIZE=page_size,
+        BUF_NUMEL_PER_PAGE=buf.stride(0),
+        POOL_SIZE=pool_size,
+        TAIL_BLOCK_ELEMS=tail_kv_cache.stride(0),
+        KPOOL_HEAD=tail_kv_cache.stride(1),
+        HEAD_DIM=head_dim,
+        S_OFFSET_NBYTES_IN_PAGE=page_size * head_dim,
+        ROUND_SCALE=round_scale,
+        BLOCK_D=triton.next_power_of_2(head_dim),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pool-level topk helpers: select pools -> expand to tokens -> append tail
+# ---------------------------------------------------------------------------
+
+
+def history_group_budget_for_topk(topk: int, pool_size: int) -> int:
+    """Number of pools to select so that expanding yields ``topk`` tokens."""
+    assert topk % pool_size == 0
+    return topk // pool_size
+
+
+def expand_pools_to_tokens(
+    group_ids: torch.Tensor,
+    group_valid: torch.Tensor,
+    topk: int,
+    pool_size: int,
+    page_table: torch.Tensor | None = None,
+    topk_offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Expand selected full-pool ids to a strict-width token topk tensor."""
+    assert group_ids.ndim == 2
+    assert group_valid.shape == group_ids.shape
+    assert topk % pool_size == 0
+    assert group_ids.shape[1] == history_group_budget_for_topk(topk, pool_size)
+    assert page_table is None or topk_offsets is None
+
+    device = group_ids.device
+    offsets = torch.arange(pool_size, device=device, dtype=torch.int64)
+    token_ids = group_ids.to(torch.int64).unsqueeze(-1) * pool_size + offsets
+    token_ids = token_ids.reshape(group_ids.shape[0], topk)
+    valid = (
+        group_valid.unsqueeze(-1)
+        .expand(-1, -1, pool_size)
+        .reshape(group_ids.shape[0], topk)
+    )
+
+    if page_table is not None:
+        assert page_table.ndim == 2
+        safe_ids = token_ids.clamp(min=0, max=page_table.shape[1] - 1)
+        output = torch.gather(page_table, dim=1, index=safe_ids).to(torch.int32)
+    elif topk_offsets is not None:
+        if topk_offsets.ndim == 2:
+            assert topk_offsets.shape[1] == 1
+            topk_offsets = topk_offsets.squeeze(1)
+        output = (token_ids + topk_offsets.to(torch.int64).unsqueeze(1)).to(torch.int32)
+    else:
+        output = token_ids.to(torch.int32)
+
+    return torch.where(valid, output, torch.full_like(output, -1))
+
+
+def append_tail_to_topk(
+    topk_result: torch.Tensor,
+    seq_lens: torch.Tensor,
+    pool_lens: torch.Tensor,
+    pool_size: int,
+    page_table: torch.Tensor | None = None,
+    topk_offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Append non-pooled tail tokens after expanded history tokens.
+
+    ``index_kpool_always_select_tail`` keeps the (incomplete) trailing pool so
+    the most recent tokens are always attended to.
+    """
+    assert topk_result.dtype == torch.int32
+    assert seq_lens.ndim == 1
+    assert pool_lens.ndim == 1
+
+    tail_pool = pool_size - 1
+    if tail_pool == 0:
+        return topk_result
+
+    rows, n_cols = topk_result.shape
+    out_cols = n_cols + tail_pool
+    out = torch.empty(
+        (rows, out_cols), dtype=topk_result.dtype, device=topk_result.device
+    )
+
+    # tail tokens: [pool_len*pool_size, seq_len) for each row.
+    pool_len = pool_lens.to(torch.int32)
+    tail_start = pool_len * pool_size
+    seq_len = seq_lens.to(torch.int32)
+    tail_count = seq_len - tail_start  # in [0, pool_size)
+
+    cols = torch.arange(out_cols, device=topk_result.device)[None, :]
+    history_len = n_cols
+    is_history = cols < history_len
+    tail_off = cols - history_len
+    is_tail = (tail_off >= 0) & (tail_off < tail_count[:, None])
+
+    # safe_hist must be per-row [rows, out_cols] so the gather reads each row's
+    # OWN history. cols is [1, out_cols]; if used directly, gather (which does
+    # NOT broadcast the index) would read only row 0 of topk_result, making every
+    # query inherit row 0's history (empty for the first token) and lose all its
+    # selected tokens — only the per-row tail would survive. This only manifests
+    # for multi-row sparse PREFILL (decode has 1 row, so it reads its own row 0).
+    safe_hist = torch.minimum(cols, torch.full_like(cols, n_cols - 1)).expand(
+        rows, out_cols
+    )
+    history_val = torch.gather(topk_result, 1, safe_hist)
+
+    tail_raw = tail_start[:, None] + tail_off
+    tail_val = tail_raw.to(torch.int32)
+    if page_table is not None:
+        safe_tail = tail_raw.clamp(min=0, max=page_table.shape[1] - 1)
+        tail_val = torch.gather(page_table, 1, safe_tail).to(torch.int32)
+    elif topk_offsets is not None:
+        tail_val = (tail_raw + topk_offsets.to(torch.int64).unsqueeze(1)).to(
+            torch.int32
+        )
+
+    out = torch.where(is_history, history_val, -1)
+    out = torch.where(is_tail, tail_val, out)
+    return out
+
+
+@triton.jit
+def _expand_pools_and_append_tail_kernel(
+    pool_ids_ptr,  # [rows, n_groups], int (any int dtype)
+    seq_lens_ptr,  # [rows], int32 (token-granular seq_len)
+    out_ptr,  # [rows, out_cols], int32
+    topk,  # n_groups * pool_size
+    out_cols,  # topk + pool_size - 1
+    POOL_SIZE: tl.constexpr,
+    BLOCK_COLS: tl.constexpr,
+    pid_s0,
+    out_s0,
+):
+    # Fuses expand_pools_to_tokens + append_tail_to_topk (identity path) into a
+    # single kernel. Each program writes one (row, column-tile) of the output.
+    row = tl.program_id(0)
+    tile = tl.program_id(1)
+    cols = tile * BLOCK_COLS + tl.arange(0, BLOCK_COLS)
+    mask = cols < out_cols
+
+    seq_len = tl.load(seq_lens_ptr + row)
+    pool_len = seq_len // POOL_SIZE
+    tail_start = pool_len * POOL_SIZE
+    tail_count = seq_len - tail_start  # in [0, POOL_SIZE)
+
+    # History region [0, topk): expand selected pool g = cols // POOL_SIZE.
+    is_history = cols < topk
+    g = cols // POOL_SIZE
+    o = cols % POOL_SIZE
+    pid = tl.load(pool_ids_ptr + row * pid_s0 + g, mask=mask & is_history, other=-1)
+    hist_val = (pid * POOL_SIZE + o).to(tl.int32)
+    hist_out = tl.where(pid >= 0, hist_val, -1)
+
+    # Tail region [topk, out_cols): the request's trailing incomplete pool.
+    tail_off = cols - topk
+    is_tail = (tail_off >= 0) & (tail_off < tail_count)
+    tail_val = (tail_start + tail_off).to(tl.int32)
+    tail_out = tl.where(is_tail, tail_val, -1)
+
+    result = tl.where(is_history, hist_out, tail_out)
+    tl.store(out_ptr + row * out_s0 + cols, result, mask=mask)
+
+
+def expand_pools_and_append_tail(
+    pool_ids: torch.Tensor,
+    seq_lens: torch.Tensor,
+    pool_size: int,
+) -> torch.Tensor:
+    """Fuse ``expand_pools_to_tokens`` + ``append_tail_to_topk`` (identity path).
+
+    Produces the same ``[rows, topk + pool_size - 1]`` int32 output as calling
+    the two functions in sequence when neither ``page_table`` nor
+    ``topk_offsets`` is passed — the only path the GLM5Next indexer exercises.
+    The kernel derives ``pool_len = seq_len // pool_size`` internally, so the
+    caller no longer needs to precompute it. Replaces ~25 elementwise kernels
+    with one Triton launch.
+    """
+    rows, n_groups = pool_ids.shape
+    topk = n_groups * pool_size
+    out_cols = topk + pool_size - 1
+    out = torch.empty((rows, out_cols), dtype=torch.int32, device=pool_ids.device)
+    BLOCK_COLS = 128
+    n_tiles = triton.cdiv(out_cols, BLOCK_COLS)
+    _expand_pools_and_append_tail_kernel[(rows, n_tiles)](
+        pool_ids,
+        seq_lens,
+        out,
+        topk,
+        out_cols,
+        POOL_SIZE=pool_size,
+        BLOCK_COLS=BLOCK_COLS,
+        pid_s0=pool_ids.stride(0),
+        out_s0=out.stride(0),
+    )
+    return out

--- a/vllm_fl/kernels/glm5_next/mhc_broadcast_tilelang.py
+++ b/vllm_fl/kernels/glm5_next/mhc_broadcast_tilelang.py
@@ -1,0 +1,341 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVIDIA first-layer mHC broadcast specialization for GLM5-Next.
+
+The checkpoint stores the first mHC projection for four residual streams, but
+the model input initially contains one stream.  The generic path materializes
+four identical copies before running the projection.  This module performs the
+algebraically equivalent projection with the stream-summed weight and expands
+the residual only while writing the fused mHC output.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import math
+from typing import Any
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_tilelang
+
+if not current_platform.is_cuda():
+    raise ImportError("GLM5-Next mHC broadcast TileLang requires NVIDIA CUDA")
+if not has_tilelang():
+    raise ImportError(
+        "tilelang is required for GLM5-Next mHC broadcast; install tilelang"
+    )
+
+# Keep the reference import order.  flashinfer must bind the real libcudart
+# before TileLang can load libcudart_stub on sm100 systems.
+with contextlib.suppress(Exception):
+    import flashinfer.comm  # noqa: F401
+
+import tilelang
+import tilelang.language as T
+
+ENABLE_PDL = current_platform.is_arch_support_pdl()
+
+pass_configs: dict[tilelang.PassConfigKey, Any] = {
+    tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    tilelang.PassConfigKey.TL_PTXAS_REGISTER_USAGE_LEVEL: 10,
+}
+
+
+@tilelang.jit(pass_configs=pass_configs)
+def mhc_pre_big_fuse_broadcast_with_norm_tilelang(
+    gemm_out_mul,
+    gemm_out_sqrsum,
+    hc_scale,
+    hc_base,
+    residual,
+    residual_out,
+    post_mix,
+    comb_mix,
+    layer_input,
+    norm_weight,
+    hidden_size: int,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    norm_eps: float,
+    n_splits: int = 1,
+    hc_mult: int = 4,
+    gemm_last_dim: int = -1,
+):
+    """Finish first-layer mHC pre, residual broadcast, and fused RMSNorm."""
+    num_tokens = T.dynamic("num_tokens")
+    hc_mult3 = hc_mult * (2 + hc_mult)
+    if gemm_last_dim < 0:
+        gemm_last_dim = hc_mult3
+    hidden_block = math.gcd(1024, hidden_size)
+
+    gemm_out_mul: T.Tensor[  # type: ignore[no-redef, valid-type]
+        [n_splits, num_tokens, gemm_last_dim], T.float32
+    ]
+    gemm_out_sqrsum: T.Tensor[  # type: ignore[no-redef, valid-type]
+        [n_splits, num_tokens], T.float32
+    ]
+    hc_scale: T.Tensor[[3], T.float32]  # type: ignore[no-redef, valid-type]
+    hc_base: T.Tensor[  # type: ignore[no-redef, valid-type]
+        [hc_mult3], T.float32
+    ]
+    residual: T.Tensor[  # type: ignore[no-redef, valid-type]
+        [num_tokens, hidden_size], T.bfloat16
+    ]
+    residual_out: T.Tensor[  # type: ignore[no-redef, valid-type]
+        [num_tokens, hc_mult, hidden_size], T.bfloat16
+    ]
+    post_mix: T.Tensor[  # type: ignore[no-redef, valid-type]
+        [num_tokens, hc_mult], T.float32
+    ]
+    comb_mix: T.Tensor[  # type: ignore[no-redef, valid-type]
+        [num_tokens, hc_mult * hc_mult], T.float32
+    ]
+    layer_input: T.Tensor[  # type: ignore[no-redef, valid-type]
+        [num_tokens, hidden_size], T.bfloat16
+    ]
+    norm_weight: T.Tensor[  # type: ignore[no-redef, valid-type]
+        [hidden_size], T.bfloat16
+    ]
+
+    with T.Kernel(num_tokens, threads=96) as i:
+        rms = T.alloc_fragment(1, T.float32)
+        mixes = T.alloc_fragment(hc_mult3, T.float32)
+        T.clear(mixes)
+        rms[0] = 0
+
+        if ENABLE_PDL:
+            T.pdl_sync()
+
+        for i_split in T.serial(n_splits):
+            rms[0] += gemm_out_sqrsum[i_split, i]
+        rms[0] = T.rsqrt(rms[0] / hidden_size + rms_eps)
+        for j in T.Parallel(hc_mult3):
+            mixes[j] = 0
+            for i_split in T.serial(n_splits):
+                mixes[j] += gemm_out_mul[i_split, i, j]
+            mixes[j] *= rms[0]
+        mixes_shared = T.alloc_shared(hc_mult3, T.float32)
+        T.copy(mixes, mixes_shared)
+
+        if T.get_thread_binding() < 32:
+            cm = T.alloc_fragment((hc_mult, hc_mult), T.float32)
+            for j in T.Parallel(hc_mult):
+                post_mix[i, j] = (
+                    T.sigmoid(
+                        mixes_shared[j + hc_mult] * hc_scale[1]
+                        + hc_base[j + hc_mult]
+                    )
+                    * hc_post_mult_value
+                )
+            for j, k in T.Parallel(hc_mult, hc_mult):
+                cm[j, k] = (
+                    mixes_shared[j * hc_mult + k + hc_mult * 2]
+                    * hc_scale[2]
+                    + hc_base[j * hc_mult + k + hc_mult * 2]
+                )
+
+            row_sum = T.alloc_fragment(hc_mult, T.float32)
+            col_sum = T.alloc_fragment(hc_mult, T.float32)
+            row_max = T.alloc_fragment(hc_mult, T.float32)
+            T.reduce_max(cm, row_max, dim=1)
+            for j, k in T.Parallel(hc_mult, hc_mult):
+                cm[j, k] = T.exp(cm[j, k] - row_max[j])
+            T.reduce_sum(cm, row_sum, dim=1)
+            for j, k in T.Parallel(hc_mult, hc_mult):
+                cm[j, k] = cm[j, k] / row_sum[j] + hc_sinkhorn_eps
+
+            T.reduce_sum(cm, col_sum, dim=0)
+            for j, k in T.Parallel(hc_mult, hc_mult):
+                cm[j, k] = cm[j, k] / (col_sum[k] + hc_sinkhorn_eps)
+
+            for _ in T.serial(sinkhorn_repeat - 1):
+                T.reduce_sum(cm, row_sum, dim=1)
+                for j, k in T.Parallel(hc_mult, hc_mult):
+                    cm[j, k] = cm[j, k] / (row_sum[j] + hc_sinkhorn_eps)
+
+                T.reduce_sum(cm, col_sum, dim=0)
+                for j, k in T.Parallel(hc_mult, hc_mult):
+                    cm[j, k] = cm[j, k] / (col_sum[k] + hc_sinkhorn_eps)
+
+            for j, k in T.Parallel(hc_mult, hc_mult):
+                comb_mix[i, j * hc_mult + k] = cm[j, k]
+        else:
+            pre_mix_shared = T.alloc_shared(hc_mult, T.float32)
+            for j in T.Parallel(hc_mult):
+                pre_mix_shared[j] = (
+                    T.sigmoid(
+                        mixes_shared[j] * hc_scale[0] + hc_base[j],
+                    )
+                    + hc_pre_eps
+                )
+
+            output_shared = T.alloc_shared(hidden_size, T.bfloat16)
+            sumsq_per_pos = T.alloc_fragment(hidden_block, T.float32)
+            T.clear(sumsq_per_pos)
+
+            for i0_h in T.Pipelined(hidden_size // hidden_block, num_stages=2):
+                xs = T.alloc_shared(hidden_block, T.bfloat16)
+                xl = T.alloc_fragment(hidden_block, T.float32)
+                T.copy(residual[i, i0_h * hidden_block], xs)
+                T.copy(xs, xl)
+
+                for i_hc, i1_h in T.Parallel(hc_mult, hidden_block):
+                    residual_out[i, i_hc, i0_h * hidden_block + i1_h] = xs[
+                        i1_h
+                    ]
+
+                ol = T.alloc_fragment(hidden_block, T.float32)
+                T.clear(ol)
+
+                for i_hc in T.serial(hc_mult):
+                    pre = pre_mix_shared[i_hc]
+                    for i1_h in T.Parallel(hidden_block):
+                        ol[i1_h] += pre * xl[i1_h]
+
+                for i1_h in T.Parallel(hidden_block):
+                    sumsq_per_pos[i1_h] += ol[i1_h] * ol[i1_h]
+                    output_shared[i0_h * hidden_block + i1_h] = T.bfloat16(
+                        ol[i1_h]
+                    )
+
+            sumsq = T.alloc_fragment(1, T.float32)
+            T.reduce_sum(sumsq_per_pos, sumsq, dim=0)
+            rsqrt_norm = T.alloc_fragment(1, T.float32)
+            rsqrt_norm[0] = T.rsqrt(sumsq[0] / hidden_size + norm_eps)
+
+            for i0_h in T.Pipelined(hidden_size // hidden_block, num_stages=2):
+                w_shared = T.alloc_shared(hidden_block, T.bfloat16)
+                w_local = T.alloc_fragment(hidden_block, T.float32)
+                T.copy(norm_weight[i0_h * hidden_block], w_shared)
+                T.copy(w_shared, w_local)
+
+                ol = T.alloc_fragment(hidden_block, T.float32)
+                for i1_h in T.Parallel(hidden_block):
+                    ol[i1_h] = (
+                        output_shared[i0_h * hidden_block + i1_h]
+                        * rsqrt_norm[0]
+                        * w_local[i1_h]
+                    )
+
+                T.copy(ol, layer_input[i, i0_h * hidden_block])
+
+        if ENABLE_PDL:
+            T.pdl_trigger()
+
+
+def mhc_pre_broadcast_tilelang(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    *,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    fn_broadcast: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run specialized first-layer mHC pre from an unexpanded ``(T, H)``."""
+    from vllm.model_executor.kernels.mhc.tilelang_kernels import (
+        compute_num_split,
+    )
+    from vllm.utils.deep_gemm import tf32_hc_prenorm_gemm
+    from vllm.utils.math_utils import cdiv
+
+    assert residual.dtype == torch.bfloat16 and residual.dim() == 2
+    assert fn.dtype == torch.float32
+    assert hc_scale.dtype == torch.float32 and hc_scale.shape == (3,)
+    assert hc_base.dtype == torch.float32
+
+    num_tokens, hidden_size = residual.shape
+    hc_mult = fn.shape[1] // hidden_size
+    hc_mult2 = hc_mult * hc_mult
+    hc_mult3 = hc_mult * (2 + hc_mult)
+    assert fn.shape == (hc_mult3, hc_mult * hidden_size)
+    assert hc_base.shape == (hc_mult3,)
+    assert fn_broadcast.dtype == torch.float32
+    assert fn_broadcast.shape == (hc_mult3, hidden_size)
+    assert norm_weight.shape == (hidden_size,)
+
+    if norm_weight.dtype != torch.bfloat16:
+        norm_weight = norm_weight.to(torch.bfloat16)
+    if not norm_weight.is_contiguous():
+        norm_weight = norm_weight.contiguous()
+
+    n_splits = compute_num_split(64, hidden_size, cdiv(num_tokens, 64))
+    residual_out = torch.empty(
+        num_tokens,
+        hc_mult,
+        hidden_size,
+        dtype=torch.bfloat16,
+        device=residual.device,
+    )
+    post_mix = torch.empty(
+        num_tokens, hc_mult, dtype=torch.float32, device=residual.device
+    )
+    comb_mix = torch.empty(
+        num_tokens, hc_mult2, dtype=torch.float32, device=residual.device
+    )
+    layer_input = torch.empty(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=residual.device
+    )
+    gemm_out_mul = torch.empty(
+        n_splits,
+        num_tokens,
+        hc_mult3,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    gemm_out_sqrsum = torch.empty(
+        n_splits, num_tokens, dtype=torch.float32, device=residual.device
+    )
+
+    tf32_hc_prenorm_gemm(
+        residual,
+        fn_broadcast,
+        gemm_out_mul,
+        gemm_out_sqrsum,
+        n_splits,
+    )
+    mhc_pre_big_fuse_broadcast_with_norm_tilelang(
+        gemm_out_mul,
+        gemm_out_sqrsum,
+        hc_scale,
+        hc_base,
+        residual,
+        residual_out,
+        post_mix,
+        comb_mix,
+        layer_input,
+        norm_weight,
+        hidden_size,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        norm_eps,
+        n_splits,
+        hc_mult,
+    )
+    return (
+        residual_out,
+        post_mix.unsqueeze(-1),
+        comb_mix.view(num_tokens, hc_mult, hc_mult),
+        layer_input,
+    )
+
+
+__all__ = [
+    "mhc_pre_big_fuse_broadcast_with_norm_tilelang",
+    "mhc_pre_broadcast_tilelang",
+]

--- a/vllm_fl/kernels/glm5_next/portable.py
+++ b/vllm_fl/kernels/glm5_next/portable.py
@@ -1,0 +1,774 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Backend-neutral GLM5-Next correctness operators.
+
+These implementations intentionally use only PyTorch tensor operations.  They
+are the last-resort path for out-of-tree accelerators when neither the NVIDIA
+reference kernels nor a matching FlagGems kernel is available.  They preserve
+the model semantics, but are not intended to be the final performance path for
+long-context serving.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+INDEX_HEAD_DIM = 128
+
+
+def get_fp8_dtype_and_max() -> tuple[torch.dtype, float]:
+    """Return the portable E4M3 storage dtype and its finite maximum.
+
+    ROCm-family runtimes use the FNUZ encoding (maximum 224); CUDA-like and
+    most other runtimes use E4M3FN (maximum 448).  FlagGems remains the
+    preferred provider and performs its own platform query.  This helper only
+    defines the last-resort PyTorch cache format.
+    """
+    if (
+        getattr(torch.version, "hip", None) is not None
+        and hasattr(torch, "float8_e4m3fnuz")
+    ):
+        return torch.float8_e4m3fnuz, 224.0
+    if hasattr(torch, "float8_e4m3fn"):
+        return torch.float8_e4m3fn, 448.0
+    raise RuntimeError(
+        "No portable E4M3 FP8 dtype is available; install the matching "
+        "FlagGems indexer cache operators for this platform."
+    )
+
+
+def safe_kda_gate(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    head_k_dim: int,
+    g_bias: torch.Tensor | None = None,
+    lower_bound: float = -5.0,
+) -> torch.Tensor:
+    """Reference ``lower_bound * sigmoid(exp(A_log) * (g + bias))``."""
+    orig_shape = g.shape[:-1]
+    g_2d = g.reshape(-1, g.shape[-1])
+    heads = A_log.numel()
+    if heads * head_k_dim != g_2d.shape[-1]:
+        raise ValueError(
+            "KDA gate hidden dimension does not match heads * head_k_dim: "
+            f"{g_2d.shape[-1]} != {heads} * {head_k_dim}"
+        )
+    gate = g_2d.float().view(-1, heads, head_k_dim)
+    if g_bias is not None:
+        gate = gate + g_bias.float().reshape(heads, head_k_dim)
+    gate = lower_bound * torch.sigmoid(
+        torch.exp(A_log.float()).reshape(1, heads, 1) * gate
+    )
+    return gate.reshape(*orig_shape, heads, head_k_dim)
+
+
+def safe_kda_gate_chunk_cumsum(
+    raw_g: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    output_dtype: torch.dtype | None = torch.float,
+    lower_bound: float = -5.0,
+) -> torch.Tensor:
+    """Chunk-local inclusive gate cumsum in the log2 units used by FLA."""
+    batch, tokens, heads, dim = raw_g.shape
+    gate = safe_kda_gate(
+        raw_g.reshape(batch, tokens, heads * dim),
+        A_log,
+        dim,
+        g_bias=g_bias,
+        lower_bound=lower_bound,
+    ).float()
+    out = torch.empty_like(gate, dtype=output_dtype or raw_g.dtype)
+    rcp_ln2 = 1.0 / math.log(2.0)
+
+    if cu_seqlens is None:
+        ranges = [(b, 0, tokens) for b in range(batch)]
+    else:
+        if batch != 1:
+            raise ValueError("Variable-length KDA expects a flattened batch of 1")
+        boundaries = cu_seqlens.detach().to("cpu", torch.int64).tolist()
+        ranges = [(0, boundaries[i], boundaries[i + 1]) for i in range(len(boundaries) - 1)]
+
+    for batch_id, seq_start, seq_end in ranges:
+        for chunk_start in range(seq_start, seq_end, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, seq_end)
+            out[batch_id, chunk_start:chunk_end] = (
+                gate[batch_id, chunk_start:chunk_end].cumsum(dim=0) * rcp_ln2
+            ).to(out.dtype)
+    return out
+
+
+def _l2norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    x_float = x.float()
+    return (x_float * torch.rsqrt(x_float.square().sum(dim=-1, keepdim=True) + eps)).to(
+        x.dtype
+    )
+
+
+def _recurrent_kda_sequence(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    state: torch.Tensor,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run one KDA sequence using the reference FP32 recurrence."""
+    dtype = v.dtype
+    q_f, k_f, v_f = q.float(), k.float(), v.float()
+    gate_f, beta_f = gate.float(), beta.float()
+    state_f = state.float()
+    output = torch.empty_like(v_f)
+    for token in range(q.shape[0]):
+        q_i = q_f[token] * scale
+        k_i = k_f[token]
+        v_i = v_f[token]
+        gate_i = gate_f[token]
+        beta_i = beta_f[token]
+        state_f = state_f * torch.exp(gate_i)[..., None]
+        residual = v_i - (k_i[..., None] * state_f).sum(dim=-2)
+        state_f = state_f + torch.einsum(
+            "hk,hv->hkv", beta_i[..., None] * k_i, residual
+        )
+        output[token] = torch.einsum("hk,hkv->hv", q_i, state_f)
+    return output.to(dtype), state_f
+
+
+def _sequence_ranges(
+    batch: int,
+    tokens: int,
+    cu_seqlens: torch.Tensor | None,
+) -> list[tuple[int, int, int]]:
+    if cu_seqlens is None:
+        return [(batch_id, 0, tokens) for batch_id in range(batch)]
+    if batch != 1:
+        raise ValueError("Variable-length KDA expects a flattened batch of 1")
+    boundaries = cu_seqlens.detach().to("cpu", torch.int64).tolist()
+    return [
+        (0, boundaries[i], boundaries[i + 1]) for i in range(len(boundaries) - 1)
+    ]
+
+
+def recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = True,
+    inplace_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    ssm_state_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Backend-neutral KDA recurrence compatible with vLLM's tensor layout."""
+    batch, tokens, heads, key_dim = q.shape
+    value_dim = v.shape[-1]
+    if scale is None:
+        scale = key_dim**-0.5
+    if use_qk_l2norm_in_kernel:
+        q = _l2norm(q)
+        k = _l2norm(k)
+
+    ranges = _sequence_ranges(batch, tokens, cu_seqlens)
+    if initial_state is None:
+        state_count = len(ranges)
+        states = torch.zeros(
+            state_count,
+            heads,
+            key_dim,
+            value_dim,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    else:
+        states = initial_state if inplace_final_state else initial_state.clone()
+
+    if ssm_state_indices is None:
+        state_indices = list(range(len(ranges)))
+    else:
+        indices_cpu = ssm_state_indices.detach().to("cpu", torch.int64)
+        if indices_cpu.ndim == 1:
+            state_indices = indices_cpu.tolist()
+        else:
+            # vLLM's regular decode path uses one state slot per request.  For
+            # speculative metadata use the first accepted slot for the request;
+            # the portable path is correctness-oriented and processes tokens in
+            # request order.
+            state_indices = indices_cpu[:, 0].tolist()
+
+    output = torch.empty_like(v)
+    final_states: list[torch.Tensor] = []
+    for seq_id, (batch_id, start, end) in enumerate(ranges):
+        state_id = int(state_indices[seq_id])
+        seq_out, seq_state = _recurrent_kda_sequence(
+            q[batch_id, start:end],
+            k[batch_id, start:end],
+            v[batch_id, start:end],
+            gate[batch_id, start:end],
+            beta[batch_id, start:end],
+            states[state_id],
+            float(scale),
+        )
+        output[batch_id, start:end] = seq_out
+        states[state_id].copy_(seq_state)
+        final_states.append(seq_state)
+
+    if not output_final_state:
+        return output, None
+    if initial_state is not None and inplace_final_state:
+        return output, initial_state
+    if cu_seqlens is not None or batch == len(ranges):
+        return output, torch.stack(final_states, dim=0)
+    return output, states
+
+
+def chunk_kda_with_safe_gate(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    lower_bound: float = -5.0,
+):
+    gate = safe_kda_gate(
+        raw_g.reshape(*raw_g.shape[:-2], -1),
+        A_log,
+        raw_g.shape[-1],
+        g_bias=g_bias,
+        lower_bound=lower_bound,
+    )
+    return recurrent_kda(
+        q,
+        k,
+        v,
+        gate,
+        beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        cu_seqlens=cu_seqlens,
+    )
+
+
+def fused_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor | None = None,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    inplace_final_state: bool = True,
+    use_qk_l2norm_in_kernel: bool = True,
+    cu_seqlens: torch.Tensor | None = None,
+    ssm_state_indices: torch.Tensor | None = None,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    del kwargs
+    if beta is None:
+        raise ValueError("KDA beta tensor is required")
+    return recurrent_kda(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=True,
+        inplace_final_state=inplace_final_state,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+    )
+
+
+def _apply_causal_conv_activation(
+    value: torch.Tensor, activation: bool | str | None
+) -> torch.Tensor:
+    if activation is True or activation in ("silu", "swish"):
+        return torch.nn.functional.silu(value)
+    if activation in (False, None):
+        return value
+    raise ValueError(f"Unsupported causal-conv activation: {activation}")
+
+
+def _causal_conv_sequence(
+    sequence: torch.Tensor,
+    state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    activation: bool | str | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference depthwise causal convolution for one ``[dim, tokens]`` row."""
+    width = weight.shape[-1]
+    history = state[..., -(width - 1) :].clone()
+    outputs = []
+    for token in range(sequence.shape[-1]):
+        window = torch.cat((history, sequence[:, token : token + 1]), dim=-1)
+        value = (window.float() * weight.float()).sum(dim=-1)
+        if bias is not None:
+            value = value + bias.float()
+        outputs.append(_apply_causal_conv_activation(value, activation))
+        history = window[:, 1:]
+    if outputs:
+        output = torch.stack(outputs, dim=-1).to(sequence.dtype)
+    else:
+        output = sequence.new_empty(sequence.shape)
+    next_state = state.clone()
+    next_state[..., -(width - 1) :] = history.to(next_state.dtype)
+    return output, next_state
+
+
+def causal_conv1d_fn(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    cache_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    activation: bool | str | None = "silu",
+    pad_slot_id: int = -1,
+    null_block_id: int = -1,
+    block_idx_first_scheduled_token: torch.Tensor | None = None,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    num_computed_tokens: torch.Tensor | None = None,
+    block_size_to_align: int = 0,
+    metadata=None,
+    validate_data: bool = False,
+) -> torch.Tensor:
+    """Portable regular-prefill subset of vLLM's causal-conv contract.
+
+    APC cache-block rotation is deliberately rejected rather than silently
+    producing a different state.  Normal continuous-batching prefill, which is
+    the GLM5-Next serving path, is fully covered.
+    """
+    del block_size_to_align, metadata, validate_data
+    if any(
+        value is not None
+        for value in (
+            block_idx_first_scheduled_token,
+            block_idx_last_scheduled_token,
+            initial_state_idx,
+            num_computed_tokens,
+        )
+    ):
+        raise NotImplementedError(
+            "Portable GLM5-Next causal_conv1d_fn does not support APC metadata"
+        )
+    if x.ndim != 2:
+        raise ValueError("Portable causal_conv1d_fn expects [dim, total_tokens]")
+    boundaries = query_start_loc.detach().to("cpu", torch.int64).tolist()
+    output = torch.empty_like(x)
+    for request, (start, end) in enumerate(zip(boundaries[:-1], boundaries[1:])):
+        state_id = request if cache_indices is None else int(cache_indices[request].item())
+        if state_id in (pad_slot_id, null_block_id) or state_id < 0:
+            output[:, start:end].zero_()
+            continue
+        use_state = (
+            has_initial_state is None
+            or bool(has_initial_state[request].item())
+        )
+        state = (
+            conv_states[state_id]
+            if use_state
+            else torch.zeros_like(conv_states[state_id])
+        )
+        request_output, next_state = _causal_conv_sequence(
+            x[:, start:end].to(conv_states.dtype),
+            state,
+            weight,
+            bias,
+            activation,
+        )
+        output[:, start:end] = request_output.to(output.dtype)
+        conv_states[state_id].copy_(next_state)
+    return output
+
+
+def causal_conv1d_update(
+    x: torch.Tensor,
+    conv_state: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    activation: bool | str | None = None,
+    conv_state_indices: torch.Tensor | None = None,
+    num_accepted_tokens: torch.Tensor | None = None,
+    query_start_loc: torch.Tensor | None = None,
+    max_query_len: int = -1,
+    null_block_id: int = -1,
+    block_idx_last_scheduled_token: torch.Tensor | None = None,
+    initial_state_idx: torch.Tensor | None = None,
+    validate_data: bool = False,
+) -> torch.Tensor:
+    """Portable plain/spec-free decode subset of vLLM's causal-conv update."""
+    del max_query_len, validate_data
+    if any(
+        value is not None
+        for value in (
+            num_accepted_tokens,
+            block_idx_last_scheduled_token,
+            initial_state_idx,
+        )
+    ):
+        raise NotImplementedError(
+            "Portable GLM5-Next causal_conv1d_update does not support "
+            "speculative/APC state rotation"
+        )
+
+    if query_start_loc is not None:
+        if x.ndim != 2:
+            raise ValueError("Varlen causal-conv update expects [tokens, dim]")
+        boundaries = query_start_loc.detach().to("cpu", torch.int64).tolist()
+        output = torch.empty_like(x)
+        for request, (start, end) in enumerate(zip(boundaries[:-1], boundaries[1:])):
+            state_id = int(conv_state_indices[request].item())
+            if state_id == null_block_id or state_id < 0:
+                output[start:end].zero_()
+                continue
+            request_output, next_state = _causal_conv_sequence(
+                x[start:end].transpose(0, 1).to(conv_state.dtype),
+                conv_state[state_id],
+                weight,
+                bias,
+                activation,
+            )
+            output[start:end] = request_output.transpose(0, 1).to(output.dtype)
+            conv_state[state_id].copy_(next_state)
+        return output
+
+    squeeze = x.ndim == 2
+    x_3d = x.unsqueeze(-1) if squeeze else x
+    if x_3d.ndim != 3:
+        raise ValueError("Decode causal-conv input must be [batch, dim, tokens]")
+    output = torch.empty_like(x_3d)
+    for request in range(x_3d.shape[0]):
+        state_id = (
+            request
+            if conv_state_indices is None
+            else int(conv_state_indices[request].item())
+        )
+        if state_id == null_block_id or state_id < 0:
+            output[request].zero_()
+            continue
+        request_output, next_state = _causal_conv_sequence(
+            x_3d[request].to(conv_state.dtype),
+            conv_state[state_id],
+            weight,
+            bias,
+            activation,
+        )
+        output[request] = request_output.to(output.dtype)
+        conv_state[state_id].copy_(next_state)
+    return output.squeeze(-1) if squeeze else output
+
+
+def hadamard128(x: torch.Tensor) -> torch.Tensor:
+    """Normalized Walsh-Hadamard transform on the last dimension."""
+    if x.shape[-1] != INDEX_HEAD_DIM:
+        raise ValueError(f"Hadamard input must have dim 128, got {x.shape[-1]}")
+    out = x.float()
+    width = 1
+    while width < INDEX_HEAD_DIM:
+        shape = (*out.shape[:-1], -1, 2, width)
+        pair = out.reshape(shape)
+        left, right = pair.unbind(dim=-2)
+        out = torch.stack((left + right, left - right), dim=-2).reshape_as(out)
+        width *= 2
+    return out * (INDEX_HEAD_DIM**-0.5)
+
+
+def _quantize_fp8_vector(
+    x: torch.Tensor, round_scale: bool
+) -> tuple[torch.Tensor, torch.Tensor]:
+    fp8_dtype, fp8_max = get_fp8_dtype_and_max()
+    absmax = x.abs().amax(dim=-1).clamp_min(1e-4)
+    scale = absmax / fp8_max
+    if round_scale:
+        scale = torch.pow(2.0, torch.ceil(torch.log2(scale)))
+    quant = (x / scale.unsqueeze(-1)).clamp(-fp8_max, fp8_max)
+    try:
+        quant = quant.to(fp8_dtype)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            "The portable GLM5-Next indexer requires float8_e4m3fn support; "
+            "provide the FlagGems FP8 cache operators for this platform."
+        ) from exc
+    return quant, scale.float()
+
+
+def fwht128_quant_fp8(q: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference Hadamard-128 plus per-row ue8m0 FP8 quantization."""
+    if q.ndim != 2 or q.shape[1] != INDEX_HEAD_DIM:
+        raise ValueError(f"Expected [rows, 128] query, got {tuple(q.shape)}")
+    rotated = hadamard128(q).to(torch.bfloat16).float()
+    quantized, scales = _quantize_fp8_vector(rotated, round_scale=True)
+    return quantized, scales.unsqueeze(-1)
+
+
+def _cache_views(
+    kv_cache: torch.Tensor, head_dim: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if kv_cache.dtype != torch.uint8 or kv_cache.ndim != 3:
+        raise ValueError("Indexer cache must be a 3-D uint8 tensor")
+    num_blocks, page_size, _ = kv_cache.shape
+    flat = kv_cache.view(num_blocks, -1)
+    value_bytes = page_size * head_dim
+    values = flat[:, :value_bytes].view(num_blocks, page_size, head_dim)
+    scales = flat[:, value_bytes:].view(torch.float32).view(num_blocks, page_size, -1)
+    return values, scales
+
+
+def write_fp8_cache(
+    kv_cache: torch.Tensor,
+    quantized: torch.Tensor,
+    scales: torch.Tensor,
+    locations: torch.Tensor,
+    head_dim: int,
+    write_mask: torch.Tensor | None = None,
+) -> None:
+    values, cache_scales = _cache_views(kv_cache, head_dim)
+    page_size = kv_cache.shape[1]
+    loc = locations.to(torch.int64)
+    valid = loc >= 0
+    if write_mask is not None:
+        valid = valid & write_mask.bool()
+    if not bool(valid.any()):
+        return
+    blocks = torch.div(loc[valid], page_size, rounding_mode="floor")
+    offsets = torch.remainder(loc[valid], page_size)
+    values[blocks, offsets] = quantized[valid].view(torch.uint8)
+    scale_values = scales[valid]
+    if scale_values.ndim == 1:
+        scale_values = scale_values.unsqueeze(-1)
+    cache_scales[blocks, offsets, : scale_values.shape[-1]] = scale_values
+
+
+def kpool_compress_and_write_cache(
+    kv_cache: torch.Tensor,
+    slot_k: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    loc: torch.Tensor,
+    pool_size: int,
+    head_dim: int = INDEX_HEAD_DIM,
+    write_mask: torch.Tensor | None = None,
+    round_scale: bool = True,
+    return_compressed: bool = False,
+    write_cache: bool = True,
+):
+    """Exact PyTorch composition of GLM's pool/rotate/FP8 cache write."""
+    if slot_k.shape != slot_score.shape:
+        raise ValueError("slot_k and slot_score must have identical shapes")
+    if slot_k.shape[1:] != (pool_size, head_dim):
+        raise ValueError("Unexpected kpool input shape")
+    probabilities = torch.softmax(
+        slot_score.float() + ape.float().unsqueeze(0), dim=1
+    )
+    pooled = (slot_k.float() * probabilities).sum(dim=1)
+    # This BF16 round-trip is part of the supplied reference implementation.
+    rotated = hadamard128(pooled.to(torch.bfloat16).float())
+    quantized, scales = _quantize_fp8_vector(rotated, round_scale)
+    if write_cache:
+        write_fp8_cache(
+            kv_cache,
+            quantized,
+            scales,
+            loc,
+            head_dim,
+            write_mask=write_mask,
+        )
+    if return_compressed:
+        return quantized, scales
+    return None
+
+
+def kpool_decode_update_and_maybe_write_cache_batched(
+    kv_cache: torch.Tensor,
+    tail_kv_cache: torch.Tensor,
+    tail_slot_mapping: torch.Tensor,
+    key: torch.Tensor,
+    slot_score: torch.Tensor,
+    ape: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    positions: torch.Tensor,
+    pool_size: int,
+    head_dim: int = INDEX_HEAD_DIM,
+    round_scale: bool = True,
+) -> None:
+    """Ordered portable decode tail update, including pool-completion writes."""
+    num_requests, next_n = key.shape[:2]
+    for request in range(num_requests):
+        for token in range(next_n):
+            position = int(positions[request, token].item())
+            tail_loc = int(tail_slot_mapping[request, token].item())
+            if position < 0 or tail_loc < 0:
+                continue
+            tail_block = tail_loc // pool_size
+            tail_offset = tail_loc % pool_size
+            # Stash first.  A completion token must be visible to the subsequent
+            # compression read, and tokens of one request are processed in order.
+            tail_kv_cache[tail_block, 0, tail_offset].copy_(key[request, token])
+            tail_kv_cache[tail_block, 1, tail_offset].copy_(
+                slot_score[request, token]
+            )
+            cache_loc = int(slot_mapping[request, token].item())
+            if position % pool_size != pool_size - 1 or cache_loc < 0:
+                continue
+            kpool_compress_and_write_cache(
+                kv_cache,
+                tail_kv_cache[tail_block, 0].unsqueeze(0),
+                tail_kv_cache[tail_block, 1].unsqueeze(0),
+                ape,
+                torch.tensor([cache_loc], dtype=torch.int64, device=key.device),
+                pool_size,
+                head_dim=head_dim,
+                round_scale=round_scale,
+            )
+
+
+def kpool_seed_tail_cache(
+    tail_kv_cache: torch.Tensor,
+    key: torch.Tensor,
+    gate_score: torch.Tensor,
+    tail_slot_mapping: torch.Tensor,
+    kpool: int,
+    head_dim: int = INDEX_HEAD_DIM,
+) -> None:
+    """Seed every request's trailing pool in its request-owned tail ring."""
+    del head_dim
+    num_tokens = tail_slot_mapping.shape[0]
+    if num_tokens == 0:
+        return
+    slots = tail_slot_mapping.to(torch.int64)
+    ahead = torch.full_like(slots, -1)
+    if num_tokens > kpool:
+        ahead[:-kpool] = slots[kpool:]
+    valid = slots >= 0
+    own_blocks = torch.div(slots.clamp_min(0), kpool, rounding_mode="floor")
+    ahead_blocks = torch.div(ahead.clamp_min(0), kpool, rounding_mode="floor")
+    same_request = (ahead >= 0) & (ahead_blocks == own_blocks)
+    keep = valid & ~same_request
+    kept_slots = slots[keep]
+    blocks = torch.div(kept_slots, kpool, rounding_mode="floor")
+    offsets = torch.remainder(kept_slots, kpool)
+    tail_kv_cache[blocks, 0, offsets] = key[keep]
+    tail_kv_cache[blocks, 1, offsets] = gate_score[keep]
+
+
+def expand_pools_to_tokens(
+    group_ids: torch.Tensor,
+    group_valid: torch.Tensor,
+    topk: int,
+    pool_size: int,
+    page_table: torch.Tensor | None = None,
+    topk_offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if topk % pool_size:
+        raise ValueError("topk must be divisible by pool_size")
+    offsets = torch.arange(pool_size, device=group_ids.device, dtype=torch.int64)
+    token_ids = (group_ids.to(torch.int64).unsqueeze(-1) * pool_size + offsets).reshape(
+        group_ids.shape[0], topk
+    )
+    valid = group_valid.unsqueeze(-1).expand(-1, -1, pool_size).reshape_as(token_ids)
+    if page_table is not None:
+        safe_ids = token_ids.clamp(min=0, max=page_table.shape[1] - 1)
+        output = torch.gather(page_table, 1, safe_ids).to(torch.int32)
+    elif topk_offsets is not None:
+        output = (token_ids + topk_offsets.reshape(-1, 1).to(torch.int64)).to(
+            torch.int32
+        )
+    else:
+        output = token_ids.to(torch.int32)
+    return torch.where(valid, output, torch.full_like(output, -1))
+
+
+def append_tail_to_topk(
+    topk_result: torch.Tensor,
+    seq_lens: torch.Tensor,
+    pool_lens: torch.Tensor,
+    pool_size: int,
+    page_table: torch.Tensor | None = None,
+    topk_offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if pool_size == 1:
+        return topk_result
+    rows, history_len = topk_result.shape
+    out_cols = history_len + pool_size - 1
+    cols = torch.arange(out_cols, device=topk_result.device).unsqueeze(0)
+    is_history = cols < history_len
+    safe_hist = cols.clamp(max=history_len - 1).expand(rows, -1)
+    history = torch.gather(topk_result, 1, safe_hist)
+    tail_start = pool_lens.to(torch.int32) * pool_size
+    tail_offset = cols - history_len
+    tail_count = seq_lens.to(torch.int32) - tail_start
+    is_tail = (tail_offset >= 0) & (tail_offset < tail_count.unsqueeze(1))
+    tail_raw = tail_start.unsqueeze(1) + tail_offset
+    if page_table is not None:
+        safe_tail = tail_raw.clamp(min=0, max=page_table.shape[1] - 1)
+        tail = torch.gather(page_table, 1, safe_tail).to(torch.int32)
+    elif topk_offsets is not None:
+        tail = (tail_raw + topk_offsets.reshape(-1, 1).to(torch.int64)).to(
+            torch.int32
+        )
+    else:
+        tail = tail_raw.to(torch.int32)
+    out = torch.where(is_history, history, torch.full_like(history, -1))
+    return torch.where(is_tail, tail, out)
+
+
+def expand_pools_and_append_tail(
+    pool_ids: torch.Tensor,
+    seq_lens: torch.Tensor,
+    pool_size: int,
+) -> torch.Tensor:
+    """Reference composition used when the fused Triton kernel is unavailable."""
+    topk = pool_ids.shape[1] * pool_size
+    expanded = expand_pools_to_tokens(
+        pool_ids,
+        pool_ids >= 0,
+        topk,
+        pool_size,
+    )
+    pool_lens = torch.div(seq_lens, pool_size, rounding_mode="floor").to(
+        torch.int32
+    )
+    return append_tail_to_topk(expanded, seq_lens, pool_lens, pool_size)
+
+
+__all__ = [
+    "append_tail_to_topk",
+    "causal_conv1d_fn",
+    "causal_conv1d_update",
+    "chunk_kda_with_safe_gate",
+    "expand_pools_and_append_tail",
+    "expand_pools_to_tokens",
+    "fwht128_quant_fp8",
+    "fused_recurrent_kda",
+    "get_fp8_dtype_and_max",
+    "hadamard128",
+    "kpool_compress_and_write_cache",
+    "kpool_decode_update_and_maybe_write_cache_batched",
+    "kpool_seed_tail_cache",
+    "recurrent_kda",
+    "safe_kda_gate",
+    "safe_kda_gate_chunk_cumsum",
+    "write_fp8_cache",
+]

--- a/vllm_fl/kernels/glm5_next/portable.py
+++ b/vllm_fl/kernels/glm5_next/portable.py
@@ -634,8 +634,12 @@ def kpool_decode_update_and_maybe_write_cache_batched(
                 continue
             kpool_compress_and_write_cache(
                 kv_cache,
-                tail_kv_cache[tail_block, 0].unsqueeze(0),
-                tail_kv_cache[tail_block, 1].unsqueeze(0),
+                tail_kv_cache[
+                    tail_block, 0, tail_offset - pool_size + 1 : tail_offset + 1
+                ].unsqueeze(0),
+                tail_kv_cache[
+                    tail_block, 1, tail_offset - pool_size + 1 : tail_offset + 1
+                ].unsqueeze(0),
                 ape,
                 torch.tensor([cache_loc], dtype=torch.int64, device=key.device),
                 pool_size,

--- a/vllm_fl/kernels/glm5_next/provider.py
+++ b/vllm_fl/kernels/glm5_next/provider.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Process-start provider override for GLM5-Next A/B validation."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Literal, cast
+
+from vllm.platforms import current_platform
+
+Provider = Literal["auto", "nvidia", "flaggems"]
+ENV_NAME = "VLLM_FL_GLM5_PROVIDER"
+
+
+@lru_cache(maxsize=1)
+def get_glm5_provider() -> Provider:
+    value = os.environ.get(ENV_NAME, "auto").strip().lower()
+    if value not in ("auto", "nvidia", "flaggems"):
+        raise ValueError(
+            f"{ENV_NAME} must be one of auto|nvidia|flaggems, got {value!r}"
+        )
+    if value == "nvidia" and not current_platform.is_cuda():
+        raise RuntimeError(
+            f"{ENV_NAME}=nvidia requires an NVIDIA CUDA platform"
+        )
+    return cast(Provider, value)
+
+
+def use_nvidia_reference() -> bool:
+    provider = get_glm5_provider()
+    return provider == "nvidia" or (
+        provider == "auto" and current_platform.is_cuda()
+    )
+
+
+__all__ = ["ENV_NAME", "get_glm5_provider", "use_nvidia_reference"]

--- a/vllm_fl/kernels/glm5_next/provider.py
+++ b/vllm_fl/kernels/glm5_next/provider.py
@@ -3,14 +3,54 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 from functools import lru_cache
 from typing import Literal, cast
 
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
 Provider = Literal["auto", "nvidia", "flaggems"]
 ENV_NAME = "VLLM_FL_GLM5_PROVIDER"
+_VLLM_NATIVE_EXTENSIONS = ("vllm._C", "vllm._C_stable_libtorch")
+
+logger = init_logger(__name__)
+
+
+def _has_vllm_native_extension() -> bool:
+    """Return whether a vLLM native CUDA ABI can be imported.
+
+    vLLM 0.24 deployments use either the legacy ``_C`` extension or the
+    stable-ABI ``_C_stable_libtorch`` extension.  The empty-build wheel has
+    neither one, even though it still provides the Python vLLM package.
+    """
+    for module_name in _VLLM_NATIVE_EXTENSIONS:
+        try:
+            importlib.import_module(module_name)
+        except (ImportError, OSError, RuntimeError):
+            continue
+        return True
+    return False
+
+
+def _has_deep_gemm() -> bool:
+    """Probe the vLLM DeepGEMM capability without failing model import."""
+    try:
+        from vllm.utils.deep_gemm import has_deep_gemm
+    except (ImportError, AttributeError, OSError, RuntimeError):
+        return False
+
+    try:
+        return bool(has_deep_gemm())
+    except (ImportError, AttributeError, OSError, RuntimeError):
+        return False
+
+
+@lru_cache(maxsize=1)
+def _has_nvidia_reference_kernels() -> bool:
+    """Check the native ABI and DeepGEMM prerequisites for GLM5's fast path."""
+    return _has_vllm_native_extension() and _has_deep_gemm()
 
 
 @lru_cache(maxsize=1)
@@ -21,17 +61,25 @@ def get_glm5_provider() -> Provider:
             f"{ENV_NAME} must be one of auto|nvidia|flaggems, got {value!r}"
         )
     if value == "nvidia" and not current_platform.is_cuda():
-        raise RuntimeError(
-            f"{ENV_NAME}=nvidia requires an NVIDIA CUDA platform"
-        )
+        raise RuntimeError(f"{ENV_NAME}=nvidia requires an NVIDIA CUDA platform")
     return cast(Provider, value)
 
 
 def use_nvidia_reference() -> bool:
     provider = get_glm5_provider()
-    return provider == "nvidia" or (
-        provider == "auto" and current_platform.is_cuda()
+    if provider == "nvidia":
+        return True
+    if provider != "auto" or not current_platform.is_cuda():
+        return False
+
+    if _has_nvidia_reference_kernels():
+        return True
+
+    logger.warning_once(
+        "GLM5-Next auto provider could not find both a vLLM native CUDA ABI "
+        "and DeepGEMM; using the FlagGems/Triton/portable implementation"
     )
+    return False
 
 
 __all__ = ["ENV_NAME", "get_glm5_provider", "use_nvidia_reference"]

--- a/vllm_fl/kernels/glm5_next/safe_kda.py
+++ b/vllm_fl/kernels/glm5_next/safe_kda.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded GLM5-Next KDA gates on top of vLLM 0.24's KDA core.
+
+The two Triton kernels are the safe-gate branches from the supplied vLLM
+reference implementation.  The recurrent/chunk KDA math is delegated to the
+unchanged vLLM 0.24 FLA core after producing the same gate tensors.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from vllm.model_executor.layers.fla.ops import kda as _kda
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import RCP_LN2, cdiv, next_power_of_2
+
+
+@triton.heuristics(
+    {
+        "HAS_BIAS": lambda args: args["g_bias"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BD": bd}, num_warps=num_warps)
+        for bd in [32, 64]
+        for num_warps in [2, 4, 8]
+    ],
+    key=["H", "D", "BT", "IS_VARLEN"],
+)
+@triton.jit(do_not_specialize=["T"])
+def _safe_gate_cumsum_kernel(
+    g,
+    A,
+    y,
+    g_bias,
+    cu_seqlens,
+    chunk_indices,
+    cumsum_scale,
+    lower_bound: tl.constexpr,
+    T,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_d, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos = i_b * T
+
+    p_g = tl.make_block_ptr(
+        g + (bos * H + i_h) * D,
+        (T, D),
+        (H * D, 1),
+        (i_t * BT, i_d * BD),
+        (BT, BD),
+        (1, 0),
+    )
+    p_y = tl.make_block_ptr(
+        y + (bos * H + i_h) * D,
+        (T, D),
+        (H * D, 1),
+        (i_t * BT, i_d * BD),
+        (BT, BD),
+        (1, 0),
+    )
+
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    if HAS_BIAS:
+        o_d = i_d * BD + tl.arange(0, BD)
+        b_bias = tl.load(g_bias + i_h * D + o_d, mask=o_d < D, other=0.0).to(
+            tl.float32
+        )
+        b_g += b_bias[None, :]
+
+    b_a = tl.exp(tl.load(A + i_h).to(tl.float32))
+    b_gate = lower_bound / (1.0 + tl.exp(-(b_a * b_g)))
+
+    # Chunk-local inclusive cumsum, stored in log2 units for the downstream
+    # exp2-based KDA core.
+    o_t = tl.arange(0, BT)
+    m_cumsum = tl.where(o_t[:, None] >= o_t[None, :], 1.0, 0.0)
+    b_y = tl.dot(m_cumsum, b_gate, allow_tf32=False) * cumsum_scale
+    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+
+
+def fused_safe_kda_gate_chunk_cumsum(
+    raw_g: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None = None,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+    chunk_size: int = _kda.FLA_CHUNK_SIZE,
+    output_dtype: torch.dtype | None = torch.float,
+    lower_bound: float = -5.0,
+) -> torch.Tensor:
+    if cu_seqlens is not None:
+        assert raw_g.shape[0] == 1
+    batch, tokens, heads, dim = raw_g.shape
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = _kda.prepare_chunk_indices(cu_seqlens, chunk_size)
+    num_chunks = (
+        cdiv(tokens, chunk_size)
+        if cu_seqlens is None
+        else len(chunk_indices)
+    )
+    A_log = A_log.reshape(-1)
+    if g_bias is not None:
+        g_bias = g_bias.reshape(-1)
+    out = torch.empty_like(raw_g, dtype=output_dtype or raw_g.dtype)
+
+    def grid(meta):
+        return (cdiv(meta["D"], meta["BD"]), num_chunks, batch * heads)
+
+    _safe_gate_cumsum_kernel[grid](
+        g=raw_g,
+        A=A_log,
+        y=out,
+        g_bias=g_bias,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        cumsum_scale=RCP_LN2,
+        lower_bound=lower_bound,
+        T=tokens,
+        H=heads,
+        D=dim,
+        BT=chunk_size,
+    )
+    return out
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": bt}, num_warps=nw, num_stages=ns)
+        for bt in _kda.BT_LIST_AUTOTUNE
+        for nw in _kda.NUM_WARPS_AUTOTUNE
+        for ns in [2, 3]
+    ],
+    key=["H", "D"],
+)
+@triton.jit
+def _safe_gate_kernel(
+    g,
+    A,
+    y,
+    g_bias,
+    lower_bound: tl.constexpr,
+    T,
+    H,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    i_t, i_h = tl.program_id(0), tl.program_id(1)
+    n_t = i_t * BT
+    b_a = tl.exp(tl.load(A + i_h).to(tl.float32))
+
+    g_ptr = tl.make_block_ptr(
+        base=g + i_h * D,
+        shape=(T, D),
+        strides=(H * D, 1),
+        offsets=(n_t, 0),
+        block_shape=(BT, BD),
+        order=(1, 0),
+    )
+    y_ptr = tl.make_block_ptr(
+        base=y + i_h * D,
+        shape=(T, D),
+        strides=(H * D, 1),
+        offsets=(n_t, 0),
+        block_shape=(BT, BD),
+        order=(1, 0),
+    )
+    b_g = tl.load(g_ptr, boundary_check=(0, 1)).to(tl.float32)
+    if HAS_BIAS:
+        n_d = tl.arange(0, BD)
+        b_bias = tl.load(g_bias + i_h * D + n_d, mask=n_d < D, other=0.0).to(
+            tl.float32
+        )
+        b_g += b_bias[None, :]
+    b_y = lower_bound / (1.0 + tl.exp(-(b_a * b_g)))
+    tl.store(y_ptr, b_y.to(y.dtype.element_ty), boundary_check=(0, 1))
+
+
+def fused_safe_kda_gate(
+    g: torch.Tensor,
+    A_log: torch.Tensor,
+    head_k_dim: int,
+    g_bias: torch.Tensor | None = None,
+    lower_bound: float = -5.0,
+) -> torch.Tensor:
+    """Compute ``lower_bound*sigmoid(exp(A_log)*(g+g_bias))`` in FP32."""
+    orig_shape = g.shape[:-1]
+    g = g.view(-1, g.shape[-1])
+    tokens, hidden = g.shape
+    heads = A_log.numel()
+    assert heads * head_k_dim == hidden
+    out = torch.empty_like(g, dtype=torch.float32)
+
+    def grid(meta):
+        return (cdiv(tokens, meta["BT"]), heads)
+
+    _safe_gate_kernel[grid](
+        g,
+        A_log,
+        out,
+        g_bias,
+        lower_bound,
+        tokens,
+        heads,
+        head_k_dim,
+        BD=next_power_of_2(head_k_dim),
+        HAS_BIAS=g_bias is not None,
+    )
+    return out.view(*orig_shape, heads, head_k_dim)
+
+
+def chunk_kda_with_safe_gate(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    g_bias: torch.Tensor | None,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    lower_bound: float = -5.0,
+):
+    """Reference prefill path: bounded gate + chunk cumsum + vLLM KDA core."""
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    if use_qk_l2norm_in_kernel:
+        q = _kda.l2norm_fwd(q.contiguous())
+        k = _kda.l2norm_fwd(k.contiguous())
+    chunk_size = _kda.FLA_CHUNK_SIZE
+    chunk_indices = (
+        _kda.prepare_chunk_indices(cu_seqlens, chunk_size)
+        if cu_seqlens is not None
+        else None
+    )
+    gate = fused_safe_kda_gate_chunk_cumsum(
+        raw_g.contiguous(),
+        A_log,
+        g_bias=g_bias,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+        lower_bound=lower_bound,
+    )
+    return _kda._chunk_kda_fwd_with_cumulative_g(
+        q=q,
+        k=k,
+        v=v.contiguous(),
+        g=gate,
+        beta=beta.contiguous(),
+        scale=scale,
+        initial_state=(initial_state.contiguous() if initial_state is not None else None),
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        chunk_size=chunk_size,
+    )
+
+
+__all__ = [
+    "chunk_kda_with_safe_gate",
+    "fused_safe_kda_gate",
+    "fused_safe_kda_gate_chunk_cumsum",
+]

--- a/vllm_fl/kernels/glm5_next/sparse_attn_indexer_kpool.py
+++ b/vllm_fl/kernels/glm5_next/sparse_attn_indexer_kpool.py
@@ -1,0 +1,1056 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Custom Sparse Attention Indexer layers."""
+
+import os
+
+import torch
+
+import vllm.envs as envs
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+from vllm.config import get_current_vllm_config_or_none
+from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
+from vllm.model_executor.custom_op import CustomOp
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _encode_layer_name,
+    _resolve_layer_name,
+    direct_register_custom_op,
+)
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerMetadata,
+)
+from vllm.v1.worker.workspace import current_workspace_manager
+
+from vllm_fl.kernels.glm5_next.indexer_backend import INDEXER_BACKEND
+
+logger = init_logger(__name__)
+
+RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
+
+# MXFP4 layout: 2 values packed per byte, ue8m0 (1-byte) scale per block of 32.
+MXFP4_BLOCK_SIZE = 32
+
+# kpool write helper: form pools from the current token batch and compress them
+# into the index K cache via the fused Triton kernel.
+
+
+def _kpool_compress_insert(
+    k: torch.Tensor,
+    gate_score: torch.Tensor,
+    ape: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    kpool: int,
+    head_dim: int,
+    round_scale: bool,
+) -> None:
+    """Pool ``kpool`` consecutive tokens into one fp8 K and write at pool slots.
+
+    ``slot_mapping`` is pool-granular (compress_ratio == kpool on the spec):
+    only the *last* token of each complete pool carries a valid (>=0) slot;
+    intra-pool tokens are -1. Every position is treated as a pool-completion
+    candidate and non-completions are masked off inside the kernel. Compacting
+    the valid rows first (``torch.nonzero`` + boolean-mask gather + an
+    ``ok.all()`` check) costs two device syncs on the eager prefill path and
+    buys nothing numerically. Assumes pool-aligned chunk starts (same
+    invariant as sglang).
+    """
+    n = slot_mapping.shape[0]
+    # No pool can complete in a batch smaller than one pool; also keeps the
+    # clamped gather indices below in bounds.
+    if n < kpool:
+        return
+    pos = torch.arange(n, device=k.device)
+    valid = slot_mapping >= 0
+    # Drop pools whose start falls before the batch (leading padding); their
+    # gate/k data is undefined anyway.
+    write_mask = valid & (pos >= kpool - 1)
+    offs = torch.arange(kpool, device=k.device)
+    idx = (pos - (kpool - 1)).clamp_min(0)[:, None] + offs[None, :]
+    INDEXER_BACKEND.kpool_compress_and_write_cache(
+        kv_cache,
+        k[idx],  # [n, kpool, head_dim]
+        gate_score[idx],
+        ape,
+        slot_mapping.to(torch.int64),
+        pool_size=kpool,
+        head_dim=head_dim,
+        write_mask=write_mask,
+        round_scale=round_scale,
+        write_cache=True,
+        return_compressed=False,
+    )
+
+
+def _build_decode_scatter_indices(
+    decode_lens: torch.Tensor,
+    num_requests: int,
+    n: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-token (request id, intra-request index) for a non-uniform decode
+    batch, with ``n == decode_lens.sum()`` as a host int (avoids a
+    device sync and keeps both repeat_interleaves sync-free).
+
+    Shared by every ``_scatter_decode_tokens_by_request`` call in a step:
+    building it per call would repeat the same repeat_interleave/cumsum chain
+    up to 5x per layer on the eager decode break.
+    """
+    device = decode_lens.device
+    dl = decode_lens.to(torch.int64)
+    req_id = torch.repeat_interleave(
+        torch.arange(num_requests, device=device, dtype=torch.int64),
+        dl,
+        output_size=n,
+    )
+    req_starts = torch.cumsum(
+        torch.cat([torch.zeros(1, device=device, dtype=torch.int64), dl[:-1]]),
+        dim=0,
+    )
+    # Broadcast the per-request start offsets to per-token (length n ==
+    # dl.sum()) so each token's intra-request index subtracts its own
+    # request's start.
+    starts = torch.repeat_interleave(req_starts, dl, output_size=n)
+    intra = torch.arange(n, device=device, dtype=torch.int64) - starts
+    return req_id, intra
+
+
+def _scatter_decode_tokens_by_request(
+    tokens: torch.Tensor,
+    pad_value,
+    num_requests: int,
+    lmax: int,
+    scatter_indices: tuple[torch.Tensor, torch.Tensor],
+) -> torch.Tensor:
+    """Group ``[N, ...]`` decode tokens into a padded ``[num_requests, lmax, ...]``
+    layout: request ``r``'s tokens at row ``r`` in order; short requests padded.
+
+    Unlike ``pack_seq_triton`` this is dtype-agnostic (needed for the int32
+    slot/pos tensors) — it scatters with the shared per-step indices from
+    ``_build_decode_scatter_indices``. Used only for the non-uniform
+    (``requires_padding``) decode batch; uniform batches use a zero-copy
+    reshape.
+    """
+    req_id, intra = scatter_indices
+    out = torch.full(
+        (num_requests, lmax, *tokens.shape[1:]),
+        pad_value,
+        dtype=tokens.dtype,
+        device=tokens.device,
+    )
+    out[req_id, intra] = tokens
+    return out
+
+
+def _decode_write_layout(
+    decode_metadata,
+    num_requests: int,
+    num_decode_tokens: int,
+) -> tuple[bool, torch.Tensor, int]:
+    """Resolve the request grouping used by the kpool decode writer.
+
+    GLM5-Next's extended indexer metadata carries the original per-request
+    decode lengths plus host-side uniformity metadata.  Stock vLLM 0.24's
+    ``DeepSeekV32IndexerDecodeMetadata`` does not have those extension fields,
+    so retain its legacy, host-static layout as a narrow compatibility path.
+    """
+    per_req_lens = getattr(decode_metadata, "per_req_decode_lens", None)
+    if per_req_lens is not None:
+        lmax = getattr(decode_metadata, "write_max_decode_len", 1)
+        use_uniform = (
+            getattr(decode_metadata, "decode_is_uniform", True)
+            and num_decode_tokens == num_requests * lmax
+        )
+        return use_uniform, per_req_lens, lmax
+
+    use_uniform = not decode_metadata.requires_padding
+    lmax = (
+        max(1, num_decode_tokens // max(1, num_requests))
+        if use_uniform
+        else max(1, num_decode_tokens)
+    )
+    return use_uniform, decode_metadata.decode_lens, lmax
+
+
+def _decode_topk_seq_lens(
+    positions: torch.Tensor,
+    decode_lens: torch.Tensor,
+    num_decode_tokens: int,
+    batch_size: int,
+    next_n: int,
+    requires_padding: bool,
+) -> torch.Tensor:
+    """Token-granular seq_len (pos + 1) per pool-topk row, layout-aware.
+
+    ``pool_topk`` (and the logits it comes from) follow the padded
+    ``[batch_size, next_n]`` grid whenever ``requires_padding`` is set, so row
+    ``(b, t)`` corresponds to flat decode token ``offset_b + t`` -- NOT
+    ``b * next_n + t``. Slicing flat ``positions[: batch_size * next_n]``
+    (the uniform-layout shortcut) misaligns every row after the first
+    non-uniform request and, past the decode region, reads prefill tokens'
+    positions; ``expand_pools_and_append_tail`` then anchors the tail at
+    another request's length, dropping the row's real tail tokens or emitting
+    indices past its sequence (out-of-bounds block-table reads). Padded rows
+    get 0 (empty tail); they are dropped by ``unpack_seq_triton`` anyway.
+    """
+    n = batch_size * next_n
+    if not requires_padding:
+        return positions[:n].to(torch.int32) + 1
+    scatter_idx = _build_decode_scatter_indices(
+        decode_lens, batch_size, num_decode_tokens
+    )
+    padded = _scatter_decode_tokens_by_request(
+        positions[:num_decode_tokens].to(torch.int32),
+        -1,
+        batch_size,
+        next_n,
+        scatter_idx,
+    )
+    return padded.reshape(n) + 1  # pad rows: -1 + 1 = 0 -> empty tail
+
+
+def _gather_workspace_shapes(
+    total_seq_lens: int,
+    head_dim: int,
+    fp8_dtype: torch.dtype,
+    use_fp4_cache: bool,
+) -> tuple[tuple[tuple[int, int], torch.dtype], tuple[tuple[int, int], torch.dtype]]:
+    """Return ((values_shape, values_dtype), (scales_shape, scales_dtype)) for
+    the K-gather workspace. FP8 path: (T, head_dim) fp8 + (T, 4) uint8 fp32
+    scales. MXFP4 path: (T, head_dim // 2) uint8 packed mxfp4 +
+    (T, head_dim // MXFP4_BLOCK_SIZE) uint8 ue8m0 scales."""
+    if use_fp4_cache:
+        return (
+            ((total_seq_lens, head_dim // 2), torch.uint8),
+            ((total_seq_lens, head_dim // MXFP4_BLOCK_SIZE), torch.uint8),
+        )
+    return (
+        ((total_seq_lens, head_dim), fp8_dtype),
+        ((total_seq_lens, 4), torch.uint8),
+    )
+
+
+def kv_cache_as_quant_view(
+    kv_cache: torch.Tensor,
+    head_dim: int,
+    use_fp4_cache: bool,
+) -> torch.Tensor:
+    """4D ``[num_blocks, block_size, 1, head_width]`` view expected by
+    DeepGEMM, from the 3D indexer kv-cache allocation."""
+    if use_fp4_cache:
+        assert kv_cache.ndim == 3 and kv_cache.dtype == torch.uint8
+        num_blocks, block_size, _ = kv_cache.shape
+        page_bytes = int(kv_cache.stride(0))
+        fp4_bytes = head_dim // 2 + head_dim // MXFP4_BLOCK_SIZE
+        return torch.as_strided(
+            kv_cache,
+            size=(num_blocks, block_size, 1, fp4_bytes),
+            stride=(page_bytes, fp4_bytes, fp4_bytes, 1),
+        )
+    return kv_cache.unsqueeze(-2)
+
+
+@eager_break_during_capture
+def sparse_attn_indexer_kpool(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q_quant: torch.Tensor,
+    q_scale: torch.Tensor | None,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    quant_block_size: int,
+    scale_fmt: str | None,
+    topk_tokens: int,
+    head_dim: int,
+    max_model_len: int,
+    total_seq_lens: int,
+    topk_indices_buffer: torch.Tensor,
+    skip_k_cache_insert: bool,
+    use_fp4_cache: bool = False,
+    # kpool params (Plan-A: gate is consumed at write time and read back at
+    # topk time to softmax-weight the pool).
+    gate_score: torch.Tensor | None = None,
+    compress_ape: torch.Tensor | None = None,
+    index_kpool: int = 1,
+    positions: torch.Tensor | None = None,
+    # Paged tail cache (in-progress pool's raw K + gate score), replacing the
+    # transient _DECODE_TAIL ring. tail_prefix resolves attn_metadata[tail_prefix]
+    # for the tail group's token-granular slot_mapping. None on the dummy/profiling
+    # path and when the tail cache is disabled.
+    tail_kv_cache: torch.Tensor | None = None,
+    tail_prefix: str | None = None,
+) -> torch.Tensor:
+    # careful! this will be None in dummy run
+    attn_metadata = get_forward_context().attn_metadata
+    fp8_dtype = current_platform.fp8_dtype()
+    k_cache_prefix = _resolve_layer_name(k_cache_prefix)
+
+    # assert isinstance(attn_metadata, dict)
+    if not isinstance(attn_metadata, dict):
+        # Reserve workspace for indexer during profiling run
+        values_spec, scales_spec = _gather_workspace_shapes(
+            total_seq_lens, head_dim, fp8_dtype, use_fp4_cache
+        )
+        current_workspace_manager().get_simultaneous(
+            values_spec,
+            scales_spec,
+            ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+        )
+
+        # Sentinel allocation so the profiler's peak-memory measurement covers
+        # the runtime logits tensor. The decode-path fp8_fp4_paged_mqa_logits
+        # output is [B*next_n, max_model_len] float32 -- sized by max_model_len,
+        # NOT bounded by the prefill chunk cap. This profiling branch returns
+        # the fake before ever calling that kernel, so its output tensor is
+        # invisible unless we size this sentinel to the real worst-case decode
+        # batch; otherwise large max_model_len / max_num_batched_tokens OOMs at
+        # warmup (the old fixed VLLM_SPARSE_INDEXER_MAX_LOGITS_MB=512MiB was
+        # ~10x too small at max_model_len=1M / b8192).
+        cfg = get_current_vllm_config_or_none()
+        worst_decode_tokens = 0
+        if cfg is not None:
+            sched = cfg.scheduler_config
+            num_spec = (
+                cfg.speculative_config.num_speculative_tokens
+                if cfg.speculative_config is not None
+                else 0
+            )
+            worst_decode_tokens = min(
+                sched.max_num_seqs * (num_spec + 1),
+                sched.max_num_batched_tokens,
+            )
+        # float32 logits -> 4 bytes/element; uint8 sentinel so elems == bytes.
+        decode_logits_elems = worst_decode_tokens * max_model_len * 4
+        prefill_cap_elems = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
+        max_logits_elems = max(decode_logits_elems, prefill_cap_elems)
+        _ = torch.empty(
+            max_logits_elems, dtype=torch.uint8, device=hidden_states.device
+        )
+
+        return sparse_attn_indexer_kpool_fake(
+            hidden_states,
+            k_cache_prefix,
+            kv_cache,
+            q_quant,
+            q_scale,
+            k,
+            weights,
+            quant_block_size,
+            scale_fmt,
+            topk_tokens,
+            head_dim,
+            max_model_len,
+            total_seq_lens,
+            topk_indices_buffer,
+            skip_k_cache_insert,
+            use_fp4_cache,
+        )
+    attn_metadata_narrowed = attn_metadata[k_cache_prefix]
+    assert isinstance(attn_metadata_narrowed, DeepseekV32IndexerMetadata)
+    slot_mapping = attn_metadata_narrowed.slot_mapping
+    has_decode = attn_metadata_narrowed.num_decodes > 0
+    has_prefill = attn_metadata_narrowed.num_prefills > 0
+    num_decode_tokens = attn_metadata_narrowed.num_decode_tokens
+
+    # q_scale is required iff the FP4 cache path is enabled; the FP8 path
+    # folds the Q scale into `weights` inside fused_indexer_q_rope_quant.
+    if use_fp4_cache:
+        assert q_scale is not None, "use_fp4_cache=True requires q_scale"
+    else:
+        assert q_scale is None, "q_scale must be None when use_fp4_cache=False"
+
+    # During speculative decoding, k may be padded to the CUDA graph batch
+    # size while slot_mapping only covers actual tokens. Truncate k to avoid
+    # out-of-bounds reads in the kernel.
+    num_tokens = slot_mapping.shape[0]
+    if k is not None:
+        k = k[:num_tokens]
+
+    if not skip_k_cache_insert:
+        assert not use_fp4_cache, "Unfused FP4 Insert is not supported yet"
+        if index_kpool > 1 and gate_score is not None and compress_ape is not None:
+            # kpool prefill write: pool kpool consecutive prefill tokens via
+            # softmax(gate+ape)-weighted sum -> Hadamard -> fp8 -> pool slots.
+            # Decode tokens (the first num_decode_tokens in the batch) cannot be
+            # pooled here — their pool's earlier tokens are not in this batch —
+            # so they are deferred to the tail-buffer kernel in has_decode.
+            # compress_ratio == index_kpool makes slot_mapping pool-granular.
+            n_prefill = num_tokens - num_decode_tokens
+            if n_prefill > 0:
+                # decode tokens are batched first; prefill tokens follow.
+                prefill_slice = slice(num_decode_tokens, num_tokens)
+                _kpool_compress_insert(
+                    k[prefill_slice],
+                    gate_score[prefill_slice],
+                    compress_ape,
+                    kv_cache,
+                    slot_mapping[prefill_slice],
+                    index_kpool,
+                    head_dim,
+                    round_scale=(scale_fmt is not None),
+                )
+                # Persist the prefill tail (trailing incomplete pool's raw K +
+                # gate score) into the paged tail cache, so the decode side can
+                # compress the boundary pool correctly -- including across PD
+                # transfer, where the connector ships this block. Their tail
+                # slots land at offsets pos % kpool of the request's tail block,
+                # exactly where the decode reconstruction reads them.
+                #
+                # This must run PER REQUEST (sglang writes the tail inside its
+                # per-request extend loop, `set_compress_tail_for_request`).
+                # Taking the batch's trailing `n_prefill % kpool` tokens only
+                # covers the LAST request: every other request in a
+                # multi-request prefill batch then compresses its boundary pool
+                # against a stale tail block (the ring is reused across
+                # requests), corrupting one pool at each request's
+                # prompt->decode boundary. Invisible on single-request probes;
+                # hit by every concurrent-serving batch.
+                if (
+                    tail_kv_cache is not None
+                    and tail_prefix is not None
+                    and os.environ.get("VLLM_KPOOL_SKIP_TAIL_CACHE") != "1"
+                ):
+                    tail_meta = attn_metadata.get(_resolve_layer_name(tail_prefix))
+                    if tail_meta is not None:
+                        assert isinstance(tail_meta, DeepseekV32IndexerMetadata)
+                        # Seed each request's trailing <= kpool raw K + gate
+                        # into the paged tail ring with one kernel. The old
+                        # scatter chain (block-id compare + nonzero/boolean
+                        # gathers + 2 indexed writes) cost ~12 elementwise ops
+                        # and 4 device syncs per layer; the kernel derives the
+                        # same per-request tail membership in-kernel: token i
+                        # is in its request's tail iff the token kpool ahead
+                        # maps to a different tail block (1 block/req) or is
+                        # past the batch. Writes are one-per-token to distinct
+                        # pos % kpool offsets, so the result is identical.
+                        INDEXER_BACKEND.kpool_seed_tail_cache(
+                            tail_kv_cache,
+                            k[prefill_slice],
+                            gate_score[prefill_slice],
+                            tail_meta.slot_mapping[prefill_slice],
+                            index_kpool,
+                            head_dim,
+                        )
+        else:
+            # standard: per-token fp8 quant + scatter (all tokens).
+            assert scale_fmt is not None
+            INDEXER_BACKEND.indexer_k_quant_and_cache(
+                k,
+                kv_cache,
+                slot_mapping,
+                quant_block_size,
+                scale_fmt,
+            )
+
+    topk_indices_buffer[: hidden_states.shape[0]] = -1
+    if has_prefill:
+        prefill_metadata = attn_metadata_narrowed.prefill
+        assert prefill_metadata is not None
+
+        # Short-sequence full-attention fast path (mirrors sglang
+        # IndexerKPool._full_topk_for_short_sequence). When every prefill
+        # request's full context is <= topk_tokens, sparse selection would
+        # pick ALL pools anyway (topk_pool = topk_tokens // index_kpool >=
+        # num_pools, plus the always-selected tail == every token), so running
+        # the MQA-logits is pointless and (in this port) triggers OOBs. Skip
+        # it and attend to every token causally instead. The index-K cache was
+        # already written above; this only fills the topk buffer. Real
+        # sparsity only kicks in for contexts > topk_tokens.
+        n_prefill_sf = num_tokens - num_decode_tokens
+        # Host-side short-prefill predicate: max_prefill_seq_len is computed
+        # in the metadata builder (exact for prefill rows) and equals
+        # positions[prefill_slice].max() + 1, so this replaces a
+        # positions.max().item() device sync per layer. -1 (unknown metadata)
+        # falls back to the device-side check.
+        if getattr(prefill_metadata, "max_prefill_seq_len", -1) >= 0:
+            short_prefill = (
+                n_prefill_sf > 0
+                and positions is not None
+                and getattr(prefill_metadata, "max_prefill_seq_len", -1) <= topk_tokens
+            )
+        else:
+            short_prefill = (
+                n_prefill_sf > 0
+                and positions is not None
+                and int(positions[num_decode_tokens:num_tokens].max().item()) + 1
+                <= topk_tokens
+            )
+        if short_prefill:
+            # short_prefill is only True when positions is not None (above),
+            # but narrow explicitly for the indexer below.
+            assert positions is not None
+            _arange = torch.arange(
+                topk_indices_buffer.shape[1],
+                device=topk_indices_buffer.device,
+                dtype=torch.int32,
+            )
+            _pos = positions[num_decode_tokens:num_tokens].to(torch.int32)
+            _buf = topk_indices_buffer[num_decode_tokens:num_tokens]
+            _buf[:] = _arange[None, :]
+            _buf[_arange[None, :] > _pos[:, None]] = -1
+
+        # Get the full shared workspace buffers once (will allocate on first use).
+        # Layout switches between FP8 (head_dim bytes + 4-byte fp32 scale) and
+        # MXFP4 (head_dim/2 bytes packed + head_dim/MXFP4_BLOCK_SIZE ue8m0
+        # scales) based on use_fp4_cache.
+        workspace_manager = current_workspace_manager()
+        values_spec, scales_spec = _gather_workspace_shapes(
+            total_seq_lens, head_dim, fp8_dtype, use_fp4_cache
+        )
+        k_quant_full, k_scale_full = workspace_manager.get_simultaneous(
+            values_spec,
+            scales_spec,
+        )
+        for chunk in prefill_metadata.chunks if not short_prefill else ():
+            k_quant = k_quant_full[: chunk.total_seq_lens]
+            k_scale = k_scale_full[: chunk.total_seq_lens]
+
+            if not chunk.skip_kv_gather:
+                INDEXER_BACKEND.cp_gather_indexer_k_quant_cache(
+                    kv_cache,
+                    k_quant,
+                    k_scale,
+                    chunk.block_table,
+                    chunk.cu_seq_lens,
+                )
+
+            q_slice = q_quant[chunk.token_start : chunk.token_end]
+            q_scale_slice = (
+                q_scale[chunk.token_start : chunk.token_end]
+                if q_scale is not None
+                else None
+            )
+            # DeepGEMM scalar-type tags (zero-copy): MXFP4 values → int8
+            # (kPackedFP4), scales → int32 squeezed to 1-D kv_sf / 2-D q_sf.
+            if use_fp4_cache:
+                q_slice_cast = q_slice.view(torch.int8)
+                k_quant_cast = k_quant.view(torch.int8)
+                k_scale_cast = k_scale.view(torch.int32).squeeze(-1)
+            else:
+                q_slice_cast = q_slice
+                k_quant_cast = k_quant
+                k_scale_cast = k_scale.view(torch.float32).squeeze(-1)
+            logits = INDEXER_BACKEND.mqa_logits(
+                (q_slice_cast, q_scale_slice),
+                (k_quant_cast, k_scale_cast),
+                weights[chunk.token_start : chunk.token_end],
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
+                clean_logits=False,
+            )
+            num_rows = logits.shape[0]
+
+            # kpool: logits are pool-granular (compress_ratio == index_kpool),
+            # so topk selects pools. We pick topk_tokens // kpool pools then
+            # expand each pool back to its kpool constituent tokens.
+            select_k = topk_tokens // index_kpool if index_kpool > 1 else topk_tokens
+            if index_kpool > 1:
+                pool_topk = torch.empty(
+                    (num_rows, select_k), dtype=torch.int32, device=logits.device
+                )
+                topk_dst = pool_topk
+            else:
+                topk_dst = topk_indices_buffer[
+                    chunk.token_start : chunk.token_end, :topk_tokens
+                ]
+
+            INDEXER_BACKEND.topk_prefill(
+                logits,
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
+                topk_dst,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                select_k,
+            )
+
+            if index_kpool > 1:
+                pool_ids = pool_topk.to(torch.int64)
+                if positions is not None:
+                    # Fused expand-pools + append-tail into one Triton kernel
+                    # (replaces ~25 elementwise ops). seq_len is token-granular
+                    # (pos+1); the kernel derives pool_len internally.
+                    q_seq = (
+                        positions[chunk.token_start : chunk.token_end].to(torch.int32)
+                        + 1
+                    )
+                    expanded = INDEXER_BACKEND.expand_pools_and_append_tail(
+                        pool_ids, q_seq, index_kpool
+                    )
+                else:
+                    valid = pool_ids >= 0
+                    expanded = INDEXER_BACKEND.expand_pools_to_tokens(
+                        pool_ids, valid, topk_tokens, index_kpool
+                    )
+                topk_indices_buffer[
+                    chunk.token_start : chunk.token_end, : expanded.shape[-1]
+                ] = expanded
+
+    if has_decode:
+        decode_metadata = attn_metadata_narrowed.decode
+        assert decode_metadata is not None
+        kv_cache_raw = kv_cache  # raw [num_blocks, block_size, head_dim+4] for writes
+        kv_cache = kv_cache_as_quant_view(kv_cache, head_dim, use_fp4_cache)
+
+        # kpool decode write (must precede the logits read). Append each decode
+        # token's k/gate to its REQUEST's tail ring; when a pool fills
+        # (pos % kpool == kpool-1) compress + write at the pool slot that
+        # compress_ratio hands us via slot_mapping.
+        #
+        # Spec verify batches next_n (>1) tokens per request. The per-request
+        # tail ring must accumulate a request's tokens IN POSITION ORDER, so we
+        # group tokens by request ([num_requests, next_n, ...]) and run the
+        # per-request kernel once per token-slot — sequential launches keep each
+        # request's tokens ordered (token t stashes before token t+1 reads it
+        # for pool completion). Mirrors sglang's _forward_cuda_target_verify
+        # (per-request kpool write plan, seqlen_per_q = write_start + k + 1).
+        # Plain decode (next_n == 1) collapses to a single launch.
+        #
+        # NOTE: positions must be TOKEN-granular (per-token position, not the
+        # pool-granular decode_metadata.seq_lens which is divided by
+        # compress_ratio). The kernel derives the pool phase and tail-ring index
+        # from pos % kpool, so a pool-granular pos misaligns every pool; a
+        # per-request pos under spec is also too short (B entries for B*next_n
+        # tokens) and reads out of bounds.
+        if (
+            index_kpool > 1
+            and gate_score is not None
+            and compress_ape is not None
+            and positions is not None
+            and not skip_k_cache_insert
+            and os.environ.get("VLLM_KPOOL_SKIP_DECODE_WRITE") != "1"
+        ):
+            num_requests = attn_metadata_narrowed.num_decodes
+            # The indexer's flatten decode path rewrites decode_lens to all-1s
+            # and reports requires_padding=False even for a variable MTP-verify
+            # batch (e.g. one request verifies 3 tokens while the rest verify
+            # 4). The logits read is fine with that, but the kpool WRITE must
+            # group tokens by their original request. Uniformity and the scatter
+            # lmax are precomputed on the host in build()
+            # (decode_is_uniform / write_max_decode_len), so this branch needs
+            # no runtime .item() -- a .item() under cudagraph capture forces a
+            # host sync and invalidates the stream.
+            use_uniform, group_lens, lmax = _decode_write_layout(
+                decode_metadata, num_requests, num_decode_tokens
+            )
+            if not use_uniform:
+                # Non-uniform decode_lens (mixed plain-decode + spec-verify, or
+                # a variable MTP-verify batch): scatter actual tokens into a
+                # padded [B, lmax] layout. int32 tensors can't go through
+                # pack_seq_triton (float/uint8 only). The scatter indices are
+                # shared by all five scatters below (and the tail slot one).
+                scatter_idx = _build_decode_scatter_indices(
+                    group_lens, num_requests, num_decode_tokens
+                )
+                dec_k = _scatter_decode_tokens_by_request(
+                    k[:num_decode_tokens], 0, num_requests, lmax, scatter_idx
+                )
+                dec_gate = _scatter_decode_tokens_by_request(
+                    gate_score[:num_decode_tokens],
+                    0,
+                    num_requests,
+                    lmax,
+                    scatter_idx,
+                )
+                dec_slot = _scatter_decode_tokens_by_request(
+                    slot_mapping[:num_decode_tokens],
+                    -1,
+                    num_requests,
+                    lmax,
+                    scatter_idx,
+                )
+                dec_pos = _scatter_decode_tokens_by_request(
+                    positions[:num_decode_tokens].to(torch.int32),
+                    -1,
+                    num_requests,
+                    lmax,
+                    scatter_idx,
+                )
+            else:
+                next_n = num_decode_tokens // num_requests
+                shape2 = (num_requests, next_n)
+                dec_k = k[:num_decode_tokens].view(*shape2, head_dim)
+                dec_gate = gate_score[:num_decode_tokens].view(*shape2, head_dim)
+                dec_slot = slot_mapping[:num_decode_tokens].view(shape2)
+                dec_pos = positions[:num_decode_tokens].to(torch.int32).view(shape2)
+            tail_meta = (
+                attn_metadata.get(_resolve_layer_name(tail_prefix))
+                if tail_prefix is not None
+                else None
+            )
+            # Paged tail cache replaces the transient _DECODE_TAIL ring. Group
+            # the tail group's token-granular slot_mapping per-request, mirroring
+            # dec_slot / dec_pos, so the kernel gets each request's current-token
+            # tail slot (block * kpool + pos % kpool).
+            if tail_meta is not None:
+                assert isinstance(tail_meta, DeepseekV32IndexerMetadata)
+            if tail_meta is None or tail_kv_cache is None:
+                dec_tail_slot = None
+            elif not use_uniform:
+                dec_tail_slot = _scatter_decode_tokens_by_request(
+                    tail_meta.slot_mapping[:num_decode_tokens],
+                    -1,
+                    num_requests,
+                    lmax,
+                    scatter_idx,
+                )
+            else:
+                dec_tail_slot = tail_meta.slot_mapping[:num_decode_tokens].view(shape2)
+            # The compress kernel writes the raw fp8 cache (not the quant view);
+            # pass the underlying kv_cache, not kv_cache_quant_view.
+            if dec_tail_slot is not None:
+                # Single batched launch over [num_requests, next_n] replaces the
+                # per-token sequential loop. The kernel iterates each request's
+                # tokens in position order internally, preserving the
+                # pool-completion read-after-stash dependency that the loop
+                # provided. Inputs are already grouped per request (uniform:
+                # view; non-uniform: _scatter_decode_tokens_by_request padded to
+                # [B, lmax]) — no per-token .contiguous() copies needed.
+                INDEXER_BACKEND.kpool_decode_update_and_maybe_write_cache_batched(
+                    kv_cache_raw,
+                    tail_kv_cache,
+                    dec_tail_slot,
+                    dec_k,
+                    dec_gate,
+                    compress_ape,
+                    dec_slot,
+                    dec_pos,
+                    index_kpool,
+                    head_dim,
+                    round_scale=(scale_fmt is not None),
+                )
+        decode_lens = decode_metadata.decode_lens
+        if decode_metadata.requires_padding:
+            # pad in edge case where we have short chunked prefill length <
+            # decode_threshold since we unstrictly split
+            # prefill and decode by decode_threshold
+            # (currently set to 1 + speculative tokens).
+            # FP8 Q is float8_e4m3fn (pack_seq_triton's fp32 pad path is OK —
+            # downstream context_lens masks stale slots). MXFP4 Q is two
+            # uint8 tensors (values + ue8m0 scales) — use the dedicated uint8
+            # packer with pad_byte=0 so padded slots dequantize to 0 and
+            # can't produce NaN/Inf in the logits kernel.
+            if q_scale is not None:
+                padded_q_quant_decode_tokens = INDEXER_BACKEND.pack_seq(
+                    q_quant[:num_decode_tokens], decode_lens, pad_value=0
+                )
+                padded_q_scale = INDEXER_BACKEND.pack_seq(
+                    q_scale[:num_decode_tokens], decode_lens, pad_value=0
+                )
+            else:
+                padded_q_quant_decode_tokens = INDEXER_BACKEND.pack_seq(
+                    q_quant[:num_decode_tokens], decode_lens
+                )
+                padded_q_scale = None
+            padded_weights = INDEXER_BACKEND.pack_seq(
+                weights[:num_decode_tokens], decode_lens, pad_value=0
+            ).reshape(-1, *weights.shape[1:])
+        else:
+            padded_q_quant_decode_tokens = q_quant[:num_decode_tokens].reshape(
+                decode_lens.shape[0], -1, *q_quant.shape[1:]
+            )
+            if q_scale is not None:
+                padded_q_scale = q_scale[:num_decode_tokens].reshape(
+                    decode_lens.shape[0], -1, *q_scale.shape[1:]
+                )
+            else:
+                padded_q_scale = None
+            padded_weights = weights[:num_decode_tokens]
+        # TODO: move and optimize below logic with triton kernels
+        batch_size = padded_q_quant_decode_tokens.shape[0]
+        next_n = padded_q_quant_decode_tokens.shape[1]
+        num_padded_tokens = batch_size * next_n
+        seq_lens = decode_metadata.seq_lens[:batch_size]
+        # seq_lens is always 2D: (B, next_n) for native spec decode, (B, 1)
+        # otherwise. deep_gemm fp8_fp4_paged_mqa_logits requires 2D context_lens;
+        # the downstream topk kernels accept both 1D and 2D.
+        padded_q_quant_cast = (
+            padded_q_quant_decode_tokens.view(torch.int8)
+            if use_fp4_cache
+            else padded_q_quant_decode_tokens
+        )
+        logits = INDEXER_BACKEND.paged_mqa_logits(
+            (padded_q_quant_cast, padded_q_scale),
+            kv_cache,
+            padded_weights[:num_padded_tokens],
+            seq_lens,
+            decode_metadata.block_table,
+            decode_metadata.schedule_metadata,
+            max_model_len=max_model_len,
+            clean_logits=False,
+        )
+        num_rows = logits.shape[0]
+        # kpool: logits are pool-granular -> select topk_tokens//kpool pools,
+        # then expand each pool back to its kpool tokens.
+        select_k = topk_tokens // index_kpool if index_kpool > 1 else topk_tokens
+        if index_kpool > 1:
+            pool_topk = torch.empty(
+                (num_rows, select_k), dtype=torch.int32, device=logits.device
+            )
+            topk_dst = pool_topk
+        else:
+            topk_dst = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
+
+        if (
+            INDEXER_BACKEND.is_nvidia
+            and current_platform.is_cuda()
+            and select_k in (512, 1024, 2048)
+        ):
+            workspace_manager = current_workspace_manager()
+            (topk_workspace,) = workspace_manager.get_simultaneous(
+                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+            )
+            torch.ops._C.persistent_topk(
+                logits,
+                seq_lens,
+                topk_dst,
+                topk_workspace,
+                select_k,
+                attn_metadata_narrowed.max_seq_len,
+            )
+        else:
+            INDEXER_BACKEND.topk_decode(
+                logits,
+                next_n,
+                seq_lens,
+                topk_dst,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                select_k,
+            )
+
+        # Resolve to token-level indices in the output buffer.
+        if index_kpool > 1:
+            pool_ids = pool_topk.to(torch.int64)
+            n = pool_topk.shape[0]
+            # NOTE: decode_metadata.seq_lens is POOL-granular (divided by
+            # compress_ratio in the indexer metadata builder) because it feeds
+            # the paged-MQA logits. The fused kernel needs TOKEN-granular seq_len,
+            # so recover it from the decode tokens' positions (pos == seq_len-1).
+            # Using the compressed seq_lens yields dec_seq=0 for seq_len<kpool
+            # -> empty topk -> the sparse MLA attends to nothing -> decode
+            # degradation. The row->token mapping must follow the PADDED
+            # [B, next_n] layout on non-uniform batches (see
+            # _decode_topk_seq_lens).
+            if positions is not None:
+                dec_seq = _decode_topk_seq_lens(
+                    positions,
+                    decode_lens,
+                    num_decode_tokens,
+                    batch_size,
+                    next_n,
+                    decode_metadata.requires_padding,
+                )
+            else:
+                dec_seq = decode_metadata.seq_lens[:n]
+                if dec_seq.ndim == 2:
+                    dec_seq = dec_seq[:, -1]
+                dec_seq = dec_seq.to(torch.int32)
+            out = INDEXER_BACKEND.expand_pools_and_append_tail(
+                pool_ids, dec_seq, index_kpool
+            )
+        else:
+            out = topk_dst
+
+        if decode_metadata.requires_padding:
+            # Drop padded query rows introduced by the next_n padding above.
+            out = INDEXER_BACKEND.unpack_seq(
+                out.reshape(batch_size, -1, out.shape[-1]), decode_lens
+            )
+        topk_indices_buffer[: out.shape[0], : out.shape[-1]] = out
+
+    return topk_indices_buffer
+
+
+def sparse_attn_indexer_kpool_fake(
+    hidden_states: torch.Tensor,
+    k_cache_prefix: LayerNameType,
+    kv_cache: torch.Tensor,
+    q_quant: torch.Tensor,
+    q_scale: torch.Tensor | None,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    quant_block_size: int,
+    scale_fmt: str | None,
+    topk_tokens: int,
+    head_dim: int,
+    max_model_len: int,
+    total_seq_lens: int,
+    topk_indices_buffer: torch.Tensor | None,
+    skip_k_cache_insert: bool,
+    use_fp4_cache: bool = False,
+    gate_score: torch.Tensor | None = None,
+    compress_ape: torch.Tensor | None = None,
+    index_kpool: int = 1,
+    positions: torch.Tensor | None = None,
+    tail_kv_cache: torch.Tensor | None = None,
+    tail_prefix: str | None = None,
+) -> torch.Tensor:
+    return topk_indices_buffer
+
+
+direct_register_custom_op(
+    op_name="sparse_attn_indexer_kpool",
+    op_func=sparse_attn_indexer_kpool,
+    # The indexer writes the index-K cache in place (prefill k-cache insert +
+    # kpool decode write), so kv_cache must be declared as mutated — otherwise
+    # under full-graph compile dynamo assumes it is unchanged across the
+    # indexer→MLA boundary and the MLA reads stale/misaligned KV. The paged tail
+    # cache is likewise written in place (prefill tail scatter + decode stash).
+    mutates_args=["topk_indices_buffer", "kv_cache", "tail_kv_cache"],
+    fake_impl=sparse_attn_indexer_kpool_fake,
+    dispatch_key=current_platform.dispatch_key,
+)
+
+
+@CustomOp.register("sparse_attn_indexer_kpool")
+class SparseAttnIndexerKpool(CustomOp):
+    """Sparse Attention Indexer Custom Op Layer. This layer is extracted as a
+    separate custom op since it involves heavy custom kernels like `mqa_logits`,
+    `paged_mqa_logits` and `top_k_per_row`, etc. Those kernels maybe requires
+    specific memory layout or implementation for different hardware backends to
+    achieve optimal performance.
+
+    For now, the default native path will use CUDA backend path. Other platform
+    may requires add the corresponding Custom Op name `sparse_attn_indexer` to
+    `custom_ops` in `CompilationConfig` to enable the platform specific path.
+    """
+
+    def __init__(
+        self,
+        k_cache,
+        quant_block_size: int,
+        scale_fmt: str,
+        topk_tokens: int,
+        head_dim: int,
+        max_model_len: int,
+        max_total_seq_len: int,
+        topk_indices_buffer: torch.Tensor,
+        skip_k_cache_insert: bool = False,
+        use_fp4_cache: bool = False,
+        tail_cache=None,
+    ):
+        super().__init__()
+        self.k_cache = k_cache
+        self.tail_cache = tail_cache
+        self.quant_block_size = quant_block_size
+        self.scale_fmt = scale_fmt
+        self.topk_tokens = topk_tokens
+        self.head_dim = head_dim
+        self.max_model_len = max_model_len
+        self.max_total_seq_len = max_total_seq_len
+        self.topk_indices_buffer = topk_indices_buffer
+        self.skip_k_cache_insert = skip_k_cache_insert
+        self.use_fp4_cache = use_fp4_cache
+        if INDEXER_BACKEND.is_nvidia and not INDEXER_BACKEND.has_nvidia_deep_gemm:
+            raise RuntimeError(
+                "Sparse Attention Indexer CUDA op requires DeepGEMM to be installed."
+            )
+
+    def forward_native(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        k: torch.Tensor,
+        weights: torch.Tensor,
+        *,
+        gate_score: torch.Tensor | None = None,
+        compress_ape: torch.Tensor | None = None,
+        index_kpool: int = 1,
+        positions: torch.Tensor | None = None,
+    ):
+        # The registered operator now dispatches each kernel in the indexer
+        # chain independently: NVIDIA keeps the original reference path;
+        # out-of-tree devices prefer FlagGems and then PyTorch correctness ops.
+        return self.forward_cuda(
+            hidden_states,
+            q_quant,
+            k,
+            weights,
+            gate_score=gate_score,
+            compress_ape=compress_ape,
+            index_kpool=index_kpool,
+            positions=positions,
+        )
+
+    def forward_cuda(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        k: torch.Tensor,
+        weights: torch.Tensor,
+        *,
+        gate_score: torch.Tensor | None = None,
+        compress_ape: torch.Tensor | None = None,
+        index_kpool: int = 1,
+        positions: torch.Tensor | None = None,
+    ):
+        # FP8 path: single tensor (per-token scale is folded into `weights`).
+        # FP4 path: (values, scales) tuple with scales required by the kernel.
+        if isinstance(q_quant, tuple):
+            q_values, q_scale = q_quant
+        else:
+            q_values, q_scale = q_quant, None
+        return torch.ops.vllm.sparse_attn_indexer_kpool(
+            hidden_states,
+            _encode_layer_name(self.k_cache.prefix),
+            self.k_cache.kv_cache,
+            q_values,
+            q_scale,
+            k,
+            weights,
+            self.quant_block_size,
+            self.scale_fmt,
+            self.topk_tokens,
+            self.head_dim,
+            self.max_model_len,
+            self.max_total_seq_len,
+            self.topk_indices_buffer,
+            self.skip_k_cache_insert,
+            self.use_fp4_cache,
+            gate_score,
+            compress_ape,
+            index_kpool,
+            positions,
+            self.tail_cache.kv_cache if self.tail_cache is not None else None,
+            self.tail_cache.prefix if self.tail_cache is not None else None,
+        )
+
+    def forward_hip(
+        self,
+        hidden_states: torch.Tensor,
+        q_quant: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        k: torch.Tensor,
+        weights: torch.Tensor,
+    ):
+        assert not self.use_fp4_cache, "AMD platform doesn't support fp4 cache yet"
+        assert isinstance(q_quant, torch.Tensor), (
+            "AMD sparse_attn_indexer expects a single FP8 q_quant tensor"
+        )
+        if rocm_aiter_ops.is_enabled():
+            return torch.ops.vllm.rocm_aiter_sparse_attn_indexer(
+                hidden_states,
+                _encode_layer_name(self.k_cache.prefix),
+                self.k_cache.kv_cache,
+                q_quant,
+                k,
+                weights,
+                self.quant_block_size,
+                self.scale_fmt,
+                self.topk_tokens,
+                self.head_dim,
+                self.max_model_len,
+                self.max_total_seq_len,
+                self.topk_indices_buffer,
+                skip_k_cache_insert=self.skip_k_cache_insert,
+            )
+        raise RuntimeError(
+            "Sparse attention indexer ROCm path is only supported on AITER. "
+            "Please enable aiter with VLLM_ROCM_USE_AITER=1"
+        )

--- a/vllm_fl/models/glm5_next.py
+++ b/vllm_fl/models/glm5_next.py
@@ -1,0 +1,1195 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM5-Next text runtime for pristine vLLM 0.24.
+
+This combines vLLM 0.24's KDA recurrent layer, DeepSeek-V3.2 sparse MLA,
+DeepSeek MoE, and mHC operators. The model-specific bounded KDA gate and the
+kpool-compressed index/tail caches are kept plugin-owned.
+"""
+
+from collections.abc import Iterable
+from types import MethodType
+
+import torch
+from einops import rearrange
+from torch import nn
+
+from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import ParallelConfig, VllmConfig
+from vllm.distributed import (
+    get_ep_group,
+    get_pp_group,
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
+from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe import FusedMoE, GateLinear
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
+    KimiGatedDeltaNetAttention,
+)
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    MambaStateCopyFuncCalculator,
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+    is_conv_state_dim_first,
+)
+from vllm.model_executor.layers.mhc import (
+    MHCFusedPostPreOp,
+    MHCPostOp,
+    MHCPreOp,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.models.deepseek_v2 import (
+    DeepseekV2MLAAttention,
+    DeepseekV2Model,
+)
+from vllm.model_executor.models.interfaces import (
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    SupportsPP,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_prefix,
+    sequence_parallel_chunk,
+)
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+
+from vllm_fl.kernels.glm5_next.provider import use_nvidia_reference
+
+if use_nvidia_reference():
+    try:
+        from vllm_fl.kernels.glm5_next.mhc_broadcast_tilelang import (
+            mhc_pre_broadcast_tilelang,
+        )
+    except (ImportError, OSError):
+        # H100 deployments may intentionally omit TileLang.  The model keeps
+        # the exact materialized mHC fallback in that case; importing the
+        # model must not make the optional vendor kernel mandatory.
+        mhc_pre_broadcast_tilelang = None
+else:
+    mhc_pre_broadcast_tilelang = None
+
+if current_platform.is_cuda():
+    from vllm.model_executor.layers.fla.ops.kda import fused_recurrent_kda
+    from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+        causal_conv1d_fn,
+        causal_conv1d_update,
+    )
+
+    from vllm_fl.kernels.glm5_next.safe_kda import (
+        chunk_kda_with_safe_gate,
+        fused_safe_kda_gate,
+    )
+else:
+    from vllm_fl.kernels.glm5_next.portable import (
+        causal_conv1d_fn,
+        causal_conv1d_update,
+        chunk_kda_with_safe_gate,
+        fused_recurrent_kda,
+        safe_kda_gate as fused_safe_kda_gate,
+    )
+
+if use_nvidia_reference():
+    from vllm.model_executor.layers.activation import SiluAndMulWithClamp
+else:
+
+    class SiluAndMulWithClamp(nn.Module):
+        """Bounded SwiGLU without constructing vLLM's CUDA custom op."""
+
+        def __init__(
+            self,
+            swiglu_limit: float,
+            alpha: float = 1.0,
+            beta: float = 0.0,
+            **kwargs,
+        ) -> None:
+            super().__init__()
+            del kwargs
+            self.swiglu_limit = float(swiglu_limit)
+            self.alpha = float(alpha)
+            self.beta = float(beta)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            dim = x.shape[-1] // 2
+            if self.alpha == 1.0 and self.beta == 0.0:
+                try:
+                    from flag_gems.fused.silu_and_mul_with_clamp import (
+                        silu_and_mul_with_clamp,
+                    )
+
+                    return silu_and_mul_with_clamp(
+                        x[..., :dim], x[..., dim:], self.swiglu_limit
+                    )
+                except (ImportError, OSError, NotImplementedError, RuntimeError):
+                    pass
+            gate = x[..., :dim].clamp(max=self.swiglu_limit)
+            up = x[..., dim:].clamp(min=-self.swiglu_limit, max=self.swiglu_limit)
+            return gate * torch.sigmoid(self.alpha * gate) * (up + self.beta)
+
+
+from vllm_fl.kernels.glm5_next.indexer_backend import INDEXER_BACKEND
+from vllm_fl.kernels.glm5_next.sparse_attn_indexer_kpool import (
+    SparseAttnIndexerKpool,
+)
+from vllm_fl.models.glm5_next_kpool import (
+    Glm5NextIndexerCache,
+    Glm5NextTailCache,
+)
+
+logger = init_logger(__name__)
+
+
+def _hc_expand(x: torch.Tensor, streams: int) -> torch.Tensor:
+    return x.unsqueeze(1).expand(-1, streams, -1).contiguous()
+
+
+def _hc_contract(x: torch.Tensor) -> torch.Tensor:
+    return x.mean(dim=1)
+
+
+class Glm5NextMLP(nn.Module):
+    """Reference GLM5-Next SwiGLU, including the trained clamp."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
+        is_sequence_parallel: bool = False,
+        prefix: str = "",
+        swiglu_limit: float | None = None,
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size] * 2,
+            bias=False,
+            quant_config=quant_config,
+            disable_tp=is_sequence_parallel,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            reduce_results=reduce_results,
+            disable_tp=is_sequence_parallel,
+            prefix=f"{prefix}.down_proj",
+        )
+        if hidden_act != "silu":
+            raise ValueError(
+                f"Unsupported activation: {hidden_act}. Only silu is supported."
+            )
+        if swiglu_limit is None:
+            raise ValueError("GLM5-Next requires a finite swiglu_limit")
+        self.act_fn = SiluAndMulWithClamp(swiglu_limit=swiglu_limit)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+
+
+class Glm5NextMoE(nn.Module):
+    """Reference GLM5-Next router and clamped shared/routed experts."""
+
+    def __init__(
+        self,
+        config,
+        parallel_config: ParallelConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        apply_routed_scale_to_output: bool = False,
+    ) -> None:
+        super().__init__()
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_rank = get_tensor_model_parallel_rank()
+        self.routed_scaling_factor = float(config.routed_scaling_factor)
+
+        self.ep_group = get_ep_group().device_group
+        self.ep_rank = get_ep_group().rank_in_group
+        self.ep_size = self.ep_group.size()
+        self.n_routed_experts = int(config.n_routed_experts)
+        self.n_shared_experts = int(config.n_shared_experts)
+        self.is_sequence_parallel = parallel_config.use_sequence_parallel_moe
+
+        if config.hidden_act != "silu":
+            raise ValueError(
+                f"Unsupported activation: {config.hidden_act}. Only silu is supported."
+            )
+
+        router_dtype_name = getattr(config, "moe_router_dtype", "float32")
+        router_dtype = getattr(torch, str(router_dtype_name))
+        self.gate = GateLinear(
+            config.hidden_size,
+            config.n_routed_experts,
+            out_dtype=router_dtype,
+            prefix=f"{prefix}.gate",
+        )
+        if getattr(config, "topk_method", None) == "noaux_tc":
+            self.gate.e_score_correction_bias = nn.Parameter(
+                torch.empty(config.n_routed_experts, dtype=torch.float32)
+            )
+        else:
+            self.gate.e_score_correction_bias = None
+
+        eplb_config = parallel_config.eplb_config
+        self.enable_eplb = parallel_config.enable_eplb
+        self.n_redundant_experts = eplb_config.num_redundant_experts
+        self.n_logical_experts = self.n_routed_experts
+        self.n_physical_experts = self.n_logical_experts + self.n_redundant_experts
+        self.n_local_physical_experts = self.n_physical_experts // self.ep_size
+        self.physical_expert_start = self.ep_rank * self.n_local_physical_experts
+        self.physical_expert_end = (
+            self.physical_expert_start + self.n_local_physical_experts
+        )
+
+        swiglu_limit = config.swiglu_limit
+        if swiglu_limit is None:
+            raise ValueError("GLM5-Next requires a finite swiglu_limit")
+        if config.n_shared_experts is None:
+            self.shared_experts = None
+        else:
+            self.shared_experts = Glm5NextMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=(
+                    config.moe_intermediate_size * config.n_shared_experts
+                ),
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                is_sequence_parallel=self.is_sequence_parallel,
+                reduce_results=False,
+                prefix=f"{prefix}.shared_experts",
+                swiglu_limit=swiglu_limit,
+            )
+
+        self.experts = FusedMoE(
+            shared_experts=self.shared_experts,
+            gate=self.gate,
+            num_experts=config.n_routed_experts,
+            top_k=config.num_experts_per_tok,
+            hidden_size=config.hidden_size,
+            intermediate_size=config.moe_intermediate_size,
+            renormalize=config.norm_topk_prob,
+            quant_config=quant_config,
+            use_grouped_topk=True,
+            num_expert_group=config.n_group,
+            topk_group=config.topk_group,
+            prefix=f"{prefix}.experts",
+            scoring_func=config.scoring_func,
+            routed_scaling_factor=self.routed_scaling_factor,
+            apply_routed_scale_to_output=apply_routed_scale_to_output,
+            e_score_correction_bias=self.gate.e_score_correction_bias,
+            enable_eplb=self.enable_eplb,
+            num_redundant_experts=self.n_redundant_experts,
+            is_sequence_parallel=self.is_sequence_parallel,
+            router_logits_dtype=self.gate.out_dtype,
+            swiglu_limit=swiglu_limit,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        already_sequence_parallel: bool = False,
+    ) -> torch.Tensor:
+        num_tokens, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        if self.is_sequence_parallel and not already_sequence_parallel:
+            hidden_states = sequence_parallel_chunk(hidden_states)
+
+        if self.experts.is_internal_router:
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states, router_logits=hidden_states
+            )
+        else:
+            router_logits, _ = self.gate(hidden_states)
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states, router_logits=router_logits
+            )
+
+        if self.is_sequence_parallel and not already_sequence_parallel:
+            final_hidden_states = tensor_model_parallel_all_gather(
+                final_hidden_states, 0
+            )[:num_tokens]
+        return final_hidden_states.view(num_tokens, hidden_dim)
+
+
+class Glm5NextLinearAttention(KimiGatedDeltaNetAttention):
+    """v0.24 KDA projections with the reference bounded gate on both paths."""
+
+    def __init__(self, config, vllm_config, prefix: str = "") -> None:
+        super().__init__(config, vllm_config, prefix)
+        kda_config = config.linear_attn_config or {}
+        self.kda_lower_bound = float(kda_config.get("gate_lower_bound", -5.0))
+        self._conv_state_dim_first = is_conv_state_dim_first()
+
+        # GLM5-Next checkpoints store A_log as [num_heads], whereas the v0.24
+        # runtime parameter is [1, 1, local_heads, 1].
+        old_loader = self.A_log.weight_loader
+
+        def load_a_log(param, loaded_weight):
+            if loaded_weight.ndim == 1:
+                loaded_weight = loaded_weight.view(1, 1, -1, 1)
+            return old_loader(param, loaded_weight)
+
+        self.A_log.weight_loader = load_a_log
+
+    def forward(
+        self, hidden_states: torch.Tensor, positions: torch.Tensor
+    ) -> torch.Tensor:
+        del positions
+        num_tokens = hidden_states.size(0)
+        q = self.q_proj(hidden_states)[0]
+        k = self.k_proj(hidden_states)[0]
+        v = self.v_proj(hidden_states)[0]
+
+        beta = self.b_proj(hidden_states)[0].float().sigmoid()
+        g1 = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
+        beta = beta.unsqueeze(0)
+        g1 = rearrange(g1, "n (h d) -> 1 n h d", d=self.head_dim)
+
+        g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
+        g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
+
+        core_attn_out = torch.zeros(
+            (1, num_tokens, self.local_num_heads, self.head_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        # Keep the metadata-dependent KDA body visible to the breakable-CG
+        # decorator. Routing through torch.ops.vllm.kda_attention makes the
+        # custom op opaque and can freeze capture-time state indices/branches.
+        self._forward(
+            q_proj_states=q,
+            k_proj_states=k,
+            v_proj_states=v,
+            g1=g1,
+            beta=beta,
+            core_attn_out=core_attn_out,
+        )
+        core_attn_out = self.o_norm(core_attn_out, g2)
+        core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
+        return self.o_proj(core_attn_out)[0]
+
+    @eager_break_during_capture
+    def _forward_reference_safe_gate(
+        self,
+        q_proj_states: torch.Tensor,
+        k_proj_states: torch.Tensor,
+        v_proj_states: torch.Tensor,
+        g1: torch.Tensor,
+        beta: torch.Tensor,
+        core_attn_out: torch.Tensor,
+    ) -> None:
+        forward_context = get_forward_context()
+        attn_metadata_raw = forward_context.attn_metadata
+
+        if attn_metadata_raw is None:
+            #     # V1 profile run
+            return
+
+        assert isinstance(attn_metadata_raw, dict)
+        attn_metadata_narrowed = attn_metadata_raw[self.prefix]
+        assert isinstance(attn_metadata_narrowed, GDNAttentionMetadata)
+        has_initial_state = attn_metadata_narrowed.has_initial_state
+        non_spec_query_start_loc = attn_metadata_narrowed.non_spec_query_start_loc
+        non_spec_state_indices_tensor = (
+            attn_metadata_narrowed.non_spec_state_indices_tensor
+        )  # noqa: E501
+        num_actual_tokens = attn_metadata_narrowed.num_actual_tokens
+        constant_caches = self.kv_cache
+
+        q_proj_states = q_proj_states[:num_actual_tokens]
+        k_proj_states = k_proj_states[:num_actual_tokens]
+        v_proj_states = v_proj_states[:num_actual_tokens]
+        g1 = g1[:, :num_actual_tokens]
+        beta = beta[:, :num_actual_tokens]
+
+        (conv_state, recurrent_state) = constant_caches
+        # conv_state must be (..., dim, width-1) for the conv kernels.
+        # DS layout stores it that way directly; SD layout needs a transpose.
+        if not self._conv_state_dim_first:
+            conv_state = conv_state.transpose(-1, -2)
+
+        conv_state_q, conv_state_k, conv_state_v = conv_state.chunk(3, dim=-2)
+
+        q_conv_weights = self.q_conv1d.weight.view(
+            self.q_conv1d.weight.size(0), self.q_conv1d.weight.size(2)
+        )
+        k_conv_weights = self.k_conv1d.weight.view(
+            self.k_conv1d.weight.size(0), self.k_conv1d.weight.size(2)
+        )
+        v_conv_weights = self.v_conv1d.weight.view(
+            self.v_conv1d.weight.size(0), self.v_conv1d.weight.size(2)
+        )
+        if attn_metadata_narrowed.num_prefills > 0:
+            q_proj_states = q_proj_states.transpose(0, 1)
+            k_proj_states = k_proj_states.transpose(0, 1)
+            v_proj_states = v_proj_states.transpose(0, 1)
+            q = causal_conv1d_fn(
+                q_proj_states,
+                q_conv_weights,
+                self.q_conv1d.bias,
+                activation="silu",
+                conv_states=conv_state_q,
+                has_initial_state=has_initial_state,
+                cache_indices=non_spec_state_indices_tensor,
+                query_start_loc=non_spec_query_start_loc,
+                metadata=attn_metadata_narrowed,
+            ).transpose(0, 1)
+            k = causal_conv1d_fn(
+                k_proj_states,
+                k_conv_weights,
+                self.k_conv1d.bias,
+                activation="silu",
+                conv_states=conv_state_k,
+                has_initial_state=has_initial_state,
+                cache_indices=non_spec_state_indices_tensor,
+                query_start_loc=non_spec_query_start_loc,
+                metadata=attn_metadata_narrowed,
+            ).transpose(0, 1)
+            v = causal_conv1d_fn(
+                v_proj_states,
+                v_conv_weights,
+                self.v_conv1d.bias,
+                activation="silu",
+                conv_states=conv_state_v,
+                has_initial_state=has_initial_state,
+                cache_indices=non_spec_state_indices_tensor,
+                query_start_loc=non_spec_query_start_loc,
+                metadata=attn_metadata_narrowed,
+            ).transpose(0, 1)
+        else:
+            assert non_spec_state_indices_tensor is not None
+            decode_conv_indices = non_spec_state_indices_tensor[
+                : attn_metadata_narrowed.num_actual_tokens
+            ]
+            q = causal_conv1d_update(
+                q_proj_states,
+                conv_state_q,
+                q_conv_weights,
+                self.q_conv1d.bias,
+                activation="silu",
+                conv_state_indices=decode_conv_indices,
+                validate_data=True,
+            )
+            k = causal_conv1d_update(
+                k_proj_states,
+                conv_state_k,
+                k_conv_weights,
+                self.k_conv1d.bias,
+                activation="silu",
+                conv_state_indices=decode_conv_indices,
+                validate_data=True,
+            )
+            v = causal_conv1d_update(
+                v_proj_states,
+                conv_state_v,
+                v_conv_weights,
+                self.v_conv1d.bias,
+                activation="silu",
+                conv_state_indices=decode_conv_indices,
+                validate_data=True,
+            )
+
+        q, k, v = map(
+            lambda x: rearrange(x, "n (h d) -> 1 n h d", d=self.head_dim), (q, k, v)
+        )
+
+        if attn_metadata_narrowed.num_prefills > 0:
+            assert non_spec_state_indices_tensor is not None
+            assert has_initial_state is not None
+            zero_idx = non_spec_state_indices_tensor[~has_initial_state]
+            recurrent_state[zero_idx] = 0
+            initial_state = recurrent_state[non_spec_state_indices_tensor].contiguous()
+            (
+                core_attn_out_non_spec,
+                last_recurrent_state,
+            ) = chunk_kda_with_safe_gate(
+                q=q,
+                k=k,
+                v=v,
+                raw_g=g1,
+                beta=beta,
+                A_log=self.A_log,
+                g_bias=self.dt_bias,
+                initial_state=initial_state,
+                output_final_state=True,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=non_spec_query_start_loc,
+                lower_bound=self.kda_lower_bound,
+            )
+            # Init cache
+            recurrent_state[non_spec_state_indices_tensor] = last_recurrent_state
+        else:
+            assert non_spec_query_start_loc is not None
+            g1 = fused_safe_kda_gate(
+                rearrange(g1, "1 n h d -> n (h d)"),
+                self.A_log,
+                self.head_dim,
+                g_bias=self.dt_bias,
+                lower_bound=self.kda_lower_bound,
+            ).unsqueeze(0)
+            (
+                core_attn_out_non_spec,
+                last_recurrent_state,
+            ) = fused_recurrent_kda(
+                q=q,
+                k=k,
+                v=v,
+                g=g1,
+                beta=beta,
+                initial_state=recurrent_state,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=non_spec_query_start_loc[
+                    : attn_metadata_narrowed.num_decodes + 1
+                ],
+                ssm_state_indices=non_spec_state_indices_tensor,
+            )
+        core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
+            0, :num_actual_tokens
+        ]
+
+    _forward = _forward_reference_safe_gate
+
+
+def _indexer_forward_nope(
+    self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb
+) -> torch.Tensor:
+    """DSA indexer projection when the checkpoint has zero RoPE channels."""
+    del rotary_emb
+    q, _ = self.wq_b(qr)
+    q = q.view(-1, self.n_head, self.head_dim)
+    kw, _ = self.wk_weights_proj(hidden_states)
+    k = self.k_norm(kw[:, : self.head_dim])
+    if getattr(self, "_wp_fp32", None) is None:
+        self._wp_fp32 = (
+            self.wk_weights_proj.weight.data[self.head_dim :, :]
+            .t()
+            .contiguous()
+            .float()
+        )
+    weights = torch.mm(hidden_states.float(), self._wp_fp32)
+
+    assert self.head_dim == 128 and self.quant_block_size == 128
+    assert self.scale_fmt == "ue8m0"
+    q = q.view(-1, self.head_dim)
+    q_fp8, q_scale = INDEXER_BACKEND.fwht128_quant_fp8(q)
+    q_fp8 = q_fp8.view(-1, self.n_head, self.head_dim)
+    q_scale = q_scale.view(-1, self.n_head, 1)
+    weights = (
+        weights.unsqueeze(-1) * q_scale * self.softmax_scale * self.n_head**-0.5
+    ).squeeze(-1)
+    gate_score = torch.nn.functional.linear(
+        hidden_states, self.index_kpool_compress_gate
+    )
+    if self.n_head < 32:
+        pad = 32 - self.n_head
+        q_fp8 = torch.cat(
+            [q_fp8, q_fp8.new_zeros(q_fp8.shape[0], pad, self.head_dim)],
+            dim=1,
+        )
+        weights = torch.cat([weights, weights.new_zeros(weights.shape[0], pad)], dim=1)
+    return self.indexer_op(
+        hidden_states,
+        q_fp8,
+        k,
+        weights,
+        gate_score=gate_score,
+        compress_ape=self.index_kpool_compress_ape,
+        index_kpool=self.index_kpool,
+        positions=positions,
+    )
+
+
+class Glm5NextMLAAttention(DeepseekV2MLAAttention):
+    """DeepSeek sparse MLA with an explicit zero-RoPE fast path."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        vllm_config = kwargs["vllm_config"]
+        config = kwargs["config"]
+        cache_config = kwargs["cache_config"]
+        super().__init__(*args, **kwargs)
+        if self.indexer is not None and config.index_kpool_compress:
+            indexer = self.indexer
+            kpool = int(config.index_kpool)
+
+            # Replace the stock per-token cache object registered by the base
+            # constructor with the kpool-compressed cache at the same prefix.
+            static_ctx = vllm_config.compilation_config.static_forward_context
+            old_cache = indexer.k_cache
+            assert static_ctx.get(old_cache.prefix) is old_cache
+            del static_ctx[old_cache.prefix]
+
+            indexer.index_kpool = kpool
+            indexer.index_kpool_compress_ape = nn.Parameter(
+                torch.zeros(kpool, indexer.head_dim, dtype=torch.float32)
+            )
+            indexer.index_kpool_compress_gate = nn.Parameter(
+                torch.empty(
+                    indexer.head_dim,
+                    config.hidden_size,
+                    dtype=torch.bfloat16,
+                )
+            )
+            indexer.k_cache = Glm5NextIndexerCache(
+                head_dim=(
+                    indexer.head_dim + indexer.head_dim // indexer.quant_block_size * 4
+                ),
+                dtype=torch.uint8,
+                prefix=old_cache.prefix,
+                cache_config=cache_config,
+                index_kpool=kpool,
+            )
+            indexer.tail_cache = Glm5NextTailCache(
+                head_dim=indexer.head_dim,
+                dtype=torch.bfloat16,
+                prefix=f"{indexer.prefix}.tail_cache",
+                cache_config=cache_config,
+                index_kpool=kpool,
+            )
+            indexer.indexer_op = SparseAttnIndexerKpool(
+                indexer.k_cache,
+                indexer.quant_block_size,
+                indexer.scale_fmt,
+                indexer.topk_tokens,
+                indexer.head_dim,
+                indexer.max_model_len,
+                indexer.max_total_seq_len,
+                indexer.topk_indices_buffer,
+                tail_cache=indexer.tail_cache,
+            )
+
+        if self.qk_rope_head_dim == 0:
+            self.mla_attn.rotary_emb = None
+            self.mla_attn.indexer_rope_emb = None
+            if self.indexer is not None:
+                self.indexer.forward = MethodType(_indexer_forward_nope, self.indexer)
+
+
+class Glm5NextDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        layer_idx: int,
+        prefix: str,
+        topk_indices_buffer: torch.Tensor | None,
+    ) -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_text_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        parallel_config = vllm_config.parallel_config
+
+        self.layer_idx = layer_idx
+        self.num_hidden_layers = config.num_hidden_layers
+        self.rms_norm_eps = config.rms_norm_eps
+        self.mhc = bool(config.mhc)
+
+        if config.is_kda_layer(layer_idx):
+            self.self_attn = Glm5NextLinearAttention(
+                config,
+                vllm_config,
+                prefix=f"{prefix}.self_attn",
+            )
+        else:
+            self.self_attn = Glm5NextMLAAttention(
+                vllm_config=vllm_config,
+                config=config,
+                hidden_size=config.hidden_size,
+                num_heads=config.num_attention_heads,
+                qk_nope_head_dim=config.qk_nope_head_dim,
+                qk_rope_head_dim=config.qk_rope_head_dim,
+                v_head_dim=config.v_head_dim,
+                q_lora_rank=config.q_lora_rank,
+                kv_lora_rank=config.kv_lora_rank,
+                max_position_embeddings=config.max_position_embeddings,
+                cache_config=cache_config,
+                # The reference checkpoint keeps MLA projections in BF16.
+                quant_config=None,
+                prefix=f"{prefix}.self_attn",
+                topk_indices_buffer=topk_indices_buffer,
+            )
+
+        if config.mlp_layer_types[layer_idx] == "sparse":
+            self.mlp = Glm5NextMoE(
+                config=config,
+                parallel_config=parallel_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
+        else:
+            self.mlp = Glm5NextMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+                swiglu_limit=config.swiglu_limit,
+            )
+
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+        if self.mhc:
+            self.n = config.mhc_num_residual_streams
+            d_model = self.n * config.hidden_size
+            mix_hc = (2 + self.n) * self.n
+            self.hc_eps = config.hc_eps
+            self.mhc_sinkhorn_iterations = config.mhc_sinkhorn_iterations
+            self.mhc_post_mult_value = config.mhc_post_mult_value
+
+            self.hc_attn_fn = nn.Parameter(
+                torch.empty(mix_hc, d_model, dtype=torch.float32)
+            )
+            # Populated after checkpoint loading.  Repeated first-layer
+            # residual streams make the projection equivalent to a projection
+            # with this stream-summed weight, without materializing the input
+            # broadcast first.
+            self.hc_attn_fn_broadcast: torch.Tensor | None = None
+            self.hc_attn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+            self.hc_attn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+            self.hc_ffn_fn = nn.Parameter(
+                torch.empty(mix_hc, d_model, dtype=torch.float32)
+            )
+            self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+            self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+
+            self.mhc_pre_op = MHCPreOp()
+            self.mhc_post_op = MHCPostOp()
+            self.mhc_fused_post_pre_op = MHCFusedPostPreOp()
+
+    def _attention(
+        self, positions: torch.Tensor, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        if isinstance(self.self_attn, DeepseekV2MLAAttention):
+            return self.self_attn(positions, hidden_states, None)
+        return self.self_attn(hidden_states, positions)
+
+    def _hc_pre(
+        self,
+        residual: torch.Tensor,
+        fn: torch.Tensor,
+        scale: torch.Tensor,
+        base: torch.Tensor,
+        norm: RMSNorm,
+    ):
+        return self.mhc_pre_op(
+            residual=residual,
+            fn=fn,
+            hc_scale=scale,
+            hc_base=base,
+            rms_eps=self.rms_norm_eps,
+            hc_pre_eps=self.hc_eps,
+            hc_sinkhorn_eps=self.hc_eps,
+            hc_post_mult_value=self.mhc_post_mult_value,
+            sinkhorn_repeat=self.mhc_sinkhorn_iterations,
+            norm_weight=norm.weight.data,
+            norm_eps=norm.variance_epsilon,
+        )
+
+    def _hc_pre_broadcast(
+        self,
+        residual: torch.Tensor,
+        norm: RMSNorm,
+    ):
+        assert mhc_pre_broadcast_tilelang is not None
+        assert self.hc_attn_fn_broadcast is not None
+        return mhc_pre_broadcast_tilelang(
+            residual,
+            self.hc_attn_fn,
+            self.hc_attn_scale,
+            self.hc_attn_base,
+            self.rms_norm_eps,
+            self.hc_eps,
+            self.hc_eps,
+            self.mhc_post_mult_value,
+            self.mhc_sinkhorn_iterations,
+            norm_weight=norm.weight.data,
+            norm_eps=norm.variance_epsilon,
+            fn_broadcast=self.hc_attn_fn_broadcast,
+        )
+
+    def _hc_fused_post_pre(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post: torch.Tensor,
+        comb: torch.Tensor,
+        fn: torch.Tensor,
+        scale: torch.Tensor,
+        base: torch.Tensor,
+        norm: RMSNorm,
+    ):
+        return self.mhc_fused_post_pre_op(
+            x=x,
+            residual=residual,
+            post_layer_mix=post,
+            comb_res_mix=comb,
+            fn=fn,
+            hc_scale=scale,
+            hc_base=base,
+            rms_eps=self.rms_norm_eps,
+            hc_pre_eps=self.hc_eps,
+            hc_sinkhorn_eps=self.hc_eps,
+            hc_post_mult_value=self.mhc_post_mult_value,
+            sinkhorn_repeat=self.mhc_sinkhorn_iterations,
+            n_splits=1,
+            tile_n=1,
+            norm_weight=norm.weight.data,
+            norm_eps=norm.variance_epsilon,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+        post: torch.Tensor | None,
+        comb: torch.Tensor | None,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        if not self.mhc:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+            hidden_states = self._attention(positions, hidden_states)
+            hidden_states, residual = self.post_attention_layernorm(
+                hidden_states, residual=residual
+            )
+            hidden_states = residual + self.mlp(hidden_states)
+            return hidden_states, residual, None, None
+
+        x = hidden_states
+        if post is None:
+            if (
+                self.layer_idx == 0
+                and x.dim() == 2
+                and self.hc_attn_fn_broadcast is not None
+                and mhc_pre_broadcast_tilelang is not None
+            ):
+                residual, post, comb, x = self._hc_pre_broadcast(
+                    x, self.input_layernorm
+                )
+            else:
+                if self.layer_idx == 0:
+                    x = _hc_expand(x, self.n)
+                residual = x
+                post, comb, x = self._hc_pre(
+                    x,
+                    self.hc_attn_fn,
+                    self.hc_attn_scale,
+                    self.hc_attn_base,
+                    self.input_layernorm,
+                )
+        else:
+            assert residual is not None and comb is not None
+            residual, post, comb, x = self._hc_fused_post_pre(
+                x,
+                residual,
+                post,
+                comb,
+                self.hc_attn_fn,
+                self.hc_attn_scale,
+                self.hc_attn_base,
+                self.input_layernorm,
+            )
+
+        x = self._attention(positions, x)
+        assert residual is not None and post is not None and comb is not None
+        residual, post, comb, x = self._hc_fused_post_pre(
+            x,
+            residual,
+            post,
+            comb,
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+            self.post_attention_layernorm,
+        )
+        x = self.mlp(x)
+
+        if self.layer_idx == self.num_hidden_layers - 1:
+            x = self.mhc_post_op(x, residual, post, comb)
+            return _hc_contract(x), None, None, None
+        return x, residual, post, comb
+
+
+@support_torch_compile
+class Glm5NextModel(nn.Module):
+    fall_back_to_pt_during_load = False
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config = vllm_config.model_config.hf_text_config
+        self.config = config
+        self.vocab_size = config.vocab_size
+
+        topk_indices_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            # kpool expands 512 pool ids to 2048 tokens, appends <=3 tail
+            # tokens, and sparse MLA requires a 128-column aligned width.
+            ((config.index_topk + config.index_kpool - 1 + 127) // 128 * 128),
+            dtype=torch.int32,
+            device=current_platform.device_type,
+        )
+
+        if get_pp_group().is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=vllm_config.quant_config,
+                prefix=f"{prefix}.embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        def get_layer(prefix: str):
+            layer_idx = int(prefix.rsplit(".", 1)[1])
+            return Glm5NextDecoderLayer(
+                vllm_config,
+                layer_idx,
+                prefix,
+                topk_indices_buffer,
+            )
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers,
+            get_layer,
+            prefix=f"{prefix}.layers",
+        )
+        if get_pp_group().is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer()
+
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "residual"], config.hidden_size
+        )
+        self.use_mha = False
+        self.num_redundant_experts = (
+            vllm_config.parallel_config.eplb_config.num_redundant_experts
+        )
+        world_size = get_tensor_model_parallel_world_size()
+        assert config.num_attention_heads % world_size == 0
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor | IntermediateTensors:
+        del kwargs
+        if get_pp_group().is_first_rank:
+            hidden_states = (
+                inputs_embeds
+                if inputs_embeds is not None
+                else self.embed_input_ids(input_ids)
+            )
+            residual = post = comb = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+            post = comb = None
+
+        for layer in self.layers[self.start_layer : self.end_layer]:
+            hidden_states, residual, post, comb = layer(
+                positions, hidden_states, residual, post, comb
+            )
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+        return self.norm(hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # The v0.24 DeepSeek loader handles fused MLA/indexer projections,
+        # dense SwiGLU stacking, expert tensors, and direct KDA/mHC parameters.
+        return DeepseekV2Model.load_weights(self, weights)
+
+    def finalize_mhc_broadcast_weights(self) -> None:
+        """Build the first-layer projection used by the NVIDIA fast path."""
+        if not get_pp_group().is_first_rank or self.start_layer >= self.end_layer:
+            return
+        if not use_nvidia_reference():
+            return
+
+        from vllm.utils.deep_gemm import is_deep_gemm_supported
+
+        if not is_deep_gemm_supported():
+            logger.warning_once(
+                "GLM5-Next mHC broadcast specialization is disabled because "
+                "DeepGEMM is unavailable; using the generic mHC path"
+            )
+            return
+
+        layer = self.layers[self.start_layer]
+        if isinstance(layer, Glm5NextDecoderLayer) and layer.layer_idx == 0:
+            layer.hc_attn_fn_broadcast = (
+                layer.hc_attn_fn.detach()
+                .view(-1, layer.n, self.config.hidden_size)
+                .sum(dim=1)
+                .contiguous()
+            )
+            logger.info_once(
+                "Enabled GLM5-Next first-layer mhc_pre_broadcast_tilelang"
+            )
+
+
+class Glm5NextForCausalLM(
+    nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid
+):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.model_config = vllm_config.model_config
+        self.vllm_config = vllm_config
+        self.config = self.model_config.hf_text_config
+        self.model = Glm5NextModel(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "model"),
+        )
+        if get_pp_group().is_last_rank:
+            self.lm_head = ParallelLMHead(
+                self.config.vocab_size,
+                self.config.hidden_size,
+                quant_config=vllm_config.quant_config,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
+        else:
+            self.lm_head = PPMissingLayer()
+        self.logits_processor = LogitsProcessor(self.config.vocab_size)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor | IntermediateTensors:
+        return self.model(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            **kwargs,
+        )
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.kda_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+        )
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        config = vllm_config.model_config.hf_text_config
+        speculative_config = vllm_config.speculative_config
+        num_spec = (
+            speculative_config.num_speculative_tokens
+            if speculative_config is not None
+            else 0
+        )
+        return MambaStateShapeCalculator.kda_state_shape(
+            vllm_config.parallel_config.tensor_parallel_size,
+            config.linear_num_heads,
+            config.linear_head_dim,
+            conv_kernel_size=config.linear_conv_kernel_dim,
+            num_spec=num_spec,
+        )
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.kda_state_copy_func()
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+            ignore_unexpected_prefixes=["model.visual."],
+        )
+        loaded = loader.load_weights(weights)
+
+        # AutoWeightsLoader accepts a checkpoint as soon as every *present*
+        # key has a destination; it does not verify the inverse condition that
+        # every runtime parameter received a checkpoint tensor.  That is too
+        # weak for a newly adapted architecture: one missed packed projection
+        # otherwise remains torch.empty() and only appears later as meaningless
+        # logits.  Audit the text model at the innermost CausalLM boundary so
+        # vision-only parameters and outer HF prefix mapping cannot obscure the
+        # result.
+        expected = {name for name, _ in self.named_parameters()}
+        missing = sorted(expected - loaded)
+        unexpected = sorted(loaded - expected)
+        logger.info(
+            "GLM5-Next strict text weight audit: loaded=%d expected=%d "
+            "missing=%d unexpected=%d",
+            len(loaded),
+            len(expected),
+            len(missing),
+            len(unexpected),
+        )
+        if unexpected:
+            logger.warning(
+                "GLM5-Next weight audit returned unexpected names: %s",
+                unexpected[:32],
+            )
+        if missing:
+            raise RuntimeError(
+                "GLM5-Next checkpoint did not initialize all text parameters; "
+                f"first missing names: {missing[:64]}"
+            )
+        self.model.finalize_mhc_broadcast_weights()
+        return loaded
+
+
+__all__ = ["Glm5NextForCausalLM"]

--- a/vllm_fl/models/glm5_next.py
+++ b/vllm_fl/models/glm5_next.py
@@ -633,7 +633,28 @@ class Glm5NextMLAAttention(DeepseekV2MLAAttention):
         vllm_config = kwargs["vllm_config"]
         config = kwargs["config"]
         cache_config = kwargs["cache_config"]
-        super().__init__(*args, **kwargs)
+        # vLLM's base MLA constructor eagerly creates its stock
+        # ``SparseAttnIndexer`` before this class can replace it with the
+        # plugin-owned kpool implementation below.  On a CUDA empty-build
+        # wheel that stock constructor rejects the missing DeepGEMM ABI even
+        # though all runtime indexer operations will be routed through the
+        # portable backend.  Suppress only that constructor-time capability
+        # guard, and only for GLM5's non-NVIDIA provider; the temporary value
+        # is restored before model construction continues.  Explicit
+        # ``VLLM_FL_GLM5_PROVIDER=nvidia`` still fails fast as intended.
+        sparse_indexer_module = None
+        original_has_deep_gemm = None
+        if current_platform.is_cuda() and not use_nvidia_reference():
+            from vllm.model_executor.layers import sparse_attn_indexer
+
+            sparse_indexer_module = sparse_attn_indexer
+            original_has_deep_gemm = sparse_indexer_module.has_deep_gemm
+            sparse_indexer_module.has_deep_gemm = lambda: True
+        try:
+            super().__init__(*args, **kwargs)
+        finally:
+            if sparse_indexer_module is not None:
+                sparse_indexer_module.has_deep_gemm = original_has_deep_gemm
         if self.indexer is not None and config.index_kpool_compress:
             indexer = self.indexer
             kpool = int(config.index_kpool)

--- a/vllm_fl/models/glm5_next.py
+++ b/vllm_fl/models/glm5_next.py
@@ -644,17 +644,36 @@ class Glm5NextMLAAttention(DeepseekV2MLAAttention):
         # ``VLLM_FL_GLM5_PROVIDER=nvidia`` still fails fast as intended.
         sparse_indexer_module = None
         original_has_deep_gemm = None
+        mla_attention_module = None
+        original_get_prefill_backend = None
         if current_platform.is_cuda() and not use_nvidia_reference():
             from vllm.model_executor.layers import sparse_attn_indexer
+            from vllm.model_executor.layers.attention import (
+                mla_attention as mla_attention_module,
+            )
+
+            from vllm_fl.dispatch.backends.flaggems.impl.mla_prefill import (
+                FlagGemsMLAPrefillBackend,
+            )
 
             sparse_indexer_module = sparse_attn_indexer
             original_has_deep_gemm = sparse_indexer_module.has_deep_gemm
             sparse_indexer_module.has_deep_gemm = lambda: True
+            original_get_prefill_backend = (
+                mla_attention_module.get_mla_prefill_backend
+            )
+            mla_attention_module.get_mla_prefill_backend = (
+                lambda _vllm_config: FlagGemsMLAPrefillBackend
+            )
         try:
             super().__init__(*args, **kwargs)
         finally:
             if sparse_indexer_module is not None:
                 sparse_indexer_module.has_deep_gemm = original_has_deep_gemm
+            if mla_attention_module is not None:
+                mla_attention_module.get_mla_prefill_backend = (
+                    original_get_prefill_backend
+                )
         if self.indexer is not None and config.index_kpool_compress:
             indexer = self.indexer
             kpool = int(config.index_kpool)

--- a/vllm_fl/models/glm5_next.py
+++ b/vllm_fl/models/glm5_next.py
@@ -646,7 +646,7 @@ class Glm5NextMLAAttention(DeepseekV2MLAAttention):
         original_has_deep_gemm = None
         mla_attention_module = None
         original_get_prefill_backend = None
-        if current_platform.is_cuda() and not use_nvidia_reference():
+        if not use_nvidia_reference():
             from vllm.model_executor.layers import sparse_attn_indexer
             from vllm.model_executor.layers.attention import (
                 mla_attention as mla_attention_module,

--- a/vllm_fl/models/glm5_next_kpool.py
+++ b/vllm_fl/models/glm5_next_kpool.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+"""vLLM 0.24 cache objects for the GLM5-Next kpool indexer."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import ClassVar
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+from vllm.v1.attention.backend import (
+    AttentionCGSupport,
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+    MultipleOf,
+)
+from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerBackend,
+    DeepseekV32IndexerMetadata,
+)
+from vllm.v1.attention.backends.utils import split_decodes_and_prefills
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import BlockHashList, KVCacheBlock
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
+from vllm.v1.kv_cache_interface import (
+    KVCacheSpec,
+    MLAAttentionSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.request import Request
+
+
+@dataclass(frozen=True, kw_only=True)
+class KpoolTailSpec(SlidingWindowSpec):
+    """One per-request circular page containing raw K and gate-score tail."""
+
+    def max_admission_blocks_per_request(
+        self, max_num_batched_tokens: int, max_model_len: int
+    ) -> int:
+        del max_num_batched_tokens, max_model_len
+        return 1
+
+    def is_uniform_with_collection(
+        self, kv_cache_specs: dict[str, KVCacheSpec]
+    ) -> bool:
+        return all(isinstance(spec, KpoolTailSpec) for spec in kv_cache_specs.values())
+
+    @property
+    def participates_in_prefix_caching(self) -> bool:
+        return False
+
+
+class KpoolTailManager(FullAttentionManager):
+    """Reference no-hit/no-prune fixed-one-block manager for the tail ring."""
+
+    supports_fine_grained_hash_lookup: ClassVar[bool] = False
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        drop_eagle_block: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        del (
+            block_hashes,
+            max_length,
+            block_pool,
+            kv_cache_spec,
+            drop_eagle_block,
+            alignment_tokens,
+            dcp_world_size,
+            pcp_world_size,
+        )
+        return tuple([] for _ in kv_cache_group_ids)
+
+    def cache_blocks(
+        self,
+        request: Request,
+        num_tokens: int,
+        retention_interval: int | None = None,
+    ) -> None:
+        del request, num_tokens, retention_interval
+
+    def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
+        del running_request_id
+        return 0
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        del num_computed_tokens
+        return 0
+
+    def remove_skipped_blocks(
+        self, request_id: str, total_computed_tokens: int
+    ) -> None:
+        del request_id, total_computed_tokens
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        del (
+            num_tokens,
+            new_computed_blocks,
+            total_computed_tokens,
+            num_tokens_main_model,
+            apply_admission_cap,
+        )
+        return max(1 - len(self.req_to_blocks.get(request_id, ())), 0)
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        # The base implementation grows with sequence length. The tail instead
+        # obtains one page on first admission and circularly reuses it forever.
+        del num_tokens, num_tokens_main_model
+        req_blocks = self.req_to_blocks[request_id]
+        if req_blocks:
+            return []
+        new_blocks = self.block_pool.get_new_blocks(1)
+        req_blocks.extend(new_blocks)
+        return new_blocks
+
+
+def compute_kpool_tail_slot_mapping(
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+    num_actual_tokens: int,
+    num_reqs: int,
+    kpool: int,
+) -> torch.Tensor:
+    """Map every real token to its request-owned circular tail block.
+
+    The generic vLLM slot mapper indexes ``block_table[request, pos //
+    block_size]``. A ``KpoolTailManager`` owns exactly one block per request,
+    so columns after zero are unset and positions beyond the first pool would
+    collapse onto physical block zero. The tail cache instead uses the first
+    block as a ring addressed by ``pos % kpool``.
+    """
+    out = slot_mapping.clone()
+    if num_actual_tokens == 0:
+        return out
+
+    device = slot_mapping.device
+    tokens = torch.arange(num_actual_tokens, device=device)
+    request_ids = torch.searchsorted(query_start_loc, tokens, right=True) - 1
+    request_ids.clamp_(min=0, max=num_reqs - 1)
+    own_blocks = block_table[:num_reqs, 0].index_select(0, request_ids)
+    own_blocks = own_blocks.to(torch.int64)
+    token_positions = positions[:num_actual_tokens].to(torch.int64)
+    out[:num_actual_tokens] = own_blocks * kpool + torch.remainder(
+        token_positions, kpool
+    )
+    return out
+
+
+class KpoolTailMetadataBuilder(AttentionMetadataBuilder):
+    _cudagraph_support = AttentionCGSupport.ALWAYS
+    supports_update_block_table = False
+    reorder_batch_threshold = None
+
+    def __init__(
+        self,
+        kv_cache_spec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        # Storage-only tail: the common builder state is sufficient. In
+        # particular, do not allocate the normal indexer's paged-MQA buffers,
+        # whose kernel block must be 32/64 rather than kpool (4).
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+
+    @classmethod
+    def get_cudagraph_support(cls, vllm_config, kv_cache_spec):
+        del vllm_config, kv_cache_spec
+        return AttentionCGSupport.ALWAYS
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> DeepseekV32IndexerMetadata:
+        del common_prefix_len, fast_build
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+            split_decodes_and_prefills(common_attn_metadata)
+        )
+        slot_mapping = common_attn_metadata.slot_mapping
+        positions = common_attn_metadata.positions
+        if positions is not None:
+            slot_mapping = compute_kpool_tail_slot_mapping(
+                slot_mapping,
+                common_attn_metadata.block_table_tensor,
+                common_attn_metadata.query_start_loc,
+                positions,
+                common_attn_metadata.num_actual_tokens,
+                common_attn_metadata.num_reqs,
+                self.kv_cache_spec.block_size,
+            )
+        return DeepseekV32IndexerMetadata(
+            seq_lens=common_attn_metadata.seq_lens,
+            max_seq_len=common_attn_metadata.max_seq_len,
+            slot_mapping=slot_mapping,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            prefill=None,
+            decode=None,
+        )
+
+
+class KpoolTailBackend(DeepseekV32IndexerBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "KPOOL_TAIL"
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return []
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [MultipleOf(1)]
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        del cache_dtype_str
+        assert num_kv_heads == 1 and head_size % 2 == 0
+        return (num_blocks, 2, block_size, head_size // 2)
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        del include_num_layers_dimension
+        return (0, 1, 2, 3)
+
+    @staticmethod
+    def get_builder_cls():
+        return KpoolTailMetadataBuilder
+
+
+class Glm5NextIndexerCache(DeepseekV32IndexerCache):
+    def __init__(self, *, index_kpool: int, **kwargs) -> None:
+        super().__init__(**kwargs)
+        assert index_kpool > 1
+        cache_config = kwargs.get("cache_config")
+        if cache_config is not None:
+            assert cache_config.block_size % index_kpool == 0, (
+                "Glm5NextIndexerCache: cache block_size "
+                f"({cache_config.block_size}) must be divisible by index_kpool "
+                f"({index_kpool}) so chunked-prefill boundaries stay aligned"
+            )
+        self.index_kpool = index_kpool
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig):
+        spec = super().get_kv_cache_spec(vllm_config)
+        assert isinstance(spec, MLAAttentionSpec)
+        spec = replace(spec, compress_ratio=self.index_kpool)
+        storage_block_size = spec.block_size // self.index_kpool
+        assert (
+            spec.block_size % self.index_kpool == 0 and storage_block_size % 32 == 0
+        ), (
+            "GLM5-Next kpool requires logical block_size to be a multiple of "
+            f"index_kpool*32 ({self.index_kpool * 32}); got {spec.block_size}."
+        )
+        return spec
+
+
+class Glm5NextTailCache(DeepseekV32IndexerCache):
+    def __init__(self, *, index_kpool: int, **kwargs) -> None:
+        super().__init__(**kwargs)
+        assert index_kpool > 1
+        self.index_kpool = index_kpool
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig):
+        del vllm_config
+        return KpoolTailSpec(
+            block_size=self.index_kpool,
+            num_kv_heads=1,
+            head_size=2 * self.head_dim,
+            head_size_v=0,
+            dtype=torch.bfloat16,
+            sliding_window=self.index_kpool,
+            indexes_kv_by_block_stride=True,
+        )
+
+    def get_attn_backend(self):
+        return KpoolTailBackend
+
+
+__all__ = [
+    "Glm5NextIndexerCache",
+    "Glm5NextTailCache",
+    "KpoolTailBackend",
+    "KpoolTailManager",
+    "KpoolTailSpec",
+]

--- a/vllm_fl/models/glm5_next_multimodal.py
+++ b/vllm_fl/models/glm5_next_multimodal.py
@@ -1,0 +1,825 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GLM5Next vision tower + multimodal processor.
+
+Self-contained fork of the GLM-OCR / GLM-4V vision transformer so GLM5Next owns its
+vision path (no inheritance from `glm_ocr`/`glm4_1v`, leaving those upstream models
+untouched). Folds in:
+  - P1: fused q/k RMSNorm (one kernel, two distinct weights) in the attention.
+  - P7: a `forward(..., encoder_metadata=)` fast path so the ModelRunnerV2 encoder
+    CUDA graph (PR #49852 + `--compilation-config cudagraph_mm_encoder=true`) can
+    replay the tower instead of re-building rotary/cu_seqlens on the CPU each call.
+  - the OCR-variant delta vs GLM-4V base (no abs-pos embeddings / post-conv norm;
+    q/k norm eps=1e-5; qkv/proj/MLP bias=True).
+
+Default (flag off) is bit-identical to the inherited eager forward.
+"""
+
+from collections.abc import Mapping
+from functools import partial
+from typing import ClassVar, Literal
+
+import numpy as np
+import torch
+import torch.nn as nn
+from einops import rearrange
+
+from vllm.config import VllmConfig
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    parallel_state,
+    utils as dist_utils,
+)
+from vllm.model_executor.layers.attention.mm_encoder_attention import (
+    MMEncoderAttention,
+)
+from vllm.model_executor.layers.conv import Conv2dLayer, Conv3dLayer
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
+from vllm.model_executor.models.glm4_1v import (
+    Glm4vDummyInputsBuilder,
+    Glm4vForConditionalGeneration,
+    Glm4vMultiModalProcessor,
+    Glm4vProcessingInfo,
+    Glm4vVisionTransformer,
+)
+from vllm.model_executor.models.interfaces import HasInnerState, IsHybrid
+from vllm.model_executor.models.utils import (
+    init_vllm_registered_model,
+    maybe_prefix,
+)
+from vllm.model_executor.models.vision import (
+    get_vit_attn_backend,
+    is_vit_use_data_parallel,
+)
+from vllm.models.deepseek_v4.common.ops import fused_q_kv_rmsnorm
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.parse import ImageSize, MultiModalDataItems
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+from vllm_fl.kernels.glm5_next.provider import use_nvidia_reference
+from vllm_fl.models.glm5_next import SiluAndMulWithClamp
+
+
+class Glm5NextVisionPatchEmbed(nn.Module):
+    def __init__(
+        self,
+        patch_size: int = 14,
+        temporal_patch_size: int = 1,
+        in_channels: int = 3,
+        hidden_size: int = 1536,
+    ) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.hidden_size = hidden_size
+
+        kernel_size = (temporal_patch_size, patch_size, patch_size)
+        self.proj = Conv3dLayer(
+            in_channels,
+            hidden_size,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=True,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        L, C = x.shape
+        x = x.view(L, -1, self.temporal_patch_size, self.patch_size, self.patch_size)
+        x = self.proj(x).view(L, self.hidden_size)
+        return x
+
+
+class Glm5NextVisionMLP(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_features: int,
+        swiglu_limit: float,
+        bias: bool = True,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        use_data_parallel = is_vit_use_data_parallel()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=in_features,
+            output_sizes=[hidden_features] * 2,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+            disable_tp=use_data_parallel,
+        )
+        self.down_proj = RowParallelLinear(
+            hidden_features,
+            in_features,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+            disable_tp=use_data_parallel,
+        )
+        # GLM5Next clamps the vision SwiGLU gate/up (matches sglang
+        # `swiglu_clamped`); GLM-OCR / GLM-4V do not. This is the behavioral
+        # delta that makes the vision tower genuinely GLM5Next-specific.
+        self.act_fn = SiluAndMulWithClamp(swiglu_limit=swiglu_limit)
+
+    def forward(self, x: torch.Tensor):
+        x, _ = self.gate_up_proj(x)
+        x = self.act_fn(x)
+        x, _ = self.down_proj(x)
+        return x
+
+
+class Glm5NextVisionAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        projection_size: int,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        use_data_parallel = is_vit_use_data_parallel()
+        self.tp_size = (
+            1 if use_data_parallel else get_tensor_model_parallel_world_size()
+        )
+        self.tp_rank = (
+            0 if use_data_parallel else parallel_state.get_tensor_model_parallel_rank()
+        )
+        self.hidden_size_per_attention_head = dist_utils.divide(
+            projection_size, num_heads
+        )
+        self.num_attention_heads_per_partition = dist_utils.divide(
+            num_heads, self.tp_size
+        )
+
+        self.head_dim = embed_dim // num_heads
+
+        # q/k norm eps hard-coded 1e-5 — distinct from block/post norm eps.
+        self.q_norm = RMSNorm(self.head_dim, eps=1e-5)
+        self.k_norm = RMSNorm(self.head_dim, eps=1e-5)
+
+        self.qkv = QKVParallelLinear(
+            hidden_size=embed_dim,
+            head_size=self.hidden_size_per_attention_head,
+            total_num_heads=num_heads,
+            total_num_kv_heads=num_heads,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj" if quant_config else f"{prefix}.qkv",
+            disable_tp=use_data_parallel,
+        )
+        self.proj = RowParallelLinear(
+            input_size=projection_size,
+            output_size=embed_dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.proj",
+            bias=True,
+            disable_tp=use_data_parallel,
+        )
+
+        self.attn = MMEncoderAttention(
+            num_heads=self.num_attention_heads_per_partition,
+            head_size=self.hidden_size_per_attention_head,
+            scale=self.hidden_size_per_attention_head**-0.5,
+            prefix=f"{prefix}.attn",
+        )
+        self.apply_rotary_emb = ApplyRotaryEmb(enforce_enable=True)
+
+    def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        seq_len, bs, _ = qkv.shape
+        q, k, v = qkv.chunk(3, dim=2)
+        new_shape = (
+            seq_len,
+            bs,
+            self.num_attention_heads_per_partition,
+            self.hidden_size_per_attention_head,
+        )
+        q, k, v = (x.view(*new_shape) for x in (q, k, v))
+        return q, k, v
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb_cos: torch.Tensor,
+        rotary_pos_emb_sin: torch.Tensor,
+        max_seqlen: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        x, _ = self.qkv(x)
+        q, k, v = self.split_qkv(x)
+
+        q_shape, k_shape = q.shape, k.shape
+        q_flat = q.reshape(-1, self.head_dim)
+        k_flat = k.reshape(-1, self.head_dim)
+        if use_nvidia_reference():
+            q, k = fused_q_kv_rmsnorm(
+                q_flat,
+                k_flat,
+                self.q_norm.weight,
+                self.k_norm.weight,
+                self.q_norm.variance_epsilon,
+            )
+        else:
+            q = self.q_norm(q_flat)
+            k = self.k_norm(k_flat)
+        q = q.view(q_shape)
+        k = k.view(k_shape)
+
+        q, k, v = (rearrange(t, "s b ... -> b s ...").contiguous() for t in (q, k, v))
+        if rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
+            qk_concat = torch.cat([q, k], dim=0)
+            qk_rotated = self.apply_rotary_emb(
+                qk_concat,
+                rotary_pos_emb_cos,
+                rotary_pos_emb_sin,
+            )
+            q, k = torch.chunk(qk_rotated, 2, dim=0)
+
+        context_layer = self.attn(
+            query=q,
+            key=k,
+            value=v,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        context_layer = rearrange(context_layer, "b s h d -> s b (h d)").contiguous()
+
+        output, _ = self.proj(context_layer)
+        return output
+
+
+class Glm5NextVisionBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        swiglu_limit: float,
+        norm_layer: partial[nn.Module] | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = partial(nn.LayerNorm, eps=1e-6)
+        self.norm1 = norm_layer(dim)
+        self.norm2 = norm_layer(dim)
+        self.attn = Glm5NextVisionAttention(
+            embed_dim=dim,
+            num_heads=num_heads,
+            projection_size=dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
+        )
+        self.mlp = Glm5NextVisionMLP(
+            dim,
+            mlp_hidden_dim,
+            swiglu_limit=swiglu_limit,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.mlp",
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb_cos: torch.Tensor,
+        rotary_pos_emb_sin: torch.Tensor,
+        max_seqlen: int | None = None,
+    ) -> torch.Tensor:
+        x_attn = self.attn(
+            self.norm1(x),
+            cu_seqlens=cu_seqlens,
+            rotary_pos_emb_cos=rotary_pos_emb_cos,
+            rotary_pos_emb_sin=rotary_pos_emb_sin,
+            max_seqlen=max_seqlen,
+        )
+        x_fused_norm, residual = self.norm2(x, residual=x_attn)
+        x = residual + self.mlp(x_fused_norm)
+        return x
+
+
+class Glm5NextPatchMerger(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        context_dim: int,
+        swiglu_limit: float,
+        quant_config: QuantizationConfig | None = None,
+        bias: bool = False,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        use_data_parallel = is_vit_use_data_parallel()
+        self.hidden_size = d_model
+        self.proj = ColumnParallelLinear(
+            self.hidden_size,
+            self.hidden_size,
+            bias=bias,
+            gather_output=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.proj",
+            disable_tp=use_data_parallel,
+        )
+        self.post_projection_norm = nn.LayerNorm(self.hidden_size)
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=self.hidden_size,
+            output_sizes=[context_dim] * 2,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+            disable_tp=use_data_parallel,
+        )
+        self.down_proj = RowParallelLinear(
+            context_dim,
+            self.hidden_size,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+            disable_tp=use_data_parallel,
+        )
+        # Merger SwiGLU is clamped too (matches sglang Glm5NextVisionPatchMerger);
+        # GLM-OCR / GLM-4V mergers are unclamped.
+        self.act_fn = SiluAndMulWithClamp(swiglu_limit=swiglu_limit)
+        self.extra_activation_func = nn.GELU()
+
+    def forward(self, x: torch.Tensor):
+        x, _ = self.proj(x)
+        x = self.extra_activation_func(self.post_projection_norm(x))
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+
+
+class Glm5NextVisionTransformer(nn.Module):
+    def __init__(
+        self,
+        text_config,  # noqa: ANN001  (kept for call-signature parity; unused — GLM5Next
+        # uses vision_config.projection_intermediate_size for the merger, not
+        # text_config.intermediate_size like GLM-OCR does.)
+        vision_config,
+        norm_eps: float = 1e-6,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        use_data_parallel = is_vit_use_data_parallel()
+        self.tp_size = (
+            1 if use_data_parallel else get_tensor_model_parallel_world_size()
+        )
+
+        patch_size = vision_config.patch_size
+        temporal_patch_size = vision_config.temporal_patch_size
+        in_channels = vision_config.in_channels
+        depth = vision_config.depth
+        self.hidden_size = vision_config.hidden_size
+        self.num_heads = vision_config.num_heads
+
+        self.patch_size = vision_config.patch_size
+        self.spatial_merge_size = vision_config.spatial_merge_size
+        self.out_hidden_size = vision_config.out_hidden_size
+
+        # GLM5Next applies a SwiGLU gate/up clamp in the vision encoder (block
+        # MLP + patch merger) that GLM-OCR / GLM-4V do not. Falls back to the
+        # text config's limit if the vision config omits it (matches sglang).
+        swiglu_limit = getattr(vision_config, "swiglu_limit", None)
+        if swiglu_limit is None:
+            swiglu_limit = getattr(text_config, "swiglu_limit", None)
+        assert swiglu_limit is not None, (
+            "GLM5Next vision requires swiglu_limit (vision_config or text_config)"
+        )
+
+        # Single construction pass — no abs-pos embeddings / post-conv norm (OCR delta).
+        self.patch_embed = Glm5NextVisionPatchEmbed(
+            patch_size=patch_size,
+            temporal_patch_size=temporal_patch_size,
+            in_channels=in_channels,
+            hidden_size=self.hidden_size,
+        )
+
+        norm_layer = partial(RMSNorm, eps=norm_eps)
+        head_dim = self.hidden_size // self.num_heads
+        self.rotary_pos_emb = get_rope(
+            head_size=head_dim,
+            max_position=8192,
+            is_neox_style=True,
+            rope_parameters={"partial_rotary_factor": 0.5},
+        )
+        self.blocks = nn.ModuleList(
+            [
+                Glm5NextVisionBlock(
+                    dim=self.hidden_size,
+                    num_heads=self.num_heads,
+                    mlp_hidden_dim=vision_config.intermediate_size,
+                    swiglu_limit=swiglu_limit,
+                    norm_layer=norm_layer,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.blocks.{layer_idx}",
+                )
+                for layer_idx in range(depth)
+            ]
+        )
+        # GLM5Next-specific merger bottleneck width.
+        self.merger = Glm5NextPatchMerger(
+            d_model=vision_config.out_hidden_size,
+            context_dim=vision_config.projection_intermediate_size,
+            swiglu_limit=swiglu_limit,
+            quant_config=quant_config,
+            bias=False,
+            prefix=f"{prefix}.merger",
+        )
+
+        self.downsample = Conv2dLayer(
+            in_channels=vision_config.hidden_size,
+            out_channels=vision_config.out_hidden_size,
+            kernel_size=vision_config.spatial_merge_size,
+            stride=vision_config.spatial_merge_size,
+        )
+        self.post_layernorm = RMSNorm(
+            vision_config.hidden_size, eps=vision_config.rms_norm_eps
+        )
+
+        self.attn_backend = get_vit_attn_backend(
+            head_size=head_dim,
+            dtype=torch.get_default_dtype(),
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    def rot_pos_emb(
+        self, grid_thw: list[list[int]]
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        pos_ids = []
+        for t, h, w in grid_thw:
+            hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
+            wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
+            hpos_ids = (
+                hpos_ids.reshape(
+                    h // self.spatial_merge_size,
+                    self.spatial_merge_size,
+                    w // self.spatial_merge_size,
+                    self.spatial_merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            wpos_ids = (
+                wpos_ids.reshape(
+                    h // self.spatial_merge_size,
+                    self.spatial_merge_size,
+                    w // self.spatial_merge_size,
+                    self.spatial_merge_size,
+                )
+                .permute(0, 2, 1, 3)
+                .flatten()
+            )
+            pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+        pos_ids = torch.cat(pos_ids, dim=0)
+        max_grid_size = max(max(h, w) for _, h, w in grid_thw)
+
+        cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
+
+        pos_ids = pos_ids.to(cos.device, non_blocking=True)
+        cos_combined = cos[pos_ids].flatten(1)
+        sin_combined = sin[pos_ids].flatten(1)
+        return cos_combined, sin_combined, pos_ids
+
+    def compute_attn_mask_seqlen(
+        self,
+        cu_seqlens: torch.Tensor,
+    ) -> torch.Tensor | None:
+        max_seqlen = None
+        if self.attn_backend in {
+            AttentionBackendEnum.FLASH_ATTN,
+            AttentionBackendEnum.ROCM_AITER_FA,
+            AttentionBackendEnum.TRITON_ATTN,
+        }:
+            max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
+        return max_seqlen
+
+    def prepare_encoder_metadata(
+        self,
+        grid_thw_list: list[list[int]],
+        *,
+        max_batch_size: int | None = None,
+        max_frames_per_batch: int | None = None,
+        max_seqlen_override: int | None = None,
+        device: torch.device | None = None,
+    ) -> dict[str, torch.Tensor | None]:
+        """Compute encoder metadata (shared by eager forward + CG capture/replay).
+
+        Forked from Glm4vVisionTransformer with the ``pos_embeds`` entry removed —
+        GLM5Next's tower has no abs-pos embeddings (``self.embeddings`` is never
+        built), so the upstream ``pos_embeds_interpolate`` call would AttributeError.
+        """
+        if device is None:
+            device = self.device
+
+        metadata: dict[str, torch.Tensor | None] = {}
+
+        rotary_cos, rotary_sin, _ = self.rot_pos_emb(grid_thw_list)
+        metadata["rotary_pos_emb_cos"] = rotary_cos
+        metadata["rotary_pos_emb_sin"] = rotary_sin
+
+        grid_thw_np = np.array(grid_thw_list, dtype=np.int32)
+        patches_per_frame = grid_thw_np[:, 1] * grid_thw_np[:, 2]
+        cu_seqlens = np.repeat(patches_per_frame, grid_thw_np[:, 0]).cumsum(
+            dtype=np.int32
+        )
+        cu_seqlens = np.concatenate([np.zeros(1, dtype=np.int32), cu_seqlens])
+
+        pad_to = (
+            max_frames_per_batch if max_frames_per_batch is not None else max_batch_size
+        )
+        if pad_to is not None:
+            num_seqs = len(cu_seqlens) - 1
+            if num_seqs < pad_to:
+                cu_seqlens = np.concatenate(
+                    [
+                        cu_seqlens,
+                        np.full(
+                            pad_to - num_seqs,
+                            cu_seqlens[-1],
+                            dtype=np.int32,
+                        ),
+                    ]
+                )
+
+        metadata["sequence_lengths"] = MMEncoderAttention.maybe_compute_seq_lens(
+            self.attn_backend, cu_seqlens, device
+        )
+
+        if max_seqlen_override is not None:
+            max_seqlen_val = max_seqlen_override
+        else:
+            max_seqlen_val = MMEncoderAttention.compute_max_seqlen(
+                self.attn_backend, cu_seqlens
+            )
+        metadata["max_seqlen"] = torch.tensor(max_seqlen_val, dtype=torch.int32)
+
+        metadata["cu_seqlens"] = MMEncoderAttention.maybe_recompute_cu_seqlens(
+            self.attn_backend,
+            cu_seqlens,
+            self.hidden_size,
+            self.tp_size,
+            device,
+        )
+
+        return metadata
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        grid_thw: torch.Tensor | list[list[int]],
+        *,
+        encoder_metadata: dict[str, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        # patchify
+        x = x.to(device=self.device, dtype=self.dtype)
+        x = self.patch_embed(x)
+
+        if encoder_metadata is not None:
+            # Encoder CUDA-graph path (PR #49852): rotary/cu_seqlens/max_seqlen are
+            # precomputed by prepare_encoder_metadata (which uses rot_pos_emb exactly
+            # as the eager rebuild does), so reuse them and skip the per-call CPU
+            # rebuild (the low-GPU-util culprit on multimodal workloads).
+            rotary_pos_emb_cos = encoder_metadata["rotary_pos_emb_cos"]
+            rotary_pos_emb_sin = encoder_metadata["rotary_pos_emb_sin"]
+            cu_seqlens = encoder_metadata["cu_seqlens"]
+            max_seqlen = encoder_metadata["max_seqlen"]
+        else:
+            if isinstance(grid_thw, list):
+                grid_thw = torch.tensor(grid_thw, dtype=torch.int32)
+            rotary_pos_emb_cos, rotary_pos_emb_sin, _ = self.rot_pos_emb(grid_thw)
+            cu_seqlens = torch.repeat_interleave(
+                grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]
+            ).cumsum(dim=0, dtype=torch.int32)
+            cu_seqlens = torch.cat([cu_seqlens.new_zeros(1), cu_seqlens])
+            cu_seqlens = cu_seqlens.to(self.device, non_blocking=True)
+            max_seqlen = self.compute_attn_mask_seqlen(cu_seqlens)
+
+        # transformers
+        x = x.unsqueeze(1)
+        for blk in self.blocks:
+            x = blk(
+                x,
+                cu_seqlens=cu_seqlens,
+                rotary_pos_emb_cos=rotary_pos_emb_cos,
+                rotary_pos_emb_sin=rotary_pos_emb_sin,
+                max_seqlen=max_seqlen,
+            )
+
+        # adapter
+        x = self.post_layernorm(x)
+        x = x.view(-1, self.spatial_merge_size, self.spatial_merge_size, x.shape[-1])
+        x = x.permute(0, 3, 1, 2)
+        x = self.downsample(x).view(-1, self.out_hidden_size)
+        x = self.merger(x)
+        return x
+
+    def load_weights(self, weights) -> set[str]:
+        # vLLM 0.24's mapper predates stacked-weight mappings. Reuse the
+        # GLM-4V loader, whose q/k/v and gate/up shard rules match this tower.
+        return Glm4vVisionTransformer.load_weights(self, weights)
+
+
+class Glm5NextProcessingInfo(Glm4vProcessingInfo):
+    """Build the checkpoint's custom image/video processor locally."""
+
+    def get_hf_processor(self, **kwargs: object):
+        del kwargs
+        processor = getattr(self, "_glm5_hf_processor", None)
+        if processor is None:
+            from vllm_fl.transformers_utils.processors.glm5_next import (
+                Glm5NextProcessor,
+            )
+
+            processor = Glm5NextProcessor.from_pretrained(self.ctx.model_config.model)
+            self._glm5_hf_processor = processor
+        return processor
+
+    @staticmethod
+    def _processor_pixel_budget(processor) -> tuple[int, int]:
+        from vllm_fl.transformers_utils.processors.glm5_next import (
+            _pixel_budget,
+        )
+
+        return _pixel_budget(
+            processor.min_image_tokens,
+            processor.max_image_tokens,
+            processor.patch_size,
+            processor.merge_size,
+            processor.temporal_patch_size,
+        )
+
+    def _get_image_max_pixels(self) -> int:
+        mm_kwargs = self.ctx.get_merged_mm_kwargs({})
+        if (override := mm_kwargs.get("max_pixels")) is not None:
+            return int(override)
+        processor = self.get_hf_processor().image_processor
+        return self._processor_pixel_budget(processor)[1]
+
+    def _get_video_max_pixels(self) -> int:
+        mm_kwargs = self.ctx.get_merged_mm_kwargs({})
+        if (override := mm_kwargs.get("max_pixels")) is not None:
+            return int(override)
+        processor = self.get_hf_processor().video_processor
+        return self._processor_pixel_budget(processor)[1]
+
+    def _get_vision_info(
+        self,
+        *,
+        image_width: int,
+        image_height: int,
+        num_frames: int = 16,
+        do_resize: bool = True,
+        max_image_pixels: int = 28 * 28 * 2 * 30000,
+    ) -> tuple[ImageSize, int]:
+        from vllm_fl.transformers_utils.processors.glm5_next import smart_resize
+
+        vision_config = self.get_hf_config().vision_config
+        patch_size = vision_config.patch_size
+        merge_size = vision_config.spatial_merge_size
+        temporal_patch_size = vision_config.temporal_patch_size
+        image_processor = self.get_hf_processor().image_processor
+        factor = patch_size * merge_size * image_processor.patch_expand_factor
+        # The inherited GLM-4V dummy-video token estimator probes frame counts
+        # just beyond the pixel budget while finding the largest fitting video.
+        # Keep one aligned spatial patch available per probed frame so that the
+        # estimator returns an over-budget token count instead of raising.
+        padded_frames = num_frames + (-num_frames % temporal_patch_size)
+        max_image_pixels = max(max_image_pixels, padded_frames * factor * factor)
+
+        if do_resize:
+            frames = max(num_frames, temporal_patch_size)
+            resized_height, resized_width = smart_resize(
+                t=frames,
+                h=image_height,
+                w=image_width,
+                t_factor=temporal_patch_size,
+                h_factor=factor,
+                w_factor=factor,
+                min_pixels=1,
+                max_pixels=max_image_pixels,
+            )
+            preprocessed_size = ImageSize(width=resized_width, height=resized_height)
+        else:
+            preprocessed_size = ImageSize(width=image_width, height=image_height)
+
+        grid_t = max(padded_frames // temporal_patch_size, 1)
+        grid_h = preprocessed_size.height // patch_size
+        grid_w = preprocessed_size.width // patch_size
+        num_patches = grid_t * grid_h * grid_w
+        return preprocessed_size, num_patches // (merge_size**2)
+
+
+class Glm5NextMultiModalProcessor(Glm4vMultiModalProcessor):
+    """Let vLLM, rather than the feature-only HF processor, update prompts."""
+
+    def _hf_processor_applies_updates(
+        self,
+        prompt_text: str,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs: Mapping[str, object],
+    ) -> bool:
+        return False
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Glm5NextMultiModalProcessor,
+    info=Glm5NextProcessingInfo,
+    dummy_inputs=Glm4vDummyInputsBuilder,
+)
+class Glm5NextForConditionalGeneration(
+    Glm4vForConditionalGeneration, HasInnerState, IsHybrid
+):
+    """GLM5-Next VLM: ViT-DP plus TP language layers and EP experts."""
+
+    has_inner_state: ClassVar[Literal[True]] = True
+    is_hybrid: ClassVar[Literal[True]] = True
+    supports_encoder_tp_data = True
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(cls, vllm_config: VllmConfig):
+        from vllm_fl.models.glm5_next import Glm5NextForCausalLM
+
+        return Glm5NextForCausalLM.get_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(cls, vllm_config: VllmConfig):
+        from vllm_fl.models.glm5_next import Glm5NextForCausalLM
+
+        return Glm5NextForCausalLM.get_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(cls):
+        from vllm_fl.models.glm5_next import Glm5NextForCausalLM
+
+        return Glm5NextForCausalLM.get_mamba_state_copy_func()
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        # Bypass Glm4vForConditionalGeneration.__init__: its language-model
+        # architecture selection does not know GLM5-Next.
+        nn.Module.__init__(self)
+        config = vllm_config.model_config.hf_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        assert multimodal_config is not None
+
+        self.config = config
+        self.model_config = vllm_config.model_config
+        self.multimodal_config = multimodal_config
+        self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+        self.is_multimodal_pruning_enabled = (
+            multimodal_config.is_multimodal_pruning_enabled()
+        )
+
+        with self._mark_tower_model(vllm_config, {"image", "video"}):
+            self.visual = Glm5NextVisionTransformer(
+                config.text_config,
+                config.vision_config,
+                norm_eps=config.vision_config.rms_norm_eps,
+                # The vision checkpoint is BF16 even when the language model
+                # comes from the separately published FP8 directory.
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "visual"),
+            )
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                hf_config=config.text_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+                architectures=["Glm5NextForCausalLM"],
+            )
+
+    def get_encoder_cudagraph_config(self):
+        config = super().get_encoder_cudagraph_config()
+        config.buffer_keys = [key for key in config.buffer_keys if key != "pos_embeds"]
+        return config
+
+
+__all__ = [
+    "Glm5NextForConditionalGeneration",
+    "Glm5NextMultiModalProcessor",
+    "Glm5NextProcessingInfo",
+    "Glm5NextVisionTransformer",
+]

--- a/vllm_fl/models/glm5_next_multimodal.py
+++ b/vllm_fl/models/glm5_next_multimodal.py
@@ -17,7 +17,7 @@ Default (flag off) is bit-identical to the inherited eager forward.
 
 from collections.abc import Mapping
 from functools import partial
-from typing import ClassVar, Literal
+from typing import Any, ClassVar, Literal
 
 import numpy as np
 import torch
@@ -30,6 +30,7 @@ from vllm.distributed import (
     parallel_state,
     utils as dist_utils,
 )
+from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mm_encoder_attention import (
     MMEncoderAttention,
 )
@@ -67,6 +68,93 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_fl.kernels.glm5_next.provider import use_nvidia_reference
 from vllm_fl.models.glm5_next import SiluAndMulWithClamp
+
+logger = init_logger(__name__)
+
+
+def _install_glm5_vision_flaggems_fallback() -> None:
+    """Keep GLM5 ViT FlashAttention usable in an empty-build vLLM wheel.
+
+    The empty vLLM build does not ship the native FlashAttention extension.
+    ``vllm_fl`` consequently installs a ``vllm.vllm_flash_attn`` stub whose
+    ``flash_attn_varlen_func`` is ``None``.  vLLM's ViT custom op imports that
+    symbol from ``fa_utils`` at execution time, after the model has already
+    selected the ``FLASH_ATTN`` backend, so changing only the backend selector
+    does not repair the call site.
+
+    This hook is deliberately loaded from the GLM5 model module rather than a
+    common plugin module.  It replaces the imported function references in all
+    vLLM 0.24 layouts seen by GLM5, and remains installed for worker forwards,
+    profile-run, and CUDA-graph replay.  FlagGems currently implements FA2;
+    force that version even if a vendor selector supplied another version.
+    """
+    if not use_nvidia_reference():
+        try:
+            from flag_gems import flash_attn_varlen_func as flaggems_flash_attn
+        except (ImportError, OSError, RuntimeError) as exc:
+            logger.warning(
+                "GLM5 portable vision attention cannot import FlagGems: %s", exc
+            )
+            return
+    else:
+        return
+
+    def _glm5_flaggems_flash_attn_varlen_func(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor | tuple[torch.Tensor, ...]:
+        # The vLLM wrapper passes ``fa_version`` when the selector can infer
+        # one.  FlagGems' portable implementation is FA2-only.
+        kwargs["fa_version"] = 2
+        result = flaggems_flash_attn(q, k, v, *args, **kwargs)
+        # ViT callers expect only the attention output.  Keep this adapter
+        # tolerant of FlagGems configurations that return an LSE tuple.
+        if isinstance(result, tuple):
+            return result[0]
+        return result
+
+    _glm5_flaggems_flash_attn_varlen_func.__name__ = (
+        "glm5_flaggems_flash_attn_varlen_func"
+    )
+    _glm5_flaggems_flash_attn_varlen_func._glm5_flaggems_vision = True  # type: ignore[attr-defined]
+
+    # ``vit_attn_wrappers`` imports from fa_utils inside the custom-op
+    # implementation on vLLM 0.24.  Newer/vendor layouts may import the same
+    # symbol at module scope; assign both forms and the owning MM module.
+    import vllm.model_executor.layers.attention.mm_encoder_attention as mm_mod
+    import vllm.v1.attention.backends.fa_utils as fa_utils
+    import vllm.v1.attention.ops.vit_attn_wrappers as vit_ops
+
+    fa_utils.flash_attn_varlen_func = _glm5_flaggems_flash_attn_varlen_func
+    vit_ops.flash_attn_varlen_func = _glm5_flaggems_flash_attn_varlen_func
+    mm_mod.flash_attn_varlen_func = _glm5_flaggems_flash_attn_varlen_func
+
+    # ``patch_mm_encoder_attention`` may query this module directly on an
+    # alternate vLLM build.  Repair its optional stub as well, but do not
+    # overwrite a working native implementation.
+    try:
+        import vllm.vllm_flash_attn as vllm_flash_attn
+
+        if getattr(vllm_flash_attn, "flash_attn_varlen_func", None) is None:
+            vllm_flash_attn.flash_attn_varlen_func = (
+                _glm5_flaggems_flash_attn_varlen_func
+            )
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    logger.info_once(
+        "GLM5-Next portable vision attention uses persistent FlagGems FA2 "
+        "fallback for empty-build vLLM"
+    )
+
+
+# Install before the vision tower is constructed.  The assignment is
+# intentionally persistent: profile_run and graph replay execute the vLLM
+# custom op long after MMEncoderAttention.__init__ has returned.
+_install_glm5_vision_flaggems_fallback()
 
 
 class Glm5NextVisionPatchEmbed(nn.Module):

--- a/vllm_fl/models/glm5_next_multimodal.py
+++ b/vllm_fl/models/glm5_next_multimodal.py
@@ -818,6 +818,79 @@ class Glm5NextProcessingInfo(Glm4vProcessingInfo):
         num_patches = grid_t * grid_h * grid_w
         return preprocessed_size, num_patches // (merge_size**2)
 
+    def get_mm_max_tokens_per_item(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> Mapping[str, int] | None:
+        """Video token ceiling from the token-budget pixel cap.
+
+        vLLM 0.24's inherited implementation reads
+        ``video_processor.size["longest_edge"]``, but the GLM-5-Next
+        token-budget processor deliberately leaves ``size`` unused
+        (``longest_edge=1``). That understates the video encoder ceiling by
+        orders of magnitude, so recompute it from ``_get_video_max_pixels``
+        and the sampler's own frame cap.
+        """
+        result: dict[str, int] = {}
+
+        if mm_counts.get("image", 0) > 0:
+            result["image"] = self.get_max_image_tokens()
+
+        if mm_counts.get("video", 0) > 0:
+            video_processor = self.get_video_processor()
+            max_pixels = self._get_video_max_pixels()
+
+            vision_config = self.get_hf_config().vision_config
+            temporal_patch_size = vision_config.temporal_patch_size
+            patch_size = vision_config.patch_size
+            merge_size = vision_config.spatial_merge_size
+
+            max_vision_tokens = max_pixels // (
+                temporal_patch_size * patch_size**2 * merge_size**2
+            )
+
+            max_grid_t = max(
+                int(getattr(video_processor, "max_frame_count_dynamic", 2048))
+                // temporal_patch_size,
+                1,
+            )
+
+            tokenizer = self.get_tokenizer()
+            max_ts_tokens = max(
+                len(tokenizer.encode(f"{t:.1f} seconds", add_special_tokens=False))
+                for t in range(min(max_grid_t, 300))
+            )
+
+            result["video"] = max_vision_tokens + max_grid_t * (2 + max_ts_tokens) + 2
+
+        return result
+
+    def _get_video_second_idx_glm46v(
+        self, metadata: dict[str, Any], total_frames: int
+    ) -> list[int]:
+        """Align video prompt timestamps with the processor's frame sampler.
+
+        vLLM's GLM-4.6V re-derivation uses a different duration-threshold
+        policy than GLM5Next's ``fps_interval`` sampler, so the placeholder
+        frame count would not match the encoded ``grid_t``. Reuse the
+        processor's sampler through :func:`glm_video_timestamp_seconds`.
+        """
+        from types import SimpleNamespace
+
+        from vllm_fl.transformers_utils.processors.glm5_next import (
+            glm_video_timestamp_seconds,
+        )
+
+        video_metadata = SimpleNamespace(
+            fps=metadata.get("fps"),
+            duration=metadata.get("duration"),
+            total_num_frames=metadata.get("total_num_frames", total_frames),
+            frames_indices=metadata.get("frames_indices"),
+            do_sample_frames=metadata.get("do_sample_frames", True),
+        )
+        return glm_video_timestamp_seconds(self.get_video_processor(), video_metadata)
+
 
 class Glm5NextMultiModalProcessor(Glm4vMultiModalProcessor):
     """Let vLLM, rather than the feature-only HF processor, update prompts."""

--- a/vllm_fl/ops/fused_moe/activation.py
+++ b/vllm_fl/ops/fused_moe/activation.py
@@ -11,6 +11,7 @@ def apply_moe_activation(
     activation: MoEActivation,
     output: torch.Tensor,
     input: torch.Tensor,
+    clamp_limit: float | None = None,
 ) -> torch.Tensor:
     """Apply MoE activation function."""
     assert input.dim() == 2, "Input must be 2D"
@@ -28,7 +29,22 @@ def apply_moe_activation(
 
     # Activations with gated multiplication (gate × activation(up))
     if activation == MoEActivation.SILU:
-        output.copy_(_silu_and_mul(None, input))
+        if clamp_limit is None:
+            output.copy_(_silu_and_mul(None, input))
+        else:
+            dim = input.shape[-1] // 2
+            try:
+                from flag_gems.fused.silu_and_mul_with_clamp import (
+                    silu_and_mul_with_clamp_out,
+                )
+
+                silu_and_mul_with_clamp_out(
+                    input[..., :dim], input[..., dim:], output, clamp_limit
+                )
+            except (ImportError, OSError, NotImplementedError, RuntimeError):
+                gate = input[..., :dim].clamp(max=clamp_limit)
+                up = input[..., dim:].clamp(min=-clamp_limit, max=clamp_limit)
+                output.copy_(F.silu(gate) * up)
     elif activation == MoEActivation.GELU:
         output.copy_(_gelu_and_mul(None, input))
     elif activation == MoEActivation.SWIGLUOAI:

--- a/vllm_fl/ops/fused_moe/fused_moe_utils.py
+++ b/vllm_fl/ops/fused_moe/fused_moe_utils.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.quantization.utils.flashinfer_utils import (
 )
 from vllm.triton_utils import tl, triton
 from vllm_fl.dispatch import CachedOp
+from vllm_fl.kernels.glm5_next.provider import use_nvidia_reference
 from vllm_fl.ops.fused_moe.activation import apply_moe_activation
 from vllm_fl.utils import use_flaggems
 
@@ -295,8 +296,47 @@ class TritonExpertsFL(TritonExperts):
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         apply_router_weight_on_input: bool,
     ):
+        # FlagGems 5.3.3's fused_experts_impl only accepts the activation
+        # enum/string and therefore drops FusedMoEQuantConfig's
+        # gemm1_clamp_limit.  GLM5-Next was trained with a finite SwiGLU
+        # limit, so taking that fast path changes every routed expert in 42
+        # layers and quickly destroys model semantics.  Keep the FlagGems
+        # path for ordinary, unclamped MoE models.  On NVIDIA, bounded SwiGLU
+        # stays on the already-validated upstream TritonExperts implementation.
+        # Other accelerators continue through the per-step FlagGems GEMMs and
+        # use the exact clamped activation below.
+        if (
+            self.quant_config.gemm1_clamp_limit is not None
+            and current_platform.is_cuda()
+            and use_nvidia_reference()
+        ):
+            return super().apply(
+                output,
+                hidden_states,
+                w1,
+                w2,
+                topk_weights,
+                topk_ids,
+                activation,
+                global_num_experts,
+                expert_map,
+                a1q_scale,
+                a2_scale,
+                workspace13,
+                workspace2,
+                expert_tokens_meta,
+                apply_router_weight_on_input,
+            )
+
         # Fast path (no LoRA, NVIDIA only): single fused FlagGems call.
-        if self._lora_context is None and current_platform.is_cuda():
+        if (
+            self._lora_context is None
+            and current_platform.is_cuda()
+            and (
+                self.quant_config.gemm1_clamp_limit is None
+                or use_nvidia_reference()
+            )
+        ):
             import flag_gems
 
             output.copy_(flag_gems.fused_experts_impl(
@@ -450,7 +490,10 @@ class TritonExpertsFL(TritonExperts):
             )
 
         apply_moe_activation(
-            activation, intermediate_cache2, intermediate_cache1.view(-1, N)
+            activation,
+            intermediate_cache2,
+            intermediate_cache1.view(-1, N),
+            clamp_limit=self.quant_config.gemm1_clamp_limit,
         )
 
         a2q_scale: torch.Tensor | None = None

--- a/vllm_fl/patches/flaggems_mm_shape_aware.py
+++ b/vllm_fl/patches/flaggems_mm_shape_aware.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""Optional shape-aware dispatch for FlagGems' ``aten.mm`` kernel.
+
+FlagGems' generic ``aten.mm`` implementation can be a good fit for large-M
+prefill GEMMs, while the native CUDA implementation can be better for tiny-M
+decode GEMVs. This module installs a *process-local* CUDA dispatch wrapper
+only when explicitly requested by policy.
+
+The wrapper is deliberately small and uses tensor metadata only.  In
+particular, it does not call ``item()``, synchronize, or inspect device data,
+so it is safe to use from CUDA-graph/static-shape paths.
+
+The common worker policy is disabled by default. Model integrations may choose
+their own default after model-specific validation. An explicit
+``VLLM_FL_FLAGOS_MM_SHAPE_AWARE`` setting always wins, and ``mm`` can still be
+excluded from FlagGems with the existing platform-specific list.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import os
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+ENABLE_ENV = "VLLM_FL_FLAGOS_MM_SHAPE_AWARE"
+THRESHOLD_ENV = "VLLM_FL_FLAGOS_MM_DECODE_MAX_M"
+DEFAULT_DECODE_MAX_M = 64
+
+
+@dataclass(frozen=True)
+class ShapeAwareMMState:
+    """Handles retained for the lifetime of the process.
+
+    ``torch.library.Library`` registrations are revoked when the Library
+    object is garbage-collected, so the handle must be kept alive globally.
+    The original kernels are ``torch.library.get_kernel``'s
+    ``SafeKernelFunction`` handles.  They must be retained and called through
+    ``call_boxed(dispatch_keys, ...)`` after the override is installed; a
+    normal Python call is not supported by torch 2.11 and a redispatch using a
+    guessed keyset can recurse or bypass the intended backend.
+    """
+
+    threshold: int
+    native_mm: Any
+    flaggems_mm: Any
+    library: Any
+
+
+_STATE: ShapeAwareMMState | None = None
+
+
+def _parse_bool_env(name: str, *, default: bool = False) -> bool:
+    """Parse an override without accepting ambiguous values."""
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    if value == "1" or value == "true":
+        return True
+    if value == "0" or value == "false":
+        return False
+    raise ValueError(
+        f"{name} must be exactly one of 0, 1, false, true; got {value!r}"
+    )
+
+
+def _parse_threshold_env(name: str = THRESHOLD_ENV) -> int:
+    """Parse the decode-M threshold strictly as a positive decimal integer."""
+
+    value = os.environ.get(name)
+    if value is None:
+        return DEFAULT_DECODE_MAX_M
+    # Do not accept whitespace, signs, floating point, or a suffix.  This
+    # prevents a typo in a launch command from silently changing the policy.
+    if re.fullmatch(r"[0-9]+", value) is None:
+        raise ValueError(f"{name} must be a positive decimal integer; got {value!r}")
+    threshold = int(value, 10)
+    if threshold < 1:
+        raise ValueError(f"{name} must be >= 1; got {value!r}")
+    return threshold
+
+
+def _is_native_candidate(a: Any, b: Any, threshold: int) -> bool:
+    """Return whether this metadata-only call should use native CUDA ``mm``."""
+
+    # ``aten.mm`` is 2-D by contract.  Keeping this check explicit also makes
+    # the wrapper robust when called through a tracing/decomposition path.
+    a_device = getattr(a, "device", None)
+    b_device = getattr(b, "device", None)
+    if getattr(a_device, "type", None) != "cuda":
+        return False
+    if getattr(b_device, "type", None) != "cuda":
+        return False
+    if getattr(a, "ndim", None) != 2 or getattr(b, "ndim", None) != 2:
+        return False
+
+    a_shape = getattr(a, "shape", ())
+    b_shape = getattr(b, "shape", ())
+    if len(a_shape) != 2 or len(b_shape) != 2 or a_shape[0] < 1:
+        return False
+    if a_shape[0] > threshold:
+        return False
+
+    # BF16 is the primary serving dtype. FP16/FP32 are included because they
+    # are supported by native CUDA and useful for unit/integration probes. Do
+    # not alter mixed-dtype or integer/FP8 dispatch semantics here.
+    supported_dtypes = (torch.float16, torch.bfloat16, torch.float32)
+    if getattr(a, "dtype", None) not in supported_dtypes:
+        return False
+    if getattr(b, "dtype", None) != getattr(a, "dtype", None):
+        return False
+
+    # Native CUDA mm handles the usual row-major activation and row/column
+    # major weight layouts.  Reject unusual strided views so that this small
+    # prototype never changes FlagGems' existing stride-normalization path.
+    a_stride = a.stride()
+    b_stride = b.stride()
+    if len(a_stride) != 2 or len(b_stride) != 2:
+        return False
+    if a_stride[1] != 1 or a_stride[0] < 1:
+        return False
+    if not (b_stride[1] == 1 or b_stride[0] == 1):
+        return False
+    return not (b_stride[0] < 1 or b_stride[1] < 1)
+
+
+def _get_registered_mm_kernel() -> Any:
+    """Capture a CUDA ``aten::mm`` kernel as a boxed-safe handle.
+
+    ``torch.library.get_kernel`` returns a ``SafeKernelFunction`` on the
+    PyTorch build used by FlagOS.  Its ``call_boxed`` method is the supported
+    way to invoke a retained dispatcher kernel from a ``with_keyset``
+    implementation.  Refuse raw Python callables: accepting one would make
+    it too easy to install a wrapper which recurses into itself.
+    """
+
+    get_kernel = getattr(torch.library, "get_kernel", None)
+    if not callable(get_kernel):
+        raise RuntimeError(
+            "Shape-aware FlagGems mm requires torch.library.get_kernel to "
+            "capture the pre-existing CUDA kernel safely"
+        )
+    try:
+        kernel = get_kernel("aten::mm", "CUDA")
+    except Exception as exc:  # pragma: no cover - backend/version dependent
+        raise RuntimeError(
+            "Unable to capture the CUDA aten::mm kernel; refusing a "
+            "potentially recursive override"
+        ) from exc
+    call_boxed = getattr(kernel, "call_boxed", None)
+    if not callable(call_boxed):
+        raise RuntimeError(
+            "torch.library.get_kernel('aten::mm', 'CUDA') did not return "
+            "a SafeKernelFunction with call_boxed; this torch build cannot "
+            "safely retain both native and FlagGems kernels"
+        )
+    return kernel
+
+
+def capture_native_mm_kernel() -> Any:
+    """Capture native CUDA ``aten.mm`` before ``flag_gems.enable``.
+
+    The worker calls this before FlagGems changes the CUDA registration.  It
+    is intentionally a separate operation so that looking up the kernel after
+    the override cannot accidentally capture the wrapper itself.
+    """
+
+    return _get_registered_mm_kernel()
+
+
+def is_shape_aware_mm_enabled(*, default: bool = False) -> bool:
+    """Return the policy switch without touching dispatch state."""
+
+    return _parse_bool_env(ENABLE_ENV, default=default)
+
+
+def is_mm_dispatch_enabled(
+    whitelist: list[str] | None,
+    blacklist: list[str] | None,
+) -> bool:
+    """Return whether FlagGems owns ``aten.mm`` for this worker.
+
+    A shape-aware override needs both the captured native kernel and the
+    post-``flag_gems.enable`` FlagGems kernel. Installing it while ``mm`` is
+    excluded would otherwise capture the native kernel twice and silently
+    defeat the explicit rollback switch. Whitelists take precedence in the
+    same way as :func:`get_flag_gems_whitelist_blacklist`.
+    """
+
+    if whitelist is not None:
+        return "mm" in whitelist
+    return "mm" not in (blacklist or ())
+
+
+def _register_override(library: Any, wrapper: Callable[..., Any]) -> None:
+    """Install the wrapper only on torch versions supporting safe override."""
+
+    impl = library.impl
+    try:
+        signature = inspect.signature(impl)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - C API variant
+        raise RuntimeError(
+            "Cannot inspect torch.library.Library.impl; refusing to override "
+            "aten::mm without an explicit with_keyset/allow_override API"
+        ) from exc
+    missing = {
+        name
+        for name in ("with_keyset", "allow_override")
+        if name not in signature.parameters
+    }
+    if missing:
+        raise RuntimeError(
+            "torch.library.Library.impl lacks "
+            f"{', '.join(sorted(missing))}; this torch build cannot safely "
+            "replace the FlagGems CUDA aten::mm kernel"
+        )
+    try:
+        impl("mm", wrapper, "CUDA", with_keyset=True, allow_override=True)
+    except TypeError as exc:  # pragma: no cover - incompatible torch ABI
+        raise RuntimeError(
+            "torch.library.Library.impl rejected the safe with_keyset/"
+            "allow_override registration; refusing a potentially recursive "
+            "aten::mm override"
+        ) from exc
+
+
+def apply_shape_aware_mm(
+    *,
+    native_mm_kernel: Any | None = None,
+    default_enabled: bool = False,
+) -> bool:
+    """Install the opt-in shape-aware CUDA ``aten.mm`` wrapper.
+
+    Returns ``True`` when a new override is installed and ``False`` when the
+    feature is disabled or was already installed.  Invalid configuration and
+    unsupported torch registration APIs raise immediately with an actionable
+    error; silently falling back would make a benchmark claim ambiguous.
+    """
+
+    global _STATE
+
+    if not _parse_bool_env(ENABLE_ENV, default=default_enabled):
+        return False
+    threshold = _parse_threshold_env()
+    if _STATE is not None:
+        if _STATE.threshold != threshold:
+            raise RuntimeError(
+                "Shape-aware FlagGems mm is already installed with threshold "
+                f"{_STATE.threshold}, cannot change it to {threshold} in-process"
+            )
+        return False
+
+    if native_mm_kernel is None:
+        raise RuntimeError(
+            "Shape-aware FlagGems mm must capture native CUDA aten::mm "
+            "before flag_gems.enable; call capture_native_mm_kernel() first"
+        )
+    if not callable(getattr(native_mm_kernel, "call_boxed", None)):
+        raise RuntimeError(
+            "native_mm_kernel is not a SafeKernelFunction with call_boxed; "
+            "refusing a recursive or ambiguous aten::mm override"
+        )
+
+    flaggems_mm = _get_registered_mm_kernel()
+
+    def shape_aware_mm(dispatch_keys: Any, a: Any, b: Any) -> Any:
+        # ``dispatch_keys`` is supplied by torch.library's with_keyset=True
+        # wrapper.  Passing it to the retained SafeKernelFunction preserves
+        # the original dispatcher context without a host sync or guessed
+        # redispatch keyset.
+        if _is_native_candidate(a, b, threshold):
+            return native_mm_kernel.call_boxed(dispatch_keys, a, b)
+        return flaggems_mm.call_boxed(dispatch_keys, a, b)
+
+    shape_aware_mm.__name__ = "shape_aware_mm"
+    shape_aware_mm._vllm_fl_shape_aware_mm = True
+    shape_aware_mm._vllm_fl_original_flaggems_mm = flaggems_mm
+    shape_aware_mm._vllm_fl_native_mm = native_mm_kernel
+
+    library = torch.library.Library("aten", "IMPL")
+    _register_override(library, shape_aware_mm)
+    _STATE = ShapeAwareMMState(
+        threshold=threshold,
+        native_mm=native_mm_kernel,
+        flaggems_mm=flaggems_mm,
+        library=library,
+    )
+    logger.info(
+        "Enabled shape-aware FlagGems aten.mm: native CUDA for M <= %d, "
+        "FlagGems for larger/unsupported shapes",
+        threshold,
+    )
+    return True
+
+
+__all__ = [
+    "DEFAULT_DECODE_MAX_M",
+    "ENABLE_ENV",
+    "ShapeAwareMMState",
+    "THRESHOLD_ENV",
+    "_is_native_candidate",
+    "_parse_bool_env",
+    "_parse_threshold_env",
+    "apply_shape_aware_mm",
+    "capture_native_mm_kernel",
+    "is_mm_dispatch_enabled",
+    "is_shape_aware_mm_enabled",
+]

--- a/vllm_fl/patches/glm5_next_kpool_v024.py
+++ b/vllm_fl/patches/glm5_next_kpool_v024.py
@@ -1,0 +1,574 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Plugin-only vLLM 0.24 KV plumbing for GLM5-Next kpool/tail caches."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import replace
+from functools import wraps
+
+from vllm.utils.math_utils import cdiv
+
+from vllm_fl.models.glm5_next_kpool import (
+    KpoolTailManager,
+    KpoolTailSpec,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _inner_specs(groups):
+    from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+
+    for group in groups:
+        spec = group.kv_cache_spec
+        if isinstance(spec, UniformTypeKVCacheSpecs):
+            yield from spec.kv_cache_specs.items()
+        else:
+            yield from ((name, spec) for name in group.layer_names)
+
+
+def _is_glm5_kpool_groups(groups) -> bool:
+    return any(isinstance(spec, KpoolTailSpec) for _, spec in _inner_specs(groups))
+
+
+def _group_glm5_kpool(vllm_config, kv_cache_spec):
+    """Reference grouping semantics without modifying the vLLM package.
+
+    Main MLA and compressed indexer layers share one token-granular block table;
+    tail rings have their own 4-token group; KDA state remains a separate group.
+    The reference tree slot-shares KDA/MLA storage as a memory optimization. This
+    plugin keeps standalone KDA tensors but preserves every allocator/cache
+    semantic involved in kpool and tail correctness.
+    """
+    from vllm.v1.kv_cache_interface import (
+        KVCacheGroupSpec,
+        MLAAttentionSpec,
+        MambaSpec,
+        UniformTypeKVCacheSpecs,
+    )
+
+    del vllm_config
+    mamba_specs = {
+        name: spec for name, spec in kv_cache_spec.items() if isinstance(spec, MambaSpec)
+    }
+    tail_specs = {
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if isinstance(spec, KpoolTailSpec)
+    }
+    attn_specs = {
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if not isinstance(spec, (MambaSpec, KpoolTailSpec))
+    }
+    assert tail_specs and all(type(spec) is MLAAttentionSpec for spec in attn_specs.values())
+    index_pages = {
+        spec.page_size_bytes
+        for spec in attn_specs.values()
+        if spec.compress_ratio > 1
+    }
+    assert len(index_pages) == 1
+    index_page = next(iter(index_pages))
+
+    attn_uniform = UniformTypeKVCacheSpecs.from_specs(attn_specs)
+    assert attn_uniform is not None
+    padded_tail_specs = {
+        name: replace(spec, page_size_padded=index_page)
+        for name, spec in tail_specs.items()
+    }
+    tail_uniform = UniformTypeKVCacheSpecs.from_specs(padded_tail_specs)
+    assert tail_uniform is not None
+
+    groups = [
+        KVCacheGroupSpec(list(attn_specs), attn_uniform),
+        KVCacheGroupSpec(list(padded_tail_specs), tail_uniform),
+    ]
+    if mamba_specs:
+        exemplar = next(iter(mamba_specs.values()))
+        assert all(spec == exemplar for spec in mamba_specs.values())
+        groups.append(KVCacheGroupSpec(list(mamba_specs), exemplar))
+    return groups
+
+
+def install_glm5_next_kpool_v024() -> None:
+    from vllm.platforms.interface import Platform
+    from vllm.v1 import kv_cache_spec_registry
+    from vllm.v1.attention.backends.mla import indexer as indexer_backend
+    from vllm.v1.core import (
+        kv_cache_coordinator,
+        kv_cache_utils,
+        single_type_kv_cache_manager,
+    )
+    from vllm.v1.kv_cache_interface import (
+        KVCacheConfig,
+        KVCacheTensor,
+    )
+    from vllm.v1.kv_cache_interface import AttentionSpec
+    from vllm.v1.worker import utils as worker_utils
+
+    # Upstream GLM5-Next rounds the hybrid attention block *after* accounting
+    # for the KDA state page.  Stock v0.24 only does the latter, which turns a
+    # requested 128-token page into 192 tokens for this model.  The kpool
+    # paged-MQA layout requires a multiple of kpool * 32, so reproduce the
+    # reference platform hook here without changing the FlagOS vLLM package.
+    original_align_descriptor = Platform.__dict__["_align_hybrid_block_size"]
+    original_align = original_align_descriptor.__func__
+    if not getattr(original_align, "_glm5_kpool", False):
+
+        def align_hybrid(cls, vllm_config, backend_cls):
+            original_align(cls, vllm_config, backend_cls)
+            text_config = vllm_config.model_config.hf_text_config
+            if not getattr(text_config, "index_kpool_compress", False):
+                return
+            kpool = int(getattr(text_config, "index_kpool", 1) or 1)
+            if kpool <= 1:
+                return
+            cache_config = vllm_config.cache_config
+            old_block_size = cache_config.block_size
+            capability = cls.get_device_capability()
+            # DeepGEMM accepts a 32-entry paged-MQA block only on SM100.
+            # H100/SM90 therefore needs kpool*64 alignment; otherwise a
+            # 384/4=96 storage block would be split into illegal 32 pages.
+            compressed_page = (
+                64 if capability is not None and capability.major < 10 else 32
+            )
+            alignment = kpool * compressed_page
+            aligned_block_size = alignment * cdiv(old_block_size, alignment)
+            if aligned_block_size == old_block_size:
+                return
+            cache_config.block_size = aligned_block_size
+            if cache_config.mamba_cache_mode == "align":
+                cache_config.mamba_block_size = aligned_block_size
+            if cache_config.mamba_page_size_padded is not None:
+                assert cache_config.mamba_page_size_padded % old_block_size == 0
+                cache_config.mamba_page_size_padded = (
+                    cache_config.mamba_page_size_padded
+                    // old_block_size
+                    * aligned_block_size
+                )
+
+        align_hybrid._glm5_kpool = True
+        Platform._align_hybrid_block_size = classmethod(align_hybrid)
+
+    # Stock v0.24 copies every AttentionSpec to the selected attention-kernel
+    # block size before constructing its metadata builder.  For a compressed
+    # indexer that would turn logical 256 / pool 4 into an invalid 16-entry
+    # DeepGEMM page.  The reference keeps the compressed spec at pool-page
+    # granularity and records the co-located MLA kernel size for block-table
+    # translation.
+    original_create_builders = worker_utils.AttentionGroup.create_metadata_builders
+    if not getattr(original_create_builders, "_glm5_kpool", False):
+
+        def create_metadata_builders(
+            self,
+            vllm_config,
+            device,
+            kernel_block_size=None,
+            num_metadata_builders=1,
+        ):
+            spec = self.kv_cache_spec
+            is_compressed = (
+                isinstance(spec, AttentionSpec)
+                and spec.storage_block_size != spec.block_size
+            )
+            if not is_compressed:
+                return original_create_builders(
+                    self,
+                    vllm_config,
+                    device,
+                    kernel_block_size,
+                    num_metadata_builders,
+                )
+
+            storage_block_size = spec.storage_block_size
+            if storage_block_size <= 64:
+                compressed_kernel_size = storage_block_size
+            else:
+                compressed_kernel_size = (
+                    64 if storage_block_size % 64 == 0 else 32
+                )
+            assert compressed_kernel_size in (32, 64)
+            assert storage_block_size % compressed_kernel_size == 0
+            compress_ratio = spec.block_size // storage_block_size
+            builder_spec = spec.copy_with_new_block_size(
+                compressed_kernel_size * compress_ratio
+            )
+            self.metadata_builders = [
+                self.backend.get_builder_cls()(
+                    builder_spec,
+                    self.layer_names,
+                    vllm_config,
+                    device,
+                )
+                for _ in range(num_metadata_builders)
+            ]
+            if kernel_block_size is not None:
+                for builder in self.metadata_builders:
+                    builder.kernel_block_size = kernel_block_size
+
+        create_metadata_builders._glm5_kpool = True
+        worker_utils.AttentionGroup.create_metadata_builders = (
+            create_metadata_builders
+        )
+
+    # The scheduler table is shared with the MLA cache and therefore contains
+    # one physical id per 64-token kernel sub-page.  The compressed index cache
+    # owns one physical page per logical block.  Translate
+    #   [4*b+0, 4*b+1, 4*b+2, 4*b+3] -> [b]
+    # before *all* stock builder operations, so prefill writes and decode reads
+    # address the same page.  A persistent buffer keeps the path graph-safe
+    # after its warm-up allocation.
+    builder_cls = indexer_backend.DeepseekV32IndexerMetadataBuilder
+    original_indexer_build = builder_cls.build
+    if not getattr(original_indexer_build, "_glm5_kpool", False):
+
+        def build_indexer_metadata(
+            self,
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build=False,
+        ):
+            spec = self.kv_cache_spec
+            kernel_block_size = getattr(self, "kernel_block_size", None)
+            if (
+                getattr(spec, "compress_ratio", 1) > 1
+                and kernel_block_size is not None
+                and spec.block_size != kernel_block_size
+            ):
+                assert spec.block_size % kernel_block_size == 0
+                factor = spec.block_size // kernel_block_size
+                compressed = (
+                    common_attn_metadata.block_table_tensor[:, ::factor]
+                    // factor
+                )
+                buffer = getattr(self, "_glm5_indexer_block_table", None)
+                rows, cols = compressed.shape
+                if buffer is None:
+                    # Keep one base address across B1/B2/... FULL graphs.
+                    # Reallocating this tensor when only the request count
+                    # changes leaves earlier graphs pointing at freed storage.
+                    max_rows = self.vllm_config.scheduler_config.max_num_batched_tokens
+                    buffer = compressed.new_empty((max_rows, cols))
+                    self._glm5_indexer_block_table = buffer
+                elif buffer.shape[1] != cols:
+                    raise RuntimeError(
+                        "GLM5-Next indexer block-table width changed after "
+                        f"initialization: {buffer.shape[1]} -> {cols}"
+                    )
+                if rows > buffer.shape[0]:
+                    raise RuntimeError(
+                        "GLM5-Next indexer block-table rows exceed the stable "
+                        f"buffer: {rows} > {buffer.shape[0]}"
+                    )
+                translated_table = buffer[:rows, :cols]
+                translated_table.copy_(compressed)
+                common_attn_metadata = common_attn_metadata.replace(
+                    block_table_tensor=translated_table
+                )
+            return original_indexer_build(
+                self,
+                common_prefix_len,
+                common_attn_metadata,
+                fast_build,
+            )
+
+        build_indexer_metadata._glm5_kpool = True
+        builder_cls.build = build_indexer_metadata
+
+    # Reference KVBlockZeroer semantics: compressed index pages never share
+    # storage with KDA state and are overwritten before their first read, so
+    # exclude them from the page-uniform zeroing pass.  Stock 0.24 includes
+    # them and asserts because their physical page is intentionally smaller
+    # than an MLA page.
+    zeroer_cls = worker_utils.KVBlockZeroer
+    original_zeroer_init = zeroer_cls.__init__
+    if not getattr(original_zeroer_init, "_glm5_kpool", False):
+
+        def init_zeroer(
+            self,
+            device,
+            pin_memory,
+            attn_groups_iter,
+            kernel_block_sizes,
+            cache_dtype,
+            static_forward_context,
+            runner_only_attn_layers=None,
+        ):
+            groups = [
+                group
+                for group in attn_groups_iter
+                if not (
+                    isinstance(group.kv_cache_spec, AttentionSpec)
+                    and group.kv_cache_spec.storage_block_size
+                    != group.kv_cache_spec.block_size
+                )
+            ]
+            return original_zeroer_init(
+                self,
+                device,
+                pin_memory,
+                groups,
+                kernel_block_sizes,
+                cache_dtype,
+                static_forward_context,
+                runner_only_attn_layers,
+            )
+
+        init_zeroer._glm5_kpool = True
+        zeroer_cls.__init__ = init_zeroer
+
+    # Register only after the built-ins; registering first would make v0.24's
+    # lazy registry incorrectly believe initialization was already complete.
+    original_register_all = single_type_kv_cache_manager.register_all_kvcache_specs
+    if not getattr(original_register_all, "_glm5_kpool", False):
+
+        @wraps(original_register_all)
+        def register_all(vllm_config):
+            original_register_all(vllm_config)
+            kv_cache_spec_registry.KVCacheSpecRegistry.register(
+                KpoolTailSpec,
+                KpoolTailManager,
+                uniform_type_base_spec=KpoolTailSpec,
+            )
+
+        register_all._glm5_kpool = True
+        single_type_kv_cache_manager.register_all_kvcache_specs = register_all
+
+    # Plugin loading can happen after another component has forced lazy
+    # registration. In that case add only our spec immediately.
+    if kv_cache_spec_registry._REGISTRY_KVCACHESPEC_LIST:
+        kv_cache_spec_registry.KVCacheSpecRegistry.register(
+            KpoolTailSpec,
+            KpoolTailManager,
+            uniform_type_base_spec=KpoolTailSpec,
+        )
+
+    # Plugin activation can occur after vLLM has imported the manager factory
+    # into kv_cache_coordinator, and on that path the lazy registry may already
+    # have resolved KpoolTailSpec through its SlidingWindowSpec base class.
+    # Explicitly route the exact tail spec here.  The native sitecustomize path
+    # registers before that import; this OOT compatibility hook makes the two
+    # activation orders semantically identical without editing vLLM.
+    original_get_manager = (
+        single_type_kv_cache_manager.get_manager_for_kv_cache_spec
+    )
+    if not getattr(original_get_manager, "_glm5_kpool", False):
+
+        @wraps(original_get_manager)
+        def get_manager_for_kv_cache_spec(
+            kv_cache_spec,
+            max_num_batched_tokens,
+            max_model_len,
+            **kwargs,
+        ):
+            if type(kv_cache_spec) is KpoolTailSpec:
+                return KpoolTailManager(kv_cache_spec, **kwargs)
+            return original_get_manager(
+                kv_cache_spec,
+                max_num_batched_tokens,
+                max_model_len,
+                **kwargs,
+            )
+
+        get_manager_for_kv_cache_spec._glm5_kpool = True
+        single_type_kv_cache_manager.get_manager_for_kv_cache_spec = (
+            get_manager_for_kv_cache_spec
+        )
+        kv_cache_coordinator.get_manager_for_kv_cache_spec = (
+            get_manager_for_kv_cache_spec
+        )
+
+    original_groups = kv_cache_utils.get_kv_cache_groups
+    if not getattr(original_groups, "_glm5_kpool", False):
+
+        @wraps(original_groups)
+        def get_groups(vllm_config, kv_cache_spec):
+            if any(isinstance(spec, KpoolTailSpec) for spec in kv_cache_spec.values()):
+                return _group_glm5_kpool(vllm_config, kv_cache_spec)
+            return original_groups(vllm_config, kv_cache_spec)
+
+        get_groups._glm5_kpool = True
+        kv_cache_utils.get_kv_cache_groups = get_groups
+
+    original_pool_bytes = kv_cache_utils._pool_bytes_per_block
+    if not getattr(original_pool_bytes, "_glm5_kpool", False):
+
+        @wraps(original_pool_bytes)
+        def pool_bytes(vllm_config, groups):
+            if _is_glm5_kpool_groups(groups):
+                # Tail pages share their sibling indexer's backing tensor.
+                total = 0
+                for _name, spec in _inner_specs(groups):
+                    if isinstance(spec, KpoolTailSpec):
+                        continue
+                    total += spec.page_size_bytes
+                return total
+            return original_pool_bytes(vllm_config, groups)
+
+        pool_bytes._glm5_kpool = True
+        kv_cache_utils._pool_bytes_per_block = pool_bytes
+
+    original_max_usage = kv_cache_utils._max_memory_usage_bytes_from_groups
+    if not getattr(original_max_usage, "_glm5_kpool", False):
+
+        @wraps(original_max_usage)
+        def max_usage(vllm_config, groups):
+            if _is_glm5_kpool_groups(groups):
+                total = 0
+                for _name, spec in _inner_specs(groups):
+                    if isinstance(spec, KpoolTailSpec):
+                        # One tail page per active request; the scheduler's
+                        # max_num_seqs is the exact worst-case request count.
+                        total += (
+                            spec.page_size_bytes
+                            * vllm_config.scheduler_config.max_num_seqs
+                        )
+                    else:
+                        total += spec.max_memory_usage_bytes(vllm_config)
+                return total
+            return original_max_usage(vllm_config, groups)
+
+        max_usage._glm5_kpool = True
+        kv_cache_utils._max_memory_usage_bytes_from_groups = max_usage
+
+    original_config = kv_cache_utils.get_kv_cache_config_from_groups
+    if not getattr(original_config, "_glm5_kpool", False):
+
+        @wraps(original_config)
+        def cache_config(vllm_config, groups, available_memory):
+            if not _is_glm5_kpool_groups(groups):
+                return original_config(vllm_config, groups, available_memory)
+
+            per_layer = dict(_inner_specs(groups))
+            tail_names = {
+                name for name, spec in per_layer.items() if isinstance(spec, KpoolTailSpec)
+            }
+            index_names = {
+                name
+                for name, spec in per_layer.items()
+                if getattr(spec, "compress_ratio", 1) > 1
+            }
+            bytes_per_block = sum(
+                spec.page_size_bytes
+                for name, spec in per_layer.items()
+                if name not in tail_names
+            )
+            num_blocks = kv_cache_utils.may_override_num_blocks(
+                vllm_config, available_memory // bytes_per_block
+            )
+
+            tensors = []
+            consumed_tail = set()
+            for name, spec in per_layer.items():
+                if name in tail_names:
+                    continue
+                shared_by = [name]
+                if name in index_names:
+                    tail_name = name.removesuffix(".k_cache") + ".tail_cache"
+                    if tail_name in tail_names:
+                        shared_by.append(tail_name)
+                        consumed_tail.add(tail_name)
+                tensors.append(
+                    KVCacheTensor(
+                        size=spec.page_size_bytes * num_blocks,
+                        shared_by=shared_by,
+                    )
+                )
+            assert consumed_tail == tail_names
+            return KVCacheConfig(
+                num_blocks=num_blocks,
+                kv_cache_tensors=tensors,
+                kv_cache_groups=groups,
+            )
+
+        cache_config._glm5_kpool = True
+        kv_cache_utils.get_kv_cache_config_from_groups = cache_config
+
+    original_concurrency = kv_cache_utils.get_max_concurrency_for_kv_cache_config
+    if not getattr(original_concurrency, "_glm5_kpool", False):
+
+        @wraps(original_concurrency)
+        def concurrency(vllm_config, cache):
+            if _is_glm5_kpool_groups(cache.kv_cache_groups):
+                max_len = vllm_config.model_config.max_model_len
+                main_block = max(
+                    spec.block_size
+                    for _, spec in _inner_specs(cache.kv_cache_groups)
+                    if getattr(spec, "compress_ratio", 1) == 1
+                    and not isinstance(spec, KpoolTailSpec)
+                )
+                return cache.num_blocks / cdiv(max_len, main_block)
+            return original_concurrency(vllm_config, cache)
+
+        concurrency._glm5_kpool = True
+        kv_cache_utils.get_max_concurrency_for_kv_cache_config = concurrency
+
+    # Opt-in scheduler-capacity diagnostics.  This remains dormant in normal
+    # serving and is useful on immutable-vLLM FlagOS images because it reports
+    # the plugin-owned cache-manager view without modifying the vLLM package.
+    if os.environ.get("VLLM_FL_GLM5_DEBUG_KV_CAPACITY") == "1":
+        from vllm.v1.core.kv_cache_manager import KVCacheManager
+
+        original_allocate_slots = KVCacheManager.allocate_slots
+        if not getattr(original_allocate_slots, "_glm5_capacity_debug", False):
+
+            @wraps(original_allocate_slots)
+            def allocate_slots_with_capacity_debug(
+                self, request, num_new_tokens, *args, **kwargs
+            ):
+                result = original_allocate_slots(
+                    self, request, num_new_tokens, *args, **kwargs
+                )
+                if result is None:
+                    count = getattr(self, "_glm5_capacity_debug_count", 0)
+                    if count < 8:
+                        self._glm5_capacity_debug_count = count + 1
+                        probe_tokens = min(
+                            request.num_computed_tokens + num_new_tokens,
+                            self.max_model_len,
+                        )
+                        per_manager = []
+                        for manager in self.coordinator.single_type_managers:
+                            try:
+                                required = manager.get_num_blocks_to_allocate(
+                                    request.request_id,
+                                    probe_tokens,
+                                    [],
+                                    request.num_computed_tokens,
+                                    probe_tokens,
+                                )
+                            except Exception as exc:  # pragma: no cover - debug only
+                                required = f"error:{exc!r}"
+                            per_manager.append(
+                                {
+                                    "manager": type(manager).__name__,
+                                    "block_size": manager.block_size,
+                                    "required": required,
+                                    "held": len(
+                                        manager.req_to_blocks.get(
+                                            request.request_id, ()
+                                        )
+                                    ),
+                                }
+                            )
+                        logger.warning(
+                            "GLM5 KV capacity rejection: request=%s "
+                            "prompt_tokens=%d computed=%d new=%d free=%d/%d "
+                            "managers=%s",
+                            request.request_id,
+                            request.num_tokens,
+                            request.num_computed_tokens,
+                            num_new_tokens,
+                            self.block_pool.get_num_free_blocks(),
+                            self.block_pool.num_gpu_blocks,
+                            per_manager,
+                        )
+                return result
+
+            allocate_slots_with_capacity_debug._glm5_capacity_debug = True
+            KVCacheManager.allocate_slots = allocate_slots_with_capacity_debug
+
+
+__all__ = ["install_glm5_next_kpool_v024"]

--- a/vllm_fl/patches/glm5_next_v024.py
+++ b/vllm_fl/patches/glm5_next_v024.py
@@ -1,0 +1,595 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Register the plugin-owned GLM5-Next implementation on vLLM 0.24."""
+
+import logging
+import os
+from functools import wraps
+from importlib.metadata import PackageNotFoundError, version
+from types import ModuleType
+
+import torch
+
+from vllm.model_executor.models.config import (
+    HybridAttentionMambaModelConfig,
+)
+from vllm.transformers_utils.model_arch_config_convertor import (
+    ModelArchConfigConvertorBase,
+)
+
+from vllm_fl.kernels.glm5_next.provider import (
+    get_glm5_provider,
+    use_nvidia_reference,
+)
+
+logger = logging.getLogger(__name__)
+
+_CAUSAL_ARCH = "Glm5NextForCausalLM"
+_CONDITIONAL_ARCH = "Glm5NextForConditionalGeneration"
+_MHC_CUDA_MAX_TOKENS = 0
+
+
+def is_vllm_024() -> bool:
+    """Return whether the installed vLLM belongs to the 0.24 ABI line.
+
+    Keep this probe local to the model adapter: the current plugin main branch
+    has no generic ``patches._version`` module, and importing a historical
+    helper would make an otherwise valid 0.24 install fail at plugin startup.
+    """
+    try:
+        release = version("vllm").split("+", 1)[0].split(".")
+    except PackageNotFoundError:
+        return False
+    return len(release) >= 2 and release[:2] == ["0", "24"]
+
+
+def _is_missing_cache_op(exc: AttributeError, op_name: str) -> bool:
+    """Return whether vLLM failed because ``_C_cache_ops`` lacks an op."""
+    message = str(exc)
+    return "_C_cache_ops" in message and op_name in message
+
+
+def _has_vllm_cache_op(op_name: str) -> bool:
+    """Probe the extension ABI without invoking a device kernel."""
+    try:
+        getattr(torch.ops._C_cache_ops, op_name)
+    except AttributeError:
+        return False
+    return True
+
+
+def _concat_and_cache_mla_bf16_fallback(
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    kv_cache_dtype: str,
+    scale: torch.Tensor,
+) -> None:
+    """Correctness fallback for a vendor MLA backend without its cache op.
+
+    This is deliberately limited to BF16 cache semantics.  Quantized cache
+    formats require the vendor or FlagGems implementation because ``scale``
+    participates in the stored representation.
+    """
+    del scale
+    if kv_cache_dtype not in ("auto", "bfloat16"):
+        raise NotImplementedError(
+            "GLM5-Next portable concat_and_cache_mla only supports BF16 KV "
+            f"cache, got {kv_cache_dtype!r}"
+        )
+    source = (
+        kv_c
+        if k_pe.shape[-1] == 0
+        else torch.cat((kv_c, k_pe), dim=-1)
+    )
+    slots = slot_mapping.flatten().to(torch.int64)
+    valid = slots >= 0
+    cache_flat = kv_cache.view(-1, kv_cache.shape[-1])
+    cache_flat[slots[valid]] = source[valid]
+
+
+def _install_mla_boundary_compat_ops(
+    custom_ops: ModuleType | None = None,
+) -> bool:
+    """Keep vendor sparse MLA while filling its optional vLLM ABI edges.
+
+    Vendor backends remain responsible for the actual sparse attention.  The
+    wrappers below only cover GLM5-Next's zero-width RoPE query and the common
+    BF16 cache-write ABI that some OOT vLLM builds do not provide.
+    """
+    if custom_ops is None:
+        from vllm import _custom_ops as custom_ops
+
+    installed = False
+    strict_flaggems = get_glm5_provider() == "flaggems"
+
+    concat_mla_q = custom_ops.concat_mla_q
+    if not getattr(concat_mla_q, "_glm5_next_nope_fix", False):
+
+        @wraps(concat_mla_q)
+        def concat_mla_q_nope(ql_nope, q_pe, q_out):
+            if strict_flaggems:
+                raise RuntimeError(
+                    "VLLM_FL_GLM5_PROVIDER=flaggems was requested, but the "
+                    "stock/vendor sparse-MLA path called "
+                    "vllm._custom_ops.concat_mla_q. The worker did not select "
+                    "FlagGemsSparseMLABackend; check the worker environment, "
+                    "Plugin FL patch/version, and vendor backend overrides."
+                )
+            if q_pe.shape[-1] == 0:
+                q_out.copy_(ql_nope)
+                return None
+            return concat_mla_q(ql_nope, q_pe, q_out)
+
+        concat_mla_q_nope._glm5_next_nope_fix = True
+        concat_mla_q_nope._glm5_next_original = concat_mla_q
+        custom_ops.concat_mla_q = concat_mla_q_nope
+        installed = True
+
+    concat_and_cache_mla = custom_ops.concat_and_cache_mla
+    if not _has_vllm_cache_op("concat_and_cache_mla") and not getattr(
+        concat_and_cache_mla, "_glm5_next_vendor_fallback", False
+    ):
+        native_cache_op_available = True
+        flaggems_cache_writer = None
+        flaggems_cache_writer_loaded = False
+
+        @wraps(concat_and_cache_mla)
+        def concat_and_cache_mla_vendor_first(
+            kv_c,
+            k_pe,
+            kv_cache,
+            slot_mapping,
+            kv_cache_dtype,
+            scale,
+        ):
+            nonlocal native_cache_op_available
+            nonlocal flaggems_cache_writer
+            nonlocal flaggems_cache_writer_loaded
+
+            if native_cache_op_available:
+                try:
+                    return concat_and_cache_mla(
+                        kv_c,
+                        k_pe,
+                        kv_cache,
+                        slot_mapping,
+                        kv_cache_dtype,
+                        scale,
+                    )
+                except AttributeError as exc:
+                    if not _is_missing_cache_op(exc, "concat_and_cache_mla"):
+                        raise
+                    native_cache_op_available = False
+                    logger.warning(
+                        "Vendor vLLM has no _C_cache_ops.concat_and_cache_mla; "
+                        "trying FlagGems and then the BF16 correctness fallback"
+                    )
+
+            if not flaggems_cache_writer_loaded:
+                flaggems_cache_writer_loaded = True
+                try:
+                    from flag_gems.fused.concat_and_cache_mla import (
+                        concat_and_cache_mla as flaggems_cache_writer_impl,
+                    )
+
+                    flaggems_cache_writer = flaggems_cache_writer_impl
+                except (ImportError, AttributeError, OSError):
+                    flaggems_cache_writer = None
+
+            if flaggems_cache_writer is not None:
+                try:
+                    flag_cache_dtype = (
+                        "auto"
+                        if kv_cache_dtype == "bfloat16"
+                        else kv_cache_dtype
+                    )
+                    return flaggems_cache_writer(
+                        kv_c,
+                        k_pe,
+                        kv_cache,
+                        slot_mapping,
+                        kv_cache_dtype=flag_cache_dtype,
+                        scale=scale,
+                    )
+                except (NotImplementedError, RuntimeError) as exc:
+                    logger.warning(
+                        "FlagGems concat_and_cache_mla rejected this workload; "
+                        "using the BF16 correctness fallback: %s",
+                        exc,
+                    )
+                    flaggems_cache_writer = None
+
+            return _concat_and_cache_mla_bf16_fallback(
+                kv_c,
+                k_pe,
+                kv_cache,
+                slot_mapping,
+                kv_cache_dtype,
+                scale,
+            )
+
+        concat_and_cache_mla_vendor_first._glm5_next_vendor_fallback = True
+        concat_and_cache_mla_vendor_first._glm5_next_original = (
+            concat_and_cache_mla
+        )
+        custom_ops.concat_and_cache_mla = concat_and_cache_mla_vendor_first
+        installed = True
+
+    return installed
+
+
+def _silu_and_mul_with_clamp_oot(self, x: torch.Tensor) -> torch.Tensor:
+    """Use FlagGems for GLM's bounded SwiGLU when its exact op is present."""
+    if self.alpha != 1.0 or self.beta != 0.0:
+        return self.forward_native(x)
+    dim = x.shape[-1] // 2
+    try:
+        from flag_gems.fused.silu_and_mul_with_clamp import (
+            silu_and_mul_with_clamp,
+        )
+
+        return silu_and_mul_with_clamp(
+            x[..., :dim], x[..., dim:], self.swiglu_limit
+        )
+    except (ImportError, OSError, NotImplementedError, RuntimeError):
+        return self.forward_native(x)
+
+
+def _mhc_rms_norm(
+    layer_input: torch.Tensor,
+    norm_weight: torch.Tensor | None,
+    norm_eps: float,
+) -> torch.Tensor:
+    """Apply the RMSNorm fused by the CUDA mHC reference kernels."""
+    if norm_weight is None:
+        return layer_input
+    layer_input_fp32 = layer_input.float()
+    inv_rms = torch.rsqrt(
+        layer_input_fp32.square().mean(dim=-1, keepdim=True) + norm_eps
+    )
+    return (layer_input_fp32 * inv_rms * norm_weight.float()).to(
+        layer_input.dtype
+    )
+
+
+def _mhc_pre_oot_with_norm(
+    self,
+    residual,
+    fn,
+    hc_scale,
+    hc_base,
+    rms_eps,
+    hc_pre_eps,
+    hc_sinkhorn_eps,
+    hc_post_mult_value,
+    sinkhorn_repeat,
+    n_splits=1,
+    norm_weight=None,
+    norm_eps=0.0,
+):
+    try:
+        from flag_gems.fused.mhc import mhc_pre
+
+        post_mix, comb_mix, layer_input = mhc_pre(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            n_splits,
+        )
+    except (ImportError, OSError, NotImplementedError, RuntimeError):
+        post_mix, comb_mix, layer_input = self.forward_native(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            n_splits,
+            norm_weight,
+            norm_eps,
+        )
+    return (
+        post_mix,
+        comb_mix,
+        _mhc_rms_norm(layer_input, norm_weight, norm_eps),
+    )
+
+
+def _mhc_post_oot_flaggems(self, x, residual, post_layer_mix, comb_res_mix):
+    try:
+        from flag_gems.fused.mhc import mhc_post
+
+        return mhc_post(x, residual, post_layer_mix, comb_res_mix)
+    except (ImportError, OSError, NotImplementedError, RuntimeError):
+        return self.forward_native(x, residual, post_layer_mix, comb_res_mix)
+
+
+def _mhc_fused_post_pre_oot_with_norm(
+    self,
+    x,
+    residual,
+    post_layer_mix,
+    comb_res_mix,
+    fn,
+    hc_scale,
+    hc_base,
+    rms_eps,
+    hc_pre_eps,
+    hc_sinkhorn_eps,
+    hc_post_mult_value,
+    sinkhorn_repeat,
+    n_splits=1,
+    tile_n=1,
+    norm_weight=None,
+    norm_eps=0.0,
+):
+    try:
+        from flag_gems.fused.mhc import mhc_post, mhc_pre
+
+        residual_cur = mhc_post(x, residual, post_layer_mix, comb_res_mix)
+        post_mix, comb_mix, layer_input = mhc_pre(
+            residual_cur,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            n_splits,
+        )
+    except (ImportError, OSError, NotImplementedError, RuntimeError):
+        residual_cur, post_mix, comb_mix, layer_input = self.forward_native(
+            x,
+            residual,
+            post_layer_mix,
+            comb_res_mix,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            n_splits,
+            tile_n,
+            norm_weight,
+            norm_eps,
+        )
+    return (
+        residual_cur,
+        post_mix,
+        comb_mix,
+        _mhc_rms_norm(layer_input, norm_weight, norm_eps),
+    )
+
+
+def _mhc_pre_oot_bounded_cuda(self, residual, *args, **kwargs):
+    if residual.shape[0] <= _MHC_CUDA_MAX_TOKENS:
+        return self.forward_cuda(residual, *args, **kwargs)
+    return _mhc_pre_oot_with_norm(self, residual, *args, **kwargs)
+
+
+def _mhc_post_oot_bounded_cuda(self, x, residual, *args, **kwargs):
+    if x.shape[0] <= _MHC_CUDA_MAX_TOKENS:
+        return self.forward_cuda(x, residual, *args, **kwargs)
+    return self.forward_native(x, residual, *args, **kwargs)
+
+
+def _mhc_fused_post_pre_oot_bounded_cuda(
+    self, x, residual, *args, **kwargs
+):
+    if x.shape[0] <= _MHC_CUDA_MAX_TOKENS:
+        return self.forward_cuda(x, residual, *args, **kwargs)
+    return _mhc_fused_post_pre_oot_with_norm(
+        self, x, residual, *args, **kwargs
+    )
+
+
+class Glm5NextModelArchConfigConvertor(ModelArchConfigConvertorBase):
+    """Preserve VLM checkpoints and default bare text configs to CausalLM."""
+
+    def is_deepseek_mla(self) -> bool:
+        # vLLM v0.24 predates the glm5_next(_text) model-type entries in its
+        # MLA allowlist. Keep the same capability check used by newer vLLM so
+        # head_size and KV-cache/backend selection use kv_lora_rank + RoPE dim.
+        return getattr(self.hf_text_config, "kv_lora_rank", None) is not None
+
+    def get_architectures(self) -> list[str]:
+        architectures = super().get_architectures()
+        if not architectures:
+            architectures = [_CAUSAL_ARCH]
+        self.hf_config.architectures = architectures.copy()
+        return architectures
+
+
+class Glm5NextForCausalLMConfig(HybridAttentionMambaModelConfig):
+    """Compose v0.24 hybrid-cache and DSA validation."""
+
+    @classmethod
+    def verify_and_update_config(cls, vllm_config) -> None:
+        HybridAttentionMambaModelConfig.verify_and_update_config(vllm_config)
+
+        text_config = vllm_config.model_config.hf_text_config
+        cache_config = vllm_config.cache_config
+        if cache_config.cache_dtype == "bfloat16":
+            cache_config.cache_dtype = "auto"
+        if getattr(text_config, "index_kpool_compress", False):
+            kpool = int(getattr(text_config, "index_kpool", 1))
+            required = kpool * 32
+            if cache_config.block_size % required:
+                logger.info(
+                    "GLM5-Next kpool changes KV block_size from %d to %d "
+                    "for a 32-entry DeepGEMM compressed page",
+                    cache_config.block_size,
+                    required,
+                )
+                cache_config.block_size = required
+
+
+def apply_glm5_next_v024_patches() -> bool:
+    """Install idempotent config, convertor, and lazy-model registrations."""
+    if not is_vllm_024():
+        return False
+
+    from vllm.config.compilation import CompilationConfig
+    from vllm.platforms import current_platform
+    from vllm.model_executor.models import config as model_config
+    from vllm.model_executor.models import registry as model_registry
+    from vllm.transformers_utils import config as transformers_config
+    from vllm.transformers_utils import model_arch_config_convertor
+    from vllm.v1.attention.backends.mla.indexer import (
+        DeepseekV32IndexerBackend,
+    )
+
+    from vllm_fl.configs.glm5_next import (
+        Glm5NextConfig,
+        Glm5NextTextConfig,
+        Glm5NextVisionConfig,
+    )
+    from vllm_fl.patches.glm5_next_kpool_v024 import (
+        install_glm5_next_kpool_v024,
+    )
+
+    install_glm5_next_kpool_v024()
+
+    # Match the 0826 integration contract: keep the metadata-dependent kpool
+    # custom op outside Inductor's piecewise CUDA-graph partitions.
+    kpool_op = "vllm::sparse_attn_indexer_kpool"
+    if kpool_op not in CompilationConfig._attention_ops:
+        CompilationConfig._attention_ops.append(kpool_op)
+
+    # vLLM dispatches every CustomOp through ``forward_oot`` when an OOT
+    # platform plugin is active.  Its default OOT implementation delegates to
+    # ``forward_native``.  That fallback is not semantically interchangeable
+    # for mHC: MHCPreOp and MHCFusedPostPreOp accept the fused RMSNorm weight
+    # and epsilon, while their torch fallbacks intentionally ignore both.
+    # GLM5-Next relies on that fused normalization twice per decoder layer, so
+    # taking the fallback removes the layer norms and destroys model output.
+    #
+    # NVIDIA FlagOS ships the same CUDA/TileLang mHC operators used by native
+    # vLLM, so bind its OOT entry points directly to the reference kernels.
+    # Other OOT devices retain the portable torch decomposition, but complete
+    # its missing fused RMSNorm explicitly.  Install either path before model
+    # construction caches CustomOp._forward_method.
+    if current_platform.is_out_of_tree():
+        from vllm.model_executor.layers.mhc import (
+            MHCFusedPostPreOp,
+            MHCPostOp,
+            MHCPreOp,
+        )
+
+        if use_nvidia_reference():
+            global _MHC_CUDA_MAX_TOKENS
+            _MHC_CUDA_MAX_TOKENS = int(
+                os.environ.get("VLLM_FL_GLM5_MHC_CUDA_MAX_TOKENS", "0")
+            )
+            if _MHC_CUDA_MAX_TOKENS > 0:
+                MHCPreOp.forward_oot = _mhc_pre_oot_bounded_cuda
+                MHCPostOp.forward_oot = _mhc_post_oot_bounded_cuda
+                MHCFusedPostPreOp.forward_oot = (
+                    _mhc_fused_post_pre_oot_bounded_cuda
+                )
+                logger.info(
+                    "Bound GLM5-Next mHC OOT dispatch to CUDA/TileLang for "
+                    "<=%d tokens and portable reference fallback above it",
+                    _MHC_CUDA_MAX_TOKENS,
+                )
+            else:
+                for mhc_op in (MHCPreOp, MHCPostOp, MHCFusedPostPreOp):
+                    mhc_op.forward_oot = mhc_op.forward_cuda
+                logger.info(
+                    "Bound GLM5-Next mHC OOT dispatch to NVIDIA CUDA/TileLang "
+                    "kernels"
+                )
+        else:
+            from vllm.model_executor.layers.activation import SiluAndMulWithClamp
+
+            MHCPreOp.forward_oot = _mhc_pre_oot_with_norm
+            MHCPostOp.forward_oot = _mhc_post_oot_flaggems
+            MHCFusedPostPreOp.forward_oot = (
+                _mhc_fused_post_pre_oot_with_norm
+            )
+            SiluAndMulWithClamp.forward_oot = _silu_and_mul_with_clamp_oot
+            logger.info(
+                "Installed GLM5-Next portable mHC OOT fallback with RMSNorm "
+                "and FlagGems bounded-SwiGLU dispatch"
+            )
+
+    config_registry = transformers_config._CONFIG_REGISTRY
+    config_registry["glm5_next"] = Glm5NextConfig
+    config_registry["glm5_next_text"] = Glm5NextTextConfig
+    config_registry["glm5_next_vision"] = Glm5NextVisionConfig
+
+    convertors = model_arch_config_convertor.MODEL_ARCH_CONFIG_CONVERTORS
+    convertors["glm5_next"] = Glm5NextModelArchConfigConvertor
+    convertors["glm5_next_text"] = Glm5NextModelArchConfigConvertor
+
+    # The indexer cache is [num_blocks, block_size, head_bytes], and its CUDA
+    # insertion/top-k paths read kv_cache.stride(0).  It therefore supports the
+    # padded physical page view already implemented by vLLM 0.24, even though
+    # the backend conservatively reports False (to reject cross-layer layout).
+    # Opt in only to block-stride indexing; this does not enable cross-layer
+    # cache sharing and requires no vLLM source mutation.
+    DeepseekV32IndexerBackend.indexes_kv_by_block_stride = classmethod(
+        lambda cls: True
+    )
+
+    # Preserve each platform's selected sparse-MLA backend, including faster
+    # vendor implementations, while filling two optional vLLM extension ABI
+    # edges.  GLM5-Next is pure NoPE, so concat_mla_q is an exact direct copy.
+    # Cache insertion remains vendor-first and only falls back when the vendor
+    # wheel genuinely lacks _C_cache_ops.concat_and_cache_mla.
+    _install_mla_boundary_compat_ops()
+
+    for architecture in (_CAUSAL_ARCH, _CONDITIONAL_ARCH):
+        model_config.MODELS_CONFIG_MAP[architecture] = Glm5NextForCausalLMConfig
+
+    model_registry._TEXT_GENERATION_MODELS.setdefault(
+        _CAUSAL_ARCH, ("glm5_next", _CAUSAL_ARCH)
+    )
+    model_registry._VLLM_MODELS.setdefault(
+        _CAUSAL_ARCH, ("glm5_next", _CAUSAL_ARCH)
+    )
+    model_registry.ModelRegistry.register_model(
+        _CAUSAL_ARCH,
+        f"vllm_fl.models.glm5_next:{_CAUSAL_ARCH}",
+    )
+
+    # Keep the checkpoint's conditional architecture so vLLM constructs the
+    # vision tower and enables --mm-encoder-tp-mode data instead of silently
+    # reducing the model to its text-only runtime.
+    model_registry._VLLM_MODELS.setdefault(
+        _CONDITIONAL_ARCH, ("glm5_next", _CONDITIONAL_ARCH)
+    )
+    model_registry.ModelRegistry.register_model(
+        _CONDITIONAL_ARCH,
+        "vllm_fl.models.glm5_next_multimodal:"
+        f"{_CONDITIONAL_ARCH}",
+    )
+
+    logger.info(
+        "Installed vLLM 0.24 GLM5-Next text/VLM runtime with bounded KDA "
+        "gate, kpool, ViT data parallelism, and provider=%s",
+        get_glm5_provider(),
+    )
+    return True
+
+
+__all__ = [
+    "Glm5NextForCausalLMConfig",
+    "Glm5NextModelArchConfigConvertor",
+    "apply_glm5_next_v024_patches",
+]

--- a/vllm_fl/patches/glm5_next_v024.py
+++ b/vllm_fl/patches/glm5_next_v024.py
@@ -27,6 +27,67 @@ _CAUSAL_ARCH = "Glm5NextForCausalLM"
 _CONDITIONAL_ARCH = "Glm5NextForConditionalGeneration"
 _MHC_CUDA_MAX_TOKENS = 0
 
+# Empty-build vLLM wheels do not provide ``vllm._C``/``_moe_C``.  GLM5's
+# portable unquantized-MoE path still needs the dispatch-owned alignment and
+# Triton-kernel entry points, but older launch recipes often whitelist only
+# ``grouped_topk,moe_sum``.  Keep this list model-local: enabling these ops for
+# every model would change the platform-wide CUDA policy, while enabling it
+# when the GLM provider has selected FlagGems is required before the first
+# profile-run/KV-cache probe.
+_GLM5_PORTABLE_MOE_OPS = (
+    "moe_align_block_size",
+    "invoke_fused_moe_triton_kernel",
+)
+
+
+def _enable_glm5_portable_moe_dispatch() -> None:
+    """Make the GLM5 portable MoE path independent of the vLLM CUDA ABI.
+
+    ``register_model`` runs before :class:`WorkerFL` initializes the dispatch
+    registry and calls ``flag_gems.only_enable``.  Add the two dispatch ops
+    required by ``TritonExpertsFL`` to an existing deployment whitelist at
+    that point, and force their per-op order away from ``vendor.cuda``.  The
+    helper is a no-op for the validated NVIDIA/DeepGEMM provider and leaves an
+    unset whitelist unset (the normal FlagGems default already enables all
+    ops).  This is intentionally GLM5-specific; no common/day0-common change
+    is needed for empty-build compatibility.
+    """
+    if use_nvidia_reference():
+        return
+
+    whitelist = os.environ.get("VLLM_FL_FLAGOS_WHITELIST", "").strip()
+    if whitelist:
+        selected = [item.strip() for item in whitelist.split(",") if item.strip()]
+        for op_name in _GLM5_PORTABLE_MOE_OPS:
+            if op_name not in selected:
+                selected.append(op_name)
+        os.environ["VLLM_FL_FLAGOS_WHITELIST"] = ",".join(selected)
+
+    # The CUDA platform config prefers FlagGems, but an explicit per-op
+    # override can still select vendor.cuda.  Replace only these GLM-owned
+    # MoE entries and preserve every unrelated deployment override.
+    per_op = os.environ.get("VLLM_FL_PER_OP", "").strip()
+    entries = [item.strip() for item in per_op.split(";") if item.strip()]
+    rewritten: list[str] = []
+    seen: set[str] = set()
+    portable_order = "flagos|reference"
+    for entry in entries:
+        if "=" in entry:
+            op_name, _order = entry.split("=", 1)
+            op_name = op_name.strip()
+            if op_name in _GLM5_PORTABLE_MOE_OPS:
+                entry = f"{op_name}={portable_order}"
+                seen.add(op_name)
+        rewritten.append(entry)
+    for op_name in _GLM5_PORTABLE_MOE_OPS:
+        if op_name not in seen:
+            rewritten.append(f"{op_name}={portable_order}")
+    os.environ["VLLM_FL_PER_OP"] = ";".join(rewritten)
+    logger.info(
+        "GLM5-Next portable provider enabled FlagGems/Triton MoE ops: %s",
+        ", ".join(_GLM5_PORTABLE_MOE_OPS),
+    )
+
 
 def is_vllm_024() -> bool:
     """Return whether the installed vLLM belongs to the 0.24 ABI line.
@@ -460,6 +521,10 @@ def apply_glm5_next_v024_patches() -> bool:
     """Install idempotent config, convertor, and lazy-model registrations."""
     if not is_vllm_024():
         return False
+
+    # Do this before WorkerFL's provider/FlagGems initialization so the
+    # portable MoE implementations are registered in every worker process.
+    _enable_glm5_portable_moe_dispatch()
 
     from vllm.config.compilation import CompilationConfig
     from vllm.platforms import current_platform

--- a/vllm_fl/patches/glm5_next_v024.py
+++ b/vllm_fl/patches/glm5_next_v024.py
@@ -422,6 +422,23 @@ class Glm5NextForCausalLMConfig(HybridAttentionMambaModelConfig):
     def verify_and_update_config(cls, vllm_config) -> None:
         HybridAttentionMambaModelConfig.verify_and_update_config(vllm_config)
 
+        # GLM5-Next's TP16 mHC/all-reduce path is not safe to capture with
+        # vLLM 0.24's breakable CUDA-graph allocator when the generic O2/O3
+        # ``fuse_allreduce_rms`` pass is enabled.  The failure happens during
+        # the first graph capture (CachingHostAllocator use-count assertion),
+        # before the server can become ready.  The reference GLM5 deployment
+        # uses FULL_AND_PIECEWISE with this pass disabled.  Keep eager mode's
+        # existing behavior intact while making graph mode safe by default;
+        # an explicit ``--enforce-eager`` still leaves the fusion enabled.
+        if not getattr(vllm_config.model_config, "enforce_eager", False):
+            pass_config = vllm_config.compilation_config.pass_config
+            if pass_config.fuse_allreduce_rms is not False:
+                pass_config.fuse_allreduce_rms = False
+                logger.info(
+                    "GLM5-Next: disabled fuse_allreduce_rms for CUDA-graph "
+                    "capture safety on the vLLM 0.24 ABI"
+                )
+
         text_config = vllm_config.model_config.hf_text_config
         cache_config = vllm_config.cache_config
         if cache_config.cache_dtype == "bfloat16":

--- a/vllm_fl/patches/glm5_next_v024.py
+++ b/vllm_fl/patches/glm5_next_v024.py
@@ -96,11 +96,17 @@ def is_vllm_024() -> bool:
     has no generic ``patches._version`` module, and importing a historical
     helper would make an otherwise valid 0.24 install fail at plugin startup.
     """
+    if os.environ.get("VLLM_FL_ASSUME_VLLM_024") == "1":
+        return True
     try:
-        release = version("vllm").split("+", 1)[0].split(".")
+        full_release = version("vllm")
+        release = full_release.split("+", 1)[0].split(".")
     except PackageNotFoundError:
         return False
-    return len(release) >= 2 and release[:2] == ["0", "24"]
+    if len(release) >= 2 and release[:2] == ["0", "24"]:
+        return True
+    # The MetaX empty-build image exposes the vLLM 0.24 API as a dev version.
+    return full_release.startswith("0.1.dev") and full_release.endswith(".empty")
 
 
 def _is_missing_cache_op(exc: AttributeError, op_name: str) -> bool:

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -21,7 +21,7 @@ for _extension in ("vllm._C", "vllm._C_stable_libtorch"):
         pass  # Non-CUDA platforms may not ship either extension.
 
 from vllm.logger import init_logger
-from vllm.platforms import Platform, PlatformEnum
+from vllm.platforms import Platform, PlatformEnum, current_platform
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -278,17 +278,32 @@ class PlatformFL(Platform):
         # validated NVIDIA MLA backend.  Bypass only for MLA, so this env does
         # not alter ViT/standard attention dispatch.
         if use_mla:
-            from vllm_fl.kernels.glm5_next.provider import get_glm5_provider
+            from vllm_fl.kernels.glm5_next.provider import (
+                get_glm5_provider,
+                use_nvidia_reference,
+            )
 
-            if get_glm5_provider() == "flaggems":
+            provider = get_glm5_provider()
+            auto_portable = (
+                provider == "auto"
+                and current_platform.is_cuda()
+                and not use_nvidia_reference()
+            )
+            if provider == "flaggems" or auto_portable:
                 from vllm_fl.dispatch.backends.flaggems.flaggems import (
                     FlagGemsBackend,
                 )
 
                 flaggems_backend = FlagGemsBackend()
                 if not flaggems_backend.is_available():
+                    if provider == "flaggems":
+                        raise RuntimeError(
+                            "VLLM_FL_GLM5_PROVIDER=flaggems requires FlagGems"
+                        )
                     raise RuntimeError(
-                        "VLLM_FL_GLM5_PROVIDER=flaggems requires FlagGems"
+                        "GLM5 auto provider selected a portable MLA backend "
+                        "because the NVIDIA ABI/DeepGEMM is unavailable, but "
+                        "FlagGems is not installed"
                     )
                 backend_path = flaggems_backend.attention_backend(
                     use_mla=use_mla,

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -273,7 +273,37 @@ class PlatformFL(Platform):
         use_mla = attn_selector_config.use_mla
         use_sparse = attn_selector_config.use_sparse
 
-        backend_path = call_op("attention_backend", use_mla=use_mla, use_sparse=use_sparse)
+        # A process-start GLM5 A/B override must also cover attention-backend
+        # selection; the generic FlagOS whitelist may otherwise keep the
+        # validated NVIDIA MLA backend.  Bypass only for MLA, so this env does
+        # not alter ViT/standard attention dispatch.
+        if use_mla:
+            from vllm_fl.kernels.glm5_next.provider import get_glm5_provider
+
+            if get_glm5_provider() == "flaggems":
+                from vllm_fl.dispatch.backends.flaggems.flaggems import (
+                    FlagGemsBackend,
+                )
+
+                flaggems_backend = FlagGemsBackend()
+                if not flaggems_backend.is_available():
+                    raise RuntimeError(
+                        "VLLM_FL_GLM5_PROVIDER=flaggems requires FlagGems"
+                    )
+                backend_path = flaggems_backend.attention_backend(
+                    use_mla=use_mla,
+                    use_sparse=use_sparse,
+                )
+                logger.info_once(
+                    "GLM5 provider override selected attention backend: %s",
+                    backend_path,
+                    scope="local",
+                )
+                return backend_path
+
+        backend_path = call_op(
+            "attention_backend", use_mla=use_mla, use_sparse=use_sparse
+        )
 
         logger.info_once(
             "Using attention backend via dispatch (use_mla=%s, use_sparse=%s): %s",

--- a/vllm_fl/platform.py
+++ b/vllm_fl/platform.py
@@ -21,7 +21,7 @@ for _extension in ("vllm._C", "vllm._C_stable_libtorch"):
         pass  # Non-CUDA platforms may not ship either extension.
 
 from vllm.logger import init_logger
-from vllm.platforms import Platform, PlatformEnum, current_platform
+from vllm.platforms import Platform, PlatformEnum
 from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -286,7 +286,8 @@ class PlatformFL(Platform):
             provider = get_glm5_provider()
             auto_portable = (
                 provider == "auto"
-                and current_platform.is_cuda()
+                and cls.device_type == "cuda"
+                and cls.vendor_name == "nvidia"
                 and not use_nvidia_reference()
             )
             if provider == "flaggems" or auto_portable:

--- a/vllm_fl/quantization/quant_linear.py
+++ b/vllm_fl/quantization/quant_linear.py
@@ -36,6 +36,7 @@ def add_oot_quant_kernel() -> None:
         _POSSIBLE_FP8_KERNELS,
         _POSSIBLE_INT8_KERNELS,
         _POSSIBLE_KERNELS,
+        _POSSIBLE_MXFP8_KERNELS,
     )
 
     source = _resolve_source_platform()
@@ -56,6 +57,14 @@ def add_oot_quant_kernel() -> None:
     if PlatformEnum.OOT not in _POSSIBLE_FP8_BLOCK_KERNELS:
         _POSSIBLE_FP8_BLOCK_KERNELS[PlatformEnum.OOT] = list(
             _POSSIBLE_FP8_BLOCK_KERNELS.get(source, [])
+        )
+
+    # ModelOpt MXFP8 has a separate registry from ordinary FP8. PlatformFL
+    # reports OOT even on NVIDIA, so inherit the native candidates, including
+    # the emulation fallback, without adding or reordering device kernels.
+    if PlatformEnum.OOT not in _POSSIBLE_MXFP8_KERNELS:
+        _POSSIBLE_MXFP8_KERNELS[PlatformEnum.OOT] = list(
+            _POSSIBLE_MXFP8_KERNELS.get(source, [])
         )
 
     # compressed-tensors selects its Linear and MoE implementations while the

--- a/vllm_fl/transformers_utils/__init__.py
+++ b/vllm_fl/transformers_utils/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin-owned transformers compatibility helpers."""

--- a/vllm_fl/transformers_utils/processors/__init__.py
+++ b/vllm_fl/transformers_utils/processors/__init__.py
@@ -1,0 +1,1 @@
+"""Plugin-owned multimodal processors."""

--- a/vllm_fl/transformers_utils/processors/glm5_next.py
+++ b/vllm_fl/transformers_utils/processors/glm5_next.py
@@ -1,0 +1,1111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""vLLM-native multimodal processor for GLM-5-Next.
+
+Ports the GLM-5-Next image/video preprocessing pipeline (``smart_resize`` +
+Qwen-VL-style patchify + GLM-5-Next fps-interval frame sampling) so vLLM does
+not depend on transformers' GLM-5-Next processor classes. Only stable
+transformers framework primitives (``BaseImageProcessorFast`` /
+``BaseVideoProcessor``, ``ProcessorMixin``, ``BatchFeature``, ``SizeDict``)
+are reused.
+
+The checkpoint's ``processor_config.json`` is the source of truth: a nested
+``image_processor`` / ``video_processor`` config in the token-budget style
+(``min_image_tokens`` / ``max_image_tokens``, ``patch_expand_factor``,
+``resize_mode``, ``fps_interval``, ``max_frame_count_dynamic``). Pixel budgets
+are derived from the token bounds; there is no ``size``-edge budget.
+"""
+
+import json
+import math
+import os
+
+import numpy as np
+import torch
+from torchvision.transforms.v2 import functional as tvF
+from transformers.image_processing_utils import BatchFeature
+from transformers.image_processing_utils_fast import (
+    BaseImageProcessorFast,
+    group_images_by_shape,
+    reorder_images,
+)
+from transformers.image_utils import (
+    OPENAI_CLIP_MEAN,
+    OPENAI_CLIP_STD,
+    ChannelDimension,
+    ImageInput,
+    PILImageResampling,
+    SizeDict,
+    get_image_size,
+)
+from transformers.models.auto.image_processing_auto import get_image_processor_config
+from transformers.processing_utils import (
+    ImagesKwargs,
+    MultiModalData,
+    ProcessingKwargs,
+    ProcessorMixin,
+    Unpack,
+    VideosKwargs,
+)
+from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
+from transformers.utils import TensorType, logging
+from transformers.video_processing_utils import BaseVideoProcessor
+from transformers.video_utils import (
+    VideoInput,
+    VideoMetadata,
+    group_videos_by_shape,
+    reorder_videos,
+)
+
+logger = logging.get_logger(__name__)
+
+# The earlier size-budget config can advertise a huge ``longest_edge``. Keep
+# the original serving guard for that schema so swapping config files does not
+# unexpectedly consume the KV-cache budget.
+_LEGACY_MM_MAX_PIXELS = 1_254_400
+
+# The token-budget config is already bounded for images (8000 tokens), but its
+# 240000-token video default makes vLLM profile an impractically large encoder
+# workload at startup. This matches the reference serving cap while retaining
+# checkpoint-exact image preprocessing.
+_MAX_VIDEO_TOKENS = 30_000
+
+# Frame-sampler fallbacks (mirror the checkpoint's fps_interval=2 /
+# max_frame_count_dynamic=2048); used when neither the request nor the
+# processor config overrides them.
+GLM_VIDEO_DEFAULT_FPS = 2.0
+GLM_VIDEO_DEFAULT_MAX_FRAMES = 2048
+
+
+def glm_sample_frame_indices(
+    total_frames: int,
+    fps: float,
+    duration: float,
+    *,
+    target_fps: float | None = None,
+    max_frame_count: int | None = None,
+    temporal_patch_size: int = 2,
+) -> list[int]:
+    """GLM video frame sampling (training-reference parity).
+
+    ``target_fps`` is the ``fps_interval`` request knob. The greedy walk
+    advances at ``1 / (temporal_patch_size * target_fps)`` seconds, so on
+    frame-dense sources it collects more candidates than ``extract_t`` and
+    the ``> extract_t`` fixup re-spreads the picks uniformly with
+    ``np.linspace`` -- that fallback is the intended reference behavior, not
+    an accident. Short clips (fewer frames than ``extract_t``) are spread at
+    evenly spaced timestamps (``floor`` sampling; the linspace variant
+    samples frames unevenly and cost 4 points on video grounding evals).
+    Request overrides: ``target_fps`` -> fps interval, ``max_frame_count``
+    -> frame cap.
+    """
+    max_frame_idx = total_frames - 1
+    if not duration:
+        duration = (round(max_frame_idx / fps) + 1) if fps else 0
+    if max_frame_count is None:
+        max_frame_count = GLM_VIDEO_DEFAULT_MAX_FRAMES
+    if target_fps is None:
+        target_fps = GLM_VIDEO_DEFAULT_FPS
+
+    extract_t = int(duration * target_fps)
+    extract_t = min(extract_t, int(max_frame_count))
+
+    duration_per_frame = 1 / fps
+    timestamps = [i * duration_per_frame for i in range(total_frames)]
+    max_second = int(duration)
+
+    if total_frames < extract_t:
+        frame_indices = [
+            math.floor(_i * total_frames / extract_t) for _i in range(extract_t)
+        ]
+    else:
+        frame_indices = []
+        current_second = 0.0
+        inv_fps = 1 / (temporal_patch_size * target_fps)
+        for frame_index in range(total_frames):
+            if timestamps[frame_index] >= current_second:
+                current_second += inv_fps
+                frame_indices.append(frame_index)
+                if current_second >= max_second:
+                    break
+
+    if len(frame_indices) < extract_t:
+        if len(frame_indices) == 0:
+            start, end = 0, max(total_frames - 1, 0)
+        else:
+            start, end = frame_indices[0], frame_indices[-1]
+        frame_indices = np.linspace(start, end, extract_t, dtype=int).tolist()
+    elif len(frame_indices) > extract_t:
+        frame_indices = np.linspace(0, total_frames - 1, extract_t, dtype=int).tolist()
+
+    seen, uniq = set(), []
+    for idx in frame_indices:
+        if idx not in seen:
+            seen.add(idx)
+            uniq.append(int(idx))
+
+    if len(uniq) & 1:
+        uniq.append(uniq[-1])
+
+    return uniq
+
+
+def glm_sample_frame_indices_legacy(
+    total_frames: int,
+    source_fps: float,
+    duration: float,
+    *,
+    target_fps: float,
+    max_frame_count: int = 640,
+    temporal_patch_size: int = 2,
+) -> list[int]:
+    """Frame sampling used by the earlier size-budget config."""
+    effective_duration = min(duration, 2400)
+    extract_t = min(
+        int(effective_duration * target_fps * temporal_patch_size),
+        max_frame_count,
+    )
+    timestamps = [index / source_fps for index in range(total_frames)]
+    max_second = int(duration)
+    if total_frames < extract_t:
+        frame_indices = [
+            math.floor(index * total_frames / extract_t) for index in range(extract_t)
+        ]
+    else:
+        frame_indices = []
+        current_second = 0.0
+        interval = 1 / (temporal_patch_size * target_fps)
+        for frame_index, timestamp in enumerate(timestamps):
+            if timestamp >= current_second:
+                current_second += interval
+                frame_indices.append(frame_index)
+                if current_second >= max_second:
+                    break
+    if len(frame_indices) < extract_t:
+        start = frame_indices[0] if frame_indices else 0
+        end = frame_indices[-1] if frame_indices else max(total_frames - 1, 0)
+        frame_indices = np.linspace(start, end, extract_t, dtype=int).tolist()
+    elif len(frame_indices) > extract_t:
+        frame_indices = np.linspace(0, total_frames - 1, extract_t, dtype=int).tolist()
+    unique = list(dict.fromkeys(map(int, frame_indices)))
+    if len(unique) & 1:
+        unique.append(unique[-1])
+    return unique
+
+
+def _ceil_to_factor(value: int, factor: int) -> int:
+    """Round a positive integer upward to the nearest multiple of factor."""
+    return math.ceil(value / factor) * factor
+
+
+def _fit_aligned_size_within_budget(
+    t: int,
+    h: int,
+    w: int,
+    h_factor: int,
+    w_factor: int,
+    max_pixels: int,
+) -> tuple[int, int]:
+    """Largest proportional size whose upward-aligned canvas fits the budget.
+
+    Binary search on the unaligned content height; each candidate is rounded
+    upward to h_factor/w_factor, so the returned canvas always satisfies
+    ``t * aligned_h * aligned_w <= max_pixels``.
+    """
+    minimum_pixels = t * h_factor * w_factor
+    if max_pixels < minimum_pixels:
+        raise ValueError(
+            f"max_pixels={max_pixels} is too small. At least "
+            f"{minimum_pixels} pixels are required for one aligned patch."
+        )
+
+    low, high = 1, h
+    best_h, best_w = h_factor, w_factor
+    while low <= high:
+        content_h = (low + high) // 2
+        content_w = max(1, math.floor(w * content_h / h))
+        aligned_h = _ceil_to_factor(content_h, h_factor)
+        aligned_w = _ceil_to_factor(content_w, w_factor)
+        if t * aligned_h * aligned_w <= max_pixels:
+            best_h, best_w = aligned_h, aligned_w
+            low = content_h + 1
+        else:
+            high = content_h - 1
+    return best_h, best_w
+
+
+def smart_resize(
+    t: int,
+    h: int,
+    w: int,
+    t_factor: int = 1,
+    h_factor: int = 28,
+    w_factor: int = 28,
+    min_pixels: int = 56 * 56,
+    max_pixels: int = 14 * 14 * 4 * 1280,
+) -> tuple[int, int]:
+    """GLM-5-Next ``smart_resize``: upward-aligned canvas under a
+    ``t_bar * h_bar * w_bar`` pixel budget.
+
+    Height/width always round UP to their factors (content is then padded,
+    never cropped or distorted); an over-budget canvas is refit by binary
+    search instead of one-shot square-root scaling. ``h_factor`` /
+    ``w_factor`` carry ``patch_expand_factor`` on top of
+    ``patch_size * merge_size``; ``t_factor`` is ``temporal_patch_size``. For
+    a still image ``t = t_factor = temporal_patch_size`` so ``t_bar =
+    temporal_patch_size``.
+    """
+    if min(t, h, w, t_factor, h_factor, w_factor) <= 0:
+        raise ValueError("Image dimensions and alignment factors must be positive.")
+    if min_pixels <= 0 or max_pixels <= 0:
+        raise ValueError("min_pixels and max_pixels must be positive.")
+    if min_pixels > max_pixels:
+        raise ValueError("min_pixels must be less than or equal to max_pixels.")
+
+    t_bar = max(t_factor, round(t / t_factor) * t_factor)
+    h_bar = _ceil_to_factor(h, h_factor)
+    w_bar = _ceil_to_factor(w, w_factor)
+
+    if t_bar * h_bar * w_bar > max_pixels:
+        h_bar, w_bar = _fit_aligned_size_within_budget(
+            t=t_bar,
+            h=h,
+            w=w,
+            h_factor=h_factor,
+            w_factor=w_factor,
+            max_pixels=max_pixels,
+        )
+    elif t_bar * h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (t * h * w))
+        h_bar = _ceil_to_factor(max(1, math.ceil(h * beta)), h_factor)
+        w_bar = _ceil_to_factor(max(1, math.ceil(w * beta)), w_factor)
+
+        # Alignment can push a candidate slightly over a tight max_pixels
+        # budget. Refit it when that happens.
+        if t_bar * h_bar * w_bar > max_pixels:
+            h_bar, w_bar = _fit_aligned_size_within_budget(
+                t=t_bar,
+                h=h,
+                w=w,
+                h_factor=h_factor,
+                w_factor=w_factor,
+                max_pixels=max_pixels,
+            )
+
+    return h_bar, w_bar
+
+
+def _get_pad_content_size(
+    image_height: int,
+    image_width: int,
+    canvas_height: int,
+    canvas_width: int,
+    allow_upscale: bool = False,
+) -> tuple[int, int]:
+    """Aspect-ratio-preserving content size that fits the canvas.
+
+    Oversized images are shrunk proportionally. Small images are enlarged
+    only when ``allow_upscale``. Padding is applied after the resize.
+    """
+    scale = min(canvas_height / image_height, canvas_width / image_width)
+    if not allow_upscale:
+        scale = min(1.0, scale)
+    content_height = max(1, min(canvas_height, math.floor(image_height * scale)))
+    content_width = max(1, min(canvas_width, math.floor(image_width * scale)))
+    return content_height, content_width
+
+
+def _resize_or_pad(
+    stacked_images: torch.Tensor,
+    target_height: int,
+    target_width: int,
+    resize_mode: str,
+    resample: "PILImageResampling | tvF.InterpolationMode | int | None",
+    resize,
+    allow_upscale: bool = False,
+) -> torch.Tensor:
+    """Resize onto the aligned canvas, or keep the aspect ratio and
+    zero-pad the right/bottom sides (``resize_mode="pad"``)."""
+    height, width = stacked_images.shape[-2:]
+
+    if resize_mode == "resize":
+        return resize(
+            stacked_images,
+            size=SizeDict(height=target_height, width=target_width),
+            resample=resample,
+        )
+
+    if resize_mode != "pad":
+        raise ValueError("resize_mode must be either 'resize' or 'pad'.")
+
+    content_height, content_width = _get_pad_content_size(
+        image_height=height,
+        image_width=width,
+        canvas_height=target_height,
+        canvas_width=target_width,
+        allow_upscale=allow_upscale,
+    )
+
+    if (content_height, content_width) != (height, width):
+        stacked_images = resize(
+            stacked_images,
+            size=SizeDict(height=content_height, width=content_width),
+            resample=resample,
+        )
+
+    # torchvision padding order: [left, top, right, bottom] -> pad only the
+    # right and bottom sides.
+    return tvF.pad(
+        stacked_images,
+        padding=[0, 0, target_width - content_width, target_height - content_height],
+        fill=0,
+    )
+
+
+def _pixel_budget(
+    min_image_tokens: int | None,
+    max_image_tokens: int | None,
+    patch_size: int,
+    merge_size: int,
+    temporal_patch_size: int,
+) -> tuple[int, int]:
+    """(min_pixels, max_pixels) from the token bounds of
+    ``processor_config.json``; one vision token covers
+    ``temporal_patch_size * (patch_size * merge_size) ** 2`` pixels."""
+    if min_image_tokens is None or max_image_tokens is None:
+        raise ValueError(
+            "min_image_tokens and max_image_tokens must be provided by "
+            "processor_config.json (or per-call kwargs)."
+        )
+    factor = temporal_patch_size * (patch_size * merge_size) ** 2
+    return min_image_tokens * factor, max_image_tokens * factor
+
+
+def _normalize_processor_config(
+    config: dict,
+    *,
+    default_min_tokens: int,
+    default_max_tokens: int,
+    is_video: bool,
+) -> dict:
+    """Normalize both released GLM5-Next processor-config schemas.
+
+    Earlier configs express pixel budgets in ``size`` and normally carry
+    ``patch_expand_factor=2``. Later configs use min/max token budgets,
+    ``patch_expand_factor=1`` and pad-mode geometry. The weights are shared,
+    so select preprocessing from the config instead of treating these as
+    different checkpoints.
+    """
+    config = dict(config)
+    patch_size = int(config.get("patch_size", 14))
+    merge_size = int(config.get("merge_size", 2))
+    temporal_patch_size = int(config.get("temporal_patch_size", 2))
+    pixels_per_token = temporal_patch_size * (patch_size * merge_size) ** 2
+
+    size = config.pop("size", None)
+    legacy_size_config = (
+        config.get("min_image_tokens") is None or config.get("max_image_tokens") is None
+    ) and isinstance(size, dict)
+    if legacy_size_config:
+        min_pixels = int(size.get("shortest_edge", pixels_per_token))
+        max_pixels = min(
+            int(size.get("longest_edge", _LEGACY_MM_MAX_PIXELS)),
+            _LEGACY_MM_MAX_PIXELS,
+        )
+        min_tokens = max(1, math.ceil(min_pixels / pixels_per_token))
+        max_tokens = max(min_tokens, max_pixels // pixels_per_token)
+        config.setdefault("min_image_tokens", min_tokens)
+        config.setdefault("max_image_tokens", max_tokens)
+        config.setdefault("patch_expand_factor", 2)
+        config.setdefault("resize_mode", "resize")
+        config.setdefault("sampling_policy", "legacy_dynamic")
+    else:
+        config.setdefault("min_image_tokens", default_min_tokens)
+        config.setdefault("max_image_tokens", default_max_tokens)
+        config["max_image_tokens"] = int(config["max_image_tokens"])
+        if is_video:
+            config["max_image_tokens"] = min(
+                config["max_image_tokens"], _MAX_VIDEO_TOKENS
+            )
+        config.setdefault("patch_expand_factor", 1)
+        config.setdefault("resize_mode", "pad")
+        config.setdefault("sampling_policy", "fps_interval")
+
+    if config["max_image_tokens"] < config["min_image_tokens"]:
+        config["min_image_tokens"] = config["max_image_tokens"]
+    return config
+
+
+class Glm5NextImageProcessorKwargs(ImagesKwargs, total=False):  # type: ignore[call-arg]
+    patch_size: int | None
+    temporal_patch_size: int | None
+    merge_size: int | None
+    patch_expand_factor: int | None
+    resize_mode: str | None
+    min_image_tokens: int | None
+    max_image_tokens: int | None
+
+
+class Glm5NextImageProcessor(BaseImageProcessorFast):
+    """Fast (torchvision) image processor for GLM-5-Next.
+
+    ``patch_expand_factor`` multiplies into the ``smart_resize`` spatial
+    factor ``patch_size * merge_size``. ``resize_mode`` picks the geometry:
+    ``"pad"`` (default) preserves the aspect ratio and zero-pads the
+    right/bottom of the upward-aligned canvas, ``"resize"`` stretches onto
+    it. Defaults mirror the checkpoint's ``image_processor`` config.
+    """
+
+    do_resize = True
+    resample = PILImageResampling.BICUBIC
+    size = {"longest_edge": 1}  # unused: budgets come from the token bounds
+    do_rescale = True
+    do_normalize = True
+    image_mean = OPENAI_CLIP_MEAN
+    image_std = OPENAI_CLIP_STD
+    do_convert_rgb = True
+    patch_size = 14
+    temporal_patch_size = 2
+    merge_size = 2
+    patch_expand_factor = 1
+    resize_mode = "pad"
+    min_image_tokens = 16
+    max_image_tokens = 8000
+    valid_kwargs = Glm5NextImageProcessorKwargs
+    model_input_names = ["pixel_values", "image_grid_thw"]
+
+    def _preprocess(
+        self,
+        images: list[torch.Tensor],
+        do_resize: bool,
+        size: SizeDict,
+        resample: "PILImageResampling | tvF.InterpolationMode | int | None",
+        do_rescale: bool,
+        rescale_factor: float,
+        do_normalize: bool,
+        image_mean: float | list[float] | None,
+        image_std: float | list[float] | None,
+        patch_size: int,
+        temporal_patch_size: int,
+        merge_size: int,
+        patch_expand_factor: int,
+        resize_mode: str | None,
+        min_image_tokens: int | None,
+        max_image_tokens: int | None,
+        disable_grouping: bool | None,
+        return_tensors: str | TensorType | None,
+        **kwargs,
+    ) -> BatchFeature:
+        resize_mode = resize_mode if resize_mode is not None else self.resize_mode
+        min_pixels, max_pixels = _pixel_budget(
+            min_image_tokens if min_image_tokens is not None else self.min_image_tokens,
+            max_image_tokens if max_image_tokens is not None else self.max_image_tokens,
+            patch_size,
+            merge_size,
+            temporal_patch_size,
+        )
+        grouped_images, grouped_images_index = group_images_by_shape(
+            images, disable_grouping=disable_grouping
+        )
+        resized_images_grouped = {}
+        for shape, stacked_images in grouped_images.items():
+            height, width = stacked_images.shape[-2:]
+            if do_resize:
+                resized_height, resized_width = smart_resize(
+                    t=temporal_patch_size,
+                    h=height,
+                    w=width,
+                    t_factor=temporal_patch_size,
+                    h_factor=patch_size * merge_size * patch_expand_factor,
+                    w_factor=patch_size * merge_size * patch_expand_factor,
+                    min_pixels=min_pixels,
+                    max_pixels=max_pixels,
+                )
+                stacked_images = _resize_or_pad(
+                    stacked_images,
+                    target_height=resized_height,
+                    target_width=resized_width,
+                    resize_mode=resize_mode,
+                    resample=resample,
+                    resize=self.resize,
+                    allow_upscale=(temporal_patch_size * height * width < min_pixels),
+                )
+            resized_images_grouped[shape] = stacked_images
+
+        resized_images = reorder_images(resized_images_grouped, grouped_images_index)
+
+        grouped_images, grouped_images_index = group_images_by_shape(
+            resized_images, disable_grouping=disable_grouping
+        )
+        processed_images_grouped = {}
+        processed_grids = {}
+
+        for shape, stacked_images in grouped_images.items():
+            resized_height, resized_width = stacked_images.shape[-2:]
+
+            patches = self.rescale_and_normalize(
+                stacked_images,
+                do_rescale,
+                rescale_factor,
+                do_normalize,
+                image_mean,
+                image_std,
+            )
+            if patches.ndim == 4:  # (B, C, H, W)
+                patches = patches.unsqueeze(1)  # (B, T=1, C, H, W)
+
+            if patches.shape[1] % temporal_patch_size != 0:
+                repeats = patches[:, -1:].repeat(
+                    1,
+                    temporal_patch_size - (patches.shape[1] % temporal_patch_size),
+                    1,
+                    1,
+                    1,
+                )
+                patches = torch.cat([patches, repeats], dim=1)
+
+            batch_size, t_len, channel = patches.shape[:3]
+            grid_t = t_len // temporal_patch_size
+            grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+
+            patches = patches.view(
+                batch_size,
+                grid_t,
+                temporal_patch_size,
+                channel,
+                grid_h // merge_size,
+                merge_size,
+                patch_size,
+                grid_w // merge_size,
+                merge_size,
+                patch_size,
+            )
+            # (B, grid_t, gh, gw, mh, mw, C, tp, ph, pw)
+            patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
+
+            flatten_patches = patches.reshape(
+                batch_size,
+                grid_t * grid_h * grid_w,
+                channel * temporal_patch_size * patch_size * patch_size,
+            )
+
+            processed_images_grouped[shape] = flatten_patches
+            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+
+        processed_images = reorder_images(
+            processed_images_grouped, grouped_images_index
+        )
+        processed_grids = reorder_images(processed_grids, grouped_images_index)
+
+        pixel_values = torch.cat(processed_images, dim=0)
+        image_grid_thw = torch.tensor(processed_grids)
+
+        return BatchFeature(
+            data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw},
+            tensor_type=return_tensors,
+        )
+
+    def preprocess(
+        self, images: ImageInput, **kwargs: Unpack[Glm5NextImageProcessorKwargs]
+    ) -> BatchFeature:
+        return super().preprocess(images, **kwargs)
+
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> int:
+        """Number of image patches (pre-merge) for a given (height, width)."""
+        images_kwargs = images_kwargs or {}
+        patch_size = images_kwargs.get("patch_size", self.patch_size)
+        merge_size = images_kwargs.get("merge_size", self.merge_size)
+        patch_expand_factor = images_kwargs.get(
+            "patch_expand_factor", self.patch_expand_factor
+        )
+        min_pixels, max_pixels = _pixel_budget(
+            images_kwargs.get("min_image_tokens", self.min_image_tokens),
+            images_kwargs.get("max_image_tokens", self.max_image_tokens),
+            patch_size,
+            merge_size,
+            self.temporal_patch_size,
+        )
+        resized_height, resized_width = smart_resize(
+            t=self.temporal_patch_size,
+            h=height,
+            w=width,
+            t_factor=self.temporal_patch_size,
+            h_factor=patch_size * merge_size * patch_expand_factor,
+            w_factor=patch_size * merge_size * patch_expand_factor,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
+        )
+        grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+        return grid_h * grid_w
+
+
+class Glm5NextVideoProcessorKwargs(VideosKwargs, total=False):  # type: ignore[call-arg]
+    fps: list[float] | float
+    patch_size: int
+    temporal_patch_size: int
+    merge_size: int
+    patch_expand_factor: int
+    resize_mode: str | None
+    target_fps: float | None
+    max_frames: int | None
+    fps_interval: int | None
+    max_frame_count_dynamic: int | None
+    min_image_tokens: int | None
+    max_image_tokens: int | None
+    sampling_policy: str | None
+
+
+class Glm5NextVideoProcessor(BaseVideoProcessor):
+    """Fast video processor for GLM-5-Next.
+
+    Shares ``smart_resize`` / the pad-mode geometry / the patchify with the
+    image processor, and adds GLM-5-Next's frame sampling
+    (``glm_sample_frame_indices``: ``fps_interval`` semantics with a
+    temporal-patch-scaled greedy walk). Defaults mirror the checkpoint's
+    ``video_processor`` config.
+    """
+
+    resample = PILImageResampling.BICUBIC
+    size = {"longest_edge": 1}  # unused: budgets come from the token bounds
+    image_mean = OPENAI_CLIP_MEAN
+    image_std = OPENAI_CLIP_STD
+    do_resize = True
+    do_rescale = True
+    do_normalize = True
+    do_convert_rgb = True
+    do_sample_frames = True
+    patch_size = 14
+    temporal_patch_size = 2
+    patch_expand_factor = 1
+    merge_size = 2
+    valid_kwargs = Glm5NextVideoProcessorKwargs
+    num_frames = 16
+    fps = 2
+    fps_interval = 2.0
+    max_frame_count_dynamic = 2048
+    resize_mode = "pad"
+    min_image_tokens = 16
+    max_image_tokens = 240000
+    sampling_policy = "fps_interval"
+    model_input_names = ["pixel_values_videos", "video_grid_thw"]
+
+    def sample_frames(
+        self,
+        metadata: VideoMetadata,
+        fps: int | float | None = None,
+        **kwargs,
+    ) -> np.ndarray:
+        """Sample frame indices with GLM's fps-interval policy.
+
+        ``fps`` / ``target_fps``, ``max_frames`` and ``fps_interval`` /
+        ``max_frame_count_dynamic`` are the overrides described in
+        :func:`glm_sample_frame_indices`.
+        """
+        if metadata is None or getattr(metadata, "fps", None) is None:
+            raise ValueError(
+                "Asked to sample frames per second but no video metadata was "
+                "provided which is required when sampling in GLM-5-Next. Please "
+                "pass in `VideoMetadata` object or set `do_sample_frames=False`."
+            )
+
+        if self.sampling_policy == "legacy_dynamic":
+            duration = metadata.duration or (
+                round((metadata.total_num_frames - 1) / metadata.fps) + 1
+            )
+            effective_duration = min(duration, 2400)
+            target_fps = kwargs.get("target_fps")
+            if not target_fps:
+                if effective_duration <= 30:
+                    target_fps = 3.0
+                elif effective_duration <= 300:
+                    target_fps = 1.0
+                else:
+                    target_fps = 0.5
+            return np.array(
+                glm_sample_frame_indices_legacy(
+                    metadata.total_num_frames,
+                    metadata.fps,
+                    duration,
+                    target_fps=target_fps,
+                    max_frame_count=kwargs.get("max_frames") or 640,
+                    temporal_patch_size=self.temporal_patch_size,
+                )
+            )
+        else:
+            target_fps = fps if fps is not None else kwargs.get("target_fps")
+            if target_fps is None:
+                target_fps = self.fps_interval
+            max_frames = kwargs.get("max_frames") or self.max_frame_count_dynamic
+        indices = glm_sample_frame_indices(
+            metadata.total_num_frames,
+            metadata.fps,
+            metadata.duration or 0,
+            target_fps=target_fps,
+            max_frame_count=max_frames,
+            temporal_patch_size=self.temporal_patch_size,
+        )
+        return np.array(indices)
+
+    def _preprocess(
+        self,
+        videos: list[torch.Tensor],
+        do_convert_rgb: bool = True,
+        do_resize: bool = True,
+        size: SizeDict | None = None,
+        resample: "PILImageResampling | int | None" = PILImageResampling.BICUBIC,
+        do_rescale: bool = True,
+        rescale_factor: float = 1 / 255.0,
+        do_normalize: bool = True,
+        image_mean: float | list[float] | None = None,
+        image_std: float | list[float] | None = None,
+        patch_size: int | None = None,
+        temporal_patch_size: int | None = None,
+        patch_expand_factor: int | None = None,
+        merge_size: int | None = None,
+        resize_mode: str | None = None,
+        min_image_tokens: int | None = None,
+        max_image_tokens: int | None = None,
+        return_tensors: str | TensorType | None = None,
+        **kwargs,
+    ) -> BatchFeature:
+        patch_expand_factor = self.patch_expand_factor
+        patch_size = patch_size if patch_size is not None else self.patch_size
+        temporal_patch_size = (
+            temporal_patch_size
+            if temporal_patch_size is not None
+            else self.temporal_patch_size
+        )
+        merge_size = merge_size if merge_size is not None else self.merge_size
+        resize_mode = resize_mode if resize_mode is not None else self.resize_mode
+        min_pixels, max_pixels = _pixel_budget(
+            min_image_tokens if min_image_tokens is not None else self.min_image_tokens,
+            max_image_tokens if max_image_tokens is not None else self.max_image_tokens,
+            patch_size,
+            merge_size,
+            temporal_patch_size,
+        )
+        grouped_videos, grouped_videos_index = group_videos_by_shape(videos)
+        resized_videos_grouped = {}
+        for shape, stacked_videos in grouped_videos.items():
+            if do_convert_rgb:
+                stacked_videos = self.convert_to_rgb(stacked_videos)
+            b, t_len, c, h, w = stacked_videos.shape
+            num_frames, height, width = t_len, h, w
+            if do_resize:
+                resized_height, resized_width = smart_resize(
+                    t=num_frames,
+                    h=height,
+                    w=width,
+                    t_factor=temporal_patch_size,
+                    h_factor=patch_size * merge_size * patch_expand_factor,
+                    w_factor=patch_size * merge_size * patch_expand_factor,
+                    min_pixels=min_pixels,
+                    max_pixels=max_pixels,
+                )
+                stacked_videos = stacked_videos.view(b * t_len, c, h, w)
+                stacked_videos = _resize_or_pad(
+                    stacked_videos,
+                    target_height=resized_height,
+                    target_width=resized_width,
+                    resize_mode=resize_mode,
+                    resample=resample,
+                    resize=self.resize,
+                    allow_upscale=(num_frames * height * width < min_pixels),
+                )
+                stacked_videos = stacked_videos.view(
+                    b, t_len, c, resized_height, resized_width
+                )
+            resized_videos_grouped[shape] = stacked_videos
+        resized_videos = reorder_videos(resized_videos_grouped, grouped_videos_index)
+
+        grouped_videos, grouped_videos_index = group_videos_by_shape(resized_videos)
+        processed_videos_grouped = {}
+        processed_grids = {}
+        for shape, stacked_videos in grouped_videos.items():
+            resized_height, resized_width = get_image_size(
+                stacked_videos[0], channel_dim=ChannelDimension.FIRST
+            )
+            stacked_videos = self.rescale_and_normalize(
+                stacked_videos,
+                do_rescale,
+                rescale_factor,
+                do_normalize,
+                image_mean,
+                image_std,
+            )
+            patches = stacked_videos
+
+            if pad := -patches.shape[1] % temporal_patch_size:
+                repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
+                patches = torch.cat((patches, repeats), dim=1)
+            batch_size, grid_t, channel = patches.shape[:3]
+            grid_t = grid_t // temporal_patch_size
+            grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+
+            patches = patches.view(
+                batch_size,
+                grid_t,
+                temporal_patch_size,
+                channel,
+                grid_h // merge_size,
+                merge_size,
+                patch_size,
+                grid_w // merge_size,
+                merge_size,
+                patch_size,
+            )
+            patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
+            flatten_patches = patches.reshape(
+                batch_size,
+                grid_t * grid_h * grid_w,
+                channel * temporal_patch_size * patch_size * patch_size,
+            )
+
+            processed_videos_grouped[shape] = flatten_patches
+            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+
+        processed_videos = reorder_videos(
+            processed_videos_grouped, grouped_videos_index
+        )
+        processed_grids = reorder_videos(processed_grids, grouped_videos_index)
+        pixel_values_videos = torch.cat(processed_videos, dim=0)
+        video_grid_thw = torch.tensor(processed_grids)
+        return BatchFeature(
+            data={
+                "pixel_values_videos": pixel_values_videos,
+                "video_grid_thw": video_grid_thw,
+            },
+            tensor_type=return_tensors,
+        )
+
+
+class Glm5NextProcessorKwargs(ProcessingKwargs, total=False):  # type: ignore[call-arg]
+    images_kwargs: Glm5NextImageProcessorKwargs
+    videos_kwargs: Glm5NextVideoProcessorKwargs
+    _defaults = {
+        "text_kwargs": {
+            "padding": False,
+            "return_token_type_ids": False,
+            "return_mm_token_type_ids": False,
+        },
+        "videos_kwargs": {"return_metadata": True},
+    }
+
+
+class Glm5NextProcessor(ProcessorMixin):
+    """Wraps a GLM-5-Next image processor, video processor and tokenizer.
+
+    This processor extracts vision features and leaves prompt expansion to
+    vLLM's multimodal prompt-update machinery.
+    """
+
+    attributes = ["image_processor", "tokenizer", "video_processor"]
+    image_processor_class = "AutoImageProcessor"
+    video_processor_class = "AutoVideoProcessor"
+    tokenizer_class = ("PreTrainedTokenizer", "PreTrainedTokenizerFast")
+
+    def __init__(
+        self,
+        image_processor=None,
+        tokenizer=None,
+        video_processor=None,
+        chat_template=None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            image_processor, tokenizer, video_processor, chat_template=chat_template
+        )
+        self.image_token = (
+            "<|image|>"
+            if not hasattr(tokenizer, "image_token")
+            else tokenizer.image_token
+        )
+        self.video_token = (
+            "<|video|>"
+            if not hasattr(tokenizer, "video_token")
+            else tokenizer.video_token
+        )
+        self.image_token_id = (
+            tokenizer.image_token_id
+            if getattr(tokenizer, "image_token_id", None)
+            else tokenizer.convert_tokens_to_ids(self.image_token)
+        )
+        self.video_token_id = (
+            tokenizer.video_token_id
+            if getattr(tokenizer, "video_token_id", None)
+            else tokenizer.convert_tokens_to_ids(self.video_token)
+        )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        """Build the processor directly from the checkpoint config.
+
+        The GLM-5-Next checkpoint stores its image/video processor configs inside
+        ``processor_config.json`` (nested ``image_processor`` / ``video_processor``,
+        token-budget style, no standalone ``preprocessor_config.json``) and
+        declares a custom ``processor_class`` that ``AutoProcessor`` cannot
+        resolve. We read the configs here, preserve the checkpoint's image
+        budget, cap the much larger video budget for serving, and instantiate
+        the vLLM-native sub-processors. The earlier size-budget schema retains
+        its existing pixel guard.
+        """
+        from transformers import AutoTokenizer
+
+        model_path = pretrained_model_name_or_path
+        tokenizer = AutoTokenizer.from_pretrained(model_path, **kwargs)
+
+        ip_cfg = _normalize_processor_config(
+            dict(get_image_processor_config(model_path)),
+            default_min_tokens=16,
+            default_max_tokens=8000,
+            is_video=False,
+        )
+        ip_cfg.pop("sampling_policy", None)
+        image_processor = Glm5NextImageProcessor(
+            **{k: v for k, v in ip_cfg.items() if k != "image_processor_type"}
+        )
+
+        with open(os.path.join(model_path, "processor_config.json")) as f:
+            vp_cfg = _normalize_processor_config(
+                dict(json.load(f)["video_processor"]),
+                default_min_tokens=16,
+                default_max_tokens=240000,
+                is_video=True,
+            )
+        video_processor = Glm5NextVideoProcessor(
+            **{k: v for k, v in vp_cfg.items() if k != "video_processor_type"}
+        )
+
+        return cls(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            video_processor=video_processor,
+        )
+
+    def __call__(
+        self,
+        images: ImageInput | None = None,
+        text: TextInput
+        | PreTokenizedInput
+        | list[TextInput]
+        | list[PreTokenizedInput] = None,
+        videos: VideoInput | None = None,
+        **kwargs: Unpack[Glm5NextProcessorKwargs],
+    ) -> BatchFeature:
+        output_kwargs = self._merge_kwargs(
+            Glm5NextProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+        if images is not None:
+            image_inputs = self.image_processor(
+                images=images, **output_kwargs["images_kwargs"]
+            )
+        else:
+            image_inputs = {}
+
+        if videos is not None:
+            videos_inputs = self.video_processor(
+                videos=videos, **output_kwargs["videos_kwargs"]
+            )
+            if "return_metadata" not in kwargs:
+                videos_inputs.pop("video_metadata")
+        else:
+            videos_inputs = {}
+
+        if not isinstance(text, list):
+            text = [text]
+
+        # Leave prompt expansion to vLLM's inherited GLM-4V prompt-update
+        # machinery. It owns both the grid-sized image replacement and the
+        # video frame/timestamp structure; duplicating that work here makes
+        # placeholder discovery validate against a different token sequence.
+        return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
+        return_mm_token_type_ids = output_kwargs["text_kwargs"].pop(
+            "return_mm_token_type_ids", False
+        )
+        text_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"])
+
+        if return_mm_token_type_ids:
+            array_ids = np.array(text_inputs["input_ids"])
+            mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
+            mm_token_type_ids[array_ids == self.image_token_id] = 1
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+        return BatchFeature(
+            data={**text_inputs, **image_inputs, **videos_inputs},
+            tensor_type=return_tensors,
+        )
+
+    def _get_num_multimodal_tokens(self, image_sizes=None, video_sizes=None, **kwargs):
+        vision_data = {}
+        if image_sizes is not None:
+            images_kwargs = dict(
+                Glm5NextProcessorKwargs._defaults.get("images_kwargs", {})
+            )
+            images_kwargs.update(kwargs)
+            merge_size = (
+                images_kwargs.get("merge_size") or self.image_processor.merge_size
+            )
+
+            num_image_patches = [
+                self.image_processor.get_number_of_image_patches(
+                    *image_size, images_kwargs
+                )
+                for image_size in image_sizes
+            ]
+            num_image_tokens = [(n // merge_size**2) for n in num_image_patches]
+            vision_data.update(
+                {
+                    "num_image_tokens": num_image_tokens,
+                    "num_image_patches": num_image_patches,
+                }
+            )
+
+        if video_sizes is not None:
+            videos_kwargs = dict(
+                Glm5NextProcessorKwargs._defaults.get("videos_kwargs", {})
+            )
+            videos_kwargs.update(kwargs)
+            merge_size = (
+                videos_kwargs.get("merge_size") or self.video_processor.merge_size
+            )
+            num_video_patches = [
+                self.video_processor.get_number_of_video_patches(
+                    *video_size, videos_kwargs
+                )
+                for video_size in video_sizes
+            ]
+            num_video_tokens = [(n // merge_size**2) for n in num_video_patches]
+            vision_data["num_video_tokens"] = num_video_tokens
+
+        return MultiModalData(**vision_data)
+
+    def post_process_image_text_to_text(
+        self,
+        generated_outputs,
+        skip_special_tokens=True,
+        clean_up_tokenization_spaces=False,
+        **kwargs,
+    ):
+        return self.tokenizer.batch_decode(
+            generated_outputs,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
+
+
+__all__ = [
+    "Glm5NextImageProcessor",
+    "Glm5NextImageProcessorFast",
+    "Glm5NextVideoProcessor",
+    "Glm5NextProcessor",
+    "glm_sample_frame_indices",
+    "glm_sample_frame_indices_legacy",
+    "smart_resize",
+]
+
+# Compatibility for callers that imported the first released class name.
+Glm5NextImageProcessorFast = Glm5NextImageProcessor

--- a/vllm_fl/transformers_utils/processors/glm5_next.py
+++ b/vllm_fl/transformers_utils/processors/glm5_next.py
@@ -193,6 +193,40 @@ def glm_sample_frame_indices_legacy(
     return unique
 
 
+def glm_video_timestamp_seconds(
+    video_processor,
+    metadata,
+) -> list[int]:
+    """Prompt-visible per-frame second indices for a GLM-5-Next video.
+
+    vLLM's inherited GLM-4.6V prompt builder re-derives the sampled frames
+    with a duration-threshold policy (``_get_video_second_idx_glm46v``), which
+    selects a different frame count than ``Glm5NextVideoProcessor``'s
+    ``fps_interval`` sampler. That desynchronizes the number of video frame
+    placeholders from the encoded ``grid_t``. This helper reuses the exact
+    processor sampler and keeps every ``temporal_patch_size``-th pick
+    (``[::2]``), which is precisely the ``grid_t`` consumed by the vision
+    tower.
+
+    ``metadata`` exposes ``fps``, ``duration``, ``total_num_frames``,
+    ``do_sample_frames`` and (when ``do_sample_frames`` is false)
+    ``frames_indices``.
+    """
+    fps = getattr(metadata, "fps", None)
+    if not fps:
+        fps = 24.0
+
+    if getattr(metadata, "do_sample_frames", True) is False:
+        frames_indices = getattr(metadata, "frames_indices", None)
+        frames = [] if frames_indices is None else [int(i) for i in frames_indices]
+    else:
+        frames = [int(index) for index in video_processor.sample_frames(metadata)]
+
+    if not frames:
+        return []
+    return [int(index / fps) for index in frames][::2]
+
+
 def _ceil_to_factor(value: int, factor: int) -> int:
     """Round a positive integer upward to the nearest multiple of factor."""
     return math.ceil(value / factor) * factor
@@ -1104,6 +1138,7 @@ __all__ = [
     "Glm5NextProcessor",
     "glm_sample_frame_indices",
     "glm_sample_frame_indices_legacy",
+    "glm_video_timestamp_seconds",
     "smart_resize",
 ]
 

--- a/vllm_fl/utils.py
+++ b/vllm_fl/utils.py
@@ -125,9 +125,11 @@ def get_flag_gems_whitelist_blacklist() -> Tuple[
     1. VLLM_FL_FLAGOS_WHITELIST env var: Only these ops use FlagGems
     2. VLLM_FL_FLAGOS_BLACKLIST env var: These ops don't use FlagGems
     3. Platform config flagos_blacklist: Default blacklist from config file
+    4. VLLM_FL_FLAGOS_BLACKLIST_APPEND: Ops appended to the selected blacklist
 
     Note: VLLM_FL_FLAGOS_WHITELIST and VLLM_FL_FLAGOS_BLACKLIST cannot be set
-    simultaneously. If whitelist is set, it completely overrides any blacklist.
+    simultaneously. If whitelist is set, it completely overrides any blacklist,
+    including VLLM_FL_FLAGOS_BLACKLIST_APPEND.
 
     Returns:
         Tuple[Optional[list[str]], Optional[list[str]]]:
@@ -139,6 +141,7 @@ def get_flag_gems_whitelist_blacklist() -> Tuple[
     """
     whitelist_str = os.environ.get("VLLM_FL_FLAGOS_WHITELIST", "")
     blacklist_str = os.environ.get("VLLM_FL_FLAGOS_BLACKLIST", "")
+    blacklist_append_str = os.environ.get("VLLM_FL_FLAGOS_BLACKLIST_APPEND", "")
 
     # Check if both env vars are set (conflict)
     if whitelist_str and blacklist_str:
@@ -158,17 +161,28 @@ def get_flag_gems_whitelist_blacklist() -> Tuple[
     # Priority 2: Blacklist from env var
     if blacklist_str:
         blacklist = [op.strip() for op in blacklist_str.split(",") if op.strip()]
-        return None, blacklist
+    else:
+        # Priority 3: Blacklist from platform config
+        try:
+            from vllm_fl.dispatch.config import get_flagos_blacklist
 
-    # Priority 3: Blacklist from platform config
-    try:
-        from vllm_fl.dispatch.config import get_flagos_blacklist
+            config_blacklist = get_flagos_blacklist()
+            if config_blacklist:
+                blacklist = list(config_blacklist)
+        except Exception:
+            pass
 
-        config_blacklist = get_flagos_blacklist()
-        if config_blacklist:
-            blacklist = config_blacklist
-    except Exception:
-        pass
+    # Add deployment exclusions without replacing platform safety defaults.
+    # Preserve insertion order so startup logs and dispatch policy stay stable.
+    if blacklist_append_str:
+        if blacklist is None:
+            blacklist = []
+        seen = set(blacklist)
+        for op in blacklist_append_str.split(","):
+            op = op.strip()
+            if op and op not in seen:
+                blacklist.append(op)
+                seen.add(op)
 
     return whitelist, blacklist
 

--- a/vllm_fl/worker/common_attention_metadata.py
+++ b/vllm_fl/worker/common_attention_metadata.py
@@ -10,7 +10,7 @@ import torch
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID, PAD_SLOT_ID
 
 from vllm_fl.compilation.graph import Graph
 
@@ -35,6 +35,7 @@ def supports_accelerator_graph() -> bool:
 def _compute_slot_mapping_graph_kernel(
     max_num_tokens,
     query_start_loc_ptr,
+    seq_lens_ptr,
     positions_ptr,
     block_table_ptr,
     block_table_stride,
@@ -43,6 +44,7 @@ def _compute_slot_mapping_graph_kernel(
     TOTAL_CP_WORLD_SIZE: tl.constexpr,
     TOTAL_CP_RANK: tl.constexpr,
     CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    NULL_BLOCK_ID: tl.constexpr,
     PAD_ID: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
@@ -61,6 +63,21 @@ def _compute_slot_mapping_graph_kernel(
 
     start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+
+    # Padded request rows are not refreshed by BlockTable.commit_block_table().
+    # Clear them in the existing per-group producer instead of launching one
+    # eager fill per cache group. seq_lens is a fixed-address device buffer, so
+    # the same captured shape can replay with a different actual request count.
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    if seq_len == 0:
+        row_offset = req_idx * block_table_stride
+        for i in range(0, block_table_stride, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(
+                block_table_ptr + row_offset + offsets,
+                NULL_BLOCK_ID,
+                mask=offsets < block_table_stride,
+            )
 
     virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
     row_offset = req_idx * block_table_stride
@@ -123,6 +140,7 @@ def compute_common_attention_metadata(
         _compute_slot_mapping_graph_kernel[(num_reqs + 1,)](
             table.max_num_batched_tokens,
             query_start_loc,
+            seq_lens,
             positions,
             table.block_table.gpu,
             table.block_table.gpu.stride(0),
@@ -131,6 +149,7 @@ def compute_common_attention_metadata(
             TOTAL_CP_WORLD_SIZE=total_cp_world_size,
             TOTAL_CP_RANK=total_cp_rank,
             CP_KV_CACHE_INTERLEAVE_SIZE=table.cp_kv_cache_interleave_size,
+            NULL_BLOCK_ID=NULL_BLOCK_ID,
             PAD_ID=PAD_SLOT_ID,
             BLOCK_SIZE=1024,
         )

--- a/vllm_fl/worker/common_attention_metadata.py
+++ b/vllm_fl/worker/common_attention_metadata.py
@@ -35,7 +35,6 @@ def supports_accelerator_graph() -> bool:
 def _compute_slot_mapping_graph_kernel(
     max_num_tokens,
     query_start_loc_ptr,
-    seq_lens_ptr,
     positions_ptr,
     block_table_ptr,
     block_table_stride,
@@ -68,8 +67,9 @@ def _compute_slot_mapping_graph_kernel(
     # Clear them in the existing per-group producer instead of launching one
     # eager fill per cache group. seq_lens is a fixed-address device buffer, so
     # the same captured shape can replay with a different actual request count.
-    seq_len = tl.load(seq_lens_ptr + req_idx)
-    if seq_len == 0:
+    # A graph-padded row has no scheduled query tokens. Do not use seq_len as
+    # the predicate: valid scheduler rows can transiently carry seq_len == 0.
+    if start_idx == end_idx:
         row_offset = req_idx * block_table_stride
         for i in range(0, block_table_stride, BLOCK_SIZE):
             offsets = i + tl.arange(0, BLOCK_SIZE)
@@ -140,7 +140,6 @@ def compute_common_attention_metadata(
         _compute_slot_mapping_graph_kernel[(num_reqs + 1,)](
             table.max_num_batched_tokens,
             query_start_loc,
-            seq_lens,
             positions,
             table.block_table.gpu,
             table.block_table.gpu.stride(0),

--- a/vllm_fl/worker/common_attention_metadata.py
+++ b/vllm_fl/worker/common_attention_metadata.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2025 BAAI. All rights reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+from vllm_fl.compilation.graph import Graph
+
+logger = init_logger(__name__)
+
+_GRAPH_DEVICE_TYPES = frozenset({"cuda", "npu", "musa", "ptpu"})
+
+
+def supports_accelerator_graph() -> bool:
+    """Return whether the active platform exposes the plugin graph API."""
+    return (
+        current_platform.device_type in _GRAPH_DEVICE_TYPES
+        and hasattr(Graph, "graph")
+        and hasattr(current_platform.torch_device_fn, "graph")
+    )
+
+
+# Adapted from vLLM's BlockTable slot-mapping kernel. The padding boundary is
+# read from query_start_loc on device so one captured graph can replay with
+# different request lengths without a host-derived launch argument.
+@triton.jit(do_not_specialize=["max_num_tokens"])
+def _compute_slot_mapping_graph_kernel(
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+
+    if req_idx == tl.num_programs(0) - 1:
+        actual_num_tokens = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+        for i in range(actual_num_tokens, max_num_tokens, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(
+                slot_mapping_ptr + offsets,
+                PAD_ID,
+                mask=offsets < max_num_tokens,
+            )
+        return
+
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+
+    virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
+    row_offset = req_idx * block_table_stride
+    for i in range(start_idx, end_idx, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0)
+        block_indices = pos // virtual_block_size
+        block_numbers = tl.load(block_table_ptr + row_offset + block_indices).to(
+            tl.int64
+        )
+
+        virtual_block_offsets = pos - block_indices * virtual_block_size
+        is_local = (
+            virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+        ) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+        local_block_offsets = (
+            virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+        ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+            virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+        )
+
+        slot_ids = block_numbers * block_size + local_block_offsets
+        slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+
+@triton.jit
+def _compute_num_computed_tokens_kernel(
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    num_computed_tokens_ptr,
+    num_reqs: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < num_reqs
+    query_start = tl.load(query_start_loc_ptr + offsets, mask=mask, other=0)
+    query_end = tl.load(query_start_loc_ptr + offsets + 1, mask=mask, other=0)
+    seq_len = tl.load(seq_lens_ptr + offsets, mask=mask, other=0)
+    tl.store(
+        num_computed_tokens_ptr + offsets,
+        seq_len - (query_end - query_start),
+        mask=mask,
+    )
+
+
+def compute_common_attention_metadata(
+    block_table: Any,
+    num_reqs: int,
+    query_start_loc: torch.Tensor,
+    positions: torch.Tensor,
+    seq_lens: torch.Tensor,
+    num_computed_tokens: torch.Tensor,
+) -> None:
+    """Populate fixed-address metadata buffers consumed by attention backends."""
+    for table in block_table.block_tables:
+        total_cp_world_size = table.pcp_world_size * table.dcp_world_size
+        total_cp_rank = table.pcp_rank * table.dcp_world_size + table.dcp_rank
+        _compute_slot_mapping_graph_kernel[(num_reqs + 1,)](
+            table.max_num_batched_tokens,
+            query_start_loc,
+            positions,
+            table.block_table.gpu,
+            table.block_table.gpu.stride(0),
+            table.block_size,
+            table.slot_mapping.gpu,
+            TOTAL_CP_WORLD_SIZE=total_cp_world_size,
+            TOTAL_CP_RANK=total_cp_rank,
+            CP_KV_CACHE_INTERLEAVE_SIZE=table.cp_kv_cache_interleave_size,
+            PAD_ID=PAD_SLOT_ID,
+            BLOCK_SIZE=1024,
+        )
+    _compute_num_computed_tokens_kernel[(triton.cdiv(num_reqs, 256),)](
+        query_start_loc,
+        seq_lens,
+        num_computed_tokens,
+        num_reqs=num_reqs,
+        BLOCK_SIZE=256,
+    )
+
+
+class CommonAttentionMetadataGraphRunner:
+    """Capture and replay common attention metadata on accelerator graphs."""
+
+    def __init__(self) -> None:
+        self.graphs: dict[tuple[int, int], Any] = {}
+        self.graph_pool = current_platform.get_global_graph_pool()
+        self._missing_graph_keys: set[tuple[int, int]] = set()
+        self._graph_capture_supported = supports_accelerator_graph()
+        self._warned_graph_unavailable = False
+
+    def clear(self) -> None:
+        self.graphs.clear()
+        self._missing_graph_keys.clear()
+
+    def run(
+        self,
+        block_table: Any,
+        num_reqs: int,
+        query_start_loc: torch.Tensor,
+        positions: torch.Tensor,
+        seq_lens: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
+        *,
+        use_graph: bool,
+        capture: bool,
+        compute: Callable[
+            [
+                Any,
+                int,
+                torch.Tensor,
+                torch.Tensor,
+                torch.Tensor,
+                torch.Tensor,
+            ],
+            None,
+        ] = compute_common_attention_metadata,
+    ) -> bool:
+        if use_graph and not self._graph_capture_supported:
+            if not self._warned_graph_unavailable:
+                logger.warning(
+                    "Accelerator graph capture is unavailable on %s; falling "
+                    "back to eager common attention metadata generation.",
+                    current_platform.device_type,
+                )
+                self._warned_graph_unavailable = True
+            use_graph = False
+
+        if not use_graph:
+            compute(
+                block_table,
+                num_reqs,
+                query_start_loc,
+                positions,
+                seq_lens,
+                num_computed_tokens,
+            )
+            return False
+
+        key = (id(block_table), num_reqs)
+        graph = self.graphs.get(key)
+        if capture:
+            if graph is not None:
+                graph.replay()
+                return True
+
+            graph = Graph.graph()
+            with current_platform.torch_device_fn.graph(graph, pool=self.graph_pool):
+                compute(
+                    block_table,
+                    num_reqs,
+                    query_start_loc,
+                    positions,
+                    seq_lens,
+                    num_computed_tokens,
+                )
+            self.graphs[key] = graph
+            return True
+
+        if graph is None:
+            if key not in self._missing_graph_keys:
+                logger.warning(
+                    "Common attention metadata graph for %d requests was not "
+                    "captured; falling back to eager execution.",
+                    num_reqs,
+                )
+                self._missing_graph_keys.add(key)
+            compute(
+                block_table,
+                num_reqs,
+                query_start_loc,
+                positions,
+                seq_lens,
+                num_computed_tokens,
+            )
+            return False
+
+        graph.replay()
+        return True

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -6638,6 +6638,15 @@ class ModelRunnerFL(
             original_pools[id(instance)] = instance.graph_pool
             instance.graph_pool = profiling_pool
 
+        # The common-attention metadata producer captures its own graphs before
+        # the decoder wrapper is entered.  Keep those profiling graphs in the
+        # same temporary pool as the decoder graphs.  If they use the global
+        # runtime pool here, the profiling cleanup drops the last graph owning
+        # that pool; the first real decoder capture then reuses a zero-refcount
+        # CachingHostAllocator pool and aborts in capture_begin().
+        original_metadata_pool = self.common_attention_metadata_graph.graph_pool
+        self.common_attention_metadata_graph.graph_pool = profiling_pool
+
         shared_memory_estimate = {}
         per_graph_estimate = {}
         encoder_memory_estimate = 0
@@ -6710,6 +6719,7 @@ class ModelRunnerFL(
             self.cudagraph_dispatcher.keys_initialized = False
             self.maybe_remove_all_loras(self.lora_config)
             self._cleanup_profiling_kv_cache()
+            self.common_attention_metadata_graph.graph_pool = original_metadata_pool
             compilation_counter.num_cudagraph_captured = saved_num_cudagraph_captured
 
         # FULL and PIECEWISE graphs share the global pool at runtime and are

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -7,6 +7,7 @@
 import functools
 import gc
 import itertools
+import os
 import threading
 import time
 from collections import defaultdict
@@ -29,7 +30,7 @@ from vllm.compilation.breakable_cudagraph import (
     is_breakable_cudagraph_enabled,
 )
 from vllm.compilation.counter import compilation_counter
-from vllm.compilation.cuda_graph import CUDAGraphStat
+from vllm.compilation.cuda_graph import CUDAGraphStat, CUDAGraphWrapper
 from vllm.compilation.monitor import set_cudagraph_capturing_enabled
 from vllm.config import (
     CompilationMode,
@@ -282,6 +283,18 @@ from vllm_fl.dispatch.io_dumper import (
     register_io_module_hooks,
 )
 GraphWrapper = GraphWrapper
+
+
+def _decoder_graph_wrappers():
+    """Return every decoder graph wrapper used by the CUDA runner."""
+    return list(GraphWrapper._all_instances) + list(
+        BreakableCUDAGraphWrapper._all_instances
+    )
+
+
+def _clear_decoder_graphs() -> None:
+    GraphWrapper.clear_all_graphs()
+    BreakableCUDAGraphWrapper.clear_all_graphs()
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -6445,6 +6458,7 @@ class ModelRunnerFL(
             # Drop captured graphs before distributed teardown. On ROCm, delayed
             # graph destruction can surface HSA faults in the next engine startup.
             CUDAGraphWrapper.clear_all_graphs()
+            BreakableCUDAGraphWrapper.clear_all_graphs()
             self.encoder_cudagraph_manager = None
         self.compilation_config.static_forward_context.clear()
         self.model = None  # type: ignore[assignment]
@@ -6576,7 +6590,7 @@ class ModelRunnerFL(
         profiling_pool = current_platform.graph_pool_handle()
         encoder_profiling_pool = current_platform.graph_pool_handle()
         original_pools: dict[int, Any] = {}
-        for instance in list(GraphWrapper._all_instances):
+        for instance in _decoder_graph_wrappers():
             original_pools[id(instance)] = instance.graph_pool
             instance.graph_pool = profiling_pool
 
@@ -6643,8 +6657,8 @@ class ModelRunnerFL(
                     )
         finally:
             set_cudagraph_capturing_enabled(False)
-            GraphWrapper.clear_all_graphs()
-            for instance in list(GraphWrapper._all_instances):
+            _clear_decoder_graphs()
+            for instance in _decoder_graph_wrappers():
                 if id(instance) in original_pools:
                     instance.graph_pool = original_pools[id(instance)]
             for key_set in self.cudagraph_dispatcher.cudagraph_keys.values():
@@ -7177,6 +7191,15 @@ class ModelRunnerFL(
         kv_caches: dict[str, torch.Tensor] = {}
         has_attn, has_mamba = False, False
 
+        if os.getenv("VLLM_FL_DEBUG_KV_CACHE") == "1":
+            logger.warning(
+                "KV cache config before reshape: tensors=%s groups=%s "
+                "kernel_block_sizes=%s",
+                self.kv_cache_config.kv_cache_tensors,
+                self.kv_cache_config.kv_cache_groups,
+                kernel_block_sizes,
+            )
+
         # Map layer names to (offset, block_stride) within the packed
         # backing tensor so we can create strided views per layer.
         layer_packing: dict[str, tuple[int, int]] = {}
@@ -7204,15 +7227,27 @@ class ModelRunnerFL(
                     num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
                 if isinstance(kv_cache_spec, AttentionSpec):
                     has_attn = True
-                    num_blocks_per_kv_block = (
-                        kv_cache_spec.block_size // kernel_block_size
-                    )
-                    kernel_num_blocks = num_blocks * num_blocks_per_kv_block
-
-                    # For MLA with compression, storage_block_size != block_size
                     if kv_cache_spec.storage_block_size != kv_cache_spec.block_size:
-                        shape_block_size = kv_cache_spec.storage_block_size
+                        # Compressed index caches are addressed in storage
+                        # entries, not logical token slots. DeepGEMM accepts
+                        # 32/64-entry pages; split only the compressed storage
+                        # block and never multiply by logical block_size.
+                        storage_block_size = kv_cache_spec.storage_block_size
+                        shape_block_size = (
+                            64
+                            if storage_block_size % 64 == 0
+                            else 32
+                        )
+                        assert storage_block_size % shape_block_size == 0
+                        num_blocks_per_kv_block = (
+                            storage_block_size // shape_block_size
+                        )
+                        kernel_num_blocks = num_blocks * num_blocks_per_kv_block
                     else:
+                        num_blocks_per_kv_block = (
+                            kv_cache_spec.block_size // kernel_block_size
+                        )
+                        kernel_num_blocks = num_blocks * num_blocks_per_kv_block
                         shape_block_size = kernel_block_size
 
                     kv_cache_shape = attn_backend.get_kv_cache_shape(
@@ -7222,15 +7257,58 @@ class ModelRunnerFL(
                         kv_cache_spec.head_size,
                         cache_dtype_str=self.cache_config.cache_dtype,
                     )
+                    if os.getenv("VLLM_FL_DEBUG_KV_CACHE") == "1":
+                        logger.warning(
+                            "KV cache reshape layer=%s spec=%s backend=%s "
+                            "raw_bytes=%d num_blocks=%d kernel_blocks=%d "
+                            "kernel_block_size=%d shape=%s packing=%s",
+                            layer_name,
+                            kv_cache_spec,
+                            attn_backend.__name__,
+                            raw_tensor.numel(),
+                            num_blocks,
+                            kernel_num_blocks,
+                            kernel_block_size,
+                            kv_cache_shape,
+                            packing,
+                        )
                     try:
                         kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
                         assert len(kv_cache_stride_order) == len(kv_cache_shape)
                     except (AttributeError, NotImplementedError):
                         kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
                     raw_tensor = kv_cache_raw_tensors[layer_name]
+                    # A padded logical cache block can be split into multiple
+                    # backend blocks (for example, GLM5-Next uses a 192-token
+                    # logical DSA indexer block and the indexer kernel consumes
+                    # 64-token blocks).  The upstream v0.24 helper applies the
+                    # complete logical-page stride to every backend block,
+                    # which makes the strided view run past the allocation.
+                    # Divide the physical page evenly across the backend blocks
+                    # so flattened kernel block ids retain a constant stride.
+                    reshape_spec = kv_cache_spec
+                    if (
+                        packing is None
+                        and kv_cache_spec.page_size_padded is not None
+                        and num_blocks_per_kv_block > 1
+                    ):
+                        assert (
+                            kv_cache_spec.page_size_bytes
+                            % num_blocks_per_kv_block
+                            == 0
+                        )
+                        reshape_spec = replace(
+                            kv_cache_spec,
+                            block_size=kernel_block_size,
+                            page_size_padded=(
+                                kv_cache_spec.page_size_bytes
+                                // num_blocks_per_kv_block
+                            ),
+                        )
+
                     kv_caches[layer_name] = _reshape_attention_kv_cache(
                         raw_tensor,
-                        kv_cache_spec,
+                        reshape_spec,
                         kv_cache_shape,
                         kv_cache_stride_order,
                         kernel_num_blocks,

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -2290,6 +2290,7 @@ class ModelRunnerFL(
         num_scheduled_tokens: dict[str, int] | None = None,
         cascade_attn_prefix_lens: list[list[int]] | None = None,
         slot_mappings: dict[int, torch.Tensor] | None = None,
+        block_table_rows_are_current: bool = False,
     ) -> tuple[PerLayerAttnMetadata, CommonAttentionMetadata | None]:
         """
         :return: tuple[attn_metadata, spec_decode_common_attn_metadata]
@@ -2329,9 +2330,10 @@ class ModelRunnerFL(
                 blk_table = self.input_batch.block_table[kv_cache_gid]
                 blk_table_tensor = blk_table.get_device_tensor(num_reqs_padded)
 
-            # Fill unused block table entries with NULL_BLOCK_ID (null block)
-            # for CUDAGraph padding. Block 0 is reserved for padding.
-            blk_table_tensor[num_reqs:num_reqs_padded].fill_(NULL_BLOCK_ID)
+            if not block_table_rows_are_current:
+                # Fill unused block table entries with NULL_BLOCK_ID (null
+                # block) for graph padding. Block 0 is reserved for padding.
+                blk_table_tensor[num_reqs:num_reqs_padded].fill_(NULL_BLOCK_ID)
             return blk_table_tensor
 
         assert slot_mappings is not None
@@ -4377,6 +4379,7 @@ class ModelRunnerFL(
                     num_scheduled_tokens=scheduler_output.num_scheduled_tokens,
                     cascade_attn_prefix_lens=cascade_attn_prefix_lens,
                     slot_mappings=slot_mappings_by_group,
+                    block_table_rows_are_current=True,
                 )
             )
 
@@ -6000,6 +6003,7 @@ class ModelRunnerFL(
                     for_cudagraph_capture=is_graph_capturing,
                     slot_mappings=slot_mappings_by_group,
                     use_spec_decode=self.speculative_config is not None,
+                    block_table_rows_are_current=True,
                 )
 
             # Dummy forwards must not update real KV-cache slots. Capture the

--- a/vllm_fl/worker/model_runner.py
+++ b/vllm_fl/worker/model_runner.py
@@ -281,6 +281,11 @@ from vllm_fl.dispatch.io_dumper import (
     init_io_dump_from_env,
     register_io_module_hooks,
 )
+from vllm_fl.worker.common_attention_metadata import (
+    CommonAttentionMetadataGraphRunner,
+    compute_common_attention_metadata,
+)
+
 GraphWrapper = GraphWrapper
 
 if TYPE_CHECKING:
@@ -783,6 +788,7 @@ class ModelRunnerFL(
         self.query_start_loc = self._make_buffer(
             self.max_num_reqs + 1, dtype=torch.int32
         )
+        self.common_attention_metadata_graph = CommonAttentionMetadataGraphRunner()
         self.seq_lens = torch.zeros(
             self.max_num_reqs, dtype=torch.int32, device=self.device
         )
@@ -2186,12 +2192,6 @@ class ModelRunnerFL(
         )
         self.seq_lens[num_reqs:].fill_(0)
 
-        self.input_batch.block_table.compute_slot_mapping(
-            num_reqs,
-            self.query_start_loc.gpu[: num_reqs + 1],
-            self.positions[:total_num_scheduled_tokens],
-        )
-
         # Copy the tensors to the GPU.
         self._prepare_input_ids(
             scheduler_output,
@@ -2403,6 +2403,7 @@ class ModelRunnerFL(
             seq_lens=self.seq_lens[:num_reqs_padded],
             _seq_lens_cpu=seq_lens_cpu,
             _num_computed_tokens_cpu=num_computed_tokens_cpu,
+            _num_computed_tokens_cache=self.num_computed_tokens[:num_reqs_padded],
             seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
             num_reqs=num_reqs_padded,
             num_actual_tokens=num_tokens_padded,
@@ -4038,12 +4039,39 @@ class ModelRunnerFL(
                 pyt_hooks.register_hooks(self.model, self.model.__class__.__name__)
                 self.layerwise_nvtx_hooks_registered = True
 
+    def _run_common_attention_metadata(
+        self,
+        num_reqs: int,
+        cudagraph_mode: CUDAGraphMode,
+        *,
+        capture: bool = False,
+    ) -> bool:
+        # Follow the globally resolved graph mode. The standalone metadata
+        # graph also benefits piecewise execution; ubatching retains eager
+        # generation because its metadata is sliced per microbatch.
+        use_graph = (
+            cudagraph_mode != CUDAGraphMode.NONE
+            and not self.parallel_config.use_ubatching
+        )
+        return self.common_attention_metadata_graph.run(
+            self.input_batch.block_table,
+            num_reqs,
+            self.query_start_loc.gpu[: num_reqs + 1],
+            self.positions,
+            self.seq_lens[:num_reqs],
+            self.num_computed_tokens[:num_reqs],
+            use_graph=use_graph,
+            capture=capture,
+            compute=compute_common_attention_metadata,
+        )
+
     def _get_slot_mappings(
         self,
         num_tokens_padded: int,
         num_reqs_padded: int,
         num_tokens_unpadded: int,
         ubatch_slices: "UBatchSlices | None" = None,
+        slot_mapping_is_current: bool = False,
     ) -> tuple[
         dict[int, torch.Tensor] | None,
         dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None,
@@ -4084,9 +4112,10 @@ class ModelRunnerFL(
                 blk_table = self.input_batch.block_table[kv_cache_gid]
                 slot_mapping = blk_table.slot_mapping.gpu[:num_tokens_padded]
 
-            # Fill unused with -1. Needed for reshape_and_cache in full cuda
-            # graph mode. `blk_table_tensor` -1 to match mamba PAD_SLOT_ID
-            slot_mapping[num_tokens_unpadded:num_tokens_padded].fill_(-1)
+            if not slot_mapping_is_current:
+                # Fill unused with -1. Needed for reshape_and_cache in full
+                # graph mode. `blk_table_tensor` -1 matches mamba PAD_SLOT_ID.
+                slot_mapping[num_tokens_unpadded:num_tokens_padded].fill_(-1)
 
             return slot_mapping
 
@@ -4322,6 +4351,7 @@ class ModelRunnerFL(
             use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
             ubatch_slices_attn = ubatch_slices_padded if pad_attn else ubatch_slices
 
+            self._run_common_attention_metadata(num_reqs_padded, cudagraph_mode)
             slot_mappings_by_group, slot_mappings = self._get_slot_mappings(
                 num_tokens_padded=num_tokens_padded
                 if pad_attn or has_separate_kv_update
@@ -4331,6 +4361,7 @@ class ModelRunnerFL(
                 ),
                 num_tokens_unpadded=num_tokens_unpadded,
                 ubatch_slices=ubatch_slices_padded,
+                slot_mapping_is_current=True,
             )
 
             attn_metadata, spec_decode_common_attn_metadata = (
@@ -5912,13 +5943,8 @@ class ModelRunnerFL(
             num_reqs_padded=num_reqs_padded,
             num_tokens_unpadded=num_tokens_unpadded,
             ubatch_slices=ubatch_slices_padded,
+            slot_mapping_is_current=True,
         )
-
-        # Dummy runs have no real slot assignments — fill with -1 so
-        # concat_and_cache kernels skip the KV write.
-        if slot_mappings_by_group is not None:
-            for sm in slot_mappings_by_group.values():
-                sm.fill_(-1)
 
         # _dummy_run shares pinned CPU buffers (seq_lens, query_start_loc,
         # etc.) with execute_model.  It must participate in the same event
@@ -5958,6 +5984,11 @@ class ModelRunnerFL(
                 # builder. Without this, stale block IDs from finished
                 # requests can corrupt Mamba state.
                 self.input_batch.block_table.commit_block_table(num_reqs_padded)
+                self._run_common_attention_metadata(
+                    num_reqs_padded,
+                    cudagraph_runtime_mode,
+                    capture=is_graph_capturing,
+                )
 
                 pad_attn = cudagraph_runtime_mode == CUDAGraphMode.FULL
                 attn_metadata, _ = self._build_attention_metadata(
@@ -5970,6 +6001,14 @@ class ModelRunnerFL(
                     slot_mappings=slot_mappings_by_group,
                     use_spec_decode=self.speculative_config is not None,
                 )
+
+            # Dummy forwards must not update real KV-cache slots. Capture the
+            # metadata producer first, then restore the existing PAD_SLOT_ID
+            # behavior before the model dummy/capture forward. Runtime replay
+            # overwrites these fixed-address buffers with current metadata.
+            if slot_mappings_by_group is not None:
+                for slot_mapping in slot_mappings_by_group.values():
+                    slot_mapping.fill_(-1)
 
         with self.maybe_dummy_run_with_lora(
             self.lora_config,
@@ -6458,6 +6497,7 @@ class ModelRunnerFL(
 
     def _cleanup_profiling_kv_cache(self) -> None:
         _accelerator_synchronize()
+        self.common_attention_metadata_graph.clear()
         if hasattr(self, "kv_caches") and self.kv_caches:
             for i in range(len(self.kv_caches)):
                 self.kv_caches[i] = None  # type: ignore

--- a/vllm_fl/worker/worker.py
+++ b/vllm_fl/worker/worker.py
@@ -244,10 +244,26 @@ class WorkerFL(WorkerBase):
         register_oot_ops()
 
         if fl_envs.USE_FLAGGEMS:
-            import flag_gems
+            # Capture native CUDA aten::mm before FlagGems changes the CUDA
+            # registration. The common policy is opt-in; model integrations
+            # may supply a validated default in their own commit.
+            from vllm_fl.patches.flaggems_mm_shape_aware import (
+                capture_native_mm_kernel,
+                is_mm_dispatch_enabled,
+                is_shape_aware_mm_enabled,
+            )
 
-            # Get whitelist and blacklist from environment variables
+            shape_aware_mm_enabled = is_shape_aware_mm_enabled()
+
+            # Resolve policy before capturing native mm. An override is valid
+            # only when FlagGems retains ownership of aten::mm.
             whitelist, blacklist = get_flag_gems_whitelist_blacklist()
+            mm_dispatch_enabled = is_mm_dispatch_enabled(whitelist, blacklist)
+            native_mm_kernel = None
+            if shape_aware_mm_enabled and mm_dispatch_enabled:
+                native_mm_kernel = capture_native_mm_kernel()
+
+            import flag_gems
 
             # Only rank 0 records the oplist to avoid file truncation and
             # interleaved writes when tensor-parallel-size > 1.
@@ -275,6 +291,16 @@ class WorkerFL(WorkerBase):
                 flag_gems.enable(
                     record=should_record, once=True, path=fl_envs.FLAGGEMS_ENABLE_OPLIST_PATH
                 )
+
+            from vllm_fl.patches.flaggems_mm_shape_aware import apply_shape_aware_mm
+
+            if shape_aware_mm_enabled and not mm_dispatch_enabled:
+                logger.warning(
+                    "[FlagGems] Skip shape-aware aten.mm because mm is "
+                    "excluded by the active whitelist/blacklist"
+                )
+            elif shape_aware_mm_enabled:
+                apply_shape_aware_mm(native_mm_kernel=native_mm_kernel)
 
     # def sleep(self, level: int = 1) -> None:
     #     TODO(lms): rewrite CuMemAllocator


### PR DESCRIPTION
## Summary

Add MetaX compatibility fixes for GLM-5.3-Flash-BF16 based on PR #454.

## Changes

- Inject the FlagGems MLA prefill backend on MetaX.
- Add torchvision `grayscale_to_rgb` compatibility for GLM-5 multimodal profiling.
- Add MetaX PyTorch fallback for paged-MQA logits.
- Add MetaX PyTorch fallback for top-k decode.
- Fix GLM-5 KPool decode cache slicing.
- Improve vLLM 0.24 API/version detection for the MetaX empty-build environment.

## Validation

Validated on two MetaX C550 nodes with Ray and Tensor Parallel 16.

The model completes weight loading, engine profiling, KV cache creation and warmup, and the service passes `/health`.

## Related

- FlagGems issue: #6191
- Based on vllm-plugin-FL PR #454