### PR TITLE
[CICD] Upgrade MetaX CI to vLLM 0.24.0

### DIFF
--- a/.github/configs/platforms.yml
+++ b/.github/configs/platforms.yml
@@ -27,7 +27,7 @@ platforms:
   hygon:
     enabled: true
   metax:
-    enabled: false
+    enabled: true
   musa:
     enabled: false
   enflame:

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -31,11 +31,11 @@ UBUNTU_VERSION="${UBUNTU_VERSION:-22.04}"
 VLLM_VERSION="${VLLM_VERSION:-0.19.0}"
 CANN_VERSION="${CANN_VERSION:-8.5.1}"
 CANN_CHIP="${CANN_CHIP:-910b}"
-METAX_BASE_IMAGE="${METAX_BASE_IMAGE:-harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl:vllm-metax-0.20.0-maca.ai3.7.0.107-torch2.8-py312-ubuntu22.04-amd64}"
+METAX_BASE_IMAGE="${METAX_BASE_IMAGE:-harbor.baai.ac.cn/plugin/metax-maca3.7.0-treenone-triton3.0.0-cxnone-plugin0.2.0-vllm0.24.0-cp312-pt280-x64:202507290700}"
 METAX_PYTHON_VERSION="${METAX_PYTHON_VERSION:-3.12}"
 METAX_PYTHON_TAG="${METAX_PYTHON_TAG:-py312}"
 METAX_MACA_VERSION="${METAX_MACA_VERSION:-3.7.0.107}"
-METAX_VLLM_VERSION="${METAX_VLLM_VERSION:-0.20.2}"
+METAX_VLLM_VERSION="${METAX_VLLM_VERSION:-0.24.0}"
 MUSA_BASE_IMAGE="${MUSA_BASE_IMAGE:-registry.mthreads.com/mcconline/inference/vllm:v0.20.2-ph1-4.3.5-torch2.7.1-v1.1.0}"
 MUSA_VERSION="${MUSA_VERSION:-4.3.5}"
 MUSA_VLLM_VERSION="${MUSA_VLLM_VERSION:-0.20.2}"
@@ -363,7 +363,7 @@ elif [[ "${PLATFORM}" == "metax" ]]; then
         --build-arg "VLLM_VERSION=${METAX_VLLM_VERSION}"
     )
     if [[ -z "${IMAGE_TAG}" ]]; then
-        IMAGE_TAG="vllm-metax-${METAX_VLLM_VERSION}-maca.ai${METAX_MACA_VERSION}-torch2.8-${METAX_PYTHON_TAG}-ubuntu22.04-amd64-ci-git"
+        IMAGE_TAG="v${METAX_VLLM_VERSION}-metax-${TARGET}"
     fi
 elif [[ "${PLATFORM}" == "musa" ]]; then
     PYTHON_VERSION="${MUSA_PYTHON_VERSION}"

--- a/docker/metax/Dockerfile
+++ b/docker/metax/Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG METAX_BASE_IMAGE=harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl:vllm-metax-0.20.0-maca.ai3.7.0.107-torch2.8-py312-ubuntu22.04-amd64
+ARG METAX_BASE_IMAGE=harbor.baai.ac.cn/plugin/metax-maca3.7.0-treenone-triton3.0.0-cxnone-plugin0.2.0-vllm0.24.0-cp312-pt280-x64:202507290700
 
 # ---------- base stage ----------
 FROM ${METAX_BASE_IMAGE} AS base
 
 ARG METAX_BASE_IMAGE
-ARG VLLM_VERSION=0.20.2
-ARG FLAGGEMS_REF=3123859968915e361e8452dd796dc6b27c956324
+ARG VLLM_VERSION=0.24.0
+ARG FLAGGEMS_REF=95ed7f9c43b23cba704baaabca4200978c0d6292
 ARG BUILD_DATE=unknown
 ARG VCS_REF=unknown
 ARG IMAGE_VERSION=unknown
@@ -62,40 +62,8 @@ RUN python -m pip install --no-cache-dir \
         ninja \
         cmake
 
-# Replace the vLLM Python package from the vendor image with official vLLM in
-# empty mode. The MetaX kernels and torch runtime remain provided by the base
-# image. Install non-editably so /workspace mounts cannot hide the package.
-RUN python -m pip uninstall -y vllm || true; \
-    python -m pip cache remove vllm || true; \
-    SITE_PACKAGES="$(python -c 'import site; print(site.getsitepackages()[0])')"; \
-    find "${SITE_PACKAGES}" -maxdepth 1 \
-        \( -name "vllm" -o -name "vllm-*.dist-info" -o -name "vllm-*.egg-info" \) \
-        -exec rm -rf {} + 2>/dev/null || true; \
-    rm -rf /tmp/vllm \
-    && git clone --depth 1 --branch "v${VLLM_VERSION}" \
-        https://github.com/vllm-project/vllm.git /tmp/vllm \
-    && VLLM_TARGET_DEVICE=empty python -m pip install --no-cache-dir \
-        --no-build-isolation --no-deps /tmp/vllm \
-    && rm -rf /tmp/vllm
-
-# FlagGems is pinned to the source revision already validated on MetaX C550.
-RUN rm -rf /tmp/FlagGems \
-    && rm -f /tmp/FlagGems.tar.gz \
-    && mkdir -p /tmp/FlagGems \
-    && curl --fail --location --retry 5 --retry-all-errors \
-        --retry-delay 5 --connect-timeout 30 --max-time 1200 \
-        "https://codeload.github.com/FlagOpen/FlagGems/tar.gz/${FLAGGEMS_REF}" \
-        --output /tmp/FlagGems.tar.gz \
-    && tar -xzf /tmp/FlagGems.tar.gz --strip-components=1 -C /tmp/FlagGems \
-    && python -m pip install --no-cache-dir \
-        -r /tmp/FlagGems/requirements/requirements_metax.txt \
-    && GEMS_VENDOR=metax python -m pip install --no-cache-dir \
-        --no-build-isolation /tmp/FlagGems \
-    && rm -rf /tmp/FlagGems /tmp/FlagGems.tar.gz \
-    && python -m pip install --no-cache-dir \
-        numpy==1.26.4 \
-        opencv-python-headless==4.11.0.86 \
-        outlines-core==0.2.14
+# The validated base image already contains vLLM 0.24.0 built with
+# VLLM_TARGET_DEVICE=empty and the MetaX-tested FlagGems revision.
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary

- Upgrade the MetaX CI image to vLLM 0.24.0.
- Use the validated MetaX prebuilt base image.
- Update the MetaX CI image tag and enable the MetaX platform.
- Keep existing workflow steps and test cases unchanged.

## Validation

- Unit tests passed.
- Functional tests passed.
- Inference and all four serving cases passed.
- Benchmark smoke test passed.
- Image pushed successfully:
  `harbor.baai.ac.cn/flagos-dev/vllm-plugin-fl:v0.24.0-metax-ci`
- Image digest:
  `sha256:7351ce7153f512a9a385c2d381f930a4d388b8dbefafaabeceaaebfe6f2f50c2`
- Verified on MetaX C550 with PyTorch 2.8.0 and vLLM 0.24.0.